### PR TITLE
Add OpenClaw video skills mapping and validator script

### DIFF
--- a/docs/sources/openclaw-video-2nP0YCjM_hk.skills.json
+++ b/docs/sources/openclaw-video-2nP0YCjM_hk.skills.json
@@ -1,0 +1,119 @@
+{
+  "video": {
+    "url": "https://www.youtube.com/watch?v=2nP0YCjM_hk",
+    "checked_at": "2026-03-22",
+    "note": "Cross-validated against repository skill slugs and OpenClaw official docs where accessible."
+  },
+  "official_references": [
+    {
+      "name": "OpenClaw Skills docs",
+      "url": "https://docs.openclaw.ai/tools/skills",
+      "purpose": "Confirms ClawHub is registry/CLI flow (install/update/sync), not a skill slug itself."
+    }
+  ],
+  "skills": [
+    {
+      "video_name": "Cloudhub",
+      "normalized_slug": null,
+      "status": "not_a_skill",
+      "repo_skill": null,
+      "source": "https://docs.openclaw.ai/tools/skills",
+      "notes": "ClawHub is the public skill registry and CLI workflow, not an installable skill package."
+    },
+    {
+      "video_name": "Find skills",
+      "normalized_slug": "find-skills",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/task-understanding-decomposition/find-skills/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Skill slug matches repository entry."
+    },
+    {
+      "video_name": "Skill Vator",
+      "normalized_slug": null,
+      "status": "unverified_slug",
+      "repo_skill": null,
+      "source": "https://www.clawhub.com",
+      "notes": "Could not verify an official slug in this environment; keep pending until registry confirmation."
+    },
+    {
+      "video_name": "Skill create",
+      "normalized_slug": "skill-creator",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/task-understanding-decomposition/skill-creator/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Repository canonical skill is skill-creator."
+    },
+    {
+      "video_name": "Web Search",
+      "normalized_slug": "tavily-search",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/task-understanding-decomposition/tavily-search/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Repository currently tracks tavily-search for realtime web retrieval."
+    },
+    {
+      "video_name": "Agent browse",
+      "normalized_slug": "agent-browser",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/engineering-workflow-automation/agent-browser/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Repository canonical skill is agent-browser."
+    },
+    {
+      "video_name": "Self-improving agent",
+      "normalized_slug": "self-improving-agent",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-agent-platform/self-improving-agent/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Skill exists in canonical tree."
+    },
+    {
+      "video_name": "Proactive agent",
+      "normalized_slug": "proactive-agent",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-agent-platform/proactive-agent/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Skill exists in canonical tree."
+    },
+    {
+      "video_name": "Agent memory",
+      "normalized_slug": null,
+      "status": "unverified_slug",
+      "repo_skill": null,
+      "source": "https://www.clawhub.com",
+      "notes": "Could not verify official slug in this environment; keep pending until registry confirmation."
+    },
+    {
+      "video_name": "Summarize",
+      "normalized_slug": "summarize",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/multimodal-media/summarize/SKILL.md",
+      "source": "https://www.clawhub.com",
+      "notes": "Skill exists in canonical tree."
+    }
+  ],
+  "verification_attempts": [
+    {
+      "date": "2026-03-22",
+      "method": "openclaw-docs",
+      "target": "https://docs.openclaw.ai/tools/skills",
+      "result": "success",
+      "evidence": "ClawHub documented as registry/install+sync flow"
+    },
+    {
+      "date": "2026-03-22",
+      "method": "clawhub-cli",
+      "command": "npx -y clawhub@latest --help",
+      "result": "failed",
+      "error": "npm registry 403 Forbidden in current environment"
+    },
+    {
+      "date": "2026-03-22",
+      "method": "direct-http",
+      "target": "https://clawhub.ai/api/...",
+      "result": "failed",
+      "error": "proxy tunnel 403 Forbidden in current environment"
+    }
+  ]
+}

