### PR TITLE
fix: auto-refresh additional README skill counters

### DIFF
--- a/scripts/refresh_repo_views.py
+++ b/scripts/refresh_repo_views.py
@@ -60,6 +60,14 @@ def update_root_readmes(repo_root: Path, category_count: int, skill_count: int) 
                     re.compile(r"当前共 \*\*\d+ 个分类 / \d+ 个技能\*\*。"),
                     f"当前共 **{category_count} 个分类 / {skill_count} 个技能**。",
                 ),
+                (
+                    re.compile(r"## 技能总览（按分类，\d+ 类 / \d+ 技能）"),
+                    f"## 技能总览（按分类，{category_count} 类 / {skill_count} 技能）",
+                ),
+                (
+                    re.compile(r"`\d+ 类 / \d+ 技能`"),
+                    f"`{category_count} 类 / {skill_count} 技能`",
+                ),
             ],
         ),
         (

--- a/tests/test_refresh_repo_views.py
+++ b/tests/test_refresh_repo_views.py
@@ -19,6 +19,50 @@ def load_module():
 
 
 class RefreshRepoViewsTests(unittest.TestCase):
+    def test_update_root_readmes_refreshes_all_cn_counters(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            readme = repo / "README.md"
+            readme_en = repo / "README.en.md"
+
+            readme.write_text(
+                textwrap.dedent(
+                    """\
+                    [![Skills](https://img.shields.io/badge/Skills-1-7c3aed)](./skills/)
+                    当前共 **1 个分类 / 1 个技能**。
+                    ## 技能总览（按分类，1 类 / 1 技能）
+                    以下 **不计入** 上方的 `1 类 / 1 技能` 统计。
+                    """
+                ),
+                encoding="utf-8",
+            )
+            readme_en.write_text(
+                textwrap.dedent(
+                    """\
+                    [![Skills](https://img.shields.io/badge/Skills-1-7c3aed)](./skills/)
+                    This repository currently contains **1 categories / 1 skills**.
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            module.update_root_readmes(repo, category_count=15, skill_count=139)
+
+            cn_updated = readme.read_text(encoding="utf-8")
+            en_updated = readme_en.read_text(encoding="utf-8")
+
+            self.assertIn("Skills-139-7c3aed", cn_updated)
+            self.assertIn("当前共 **15 个分类 / 139 个技能**。", cn_updated)
+            self.assertIn("## 技能总览（按分类，15 类 / 139 技能）", cn_updated)
+            self.assertIn("`15 类 / 139 技能`", cn_updated)
+            self.assertIn("Skills-139-7c3aed", en_updated)
+            self.assertIn(
+                "This repository currently contains **15 categories / 139 skills**.",
+                en_updated,
+            )
+
     def test_refresh_repo_views_generates_category_readmes_and_openclaw_export(self):
         module = load_module()
 


### PR DESCRIPTION
### Motivation
- The Chinese README contains additional occurrences of the category/skill counters that were not being updated by the refresh script, causing stale counts in headings and inline references.

### Description
- Extend `update_root_readmes` in `scripts/refresh_repo_views.py` to replace the Chinese overview heading `## 技能总览（按分类，X 类 / Y 技能）` and inline backticked references ``X 类 / Y 技能`` in addition to the existing badge and intro counters.
- Add a unit test `test_update_root_readmes_refreshes_all_cn_counters` to `tests/test_refresh_repo_views.py` that verifies both Chinese and English README counters (badge, intro sentence, heading, and inline code reference) are updated.
- Changes touch `scripts/refresh_repo_views.py` and `tests/test_refresh_repo_views.py` and keep the previous behavior for English README updates.

### Testing
- Ran `python -m unittest tests.test_refresh_repo_views -v` and both tests passed (2 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf70d491888325bc19832363e9d0a3)