--- a/scripts/validate_openclaw_video_sources.py
+++ b/scripts/validate_openclaw_video_sources.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate OpenClaw video skills mapping JSON against repository skill files."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+REQUIRED_TOP = {"video", "official_references", "skills"}
+REQUIRED_SKILL_KEYS = {"video_name", "normalized_slug", "status", "repo_skill", "source", "notes"}
+VALID_STATUS = {"verified_in_repo", "not_a_skill", "unverified_slug"}
+
+
+def parse_name_from_skill_md(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    # minimal frontmatter parser: first line '---', then key: value until next '---'
+    if not text.startswith("---\n"):
+        return None
+    fm = text.split("\n---\n", 1)[0]
+    m = re.search(r"^name:\s*['\"]?([^'\"\n]+)['\"]?\s*$", fm, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+def validate(mapping_path: Path, repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    data = json.loads(mapping_path.read_text(encoding="utf-8"))
+
+    missing_top = REQUIRED_TOP - set(data.keys())
+    if missing_top:
+        errors.append(f"Missing top-level keys: {sorted(missing_top)}")
+
+    skills = data.get("skills", [])
+    if not isinstance(skills, list) or not skills:
+        errors.append("skills must be a non-empty array")
+        return errors
+
+    for idx, item in enumerate(skills, 1):
+        missing = REQUIRED_SKILL_KEYS - set(item.keys())
+        if missing:
+            errors.append(f"skills[{idx}] missing keys: {sorted(missing)}")
+            continue
+
+        status = item["status"]
+        slug = item["normalized_slug"]
+        repo_skill = item["repo_skill"]
+
+        if status not in VALID_STATUS:
+            errors.append(f"skills[{idx}] invalid status: {status}")
+
+        if status == "verified_in_repo":
+            if not slug:
+                errors.append(f"skills[{idx}] verified_in_repo must have normalized_slug")
+            if not repo_skill:
+                errors.append(f"skills[{idx}] verified_in_repo must have repo_skill")
+                continue
+            path = repo_root / repo_skill
+            if not path.exists():
+                errors.append(f"skills[{idx}] repo_skill does not exist: {repo_skill}")
+                continue
+            parsed_name = parse_name_from_skill_md(path)
+            if parsed_name != slug:
+                errors.append(
+                    f"skills[{idx}] slug mismatch: normalized_slug={slug}, SKILL.md name={parsed_name}, file={repo_skill}"
+                )
+
+        if status in {"not_a_skill", "unverified_slug"} and slug is not None:
+            errors.append(f"skills[{idx}] status {status} should keep normalized_slug as null until verified")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mapping",
+        default="docs/sources/openclaw-video-2nP0YCjM_hk.skills.json",
+        help="Path to mapping JSON",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    mapping_path = repo_root / args.mapping
+    errors = validate(mapping_path, repo_root)
+    if errors:
+        print("Validation failed:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print("Validation passed:")
+    print(f"- mapping: {args.mapping}")
+    print("- all verified_in_repo entries exist and match SKILL.md frontmatter name")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a machine-readable mapping of the OpenClaw YouTube video to repository skill entries and capture verification attempts and official references.
- Ensure mapping accuracy by adding a validator that checks mapping keys, statuses, file existence, and SKILL.md frontmatter consistency.

### Description
- Add `docs/sources/openclaw-video-2nP0YCjM_hk.skills.json` containing video metadata, official references, a list of skills with normalized slugs/statuses/repo paths/notes, and verification attempts.
- Add `scripts/validate_openclaw_video_sources.py` which validates top-level keys, required skill fields, allowed `status` values, ensures `verified_in_repo` entries reference existing `SKILL.md` files, and verifies the SKILL.md frontmatter `name` matches `normalized_slug`.
- The validator reports detailed errors, prints a success summary on pass, exits with non-zero status on failure, and is invoked via the included command-line interface.

### Testing
- Ran `python scripts/validate_openclaw_video_sources.py --mapping docs/sources/openclaw-video-2nP0YCjM_hk.skills.json` to validate the new mapping and the script returned success.
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf542ca1248325972eb17d54afc5a3)