### PR TITLE
feat: automate skill curation and upstream sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,215 @@
 # Repository Agent Instructions
 
-This repository supports multiple AI clients, but they must not install skills from the same path.
+This repository is the world's most comprehensive curated collection of high-quality AI Agent Skills. It supports automated skill discovery, quality-gated ingestion, and upstream synchronization.
+
+## Architecture Overview
+
+```
+skills/<category>/<skill>/SKILL.md    ← Canonical categorized source (AI clients read from here)
+openclaw-skills/<skill>/SKILL.md      ← Auto-generated flat export for OpenClaw
+docs/sources/in-house.skills.json     ← Provenance mapping (every skill tracked)
+docs/catalog.json                     ← Machine-readable full catalog
+docs/TAGS-INDEX.md                    ← Cross-category tag-based index
+```
 
 ## Installation Root By Client
 
-- `OpenClaw`: use `openclaw-skills/`
-- `Codex`, `Claude Code`, and similar coding assistants: use `skills/`
+- `OpenClaw`: use `openclaw-skills/` (flat layout)
+- `Codex`, `Claude Code`, `Cursor`, and similar: use `skills/` (categorized layout)
 
-## Why
+## Golden Rules
 
-- `skills/` is the canonical categorized source tree:
-  - `skills/<category>/<skill>/SKILL.md`
-- OpenClaw does not reliably discover that categorized layout from the repo root or the `skills/` root.
-- `openclaw-skills/` is the generated flat export for OpenClaw:
-  - `openclaw-skills/<skill>/SKILL.md`
+1. **Never manually edit** `openclaw-skills/`, `skills/*/README.md`, `docs/catalog.json`, or `docs/TAGS-INDEX.md` — they are auto-generated.
+2. **Always run the full pipeline** after any skill change (see §Pipeline below).
+3. **Every skill must have complete frontmatter** (name, description, version, tags, quality, source).
+4. **Every skill must pass quality lint** (`python scripts/lint_skill_quality.py --min-lines 50`).
+5. **Source provenance must be tracked** — every skill has an entry in `docs/sources/*.skills.json`.
 
-## Rules
+---
 
-- Do not point OpenClaw at the repository root.
-- Do not point OpenClaw at `skills/`.
-- Do not manually edit `openclaw-skills/`; regenerate it from source.
-- Do not manually edit generated category `README.md` files under `skills/*/README.md`; regenerate them from source.
-- When source skills change, refresh the OpenClaw export with:
+## Automated Operations (SOP for AI Agents)
 
-```bash
-python3 scripts/refresh_repo_views.py
+### Operation 1: Discover & Add New Skills (全网搜集优秀技能)
+
+**Trigger**: User says "add best skills", "find new skills", "搜集优秀技能", "增加一些好的skills" or similar.
+
+**Procedure**:
+
+```
+Step 1: DISCOVER — Search all platforms for candidate skills
+  ├── Run: python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json
+  ├── Additionally search manually via:
+  │   ├── npx skills find "<keyword>"          (skills.sh)
+  │   ├── clawhub search "<keyword>"           (ClawHub)
+  │   ├── web_search for GitHub trending repos with SKILL.md
+  │   └── Check watched repos: alirezarezvani/claude-skills, opera/superpowers
+  └── Collect: skill name, source URL, description, quality indicators
+
+Step 2: EVALUATE — Score and filter candidates
+  ├── Dedup against existing skills: compare with skills/*/*/SKILL.md directory names
+  ├── Quality criteria (must meet ALL):
+  │   ├── Content depth: original SKILL.md ≥ 50 lines (or you will expand it)
+  │   ├── Practical value: contains actionable guidance, not just descriptions
+  │   ├── Non-overlapping: does not duplicate an existing skill's coverage
+  │   └── Well-scoped: focused on one domain, not a vague meta-skill
+  └── Assign recommended category from the 15 existing categories (see §Categories)
+
+Step 3: INGEST — Download and add to repository
+  ├── For each approved skill:
+  │   ├── Download SKILL.md from source (GitHub raw URL, skills.sh, etc.)
+  │   ├── If content < 80 lines, expand with professional content to ≥ 100 lines
+  │   ├── Ensure these sections exist: Trigger/When to Use, Core Capabilities, Common Patterns (with code blocks), Boundaries
+  │   ├── Place in: skills/<category>/<skill-name>/SKILL.md
+  │   └── If skill has auxiliary files (templates, configs), include them
+  └── Run: python scripts/ingest_skill.py --dir skills/<category>/<skill-name> --source "<source_url>"
+       (This auto-enriches frontmatter and updates provenance mapping)
+
+Step 4: PIPELINE — Run full refresh and validation
+  ├── python scripts/enrich_frontmatter.py
+  ├── python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json
+  ├── python scripts/refresh_repo_views.py
+  ├── python scripts/generate_tags_index.py
+  ├── python scripts/build_catalog_json.py
+  ├── python scripts/lint_skill_quality.py --min-lines 50
+  ├── python -m unittest discover tests -v
+  └── git diff --exit-code  (verify generated files are committed)
+
+Step 5: COMMIT & PUSH
+  ├── git add -A
+  ├── git commit -m "feat: add N new skills from <sources>"
+  └── git push
 ```
 
-## Recommended Usage
+### Operation 2: Check & Update Existing Skills (检查并更新现有技能)
 
-### For OpenClaw
+**Trigger**: User says "check for updates", "update skills", "检查更新", "同步最新" or similar.
 
-- Clone this repository.
-- Configure OpenClaw to load from the cloned repo's `openclaw-skills/` directory, for example via `skills.load.extraDirs`.
-- Verify with:
+**Procedure**:
 
-```bash
-openclaw skills list
-openclaw skills check
+```
+Step 1: CHECK UPSTREAM — Scan for updated skills
+  ├── Run: python scripts/sync_upstream.py --check-only
+  │   (Reads docs/sources/in-house.skills.json, checks upstream repos for new commits)
+  └── Output: list of skills with available updates and their diffs
+
+Step 2: APPLY UPDATES
+  ├── Run: python scripts/sync_upstream.py --apply
+  │   (Downloads latest SKILL.md from upstream, replaces local, updates metadata)
+  ├── For each updated skill:
+  │   ├── Preserve local frontmatter enrichments (tags, quality, etc.)
+  │   ├── Update: updated_at, version (bump patch)
+  │   └── Verify content quality after merge
+  └── If conflicts exist, prefer upstream content but keep local frontmatter
+
+Step 3: QUALITY CHECK
+  ├── python scripts/lint_skill_quality.py --min-lines 50
+  └── Manually review any WARN/FAIL results
+
+Step 4: PIPELINE — Same as Operation 1, Step 4
+
+Step 5: COMMIT & PUSH
+  ├── git add -A
+  ├── git commit -m "chore: sync upstream updates for N skills"
+  └── git push
 ```
 
-### For Codex / Claude Code
+### Operation 3: Combined — Discover + Update (搜集新技能并更新旧技能)
 
-- Clone this repository.
-- Read and use skills from the categorized `skills/` tree.
-- Preserve category organization when creating or editing skills.
+**Trigger**: User says "add new and update existing", "全面更新", "搜集新的并更新旧的" or similar.
+
+**Procedure**: Execute Operation 2 first (update existing), then Operation 1 (add new). This ensures the baseline is current before adding new skills.
+
+---
+
+## Categories (15 total)
+
+| Category Directory | Description | Example Skills |
+|---|---|---|
+| `developer-engineering` | Programming languages, frameworks, dev tools | kubernetes-specialist, nextjs-app-router, rust-engineer |
+| `devops-sre` | Infrastructure, CI/CD, monitoring, reliability | senior-devops, senior-architect |
+| `finance-investing` | Financial analysis, trading, portfolio management | financial-analyst, saas-metrics-coach |
+| `growth-operations-xiaohongshu` | Marketing, SEO, social media, growth | seo-audit, campaign-manager |
+| `product-design` | UX/UI, product management, design systems | figma, ux-researcher-designer |
+| `security-and-reliability` | Security auditing, compliance, threat modeling | security-best-practices, skill-security-auditor |
+| `ai-agent-platform` | Agent design, orchestration, memory systems | agent-hub, self-improving-agent |
+| `engineering-workflow-automation` | Git workflows, CI/CD automation, code generation | yeet, web-scraper |
+| `operations-general` | Productivity, search, communication, utilities | summarize, confidence-check |
+| `task-understanding-decomposition` | Task planning, decomposition, execution | gog, subagent-driven-development |
+| `deployment-platforms` | Platform-specific deployment guides | cloudflare-workers, vercel |
+| `office-automation` | Document processing, spreadsheets, presentations | spreadsheet, presentation |
+| `media-and-content` | Content creation, video, social media | video-script-creator, social-content |
+| `cross-border-ecommerce` | International trade, sourcing, product selection | product-selection, tariff-search |
+| `customer-lifecycle` | CRM, customer success, retention | customer-onboarding, churn-prevention |
+
+**Category selection rules**:
+- Match primary function, not secondary use case
+- If a skill spans two categories, choose the one with fewer skills to balance distribution
+- If uncertain, use `operations-general` as default
+
+---
+
+## Frontmatter Schema (Required)
+
+Every `SKILL.md` must have this frontmatter:
+
+```yaml
+---
+name: skill-name                    # Must match directory name
+description: "One-line description" # Quoted if contains special chars
+version: "1.0.0"                    # Semver
+author: seaworld008                 # Contributor GitHub ID
+source: in-house                    # in-house | skills.sh | clawhub | github:<owner>/<repo> | community
+source_url: ""                      # Original URL if from external source
+tags: [tag1, tag2, tag3]            # Cross-category searchable tags
+created_at: "2026-03-27"            # YYYY-MM-DD
+updated_at: "2026-03-27"            # YYYY-MM-DD
+quality: 4                          # 1-5 (1=stub, 3=acceptable, 5=best-in-class)
+complexity: intermediate            # beginner | intermediate | advanced
+---
+```
+
+## Quality Standards
+
+| Rating | Lines | Requirements |
+|--------|-------|-------------|
+| 5 (Best) | ≥200 | Comprehensive guide with multiple code examples, edge cases, anti-patterns |
+| 4 (Good) | ≥100 | Solid coverage with code examples and practical templates |
+| 3 (OK) | ≥80 | Basic coverage with at least 1 code block |
+| 2 (Thin) | ≥50 | Minimal viable content, needs expansion |
+| 1 (Stub) | <50 | Placeholder only — should not be committed |
+
+**Minimum for commit**: quality ≥ 2, lines ≥ 50
+
+---
+
+## Script Reference
+
+| Script | Purpose | When to Run |
+|--------|---------|-------------|
+| `discover_new_skills.py` | Search GitHub/skills.sh/ClawHub for new skills | Operation 1, Step 1 |
+| `ingest_skill.py` | Register a new skill's provenance and enrich metadata | Operation 1, Step 3 |
+| `sync_upstream.py` | Check and apply upstream updates | Operation 2 |
+| `enrich_frontmatter.py` | Auto-fill missing frontmatter fields | After any skill addition |
+| `bootstrap_in_house_sources.py` | Regenerate provenance mapping | After any skill addition |
+| `refresh_repo_views.py` | Regenerate category READMEs + openclaw export | After any change |
+| `generate_tags_index.py` | Regenerate docs/TAGS-INDEX.md | After any change |
+| `build_catalog_json.py` | Regenerate docs/catalog.json | After any change |
+| `lint_skill_quality.py` | Quality gate check | Before commit |
+| `generate_changelog.py` | Auto-generate CHANGELOG.md | Before release |
+
+### One-liner: Full Pipeline
+
+```bash
+python scripts/enrich_frontmatter.py && \
+python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json && \
+python scripts/refresh_repo_views.py && \
+python scripts/generate_tags_index.py && \
+python scripts/build_catalog_json.py && \
+python scripts/lint_skill_quality.py --min-lines 50 && \
+python -m unittest discover tests -v
+```
+
+Windows (PowerShell):
+```powershell
+python scripts/enrich_frontmatter.py; python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json; python scripts/refresh_repo_views.py; python scripts/generate_tags_index.py; python scripts/build_catalog_json.py; python scripts/lint_skill_quality.py --min-lines 50; python -m unittest discover tests -v
+```

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -13,191 +13,15 @@
   ],
   "skills": [
     {
-      "video_name": "agent-hub",
-      "normalized_slug": "agent-hub",
+      "video_name": "agent-browser",
+      "normalized_slug": "agent-browser",
       "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/agent-hub/SKILL.md",
+      "repo_skill": "skills/engineering-workflow-automation/agent-browser/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/agent-hub",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "chatgpt-apps",
-      "normalized_slug": "chatgpt-apps",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/chatgpt-apps/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/chatgpt-apps",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "develop-web-game",
-      "normalized_slug": "develop-web-game",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/develop-web-game/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/develop-web-game",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "figma",
-      "normalized_slug": "figma",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/figma/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/figma",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "figma-implement-design",
-      "normalized_slug": "figma-implement-design",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/figma-implement-design/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/figma-implement-design",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "openai-docs",
-      "normalized_slug": "openai-docs",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/openai-docs/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/openai-docs",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "proactive-agent",
-      "normalized_slug": "proactive-agent",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/proactive-agent/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/proactive-agent",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "self-improving-agent",
-      "normalized_slug": "self-improving-agent",
-      "status": "in_house",
-      "repo_skill": "skills/ai-agent-platform/self-improving-agent/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/ai-agent-platform/self-improving-agent",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "cloudflare-deploy",
-      "normalized_slug": "cloudflare-deploy",
-      "status": "in_house",
-      "repo_skill": "skills/deployment-platforms/cloudflare-deploy/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/deployment-platforms/cloudflare-deploy",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "netlify-deploy",
-      "normalized_slug": "netlify-deploy",
-      "status": "in_house",
-      "repo_skill": "skills/deployment-platforms/netlify-deploy/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/deployment-platforms/netlify-deploy",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "render-deploy",
-      "normalized_slug": "render-deploy",
-      "status": "in_house",
-      "repo_skill": "skills/deployment-platforms/render-deploy/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/deployment-platforms/render-deploy",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "vercel-deploy",
-      "normalized_slug": "vercel-deploy",
-      "status": "in_house",
-      "repo_skill": "skills/deployment-platforms/vercel-deploy/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/deployment-platforms/vercel-deploy",
+        "path": "skills/engineering-workflow-automation/agent-browser",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -214,6 +38,70 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/agent-designer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "agent-hub",
+      "normalized_slug": "agent-hub",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/agent-hub/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/agent-hub",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "agent-workflow-designer",
+      "normalized_slug": "agent-workflow-designer",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/agent-workflow-designer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/agent-workflow-designer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "agile-product-owner",
+      "normalized_slug": "agile-product-owner",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/agile-product-owner/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/agile-product-owner",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "algorithmic-art",
+      "normalized_slug": "algorithmic-art",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/algorithmic-art/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/algorithmic-art",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -253,6 +141,22 @@
       }
     },
     {
+      "video_name": "app-store-optimization",
+      "normalized_slug": "app-store-optimization",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/app-store-optimization/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/app-store-optimization",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "aws-solution-architect",
       "normalized_slug": "aws-solution-architect",
       "status": "in_house",
@@ -262,6 +166,134 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/aws-solution-architect",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "brainstorming",
+      "normalized_slug": "brainstorming",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/brainstorming/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/brainstorming",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "brand-guidelines",
+      "normalized_slug": "brand-guidelines",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/brand-guidelines/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/brand-guidelines",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "campaign-analytics",
+      "normalized_slug": "campaign-analytics",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/campaign-analytics/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/campaign-analytics",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "canvas-design",
+      "normalized_slug": "canvas-design",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/canvas-design/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/canvas-design",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "capture-screen",
+      "normalized_slug": "capture-screen",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/capture-screen/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/capture-screen",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "changelog-generator",
+      "normalized_slug": "changelog-generator",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/changelog-generator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/changelog-generator",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "chatgpt-apps",
+      "normalized_slug": "chatgpt-apps",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/chatgpt-apps/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/chatgpt-apps",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "ci-cd-pipeline-builder",
+      "normalized_slug": "ci-cd-pipeline-builder",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/ci-cd-pipeline-builder/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/ci-cd-pipeline-builder",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -285,6 +317,38 @@
       }
     },
     {
+      "video_name": "cloudflare-deploy",
+      "normalized_slug": "cloudflare-deploy",
+      "status": "in_house",
+      "repo_skill": "skills/deployment-platforms/cloudflare-deploy/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/deployment-platforms/cloudflare-deploy",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "cloudflare-troubleshooting",
+      "normalized_slug": "cloudflare-troubleshooting",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/cloudflare-troubleshooting/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/cloudflare-troubleshooting",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "codebase-onboarding",
       "normalized_slug": "codebase-onboarding",
       "status": "in_house",
@@ -294,6 +358,86 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/codebase-onboarding",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "competitive-teardown",
+      "normalized_slug": "competitive-teardown",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/competitive-teardown/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/competitive-teardown",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "competitors-analysis",
+      "normalized_slug": "competitors-analysis",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/competitors-analysis/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/competitors-analysis",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "comps-valuation-analyst",
+      "normalized_slug": "comps-valuation-analyst",
+      "status": "in_house",
+      "repo_skill": "skills/finance-investing/comps-valuation-analyst/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/finance-investing/comps-valuation-analyst",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "confidence-check",
+      "normalized_slug": "confidence-check",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/confidence-check/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/confidence-check",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "content-creator",
+      "normalized_slug": "content-creator",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/content-creator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/content-creator",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -349,6 +493,22 @@
       }
     },
     {
+      "video_name": "deep-research",
+      "normalized_slug": "deep-research",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/deep-research/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/deep-research",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "dependency-auditor",
       "normalized_slug": "dependency-auditor",
       "status": "in_house",
@@ -358,6 +518,54 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/dependency-auditor",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "develop-web-game",
+      "normalized_slug": "develop-web-game",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/develop-web-game/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/develop-web-game",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "doc",
+      "normalized_slug": "doc",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/doc/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/doc",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "doc-coauthoring",
+      "normalized_slug": "doc-coauthoring",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/doc-coauthoring/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/doc-coauthoring",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -381,15 +589,15 @@
       }
     },
     {
-      "video_name": "frontend-design",
-      "normalized_slug": "frontend-design",
+      "video_name": "docs-cleaner",
+      "normalized_slug": "docs-cleaner",
       "status": "in_house",
-      "repo_skill": "skills/developer-engineering/frontend-design/SKILL.md",
+      "repo_skill": "skills/operations-general/docs-cleaner/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/frontend-design",
+        "path": "skills/operations-general/docs-cleaner",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -397,735 +605,15 @@
       }
     },
     {
-      "video_name": "git-worktree-manager",
-      "normalized_slug": "git-worktree-manager",
+      "video_name": "docx",
+      "normalized_slug": "docx",
       "status": "in_house",
-      "repo_skill": "skills/developer-engineering/git-worktree-manager/SKILL.md",
+      "repo_skill": "skills/office-white-collar/docx/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/git-worktree-manager",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "github-contributor",
-      "normalized_slug": "github-contributor",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/github-contributor/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/github-contributor",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "graphql-expert",
-      "normalized_slug": "graphql-expert",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/graphql-expert/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/graphql-expert",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "i18n-expert",
-      "normalized_slug": "i18n-expert",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/i18n-expert/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/i18n-expert",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "kubernetes-specialist",
-      "normalized_slug": "kubernetes-specialist",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/kubernetes-specialist/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/kubernetes-specialist",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "mcp-builder",
-      "normalized_slug": "mcp-builder",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/mcp-builder/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/mcp-builder",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "mcp-server-builder",
-      "normalized_slug": "mcp-server-builder",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/mcp-server-builder/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/mcp-server-builder",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "migration-architect",
-      "normalized_slug": "migration-architect",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/migration-architect/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/migration-architect",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "monorepo-navigator",
-      "normalized_slug": "monorepo-navigator",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/monorepo-navigator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/monorepo-navigator",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "nextjs-app-router",
-      "normalized_slug": "nextjs-app-router",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/nextjs-app-router/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/nextjs-app-router",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "performance-profiler",
-      "normalized_slug": "performance-profiler",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/performance-profiler/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/performance-profiler",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "pr-review-expert",
-      "normalized_slug": "pr-review-expert",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/pr-review-expert/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/pr-review-expert",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "promptfoo-evaluation",
-      "normalized_slug": "promptfoo-evaluation",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/promptfoo-evaluation/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/promptfoo-evaluation",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "python-performance",
-      "normalized_slug": "python-performance",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/python-performance/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/python-performance",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "qa-expert",
-      "normalized_slug": "qa-expert",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/qa-expert/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/qa-expert",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "repomix-safe-mixer",
-      "normalized_slug": "repomix-safe-mixer",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/repomix-safe-mixer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/repomix-safe-mixer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "rust-engineer",
-      "normalized_slug": "rust-engineer",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/rust-engineer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/rust-engineer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "skill-tester",
-      "normalized_slug": "skill-tester",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/skill-tester/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/skill-tester",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "supabase-postgres",
-      "normalized_slug": "supabase-postgres",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/supabase-postgres/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/supabase-postgres",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "systematic-debugging",
-      "normalized_slug": "systematic-debugging",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/systematic-debugging/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/systematic-debugging",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "tailwind-design-system",
-      "normalized_slug": "tailwind-design-system",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/tailwind-design-system/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/tailwind-design-system",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "tech-debt-tracker",
-      "normalized_slug": "tech-debt-tracker",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/tech-debt-tracker/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/tech-debt-tracker",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "terraform-engineer",
-      "normalized_slug": "terraform-engineer",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/terraform-engineer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/terraform-engineer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "test-driven-development",
-      "normalized_slug": "test-driven-development",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/test-driven-development/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/test-driven-development",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "typescript-best-practices",
-      "normalized_slug": "typescript-best-practices",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/typescript-best-practices/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/typescript-best-practices",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "web-artifacts-builder",
-      "normalized_slug": "web-artifacts-builder",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/web-artifacts-builder/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/web-artifacts-builder",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "webapp-testing",
-      "normalized_slug": "webapp-testing",
-      "status": "in_house",
-      "repo_skill": "skills/developer-engineering/webapp-testing/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/developer-engineering/webapp-testing",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "changelog-generator",
-      "normalized_slug": "changelog-generator",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/changelog-generator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/changelog-generator",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "ci-cd-pipeline-builder",
-      "normalized_slug": "ci-cd-pipeline-builder",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/ci-cd-pipeline-builder/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/ci-cd-pipeline-builder",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "cloudflare-troubleshooting",
-      "normalized_slug": "cloudflare-troubleshooting",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/cloudflare-troubleshooting/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/cloudflare-troubleshooting",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "env-secrets-manager",
-      "normalized_slug": "env-secrets-manager",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/env-secrets-manager/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/env-secrets-manager",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "github-ops",
-      "normalized_slug": "github-ops",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/github-ops/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/github-ops",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "incident-commander",
-      "normalized_slug": "incident-commander",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/incident-commander/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/incident-commander",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "observability-designer",
-      "normalized_slug": "observability-designer",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/observability-designer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/observability-designer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "release-manager",
-      "normalized_slug": "release-manager",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/release-manager/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/release-manager",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "senior-architect",
-      "normalized_slug": "senior-architect",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/senior-architect/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/senior-architect",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "senior-devops",
-      "normalized_slug": "senior-devops",
-      "status": "in_house",
-      "repo_skill": "skills/devops-sre/senior-devops/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/devops-sre/senior-devops",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "agent-browser",
-      "normalized_slug": "agent-browser",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/agent-browser/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/agent-browser",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "gh-address-comments",
-      "normalized_slug": "gh-address-comments",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/gh-address-comments/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/gh-address-comments",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "gh-fix-ci",
-      "normalized_slug": "gh-fix-ci",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/gh-fix-ci/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/gh-fix-ci",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "github",
-      "normalized_slug": "github",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/github/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/github",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "jupyter-notebook",
-      "normalized_slug": "jupyter-notebook",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/jupyter-notebook/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/jupyter-notebook",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "playwright",
-      "normalized_slug": "playwright",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/playwright/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/playwright",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "web-scraper",
-      "normalized_slug": "web-scraper",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/web-scraper/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/web-scraper",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "yeet",
-      "normalized_slug": "yeet",
-      "status": "in_house",
-      "repo_skill": "skills/engineering-workflow-automation/yeet/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/engineering-workflow-automation/yeet",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "comps-valuation-analyst",
-      "normalized_slug": "comps-valuation-analyst",
-      "status": "in_house",
-      "repo_skill": "skills/finance-investing/comps-valuation-analyst/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/comps-valuation-analyst",
+        "path": "skills/office-white-collar/docx",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1149,6 +637,22 @@
       }
     },
     {
+      "video_name": "env-secrets-manager",
+      "normalized_slug": "env-secrets-manager",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/env-secrets-manager/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/env-secrets-manager",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "event-driven-tracker",
       "normalized_slug": "event-driven-tracker",
       "status": "in_house",
@@ -1165,6 +669,38 @@
       }
     },
     {
+      "video_name": "excel-automation",
+      "normalized_slug": "excel-automation",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/excel-automation/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/excel-automation",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "fact-checker",
+      "normalized_slug": "fact-checker",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/fact-checker/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/fact-checker",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "factor-backtester",
       "normalized_slug": "factor-backtester",
       "status": "in_house",
@@ -1174,6 +710,38 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/factor-backtester",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "figma",
+      "normalized_slug": "figma",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/figma/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/figma",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "figma-implement-design",
+      "normalized_slug": "figma-implement-design",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/figma-implement-design/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/figma-implement-design",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1213,6 +781,262 @@
       }
     },
     {
+      "video_name": "find-skills",
+      "normalized_slug": "find-skills",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/find-skills/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/find-skills",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "frontend-design",
+      "normalized_slug": "frontend-design",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/frontend-design/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/frontend-design",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "gh-address-comments",
+      "normalized_slug": "gh-address-comments",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/gh-address-comments/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/gh-address-comments",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "gh-fix-ci",
+      "normalized_slug": "gh-fix-ci",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/gh-fix-ci/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/gh-fix-ci",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "git-worktree-manager",
+      "normalized_slug": "git-worktree-manager",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/git-worktree-manager/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/git-worktree-manager",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "github",
+      "normalized_slug": "github",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/github/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/github",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "github-contributor",
+      "normalized_slug": "github-contributor",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/github-contributor/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/github-contributor",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "github-ops",
+      "normalized_slug": "github-ops",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/github-ops/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/github-ops",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "gog",
+      "normalized_slug": "gog",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/gog/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/gog",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "graphql-expert",
+      "normalized_slug": "graphql-expert",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/graphql-expert/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/graphql-expert",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "i18n-expert",
+      "normalized_slug": "i18n-expert",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/i18n-expert/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/i18n-expert",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "imagegen",
+      "normalized_slug": "imagegen",
+      "status": "in_house",
+      "repo_skill": "skills/multimodal-media/imagegen/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/multimodal-media/imagegen",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "incident-commander",
+      "normalized_slug": "incident-commander",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/incident-commander/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/incident-commander",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "input-guard",
+      "normalized_slug": "input-guard",
+      "status": "in_house",
+      "repo_skill": "skills/openclaw-memory-and-safety/input-guard/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/openclaw-memory-and-safety/input-guard",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "internal-comms",
+      "normalized_slug": "internal-comms",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/internal-comms/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/internal-comms",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "interview-system-designer",
+      "normalized_slug": "interview-system-designer",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/interview-system-designer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/interview-system-designer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "investment-memo-writer",
       "normalized_slug": "investment-memo-writer",
       "status": "in_house",
@@ -1222,6 +1046,86 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/investment-memo-writer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "jupyter-notebook",
+      "normalized_slug": "jupyter-notebook",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/jupyter-notebook/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/jupyter-notebook",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "kubernetes-specialist",
+      "normalized_slug": "kubernetes-specialist",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/kubernetes-specialist/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/kubernetes-specialist",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "landing-page-generator",
+      "normalized_slug": "landing-page-generator",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/landing-page-generator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/landing-page-generator",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "linear",
+      "normalized_slug": "linear",
+      "status": "in_house",
+      "repo_skill": "skills/knowledge-and-pm-integrations/linear/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/knowledge-and-pm-integrations/linear",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "link-checker",
+      "normalized_slug": "link-checker",
+      "status": "in_house",
+      "repo_skill": "skills/security-and-reliability/link-checker/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/security-and-reliability/link-checker",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1245,159 +1149,15 @@
       }
     },
     {
-      "video_name": "options-strategy-evaluator",
-      "normalized_slug": "options-strategy-evaluator",
+      "video_name": "markdown-tools",
+      "normalized_slug": "markdown-tools",
       "status": "in_house",
-      "repo_skill": "skills/finance-investing/options-strategy-evaluator/SKILL.md",
+      "repo_skill": "skills/office-white-collar/markdown-tools/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/options-strategy-evaluator",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "portfolio-risk-manager",
-      "normalized_slug": "portfolio-risk-manager",
-      "status": "in_house",
-      "repo_skill": "skills/finance-investing/portfolio-risk-manager/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/portfolio-risk-manager",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "saas-metrics-coach",
-      "normalized_slug": "saas-metrics-coach",
-      "status": "in_house",
-      "repo_skill": "skills/finance-investing/saas-metrics-coach/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/saas-metrics-coach",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "sec-filing-reviewer",
-      "normalized_slug": "sec-filing-reviewer",
-      "status": "in_house",
-      "repo_skill": "skills/finance-investing/sec-filing-reviewer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/sec-filing-reviewer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "stock-screener-builder",
-      "normalized_slug": "stock-screener-builder",
-      "status": "in_house",
-      "repo_skill": "skills/finance-investing/stock-screener-builder/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/finance-investing/stock-screener-builder",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "algorithmic-art",
-      "normalized_slug": "algorithmic-art",
-      "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/algorithmic-art/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/algorithmic-art",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "app-store-optimization",
-      "normalized_slug": "app-store-optimization",
-      "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/app-store-optimization/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/app-store-optimization",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "campaign-analytics",
-      "normalized_slug": "campaign-analytics",
-      "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/campaign-analytics/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/campaign-analytics",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "competitors-analysis",
-      "normalized_slug": "competitors-analysis",
-      "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/competitors-analysis/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/competitors-analysis",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "content-creator",
-      "normalized_slug": "content-creator",
-      "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/content-creator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/content-creator",
+        "path": "skills/office-white-collar/markdown-tools",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1437,15 +1197,15 @@
       }
     },
     {
-      "video_name": "prompt-engineer-toolkit",
-      "normalized_slug": "prompt-engineer-toolkit",
+      "video_name": "mcp-builder",
+      "normalized_slug": "mcp-builder",
       "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/prompt-engineer-toolkit/SKILL.md",
+      "repo_skill": "skills/developer-engineering/mcp-builder/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/prompt-engineer-toolkit",
+        "path": "skills/developer-engineering/mcp-builder",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1453,15 +1213,15 @@
       }
     },
     {
-      "video_name": "seo-audit",
-      "normalized_slug": "seo-audit",
+      "video_name": "mcp-server-builder",
+      "normalized_slug": "mcp-server-builder",
       "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/seo-audit/SKILL.md",
+      "repo_skill": "skills/developer-engineering/mcp-server-builder/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/seo-audit",
+        "path": "skills/developer-engineering/mcp-server-builder",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1469,15 +1229,15 @@
       }
     },
     {
-      "video_name": "social-media-analyzer",
-      "normalized_slug": "social-media-analyzer",
+      "video_name": "meeting-minutes-taker",
+      "normalized_slug": "meeting-minutes-taker",
       "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/social-media-analyzer/SKILL.md",
+      "repo_skill": "skills/office-white-collar/meeting-minutes-taker/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/social-media-analyzer",
+        "path": "skills/office-white-collar/meeting-minutes-taker",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1485,15 +1245,15 @@
       }
     },
     {
-      "video_name": "twitter-reader",
-      "normalized_slug": "twitter-reader",
+      "video_name": "mermaid-tools",
+      "normalized_slug": "mermaid-tools",
       "status": "in_house",
-      "repo_skill": "skills/growth-operations-xiaohongshu/twitter-reader/SKILL.md",
+      "repo_skill": "skills/office-white-collar/mermaid-tools/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/growth-operations-xiaohongshu/twitter-reader",
+        "path": "skills/office-white-collar/mermaid-tools",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1501,15 +1261,63 @@
       }
     },
     {
-      "video_name": "linear",
-      "normalized_slug": "linear",
+      "video_name": "migration-architect",
+      "normalized_slug": "migration-architect",
       "status": "in_house",
-      "repo_skill": "skills/knowledge-and-pm-integrations/linear/SKILL.md",
+      "repo_skill": "skills/developer-engineering/migration-architect/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/knowledge-and-pm-integrations/linear",
+        "path": "skills/developer-engineering/migration-architect",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "monorepo-navigator",
+      "normalized_slug": "monorepo-navigator",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/monorepo-navigator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/monorepo-navigator",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "netlify-deploy",
+      "normalized_slug": "netlify-deploy",
+      "status": "in_house",
+      "repo_skill": "skills/deployment-platforms/netlify-deploy/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/deployment-platforms/netlify-deploy",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "nextjs-app-router",
+      "normalized_slug": "nextjs-app-router",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/nextjs-app-router/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/nextjs-app-router",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1581,15 +1389,15 @@
       }
     },
     {
-      "video_name": "imagegen",
-      "normalized_slug": "imagegen",
+      "video_name": "observability-designer",
+      "normalized_slug": "observability-designer",
       "status": "in_house",
-      "repo_skill": "skills/multimodal-media/imagegen/SKILL.md",
+      "repo_skill": "skills/devops-sre/observability-designer/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/imagegen",
+        "path": "skills/devops-sre/observability-designer",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1597,15 +1405,15 @@
       }
     },
     {
-      "video_name": "screenshot",
-      "normalized_slug": "screenshot",
+      "video_name": "openai-docs",
+      "normalized_slug": "openai-docs",
       "status": "in_house",
-      "repo_skill": "skills/multimodal-media/screenshot/SKILL.md",
+      "repo_skill": "skills/ai-agent-platform/openai-docs/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/screenshot",
+        "path": "skills/ai-agent-platform/openai-docs",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1613,207 +1421,15 @@
       }
     },
     {
-      "video_name": "sora",
-      "normalized_slug": "sora",
+      "video_name": "options-strategy-evaluator",
+      "normalized_slug": "options-strategy-evaluator",
       "status": "in_house",
-      "repo_skill": "skills/multimodal-media/sora/SKILL.md",
+      "repo_skill": "skills/finance-investing/options-strategy-evaluator/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/sora",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "speech",
-      "normalized_slug": "speech",
-      "status": "in_house",
-      "repo_skill": "skills/multimodal-media/speech/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/speech",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "summarize",
-      "normalized_slug": "summarize",
-      "status": "in_house",
-      "repo_skill": "skills/multimodal-media/summarize/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/summarize",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "transcribe",
-      "normalized_slug": "transcribe",
-      "status": "in_house",
-      "repo_skill": "skills/multimodal-media/transcribe/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/multimodal-media/transcribe",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "capture-screen",
-      "normalized_slug": "capture-screen",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/capture-screen/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/capture-screen",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "doc",
-      "normalized_slug": "doc",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/doc/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/doc",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "doc-coauthoring",
-      "normalized_slug": "doc-coauthoring",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/doc-coauthoring/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/doc-coauthoring",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "docx",
-      "normalized_slug": "docx",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/docx/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/docx",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "excel-automation",
-      "normalized_slug": "excel-automation",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/excel-automation/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/excel-automation",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "gog",
-      "normalized_slug": "gog",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/gog/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/gog",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "markdown-tools",
-      "normalized_slug": "markdown-tools",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/markdown-tools/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/markdown-tools",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "meeting-minutes-taker",
-      "normalized_slug": "meeting-minutes-taker",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/meeting-minutes-taker/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/meeting-minutes-taker",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "mermaid-tools",
-      "normalized_slug": "mermaid-tools",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/mermaid-tools/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/mermaid-tools",
+        "path": "skills/finance-investing/options-strategy-evaluator",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1853,6 +1469,54 @@
       }
     },
     {
+      "video_name": "performance-profiler",
+      "normalized_slug": "performance-profiler",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/performance-profiler/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/performance-profiler",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "playwright",
+      "normalized_slug": "playwright",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/playwright/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/playwright",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "portfolio-risk-manager",
+      "normalized_slug": "portfolio-risk-manager",
+      "status": "in_house",
+      "repo_skill": "skills/finance-investing/portfolio-risk-manager/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/finance-investing/portfolio-risk-manager",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "ppt-creator",
       "normalized_slug": "ppt-creator",
       "status": "in_house",
@@ -1885,15 +1549,15 @@
       }
     },
     {
-      "video_name": "spreadsheet",
-      "normalized_slug": "spreadsheet",
+      "video_name": "pr-review-expert",
+      "normalized_slug": "pr-review-expert",
       "status": "in_house",
-      "repo_skill": "skills/office-white-collar/spreadsheet/SKILL.md",
+      "repo_skill": "skills/developer-engineering/pr-review-expert/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/spreadsheet",
+        "path": "skills/developer-engineering/pr-review-expert",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -1901,319 +1565,15 @@
       }
     },
     {
-      "video_name": "transcript-fixer",
-      "normalized_slug": "transcript-fixer",
+      "video_name": "proactive-agent",
+      "normalized_slug": "proactive-agent",
       "status": "in_house",
-      "repo_skill": "skills/office-white-collar/transcript-fixer/SKILL.md",
+      "repo_skill": "skills/ai-agent-platform/proactive-agent/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/transcript-fixer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "xlsx",
-      "normalized_slug": "xlsx",
-      "status": "in_house",
-      "repo_skill": "skills/office-white-collar/xlsx/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/office-white-collar/xlsx",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "input-guard",
-      "normalized_slug": "input-guard",
-      "status": "in_house",
-      "repo_skill": "skills/openclaw-memory-and-safety/input-guard/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/openclaw-memory-and-safety/input-guard",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "rag-architect",
-      "normalized_slug": "rag-architect",
-      "status": "in_house",
-      "repo_skill": "skills/openclaw-memory-and-safety/rag-architect/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/openclaw-memory-and-safety/rag-architect",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "runbook-generator",
-      "normalized_slug": "runbook-generator",
-      "status": "in_house",
-      "repo_skill": "skills/openclaw-memory-and-safety/runbook-generator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/openclaw-memory-and-safety/runbook-generator",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "brand-guidelines",
-      "normalized_slug": "brand-guidelines",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/brand-guidelines/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/brand-guidelines",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "confidence-check",
-      "normalized_slug": "confidence-check",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/confidence-check/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/confidence-check",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "docs-cleaner",
-      "normalized_slug": "docs-cleaner",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/docs-cleaner/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/docs-cleaner",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "fact-checker",
-      "normalized_slug": "fact-checker",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/fact-checker/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/fact-checker",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "internal-comms",
-      "normalized_slug": "internal-comms",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/internal-comms/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/internal-comms",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "interview-system-designer",
-      "normalized_slug": "interview-system-designer",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/interview-system-designer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/interview-system-designer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "slack-gif-creator",
-      "normalized_slug": "slack-gif-creator",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/slack-gif-creator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/slack-gif-creator",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "supermemory",
-      "normalized_slug": "supermemory",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/supermemory/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/supermemory",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "teams-channel-post-writer",
-      "normalized_slug": "teams-channel-post-writer",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/teams-channel-post-writer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/teams-channel-post-writer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "theme-factory",
-      "normalized_slug": "theme-factory",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/theme-factory/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/theme-factory",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "weather",
-      "normalized_slug": "weather",
-      "status": "in_house",
-      "repo_skill": "skills/operations-general/weather/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/operations-general/weather",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "agile-product-owner",
-      "normalized_slug": "agile-product-owner",
-      "status": "in_house",
-      "repo_skill": "skills/product-design/agile-product-owner/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/product-design/agile-product-owner",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "canvas-design",
-      "normalized_slug": "canvas-design",
-      "status": "in_house",
-      "repo_skill": "skills/product-design/canvas-design/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/product-design/canvas-design",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "competitive-teardown",
-      "normalized_slug": "competitive-teardown",
-      "status": "in_house",
-      "repo_skill": "skills/product-design/competitive-teardown/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/product-design/competitive-teardown",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "landing-page-generator",
-      "normalized_slug": "landing-page-generator",
-      "status": "in_house",
-      "repo_skill": "skills/product-design/landing-page-generator/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/product-design/landing-page-generator",
+        "path": "skills/ai-agent-platform/proactive-agent",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2269,6 +1629,214 @@
       }
     },
     {
+      "video_name": "prompt-engineer-toolkit",
+      "normalized_slug": "prompt-engineer-toolkit",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/prompt-engineer-toolkit/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/prompt-engineer-toolkit",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "prompt-optimizer",
+      "normalized_slug": "prompt-optimizer",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/prompt-optimizer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/prompt-optimizer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "promptfoo-evaluation",
+      "normalized_slug": "promptfoo-evaluation",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/promptfoo-evaluation/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/promptfoo-evaluation",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "python-performance",
+      "normalized_slug": "python-performance",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/python-performance/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/python-performance",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "qa-expert",
+      "normalized_slug": "qa-expert",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/qa-expert/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/qa-expert",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "rag-architect",
+      "normalized_slug": "rag-architect",
+      "status": "in_house",
+      "repo_skill": "skills/openclaw-memory-and-safety/rag-architect/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/openclaw-memory-and-safety/rag-architect",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "reflect-learn",
+      "normalized_slug": "reflect-learn",
+      "status": "in_house",
+      "repo_skill": "skills/task-understanding-decomposition/reflect-learn/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/task-understanding-decomposition/reflect-learn",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "release-manager",
+      "normalized_slug": "release-manager",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/release-manager/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/release-manager",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "render-deploy",
+      "normalized_slug": "render-deploy",
+      "status": "in_house",
+      "repo_skill": "skills/deployment-platforms/render-deploy/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/deployment-platforms/render-deploy",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "repomix-safe-mixer",
+      "normalized_slug": "repomix-safe-mixer",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/repomix-safe-mixer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/repomix-safe-mixer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "runbook-generator",
+      "normalized_slug": "runbook-generator",
+      "status": "in_house",
+      "repo_skill": "skills/openclaw-memory-and-safety/runbook-generator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/openclaw-memory-and-safety/runbook-generator",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "rust-engineer",
+      "normalized_slug": "rust-engineer",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/rust-engineer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/rust-engineer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "saas-metrics-coach",
+      "normalized_slug": "saas-metrics-coach",
+      "status": "in_house",
+      "repo_skill": "skills/finance-investing/saas-metrics-coach/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/finance-investing/saas-metrics-coach",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "saas-scaffolder",
       "normalized_slug": "saas-scaffolder",
       "status": "in_house",
@@ -2285,15 +1853,15 @@
       }
     },
     {
-      "video_name": "ui-design-system",
-      "normalized_slug": "ui-design-system",
+      "video_name": "screenshot",
+      "normalized_slug": "screenshot",
       "status": "in_house",
-      "repo_skill": "skills/product-design/ui-design-system/SKILL.md",
+      "repo_skill": "skills/multimodal-media/screenshot/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/product-design/ui-design-system",
+        "path": "skills/multimodal-media/screenshot",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2301,31 +1869,15 @@
       }
     },
     {
-      "video_name": "ux-researcher-designer",
-      "normalized_slug": "ux-researcher-designer",
+      "video_name": "sec-filing-reviewer",
+      "normalized_slug": "sec-filing-reviewer",
       "status": "in_house",
-      "repo_skill": "skills/product-design/ux-researcher-designer/SKILL.md",
+      "repo_skill": "skills/finance-investing/sec-filing-reviewer/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/product-design/ux-researcher-designer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "link-checker",
-      "normalized_slug": "link-checker",
-      "status": "in_house",
-      "repo_skill": "skills/security-and-reliability/link-checker/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/security-and-reliability/link-checker",
+        "path": "skills/finance-investing/sec-filing-reviewer",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2381,6 +1933,54 @@
       }
     },
     {
+      "video_name": "self-improving-agent",
+      "normalized_slug": "self-improving-agent",
+      "status": "in_house",
+      "repo_skill": "skills/ai-agent-platform/self-improving-agent/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/ai-agent-platform/self-improving-agent",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "senior-architect",
+      "normalized_slug": "senior-architect",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/senior-architect/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/senior-architect",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "senior-devops",
+      "normalized_slug": "senior-devops",
+      "status": "in_house",
+      "repo_skill": "skills/devops-sre/senior-devops/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/devops-sre/senior-devops",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "sentry",
       "normalized_slug": "sentry",
       "status": "in_house",
@@ -2397,127 +1997,15 @@
       }
     },
     {
-      "video_name": "skill-security-auditor",
-      "normalized_slug": "skill-security-auditor",
+      "video_name": "seo-audit",
+      "normalized_slug": "seo-audit",
       "status": "in_house",
-      "repo_skill": "skills/security-and-reliability/skill-security-auditor/SKILL.md",
+      "repo_skill": "skills/growth-operations-xiaohongshu/seo-audit/SKILL.md",
       "source": "https://github.com/your-org/Commonly-used-high-value-skills",
       "notes": "In-house canonical skill (local repository source of truth).",
       "upstream": {
         "repo": "local-repo/in-house",
-        "path": "skills/security-and-reliability/skill-security-auditor",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "skill-vetter",
-      "normalized_slug": "skill-vetter",
-      "status": "in_house",
-      "repo_skill": "skills/security-and-reliability/skill-vetter/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/security-and-reliability/skill-vetter",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "agent-workflow-designer",
-      "normalized_slug": "agent-workflow-designer",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/agent-workflow-designer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/agent-workflow-designer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "brainstorming",
-      "normalized_slug": "brainstorming",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/brainstorming/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/brainstorming",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "deep-research",
-      "normalized_slug": "deep-research",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/deep-research/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/deep-research",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "find-skills",
-      "normalized_slug": "find-skills",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/find-skills/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/find-skills",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "prompt-optimizer",
-      "normalized_slug": "prompt-optimizer",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/prompt-optimizer/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/prompt-optimizer",
-        "ref": "main",
-        "last_checked_at": "2026-03-27",
-        "last_synced_at": "2026-03-27",
-        "last_synced_commit": null
-      }
-    },
-    {
-      "video_name": "reflect-learn",
-      "normalized_slug": "reflect-learn",
-      "status": "in_house",
-      "repo_skill": "skills/task-understanding-decomposition/reflect-learn/SKILL.md",
-      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
-      "notes": "In-house canonical skill (local repository source of truth).",
-      "upstream": {
-        "repo": "local-repo/in-house",
-        "path": "skills/task-understanding-decomposition/reflect-learn",
+        "path": "skills/growth-operations-xiaohongshu/seo-audit",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2557,6 +2045,54 @@
       }
     },
     {
+      "video_name": "skill-security-auditor",
+      "normalized_slug": "skill-security-auditor",
+      "status": "in_house",
+      "repo_skill": "skills/security-and-reliability/skill-security-auditor/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/security-and-reliability/skill-security-auditor",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "skill-tester",
+      "normalized_slug": "skill-tester",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/skill-tester/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/skill-tester",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "skill-vetter",
+      "normalized_slug": "skill-vetter",
+      "status": "in_house",
+      "repo_skill": "skills/security-and-reliability/skill-vetter/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/security-and-reliability/skill-vetter",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "skills-search",
       "normalized_slug": "skills-search",
       "status": "in_house",
@@ -2566,6 +2102,102 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/task-understanding-decomposition/skills-search",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "slack-gif-creator",
+      "normalized_slug": "slack-gif-creator",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/slack-gif-creator/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/slack-gif-creator",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "social-media-analyzer",
+      "normalized_slug": "social-media-analyzer",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/social-media-analyzer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/social-media-analyzer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "sora",
+      "normalized_slug": "sora",
+      "status": "in_house",
+      "repo_skill": "skills/multimodal-media/sora/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/multimodal-media/sora",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "speech",
+      "normalized_slug": "speech",
+      "status": "in_house",
+      "repo_skill": "skills/multimodal-media/speech/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/multimodal-media/speech",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "spreadsheet",
+      "normalized_slug": "spreadsheet",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/spreadsheet/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/spreadsheet",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "stock-screener-builder",
+      "normalized_slug": "stock-screener-builder",
+      "status": "in_house",
+      "repo_skill": "skills/finance-investing/stock-screener-builder/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/finance-investing/stock-screener-builder",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2589,6 +2221,86 @@
       }
     },
     {
+      "video_name": "summarize",
+      "normalized_slug": "summarize",
+      "status": "in_house",
+      "repo_skill": "skills/multimodal-media/summarize/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/multimodal-media/summarize",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "supabase-postgres",
+      "normalized_slug": "supabase-postgres",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/supabase-postgres/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/supabase-postgres",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "supermemory",
+      "normalized_slug": "supermemory",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/supermemory/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/supermemory",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "systematic-debugging",
+      "normalized_slug": "systematic-debugging",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/systematic-debugging/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/systematic-debugging",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "tailwind-design-system",
+      "normalized_slug": "tailwind-design-system",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/tailwind-design-system/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/tailwind-design-system",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
       "video_name": "tavily-search",
       "normalized_slug": "tavily-search",
       "status": "in_house",
@@ -2598,6 +2310,262 @@
       "upstream": {
         "repo": "local-repo/in-house",
         "path": "skills/task-understanding-decomposition/tavily-search",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "teams-channel-post-writer",
+      "normalized_slug": "teams-channel-post-writer",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/teams-channel-post-writer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/teams-channel-post-writer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "tech-debt-tracker",
+      "normalized_slug": "tech-debt-tracker",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/tech-debt-tracker/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/tech-debt-tracker",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "terraform-engineer",
+      "normalized_slug": "terraform-engineer",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/terraform-engineer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/terraform-engineer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "test-driven-development",
+      "normalized_slug": "test-driven-development",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/test-driven-development/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/test-driven-development",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "theme-factory",
+      "normalized_slug": "theme-factory",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/theme-factory/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/theme-factory",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "transcribe",
+      "normalized_slug": "transcribe",
+      "status": "in_house",
+      "repo_skill": "skills/multimodal-media/transcribe/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/multimodal-media/transcribe",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "transcript-fixer",
+      "normalized_slug": "transcript-fixer",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/transcript-fixer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/transcript-fixer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "twitter-reader",
+      "normalized_slug": "twitter-reader",
+      "status": "in_house",
+      "repo_skill": "skills/growth-operations-xiaohongshu/twitter-reader/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/growth-operations-xiaohongshu/twitter-reader",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "typescript-best-practices",
+      "normalized_slug": "typescript-best-practices",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/typescript-best-practices/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/typescript-best-practices",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "ui-design-system",
+      "normalized_slug": "ui-design-system",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/ui-design-system/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/ui-design-system",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "ux-researcher-designer",
+      "normalized_slug": "ux-researcher-designer",
+      "status": "in_house",
+      "repo_skill": "skills/product-design/ux-researcher-designer/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/product-design/ux-researcher-designer",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "vercel-deploy",
+      "normalized_slug": "vercel-deploy",
+      "status": "in_house",
+      "repo_skill": "skills/deployment-platforms/vercel-deploy/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/deployment-platforms/vercel-deploy",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "weather",
+      "normalized_slug": "weather",
+      "status": "in_house",
+      "repo_skill": "skills/operations-general/weather/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/operations-general/weather",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "web-artifacts-builder",
+      "normalized_slug": "web-artifacts-builder",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/web-artifacts-builder/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/web-artifacts-builder",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "web-scraper",
+      "normalized_slug": "web-scraper",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/web-scraper/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/web-scraper",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "webapp-testing",
+      "normalized_slug": "webapp-testing",
+      "status": "in_house",
+      "repo_skill": "skills/developer-engineering/webapp-testing/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/developer-engineering/webapp-testing",
         "ref": "main",
         "last_checked_at": "2026-03-27",
         "last_synced_at": "2026-03-27",
@@ -2619,6 +2587,38 @@
         "last_synced_at": "2026-03-27",
         "last_synced_commit": null
       }
+    },
+    {
+      "video_name": "xlsx",
+      "normalized_slug": "xlsx",
+      "status": "in_house",
+      "repo_skill": "skills/office-white-collar/xlsx/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/office-white-collar/xlsx",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
+    },
+    {
+      "video_name": "yeet",
+      "normalized_slug": "yeet",
+      "status": "in_house",
+      "repo_skill": "skills/engineering-workflow-automation/yeet/SKILL.md",
+      "source": "https://github.com/your-org/Commonly-used-high-value-skills",
+      "notes": "In-house canonical skill (local repository source of truth).",
+      "upstream": {
+        "repo": "local-repo/in-house",
+        "path": "skills/engineering-workflow-automation/yeet",
+        "ref": "main",
+        "last_checked_at": "2026-03-27",
+        "last_synced_at": "2026-03-27",
+        "last_synced_commit": null
+      }
     }
   ],
   "verification_attempts": [
@@ -2628,6 +2628,41 @@
       "target": "skills/*/*/SKILL.md",
       "result": "success",
       "evidence": "Discovered 163 local skills"
+    },
+    {
+      "date": "2026-03-27",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 163 local skills"
+    },
+    {
+      "date": "2026-03-27",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 163 local skills"
+    },
+    {
+      "date": "2026-03-27",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 163 local skills"
+    },
+    {
+      "date": "2026-03-27",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 163 local skills"
+    },
+    {
+      "date": "2026-03-27",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 163 local skills"
     }
   ]
 }

--- a/scripts/auto_curate_skills.py
+++ b/scripts/auto_curate_skills.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+"""Unified orchestration for syncing, discovering, scoring, and curating skills."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PR_BODY = "docs/sources/reports/curation-pr.md"
+
+TRUSTED_SOURCE_SCORES = {
+    "vercel-labs/agent-skills": 28,
+    "supabase/agent-skills": 26,
+    "obra/superpowers": 24,
+    "alirezarezvani/claude-skills": 22,
+    "google-labs-code/stitch-skills": 18,
+    "ComposioHQ/awesome-claude-skills": 14,
+}
+
+CATEGORY_KEYWORDS = {
+    "developer-engineering": {"react", "nextjs", "typescript", "python", "rust", "debug", "test", "graphql", "api"},
+    "devops-sre": {"terraform", "docker", "kubernetes", "aws", "infra", "ci", "cd", "runbook", "sre"},
+    "finance-investing": {"finance", "invest", "portfolio", "valuation", "stock", "trading"},
+    "growth-operations-xiaohongshu": {"seo", "marketing", "campaign", "growth", "social"},
+    "product-design": {"design", "ux", "ui", "figma", "landing-page"},
+    "security-and-reliability": {"security", "compliance", "threat", "reliability", "audit"},
+    "ai-agent-platform": {"agent", "llm", "prompt", "rag", "memory"},
+    "engineering-workflow-automation": {"automation", "workflow", "review", "refactor", "scraping"},
+    "operations-general": {"summary", "communication", "productivity", "search"},
+    "task-understanding-decomposition": {"plan", "task", "decomposition", "subagent"},
+    "deployment-platforms": {"vercel", "cloudflare", "render", "netlify", "deploy"},
+    "office-automation": {"spreadsheet", "excel", "ppt", "document", "notion"},
+    "media-and-content": {"video", "content", "script", "audio", "image"},
+    "cross-border-ecommerce": {"ecommerce", "sourcing", "tariff", "product-selection"},
+    "customer-lifecycle": {"customer", "crm", "retention", "onboarding", "churn"},
+}
+
+ACTIONABLE_NAME_TOKENS = {
+    "best-practices": 12,
+    "automation": 10,
+    "debug": 10,
+    "security": 12,
+    "deploy": 10,
+    "review": 8,
+    "testing": 8,
+    "runbook": 9,
+    "infra": 8,
+}
+
+FULL_PIPELINE_COMMANDS = [
+    ["scripts/enrich_frontmatter.py"],
+    ["scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"],
+    ["scripts/refresh_repo_views.py"],
+    ["scripts/generate_tags_index.py"],
+    ["scripts/build_catalog_json.py"],
+    ["scripts/lint_skill_quality.py", "--min-lines", "50"],
+    ["-m", "unittest", "discover", "tests", "-v"],
+]
+
+
+def resolve_python_cmd() -> list[str]:
+    return [sys.executable] if sys.executable else ["python"]
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def fetch_url(url: str, headers: dict | None = None) -> str | None:
+    request_headers = {"User-Agent": "skills-auto-curator"}
+    if headers:
+        request_headers.update(headers)
+    req = urllib.request.Request(url, headers=request_headers)
+    try:
+        with urllib.request.urlopen(req, timeout=20) as response:
+            return response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError):
+        return None
+
+
+def github_api_get(url: str, token: str | None = None) -> dict | list | None:
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    raw = fetch_url(url, headers=headers)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def get_local_skill_names(skills_dir: Path) -> set[str]:
+    names = set()
+    if not skills_dir.exists():
+        return names
+    for skill_md in skills_dir.glob("*/*/SKILL.md"):
+        names.add(skill_md.parent.name)
+    return names
+
+
+def parse_repo_from_candidate(candidate: dict) -> str | None:
+    source = candidate.get("source", "")
+    match = re.search(r"\(([^)]+/[^)]+)\)", source)
+    if match:
+        return match.group(1)
+
+    url = candidate.get("url", "")
+    match = re.search(r"github\.com/([^/]+/[^/]+)", url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "unnamed-skill"
+
+
+def suggest_category(name: str, description: str) -> str:
+    haystack = f"{name} {description}".lower()
+    best_category = "operations-general"
+    best_score = 0
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        score = sum(1 for token in keywords if token in haystack)
+        if score > best_score:
+            best_category = category
+            best_score = score
+    return best_category
+
+
+def score_candidate(candidate: dict) -> tuple[int, list[str]]:
+    name = candidate.get("name", "")
+    description = candidate.get("description", "")
+    source = candidate.get("source", "")
+    repo = parse_repo_from_candidate(candidate)
+
+    score = 0
+    reasons: list[str] = []
+
+    if repo and repo in TRUSTED_SOURCE_SCORES:
+        score += TRUSTED_SOURCE_SCORES[repo]
+        reasons.append(f"trusted_source:{repo}")
+    elif source.startswith("skills.sh"):
+        score += 12
+        reasons.append("trusted_registry:skills.sh")
+    elif source.startswith("GitHub"):
+        score += 8
+        reasons.append("trusted_registry:github")
+
+    stars = int(candidate.get("repo_stars", 0) or 0)
+    if stars > 0:
+        star_score = min(15, int(math.log10(stars + 1) * 5))
+        score += star_score
+        reasons.append(f"popularity:{star_score}")
+
+    lowered = f"{name} {description}".lower()
+    for token, bonus in ACTIONABLE_NAME_TOKENS.items():
+        if token in lowered:
+            score += bonus
+            reasons.append(f"keyword:{token}")
+
+    if len(description.strip()) >= 20:
+        score += 6
+        reasons.append("descriptive_summary")
+
+    if "[repo]" in name:
+        score -= 20
+        reasons.append("repo_only_not_skill")
+
+    return score, reasons
+
+
+def rank_discoveries(report: dict, *, existing_names: set[str], limit: int, min_score: int = 0) -> list[dict]:
+    ranked = []
+    for item in report.get("discoveries", []):
+        name = item.get("name", "").strip()
+        if not name or name in existing_names or name.startswith("[repo]"):
+            continue
+
+        score, reasons = score_candidate(item)
+        if score < min_score:
+            continue
+
+        candidate = dict(item)
+        candidate["slug"] = slugify(name)
+        candidate["curation_score"] = score
+        candidate["score_reasons"] = reasons
+        candidate["recommended_category"] = suggest_category(name, item.get("description", ""))
+        candidate["source_repo"] = parse_repo_from_candidate(item)
+        ranked.append(candidate)
+
+    ranked.sort(key=lambda item: (-item["curation_score"], -int(item.get("repo_stars", 0) or 0), item["name"]))
+    return ranked[:limit]
+
+
+def curate_candidates(
+    *,
+    repo_root: Path,
+    discovery_output: Path,
+    candidate_output: Path,
+    top: int,
+    min_score: int,
+) -> dict:
+    report = json.loads(discovery_output.read_text(encoding="utf-8"))
+    ranked = rank_discoveries(
+        report,
+        existing_names=get_local_skill_names(repo_root / "skills"),
+        limit=top,
+        min_score=min_score,
+    )
+    payload = {
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_report": str(discovery_output.relative_to(repo_root)),
+        "selected_count": len(ranked),
+        "selected": ranked,
+    }
+    candidate_output.parent.mkdir(parents=True, exist_ok=True)
+    candidate_output.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def build_execution_plan(
+    *,
+    python_cmd: list[str],
+    discovery_output: str,
+    candidate_output: str,
+    sync_mode: str,
+    top: int,
+    min_score: int,
+) -> list[dict]:
+    steps: list[dict] = []
+    if sync_mode == "check":
+        steps.append({"name": "sync-upstream-check", "cmd": python_cmd + ["scripts/sync_upstream.py", "--check-only"]})
+    elif sync_mode == "apply":
+        steps.append({"name": "sync-upstream-apply", "cmd": python_cmd + ["scripts/sync_upstream.py", "--apply"]})
+
+    steps.append(
+        {
+            "name": "discover-new-skills",
+            "cmd": python_cmd + ["scripts/discover_new_skills.py", "--output", discovery_output],
+        }
+    )
+    steps.append(
+        {
+            "name": "rank-candidates",
+            "cmd": python_cmd
+            + [
+                "scripts/auto_curate_skills.py",
+                "--curate-only",
+                "--discovery-output",
+                discovery_output,
+                "--candidate-output",
+                candidate_output,
+                "--top",
+                str(top),
+                "--min-score",
+                str(min_score),
+            ],
+        }
+    )
+
+    for command in FULL_PIPELINE_COMMANDS:
+        steps.append({"name": command[0], "cmd": python_cmd + command})
+    return steps
+
+
+def run_plan(steps: list[dict], *, repo_root: Path) -> None:
+    for step in steps:
+        cmd = step["cmd"]
+        print("$", " ".join(cmd))
+        run_command(cmd, cwd=repo_root)
+
+
+def build_branch_name(topic: str, timestamp: datetime | None = None) -> str:
+    timestamp = timestamp or datetime.now(UTC)
+    slug = slugify(topic)
+    return f"codex/{slug}-{timestamp.strftime('%Y%m%d-%H%M%S')}"
+
+
+def get_git_status(repo_root: Path) -> str:
+    result = run_command(["git", "status", "--short"], cwd=repo_root, capture_output=True)
+    return result.stdout.strip()
+
+
+def assert_clean_worktree(repo_root: Path, status_output: str | None = None) -> None:
+    status = status_output if status_output is not None else get_git_status(repo_root)
+    if status.strip():
+        raise RuntimeError("Cannot auto-commit or open PR from a dirty worktree.")
+
+
+def write_pr_summary(
+    output_path: Path,
+    *,
+    candidate_report: dict,
+    ingest_result: dict,
+    sync_mode: str,
+    branch_name: str,
+    base_branch: str,
+) -> None:
+    selected = candidate_report.get("selected", [])
+    ingested = ingest_result.get("ingested", [])
+    skipped = ingest_result.get("skipped", [])
+
+    lines = [
+        "# Skills curation automation",
+        "",
+        "## Summary",
+        f"- Sync mode: `{sync_mode}`",
+        f"- Target base branch: `{base_branch}`",
+        f"- Working branch: `{branch_name}`",
+        f"- Ranked candidates: `{candidate_report.get('selected_count', len(selected))}`",
+        f"- Ingested candidates: `{len(ingested)}`",
+        f"- Skipped candidates: `{len(skipped)}`",
+        "",
+        "## Top candidates",
+    ]
+
+    if selected:
+        for item in selected[:10]:
+            lines.append(
+                f"- `{item['name']}` score={item.get('curation_score', '-')}, category=`{item.get('recommended_category', '-')}`"
+            )
+    else:
+        lines.append("- No candidates selected.")
+
+    lines.extend(["", "## Ingested"])
+    if ingested:
+        for item in ingested:
+            lines.append(f"- `{item['name']}` -> `{item['path']}`")
+    else:
+        lines.append("- No candidates were ingested.")
+
+    lines.extend(["", "## Skipped"])
+    if skipped:
+        for item in skipped:
+            lines.append(f"- `{item['name']}` skipped: `{item['reason']}`")
+    else:
+        lines.append("- No candidates were skipped.")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def ensure_branch(repo_root: Path, branch_name: str) -> None:
+    run_command(["git", "switch", "-c", branch_name], cwd=repo_root)
+
+
+def stage_and_commit(repo_root: Path, message: str) -> bool:
+    status = get_git_status(repo_root)
+    if not status:
+        return False
+    run_command(["git", "add", "-A"], cwd=repo_root)
+    run_command(["git", "commit", "-m", message], cwd=repo_root)
+    return True
+
+
+def gh_is_authenticated(repo_root: Path) -> bool:
+    result = run_command(["gh", "auth", "status"], cwd=repo_root, check=False, capture_output=True)
+    return result.returncode == 0
+
+
+def create_pull_request(
+    repo_root: Path,
+    *,
+    base_branch: str,
+    title: str,
+    body_path: Path,
+) -> None:
+    run_command(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base_branch,
+            "--title",
+            title,
+            "--body-file",
+            str(body_path),
+        ],
+        cwd=repo_root,
+    )
+
+
+def github_raw_url(repo: str, path: str, ref: str = "main") -> str:
+    return f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
+
+
+def discover_upstream_skill_path(repo: str, slug: str, token: str | None) -> str | None:
+    guesses = [
+        f"skills/{slug}/SKILL.md",
+        f"{slug}/SKILL.md",
+    ]
+    for guess in guesses:
+        if fetch_url(github_raw_url(repo, guess)):
+            return guess
+
+    query = urllib.parse.quote(f"filename:SKILL.md repo:{repo} {slug}")
+    results = github_api_get(f"https://api.github.com/search/code?q={query}&per_page=10", token)
+    if not isinstance(results, dict):
+        return None
+    for item in results.get("items", []):
+        path = item.get("path", "")
+        if path.endswith("/SKILL.md") and slug in path.lower():
+            return path
+    return None
+
+
+def synthesize_frontmatter(markdown: str, *, slug: str, description: str, source_id: str, source_url: str) -> str:
+    if markdown.startswith("---\n") and re.search(r"^name:\s*", markdown, re.MULTILINE):
+        return markdown
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    desc = description.strip() or f"Imported skill for {slug}."
+    frontmatter = [
+        "---",
+        f"name: {slug}",
+        f'description: "{desc.replace(chr(34), chr(39))}"',
+        'version: "1.0.0"',
+        'author: "seaworld008"',
+        f'source: "{source_id}"',
+        f'source_url: "{source_url}"',
+        'tags: ["imported"]',
+        f'created_at: "{today}"',
+        f'updated_at: "{today}"',
+        "quality: 2",
+        'complexity: "intermediate"',
+        "---",
+        "",
+    ]
+    return "\n".join(frontmatter) + markdown.lstrip()
+
+
+def fetch_candidate_markdown(candidate: dict, token: str | None = None) -> tuple[str | None, str | None]:
+    url = candidate.get("url", "")
+    repo = candidate.get("source_repo")
+    slug = candidate.get("slug") or slugify(candidate.get("name", ""))
+
+    blob_match = re.search(r"github\.com/([^/]+/[^/]+)/blob/([^/]+)/(.*)$", url)
+    if blob_match:
+        repo = blob_match.group(1)
+        ref = blob_match.group(2)
+        path = blob_match.group(3)
+        return fetch_url(github_raw_url(repo, path, ref)), repo
+
+    if repo:
+        path = discover_upstream_skill_path(repo, slug, token)
+        if path:
+            return fetch_url(github_raw_url(repo, path)), repo
+    return None, repo
+
+
+def ingest_candidates(
+    *,
+    repo_root: Path,
+    report: dict,
+    limit: int,
+    python_cmd: list[str],
+) -> dict:
+    token = None
+    ingested = []
+    skipped = []
+
+    for candidate in report.get("selected", [])[:limit]:
+        markdown, repo = fetch_candidate_markdown(candidate, token=token)
+        if not markdown:
+            skipped.append({"name": candidate["name"], "reason": "upstream_markdown_not_found"})
+            continue
+        if len(markdown.splitlines()) < 50:
+            skipped.append({"name": candidate["name"], "reason": "content_below_quality_floor"})
+            continue
+
+        category = candidate["recommended_category"]
+        slug = candidate["slug"]
+        skill_dir = repo_root / "skills" / category / slug
+        skill_dir.mkdir(parents=True, exist_ok=True)
+
+        source_id = f"github:{repo}" if repo else "community"
+        prepared = synthesize_frontmatter(
+            markdown,
+            slug=slug,
+            description=candidate.get("description", ""),
+            source_id=source_id,
+            source_url=candidate.get("url", ""),
+        )
+        (skill_dir / "SKILL.md").write_text(prepared, encoding="utf-8")
+
+        cmd = python_cmd + [
+            "scripts/ingest_skill.py",
+            "--dir",
+            str(skill_dir.relative_to(repo_root)),
+            "--source",
+            source_id,
+            "--source-url",
+            candidate.get("url", ""),
+            "--skip-pipeline",
+        ]
+        run_command(cmd, cwd=repo_root)
+        ingested.append({"name": candidate["name"], "path": str(skill_dir.relative_to(repo_root))})
+
+    return {"ingested": ingested, "skipped": skipped}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Unified sync + discovery + curation workflow.")
+    parser.add_argument("--sync-mode", choices=["skip", "check", "apply"], default="check")
+    parser.add_argument("--discovery-output", default="docs/sources/reports/discovery.json")
+    parser.add_argument("--candidate-output", default="docs/sources/reports/curation-candidates.json")
+    parser.add_argument("--top", type=int, default=20)
+    parser.add_argument("--min-score", type=int, default=20)
+    parser.add_argument("--curate-only", action="store_true", help="Only rank candidates from an existing discovery report")
+    parser.add_argument("--execute", action="store_true", help="Run the generated orchestration plan")
+    parser.add_argument("--auto-ingest-top", type=int, default=0, help="Best-effort fetch and ingest the top N ranked candidates")
+    parser.add_argument("--skip-pipeline", action="store_true", help="Skip the post-ingestion refresh pipeline")
+    parser.add_argument("--prepare-pr", action="store_true", help="Write PR summary and prepare a branch after execution")
+    parser.add_argument("--open-pr", action="store_true", help="Open a GitHub PR after commit")
+    parser.add_argument("--branch-name", default=None, help="Override the generated codex/ branch name")
+    parser.add_argument("--base-branch", default="main", help="Base branch for the pull request")
+    parser.add_argument("--commit-message", default="feat: automate skills curation update", help="Commit message for auto-generated changes")
+    parser.add_argument("--pr-title", default="feat: automate skills curation update", help="PR title when --open-pr is used")
+    parser.add_argument("--pr-body-path", default=DEFAULT_PR_BODY, help="Where to write the PR body markdown")
+    args = parser.parse_args()
+
+    repo_root = REPO_ROOT
+    discovery_output = repo_root / args.discovery_output
+    candidate_output = repo_root / args.candidate_output
+    python_cmd = resolve_python_cmd()
+    initial_status = get_git_status(repo_root) if (args.prepare_pr or args.open_pr) else ""
+    if args.prepare_pr or args.open_pr:
+        assert_clean_worktree(repo_root, status_output=initial_status)
+
+    if args.curate_only:
+        report = curate_candidates(
+            repo_root=repo_root,
+            discovery_output=discovery_output,
+            candidate_output=candidate_output,
+            top=args.top,
+            min_score=args.min_score,
+        )
+        print(f"Wrote candidate report: {candidate_output.relative_to(repo_root)} ({report['selected_count']} selected)")
+        return 0
+
+    steps = build_execution_plan(
+        python_cmd=python_cmd,
+        discovery_output=args.discovery_output,
+        candidate_output=args.candidate_output,
+        sync_mode=args.sync_mode,
+        top=args.top,
+        min_score=args.min_score,
+    )
+
+    if not args.execute:
+        print("Planned commands:")
+        for step in steps:
+            print("$", " ".join(step["cmd"]))
+        return 0
+
+    pre_pipeline = steps[:-len(FULL_PIPELINE_COMMANDS)]
+    pipeline_steps = steps[-len(FULL_PIPELINE_COMMANDS):]
+    run_plan(pre_pipeline, repo_root=repo_root)
+
+    report = json.loads(candidate_output.read_text(encoding="utf-8"))
+    ingest_result = {"ingested": [], "skipped": []}
+    if args.auto_ingest_top > 0:
+        ingest_result = ingest_candidates(
+            repo_root=repo_root,
+            report=report,
+            limit=args.auto_ingest_top,
+            python_cmd=python_cmd,
+        )
+        print(json.dumps(ingest_result, ensure_ascii=False, indent=2))
+    if not args.skip_pipeline:
+        run_plan(pipeline_steps, repo_root=repo_root)
+
+    if args.prepare_pr or args.open_pr:
+        branch_name = args.branch_name or build_branch_name("skills-curation")
+        ensure_branch(repo_root, branch_name)
+        pr_body_path = repo_root / args.pr_body_path
+        write_pr_summary(
+            pr_body_path,
+            candidate_report=report,
+            ingest_result=ingest_result,
+            sync_mode=args.sync_mode,
+            branch_name=branch_name,
+            base_branch=args.base_branch,
+        )
+        committed = stage_and_commit(repo_root, args.commit_message)
+        if not committed:
+            print("No changes detected after curation; skipped commit/PR preparation.")
+            return 0
+        if args.open_pr:
+            if not gh_is_authenticated(repo_root):
+                raise RuntimeError("GitHub CLI is not authenticated; cannot open PR.")
+            create_pull_request(
+                repo_root,
+                base_branch=args.base_branch,
+                title=args.pr_title,
+                body_path=pr_body_path,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_in_house_sources.py
+++ b/scripts/bootstrap_in_house_sources.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
-"""Bootstrap an in-house provenance mapping for all local skills.
+"""Bootstrap or refresh the repository skill provenance mapping.
 
-This ensures global source coverage even before external-source mappings are completed.
+The original implementation rewrote every entry as `in_house`, which erased
+externally tracked provenance metadata. This version preserves existing tracked
+entries and only backfills truly local-only skills.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import re
+from copy import deepcopy
 from datetime import date
 from pathlib import Path
+
+
+CANONICAL_NOTE = "In-house canonical skill (local repository source of truth)."
 
 
 def parse_frontmatter_name(skill_md: Path) -> str:
@@ -20,6 +26,174 @@ def parse_frontmatter_name(skill_md: Path) -> str:
     return m.group(1).strip()
 
 
+def load_existing_payload(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_default_entry(name: str, rel: str, repo_url: str, today: str) -> dict:
+    return {
+        "video_name": name,
+        "normalized_slug": name,
+        "status": "in_house",
+        "repo_skill": rel,
+        "source": repo_url,
+        "notes": CANONICAL_NOTE,
+        "upstream": {
+            "repo": "local-repo/in-house",
+            "path": rel.rsplit("/", 1)[0],
+            "ref": "main",
+            "last_checked_at": today,
+            "last_synced_at": today,
+            "last_synced_commit": None,
+        },
+    }
+
+
+def merge_existing_entry(existing: dict, *, name: str, rel: str, repo_url: str, today: str) -> dict:
+    merged = deepcopy(existing)
+    merged["video_name"] = name
+    merged["repo_skill"] = rel
+
+    status = merged.get("status") or "in_house"
+    if status in {"verified_in_repo", "in_house"} or merged.get("normalized_slug") in (None, ""):
+        merged["normalized_slug"] = name
+
+    if not merged.get("source"):
+        merged["source"] = repo_url
+    if not merged.get("notes"):
+        merged["notes"] = CANONICAL_NOTE
+
+    upstream = deepcopy(merged.get("upstream") or {})
+    if status == "in_house":
+        upstream.setdefault("repo", "local-repo/in-house")
+        upstream.setdefault("path", rel.rsplit("/", 1)[0])
+        upstream.setdefault("ref", "main")
+        upstream["last_checked_at"] = today
+        upstream.setdefault("last_synced_at", today)
+        upstream.setdefault("last_synced_commit", None)
+    else:
+        upstream.setdefault("path", rel.rsplit("/", 1)[0])
+        upstream.setdefault("ref", "main")
+        upstream["last_checked_at"] = today
+    if upstream:
+        merged["upstream"] = upstream
+
+    return merged
+
+
+def build_official_references(existing_payload: dict | None, repo_url: str) -> list[dict]:
+    references: list[dict] = []
+    seen_urls: set[str] = set()
+    if existing_payload:
+        for item in existing_payload.get("official_references", []):
+            if not isinstance(item, dict):
+                continue
+            url = item.get("url")
+            if url and url not in seen_urls:
+                references.append(item)
+                seen_urls.add(url)
+
+    if repo_url not in seen_urls:
+        references.append(
+            {
+                "name": "Repository canonical skills tree",
+                "url": repo_url,
+                "purpose": "Marks local source-of-truth skills as in_house.",
+            }
+        )
+    return references
+
+
+def build_verification_attempts(
+    *,
+    existing_payload: dict | None,
+    today: str,
+    skill_count: int,
+) -> list[dict]:
+    attempts = []
+    if existing_payload:
+        for item in existing_payload.get("verification_attempts", []):
+            if isinstance(item, dict):
+                attempts.append(item)
+    attempts.append(
+        {
+            "date": today,
+            "method": "local-scan",
+            "target": "skills/*/*/SKILL.md",
+            "result": "success",
+            "evidence": f"Merged provenance for {skill_count} local skills",
+        }
+    )
+    return attempts
+
+
+def build_in_house_mapping(
+    *,
+    repo_root: Path,
+    repo_url: str,
+    existing_payload: dict | None = None,
+    today: str | None = None,
+) -> dict:
+    today = today or date.today().isoformat()
+    skill_files = sorted(repo_root.glob("skills/*/*/SKILL.md"))
+
+    existing_by_path: dict[str, dict] = {}
+    existing_by_name: dict[str, dict] = {}
+    if existing_payload:
+        for entry in existing_payload.get("skills", []):
+            if not isinstance(entry, dict):
+                continue
+            repo_skill = entry.get("repo_skill")
+            video_name = entry.get("video_name")
+            if repo_skill:
+                existing_by_path[repo_skill] = entry
+            if video_name:
+                existing_by_name[video_name] = entry
+
+    skills = []
+    for sf in skill_files:
+        name = parse_frontmatter_name(sf)
+        rel = sf.relative_to(repo_root).as_posix()
+        existing = existing_by_path.get(rel) or existing_by_name.get(name)
+        if existing:
+            skills.append(
+                merge_existing_entry(
+                    existing,
+                    name=name,
+                    rel=rel,
+                    repo_url=repo_url,
+                    today=today,
+                )
+            )
+        else:
+            skills.append(build_default_entry(name, rel, repo_url, today))
+
+    skills.sort(key=lambda item: item["video_name"])
+
+    video = {
+        "url": repo_url,
+        "checked_at": today,
+        "note": "Auto-generated provenance mapping for all local skills.",
+    }
+    if existing_payload and isinstance(existing_payload.get("video"), dict):
+        video.update({k: v for k, v in existing_payload["video"].items() if k != "checked_at"})
+        video["url"] = repo_url
+        video["checked_at"] = today
+
+    return {
+        "video": video,
+        "official_references": build_official_references(existing_payload, repo_url),
+        "skills": skills,
+        "verification_attempts": build_verification_attempts(
+            existing_payload=existing_payload,
+            today=today,
+            skill_count=len(skills),
+        ),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--write-json", default="docs/sources/in-house.skills.json")
@@ -27,62 +201,17 @@ def main() -> int:
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
-    today = date.today().isoformat()
-    skill_files = sorted(root.glob("skills/*/*/SKILL.md"))
-
-    skills = []
-    for sf in skill_files:
-        name = parse_frontmatter_name(sf)
-        rel = sf.relative_to(root).as_posix()
-        skills.append(
-            {
-                "video_name": name,
-                "normalized_slug": name,
-                "status": "in_house",
-                "repo_skill": rel,
-                "source": args.repo_url,
-                "notes": "In-house canonical skill (local repository source of truth).",
-                "upstream": {
-                    "repo": "local-repo/in-house",
-                    "path": rel.rsplit("/", 1)[0],
-                    "ref": "main",
-                    "last_checked_at": today,
-                    "last_synced_at": today,
-                    "last_synced_commit": None,
-                },
-            }
-        )
-
-    payload = {
-        "video": {
-            "url": args.repo_url,
-            "checked_at": today,
-            "note": "Auto-generated in-house provenance mapping for all local skills.",
-        },
-        "official_references": [
-            {
-                "name": "Repository canonical skills tree",
-                "url": args.repo_url,
-                "purpose": "Marks local source-of-truth skills as in_house.",
-            }
-        ],
-        "skills": skills,
-        "verification_attempts": [
-            {
-                "date": today,
-                "method": "local-scan",
-                "target": "skills/*/*/SKILL.md",
-                "result": "success",
-                "evidence": f"Discovered {len(skills)} local skills",
-            }
-        ],
-    }
-
     out = root / args.write_json
+    payload = build_in_house_mapping(
+        repo_root=root,
+        repo_url=args.repo_url,
+        existing_payload=load_existing_payload(out),
+    )
+
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     print(f"Wrote in-house mapping: {out.relative_to(root)}")
-    print(f"Skills mapped: {len(skills)}")
+    print(f"Skills mapped: {len(payload['skills'])}")
     return 0
 
 

--- a/scripts/discover_new_skills.py
+++ b/scripts/discover_new_skills.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Discover new agent skills from external sources.
 
-Scans GitHub for popular repositories containing SKILL.md files,
+Scans GitHub, skills.sh, and ClawHub for popular agent skills,
 compares against locally indexed skills, and reports new discoveries.
 """
 from __future__ import annotations
@@ -9,11 +9,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.request
 import urllib.error
+import urllib.parse
 from datetime import datetime
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -31,13 +34,38 @@ SEARCH_QUERIES = [
     "claude code skill SKILL.md stars:>5",
 ]
 
+# Standard search keywords for skills.sh and ClawHub
+SEARCH_KEYWORDS = [
+    "kubernetes", "docker", "terraform", "aws", "react", "nextjs",
+    "python", "rust", "typescript", "testing", "security", "devops",
+    "database", "api", "performance", "debugging", "automation",
+    "documentation", "code review", "refactoring", "supabase",
+    "tailwind", "graphql", "web scraping", "data analysis",
+]
+
 
 def get_local_skill_names(skills_dir: Path) -> set[str]:
     """Return set of locally indexed skill directory names."""
     names = set()
+    if not skills_dir.exists():
+        return names
     for skill_md in skills_dir.glob("*/*/SKILL.md"):
         names.add(skill_md.parent.name)
     return names
+
+
+def fetch_url(url: str, headers: dict | None = None) -> str | None:
+    """Fetch URL content with standard error handling."""
+    if headers is None:
+        headers = {"User-Agent": "skills-discovery-bot"}
+    
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read().decode("utf-8")
+    except Exception as e:
+        print(f"  Warning: Request failed for {url}: {e}", file=sys.stderr)
+        return None
 
 
 def github_api_get(url: str, token: str | None = None) -> dict | list | None:
@@ -49,13 +77,13 @@ def github_api_get(url: str, token: str | None = None) -> dict | list | None:
     if token:
         headers["Authorization"] = f"token {token}"
     
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            return json.loads(resp.read().decode())
-    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
-        print(f"  Warning: API request failed for {url}: {e}", file=sys.stderr)
-        return None
+    content = fetch_url(url, headers)
+    if content:
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return None
+    return None
 
 
 def discover_from_watched_repos(token: str | None) -> list[dict]:
@@ -82,22 +110,22 @@ def discover_from_watched_repos(token: str | None) -> list[dict]:
                 skill_name = parts[-2]
                 discoveries.append({
                     "name": skill_name,
-                    "source_repo": repo,
-                    "source_path": path,
+                    "source": f"GitHub ({repo})",
+                    "url": f"https://github.com/{repo}/blob/main/{path}",
                     "repo_stars": info.get("stargazers_count", 0),
-                    "repo_description": info.get("description", ""),
+                    "description": info.get("description", ""),
                     "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
                 })
     return discoveries
 
 
-def discover_from_search(token: str | None) -> list[dict]:
+def discover_from_github_search(token: str | None) -> list[dict]:
     """Search GitHub for repositories with SKILL.md files."""
     discoveries = []
     seen_repos = set()
     
     for query in SEARCH_QUERIES:
-        print(f"  Searching: {query}")
+        print(f"  GitHub Searching: {query}")
         encoded_q = urllib.parse.quote(query)
         url = f"https://api.github.com/search/repositories?q={encoded_q}&sort=stars&per_page=20"
         results = github_api_get(url, token)
@@ -112,12 +140,134 @@ def discover_from_search(token: str | None) -> list[dict]:
             
             discoveries.append({
                 "name": f"[repo] {full_name}",
-                "source_repo": full_name,
-                "source_path": "",
+                "source": "GitHub Search",
+                "url": repo.get("html_url", ""),
                 "repo_stars": repo.get("stargazers_count", 0),
-                "repo_description": repo.get("description", ""),
+                "description": repo.get("description", ""),
                 "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
             })
+    return discoveries
+
+
+def discover_from_skills_sh(keywords: list[str]) -> list[dict]:
+    """Search skills.sh for skills."""
+    discoveries = []
+    seen_ids = set()
+    
+    for kw in keywords:
+        print(f"  skills.sh searching: {kw}")
+        # Try API
+        api_url = f"https://skills.sh/api/search?q={urllib.parse.quote(kw)}"
+        content = fetch_url(api_url)
+        if content:
+            try:
+                data = json.loads(content)
+                for item in data.get("skills", []):
+                    skill_id = item.get("id")
+                    if skill_id and skill_id not in seen_ids:
+                        seen_ids.add(skill_id)
+                        discoveries.append({
+                            "name": item.get("name", ""),
+                            "source": f"skills.sh ({item.get('source', '')})",
+                            "url": f"https://skills.sh/{item.get('id', '')}",
+                            "repo_stars": item.get("installs", 0),  # Use installs as stars equivalent
+                            "description": f"Installs: {item.get('installs', 0)}",
+                            "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
+                        })
+                continue
+            except json.JSONDecodeError:
+                pass
+        
+        # Fallback to scraping
+        page_url = f"https://skills.sh/s/{urllib.parse.quote(kw)}"
+        html = fetch_url(page_url)
+        if html:
+            # Simple regex to extract skill links and names from HTML
+            # Look for <a> tags with skill paths or specific patterns
+            # Pattern based on web_fetch: [**name** \n\n source \n\n installs](url)
+            # In HTML it might look like <a href="/source/skill">...<strong>name</strong>...
+            matches = re.finditer(r'href="/([^"]+/[^"]+/[^"]+)"[^>]*>.*?<strong>(.*?)</strong>.*?(\d+\.?\d*[Kk]?)', html, re.DOTALL)
+            for m in matches:
+                skill_id = m.group(1)
+                if skill_id not in seen_ids:
+                    seen_ids.add(skill_id)
+                    installs_str = m.group(3).lower()
+                    installs = 0
+                    if 'k' in installs_str:
+                        try:
+                            installs = int(float(installs_str.replace('k', '')) * 1000)
+                        except ValueError: pass
+                    else:
+                        try: installs = int(installs_str)
+                        except ValueError: pass
+                    
+                    discoveries.append({
+                        "name": m.group(2).strip(),
+                        "source": "skills.sh (scraped)",
+                        "url": f"https://skills.sh/{skill_id}",
+                        "repo_stars": installs,
+                        "description": f"Installs: {m.group(3)}",
+                        "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
+                    })
+    
+    if not discoveries:
+        print("  Warning: skills.sh discovery yielded no results (or failed).", file=sys.stderr)
+    return discoveries
+
+
+def discover_from_clawhub(keywords: list[str]) -> list[dict]:
+    """Search ClawHub for skills."""
+    discoveries = []
+    seen_slugs = set()
+    
+    for kw in keywords:
+        print(f"  ClawHub searching: {kw}")
+        # Try API
+        api_url = f"https://clawhub.com/api/search?q={urllib.parse.quote(kw)}"
+        content = fetch_url(api_url)
+        if content:
+            try:
+                data = json.loads(content)
+                # Results can be a list or a dict with "results"
+                results = data if isinstance(data, list) else data.get("results", [])
+                for item in results:
+                    slug = item.get("slug")
+                    if slug and slug not in seen_slugs:
+                        seen_slugs.add(slug)
+                        discoveries.append({
+                            "name": item.get("displayName", slug),
+                            "source": "ClawHub",
+                            "url": f"https://clawhub.com/s/{slug}",
+                            "repo_stars": int(item.get("score", 0) * 10), # Pseudo-score
+                            "description": item.get("summary", ""),
+                            "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
+                        })
+                continue
+            except (json.JSONDecodeError, TypeError):
+                pass
+        
+        # Fallback to scraping
+        page_url = f"https://clawhub.com/search?q={urllib.parse.quote(kw)}"
+        html = fetch_url(page_url)
+        if html:
+            # ClawHub is often client-side rendered, but let's try to catch any baked-in data
+            # Or look for patterns in the HTML
+            matches = re.finditer(r'href="/s/([^"]+)"[^>]*>.*?<h[^>]*>(.*?)</h', html, re.DOTALL)
+            for m in matches:
+                slug = m.group(1)
+                if slug not in seen_slugs:
+                    seen_slugs.add(slug)
+                    discoveries.append({
+                        "name": m.group(2).strip(),
+                        "source": "ClawHub (scraped)",
+                        "url": f"https://clawhub.com/s/{slug}",
+                        "repo_stars": 0,
+                        "description": "",
+                        "discovered_at": datetime.utcnow().strftime("%Y-%m-%d"),
+                    })
+    
+    if not discoveries:
+        print("  Warning: ClawHub discovery yielded no results (or failed).", file=sys.stderr)
     return discoveries
 
 
@@ -127,6 +277,8 @@ def main() -> None:
                         help="Output JSON file path (default: docs/sources/reports/discovery.json)")
     parser.add_argument("--skills-dir", default="skills",
                         help="Local skills directory (default: skills)")
+    parser.add_argument("--keywords", help="Comma-separated list of custom keywords to search")
+    parser.add_argument("--recommend", action="store_true", help="Output a recommendation Markdown table")
     args = parser.parse_args()
     
     skills_dir = REPO_ROOT / args.skills_dir
@@ -137,33 +289,72 @@ def main() -> None:
     local_names = get_local_skill_names(skills_dir)
     print(f"Local skills indexed: {len(local_names)}")
     
-    # Discover from all sources
-    print("\n--- Checking watched repositories ---")
-    watched = discover_from_watched_repos(token)
-    print(f"  Found {len(watched)} skills in watched repos")
+    keywords = SEARCH_KEYWORDS
+    if args.keywords:
+        keywords = [k.strip() for k in args.keywords.split(",")]
     
-    print("\n--- Searching GitHub ---")
-    searched = discover_from_search(token)
-    print(f"  Found {len(searched)} candidate repos")
+    # Discovery functions
+    all_discoveries = []
     
-    all_discoveries = watched + searched
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        print("\n--- Checking watched repositories ---")
+        f_watched = executor.submit(discover_from_watched_repos, token)
+        
+        print("\n--- Searching GitHub ---")
+        f_github = executor.submit(discover_from_github_search, token)
+        
+        print("\n--- Searching skills.sh ---")
+        f_skills_sh = executor.submit(discover_from_skills_sh, keywords)
+        
+        print("\n--- Searching ClawHub ---")
+        f_clawhub = executor.submit(discover_from_clawhub, keywords)
+        
+        all_discoveries.extend(f_watched.result())
+        all_discoveries.extend(f_github.result())
+        all_discoveries.extend(f_skills_sh.result())
+        all_discoveries.extend(f_clawhub.result())
     
-    # Filter out already indexed skills
-    new_discoveries = [d for d in all_discoveries if d["name"] not in local_names]
+    # Filter out duplicates and already indexed skills
+    seen_names = set()
+    unique_discoveries = []
+    for d in all_discoveries:
+        # Check if already indexed
+        if d["name"] in local_names:
+            continue
+        # Deduplicate within discovery session
+        if d["name"] in seen_names:
+            continue
+        seen_names.add(d["name"])
+        unique_discoveries.append(d)
+    
+    # Sort by "stars" (installs or repo stars)
+    unique_discoveries.sort(key=lambda x: x.get("repo_stars", 0), reverse=True)
     
     report = {
         "generated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         "local_skill_count": len(local_names),
         "total_discovered": len(all_discoveries),
-        "new_discoveries": len(new_discoveries),
-        "discoveries": sorted(new_discoveries, key=lambda x: x.get("repo_stars", 0), reverse=True),
+        "unique_discovered": len(unique_discoveries),
+        "discoveries": unique_discoveries,
     }
     
     output_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
     print(f"\nWrote discovery report: {output_path}")
-    print(f"Total discovered: {len(all_discoveries)}, New: {len(new_discoveries)}")
+    print(f"Total discovered: {len(all_discoveries)}, Unique/New: {len(unique_discoveries)}")
+    
+    if args.recommend:
+        print("\n### Recommended New Skills (Top 20)")
+        print("| Skill | Source | Stars/Installs | Description |")
+        print("| :--- | :--- | :--- | :--- |")
+        for d in unique_discoveries[:20]:
+            name = d["name"]
+            url = d["url"]
+            source = d["source"]
+            stars = d["repo_stars"]
+            desc = d["description"].replace("\n", " ")[:100]
+            if len(d["description"]) > 100: desc += "..."
+            print(f"| [{name}]({url}) | {source} | {stars} | {desc} |")
 
 
 if __name__ == "__main__":
-    import urllib.parse
     main()

--- a/scripts/ingest_skill.py
+++ b/scripts/ingest_skill.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Register a new skill into the repository's provenance system.
+
+This script handles the "last mile" of skill ingestion:
+1. Validates the SKILL.md exists and has required frontmatter
+2. Enriches frontmatter with missing fields (source, tags, dates)
+3. Updates the provenance mapping (in-house.skills.json)
+4. Optionally runs the full refresh pipeline
+
+Usage:
+    # Register a single skill
+    python scripts/ingest_skill.py --dir skills/developer-engineering/vue-composition-api --source "github:vuejs/vue"
+
+    # Register with explicit category and source URL
+    python scripts/ingest_skill.py --dir skills/devops-sre/ansible-expert --source "skills.sh" --source-url "https://skills.sh/s/ansible"
+
+    # Batch register all untracked skills
+    python scripts/ingest_skill.py --batch
+
+    # Dry run (show what would be done without writing)
+    python scripts/ingest_skill.py --batch --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+PROVENANCE_FILE = REPO_ROOT / "docs" / "sources" / "in-house.skills.json"
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Extract frontmatter key-value pairs from SKILL.md content."""
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            fm[key.strip()] = val.strip().strip('"').strip("'")
+    return fm
+
+
+def update_frontmatter_field(content: str, key: str, value: str) -> str:
+    """Add or update a single frontmatter field."""
+    m = re.match(r"^(---\s*\n)(.*?)(\n---)", content, re.DOTALL)
+    if not m:
+        return content
+    header, fm_body, footer = m.group(1), m.group(2), m.group(3)
+
+    # Check if key already exists
+    pattern = re.compile(rf"^{re.escape(key)}:\s*.*$", re.MULTILINE)
+    if pattern.search(fm_body):
+        # Update existing
+        fm_body = pattern.sub(f"{key}: {value}", fm_body)
+    else:
+        # Add before closing ---
+        fm_body = fm_body.rstrip() + f"\n{key}: {value}"
+
+    return header + fm_body + footer + content[m.end():]
+
+
+def get_tracked_skills(provenance_path: Path) -> set[str]:
+    """Return set of skill names already in the provenance file."""
+    if not provenance_path.exists():
+        return set()
+    data = json.loads(provenance_path.read_text(encoding="utf-8"))
+    return {
+        entry.get("video_name", "")
+        for entry in data.get("skills", [])
+    }
+
+
+def find_untracked_skills(skills_dir: Path, tracked: set[str]) -> list[Path]:
+    """Find skills that exist on disk but are not in the provenance mapping."""
+    untracked = []
+    for skill_md in sorted(skills_dir.glob("*/*/SKILL.md")):
+        skill_name = skill_md.parent.name
+        if skill_name not in tracked:
+            untracked.append(skill_md.parent)
+    return untracked
+
+
+def get_git_created_date(filepath: Path) -> str:
+    """Get the first commit date for a file from git log."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--diff-filter=A", "--format=%aI", "--", str(filepath)],
+            capture_output=True, text=True, cwd=REPO_ROOT, timeout=10
+        )
+        if result.stdout.strip():
+            return result.stdout.strip().split("T")[0]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return date.today().isoformat()
+
+
+def ingest_one(skill_dir: Path, source: str, source_url: str, dry_run: bool) -> bool:
+    """Ingest a single skill directory."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        print(f"  ERROR: {skill_md} does not exist", file=sys.stderr)
+        return False
+
+    content = skill_md.read_text(encoding="utf-8", errors="replace")
+    fm = parse_frontmatter(content)
+
+    if not fm.get("name"):
+        print(f"  ERROR: {skill_dir.name} — missing 'name' in frontmatter", file=sys.stderr)
+        return False
+
+    skill_name = fm["name"]
+    category = skill_dir.parent.name
+    today = date.today().isoformat()
+
+    print(f"  Ingesting: {skill_name} ({category})")
+
+    if dry_run:
+        print(f"    [DRY RUN] Would enrich frontmatter and update provenance")
+        return True
+
+    # Enrich frontmatter with source info
+    updated = content
+    if not fm.get("source") or fm.get("source") == "in-house":
+        if source:
+            updated = update_frontmatter_field(updated, "source", f'"{source}"')
+    if not fm.get("source_url") and source_url:
+        updated = update_frontmatter_field(updated, "source_url", f'"{source_url}"')
+    if not fm.get("created_at"):
+        created = get_git_created_date(skill_md)
+        updated = update_frontmatter_field(updated, "created_at", f'"{created}"')
+    if not fm.get("updated_at"):
+        updated = update_frontmatter_field(updated, "updated_at", f'"{today}"')
+
+    if updated != content:
+        skill_md.write_text(updated, encoding="utf-8")
+        print(f"    Updated frontmatter")
+
+    return True
+
+
+def run_pipeline(dry_run: bool) -> None:
+    """Run the post-ingestion pipeline."""
+    if dry_run:
+        print("\n[DRY RUN] Would run pipeline scripts")
+        return
+
+    print("\nRunning post-ingestion pipeline...")
+    scripts = [
+        ["python", "scripts/enrich_frontmatter.py"],
+        ["python", "scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"],
+        ["python", "scripts/refresh_repo_views.py"],
+        ["python", "scripts/generate_tags_index.py"],
+        ["python", "scripts/build_catalog_json.py"],
+    ]
+    for cmd in scripts:
+        print(f"  Running: {' '.join(cmd)}")
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+        if result.returncode != 0:
+            print(f"    WARNING: {cmd[1]} returned {result.returncode}", file=sys.stderr)
+            if result.stderr:
+                print(f"    {result.stderr.strip()[:200]}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Register new skills into the repository's provenance system.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --dir skills/developer-engineering/vue-expert --source "github:vuejs/vue"
+  %(prog)s --batch --dry-run
+  %(prog)s --batch --source "community"
+        """
+    )
+    parser.add_argument("--dir", type=Path, help="Path to the skill directory to ingest")
+    parser.add_argument("--source", default="in-house",
+                        help="Source identifier (in-house, skills.sh, clawhub, github:<owner>/<repo>, community)")
+    parser.add_argument("--source-url", default="", help="Original source URL")
+    parser.add_argument("--batch", action="store_true",
+                        help="Batch ingest all untracked skills")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be done without writing")
+    parser.add_argument("--skip-pipeline", action="store_true",
+                        help="Skip the post-ingestion pipeline")
+    args = parser.parse_args()
+
+    if not args.dir and not args.batch:
+        parser.error("Specify --dir <path> for single ingestion or --batch for all untracked skills")
+
+    success_count = 0
+    fail_count = 0
+
+    if args.batch:
+        tracked = get_tracked_skills(PROVENANCE_FILE)
+        untracked = find_untracked_skills(SKILLS_DIR, tracked)
+        print(f"Found {len(untracked)} untracked skills (out of {len(tracked)} tracked)")
+        for skill_dir in untracked:
+            ok = ingest_one(skill_dir, args.source, args.source_url, args.dry_run)
+            if ok:
+                success_count += 1
+            else:
+                fail_count += 1
+    else:
+        skill_dir = REPO_ROOT / args.dir if not args.dir.is_absolute() else args.dir
+        ok = ingest_one(skill_dir, args.source, args.source_url, args.dry_run)
+        if ok:
+            success_count += 1
+        else:
+            fail_count += 1
+
+    print(f"\nIngestion complete: {success_count} succeeded, {fail_count} failed")
+
+    if success_count > 0 and not args.skip_pipeline:
+        run_pipeline(args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/provenance_pipeline.py
+++ b/scripts/provenance_pipeline.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 from pathlib import Path
+
+
+def resolve_python_cmd() -> list[str]:
+    """Use the current interpreter so nested subprocesses work cross-platform."""
+    return [sys.executable] if sys.executable else ["python"]
 
 
 def run(cmd: list[str], root: Path) -> None:
@@ -27,22 +33,23 @@ def main() -> int:
     p = cfg["paths"]
     stale_days = str(cfg.get("stale_days", 30))
     coverage = str(cfg.get("coverage_min_percent", 95))
+    python_cmd = resolve_python_cmd()
 
     # 1) Ensure in-house mapping is up to date.
-    run(["python3", "scripts/bootstrap_in_house_sources.py", "--write-json", p["in_house_mapping"]], root)
+    run(python_cmd + ["scripts/bootstrap_in_house_sources.py", "--write-json", p["in_house_mapping"]], root)
 
     # 2) Validate + gate.
-    run(["python3", "scripts/validate_skill_sources.py"], root)
-    run(["python3", "scripts/check_source_coverage.py", "--min-percent", coverage], root)
+    run(python_cmd + ["scripts/validate_skill_sources.py"], root)
+    run(python_cmd + ["scripts/check_source_coverage.py", "--min-percent", coverage], root)
 
     # 3) Reporting artifacts.
-    run(["python3", "scripts/skills_refresh_planner.py", "--stale-days", stale_days, "--write-json", p["refresh_queue"]], root)
-    run(["python3", "scripts/build_skills_catalog.py", "--write-json", p["catalog"]], root)
-    run(["python3", "scripts/generate_sources_index.py", "--write-json", p["sources_index"]], root)
+    run(python_cmd + ["scripts/skills_refresh_planner.py", "--stale-days", stale_days, "--write-json", p["refresh_queue"]], root)
+    run(python_cmd + ["scripts/build_skills_catalog.py", "--write-json", p["catalog"]], root)
+    run(python_cmd + ["scripts/generate_sources_index.py", "--write-json", p["sources_index"]], root)
 
     if args.mode == "all":
-        run(["python3", "scripts/skills_bulk_update_stub.py", "--queue", p["refresh_queue"], "--write-plan", p["bulk_plan"]], root)
-        run(["python3", "scripts/check_upstream_github_updates.py", "--write-json", p["upstream_check"]], root)
+        run(python_cmd + ["scripts/skills_bulk_update_stub.py", "--queue", p["refresh_queue"], "--write-plan", p["bulk_plan"]], root)
+        run(python_cmd + ["scripts/check_upstream_github_updates.py", "--write-json", p["upstream_check"]], root)
 
     print("Provenance pipeline completed.")
     return 0

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Check and synchronize upstream changes for tracked skills.
+
+Reads the provenance mapping to find skills with external upstream sources,
+checks for newer versions, and optionally applies updates.
+
+Usage:
+    # Check only — report which skills have upstream updates
+    python scripts/sync_upstream.py --check-only
+
+    # Apply updates — download and replace with upstream versions
+    python scripts/sync_upstream.py --apply
+
+    # Dry run — show what would be updated without writing
+    python scripts/sync_upstream.py --apply --dry-run
+
+    # Check a specific source only
+    python scripts/sync_upstream.py --check-only --source "github:alirezarezvani/claude-skills"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+PROVENANCE_FILE = REPO_ROOT / "docs" / "sources" / "in-house.skills.json"
+
+
+def github_raw_url(repo: str, path: str, ref: str = "main") -> str:
+    """Construct a GitHub raw content URL."""
+    return f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
+
+
+def fetch_url(url: str, token: str | None = None) -> str | None:
+    """Fetch content from a URL."""
+    headers = {"User-Agent": "skills-sync-bot"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError) as e:
+        print(f"    Warning: fetch failed for {url}: {e}", file=sys.stderr)
+        return None
+
+
+def github_api_get(url: str, token: str | None = None) -> dict | None:
+    """Make a GET request to GitHub API."""
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "skills-sync-bot",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+        print(f"    Warning: API request failed: {e}", file=sys.stderr)
+        return None
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Extract frontmatter key-value pairs."""
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            fm[key.strip()] = val.strip().strip('"').strip("'")
+    return fm
+
+
+def merge_frontmatter(local_content: str, upstream_content: str) -> str:
+    """Merge upstream content body with local frontmatter enrichments.
+    
+    Strategy: Keep local frontmatter (tags, quality, author, etc.) but take
+    upstream body content. Update version and updated_at.
+    """
+    local_fm = parse_frontmatter(local_content)
+    upstream_fm = parse_frontmatter(upstream_content)
+
+    # Extract body from upstream (everything after ---)
+    upstream_body_match = re.match(r"^---\s*\n.*?\n---\s*\n(.*)", upstream_content, re.DOTALL)
+    upstream_body = upstream_body_match.group(1) if upstream_body_match else upstream_content
+
+    # Build merged frontmatter: upstream basics + local enrichments
+    merged_fm = {}
+    # From upstream: name, description (authoritative)
+    merged_fm["name"] = upstream_fm.get("name", local_fm.get("name", ""))
+    merged_fm["description"] = upstream_fm.get("description", local_fm.get("description", ""))
+    # From local: enrichments
+    for key in ["version", "author", "source", "source_url", "tags", "created_at", "quality", "complexity"]:
+        if key in local_fm:
+            merged_fm[key] = local_fm[key]
+    # Update metadata
+    merged_fm["updated_at"] = date.today().isoformat()
+    # Bump patch version
+    ver = merged_fm.get("version", "1.0.0")
+    parts = ver.split(".")
+    if len(parts) == 3:
+        parts[2] = str(int(parts[2]) + 1)
+        merged_fm["version"] = ".".join(parts)
+
+    # Build frontmatter string
+    fm_lines = ["---"]
+    field_order = ["name", "description", "version", "author", "source", "source_url",
+                   "tags", "created_at", "updated_at", "quality", "complexity"]
+    for key in field_order:
+        if key in merged_fm:
+            val = merged_fm[key]
+            # Quote values with special chars
+            if key == "tags" or (isinstance(val, str) and not val.startswith("[") and
+                                 any(c in val for c in ":,#'\"[]")):
+                if not val.startswith('"'):
+                    val = f'"{val}"'
+            fm_lines.append(f"{key}: {val}")
+    fm_lines.append("---")
+    fm_lines.append("")
+
+    return "\n".join(fm_lines) + upstream_body
+
+
+def load_skills_with_upstream() -> list[dict]:
+    """Load skills that have external upstream sources from frontmatter."""
+    results = []
+    for skill_md in sorted(SKILLS_DIR.glob("*/*/SKILL.md")):
+        content = skill_md.read_text(encoding="utf-8", errors="replace")
+        fm = parse_frontmatter(content)
+        source = fm.get("source", "in-house")
+        
+        # Only process skills with external sources
+        if source.startswith("github:"):
+            repo = source.replace("github:", "")
+            skill_name = fm.get("name", skill_md.parent.name)
+            results.append({
+                "name": skill_name,
+                "category": skill_md.parent.parent.name,
+                "source": source,
+                "repo": repo,
+                "local_path": skill_md,
+                "source_url": fm.get("source_url", ""),
+                "local_content": content,
+            })
+        elif source in ("skills.sh", "clawhub", "community"):
+            # These don't have auto-syncable upstreams yet
+            pass
+    return results
+
+
+def check_upstream_changes(skill: dict, token: str | None) -> dict | None:
+    """Check if upstream has changes for a skill."""
+    repo = skill["repo"]
+    skill_name = skill["name"]
+    
+    # Try common paths in the upstream repo
+    candidate_paths = [
+        f"skills/{skill_name}/SKILL.md",
+        f"skills/{skill['category']}/{skill_name}/SKILL.md",
+        f"{skill_name}/SKILL.md",
+    ]
+    
+    for path in candidate_paths:
+        url = github_raw_url(repo, path)
+        upstream_content = fetch_url(url, token)
+        if upstream_content and "---" in upstream_content[:10]:
+            # Compare content (ignore frontmatter for diff)
+            local_body = re.sub(r"^---.*?---\s*", "", skill["local_content"], flags=re.DOTALL).strip()
+            upstream_body = re.sub(r"^---.*?---\s*", "", upstream_content, flags=re.DOTALL).strip()
+            
+            if local_body != upstream_body:
+                return {
+                    "skill": skill,
+                    "upstream_path": path,
+                    "upstream_content": upstream_content,
+                    "changes": "body_changed",
+                }
+            else:
+                return None  # No changes
+    
+    return None  # Could not find upstream file
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check and synchronize upstream changes for tracked skills."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check-only", action="store_true", help="Only report updates, don't apply")
+    group.add_argument("--apply", action="store_true", help="Apply upstream updates to local files")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without writing")
+    parser.add_argument("--source", help="Filter to a specific source (e.g. 'github:obra/superpowers')")
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    skills = load_skills_with_upstream()
+    
+    if args.source:
+        skills = [s for s in skills if s["source"] == args.source]
+    
+    print(f"Checking {len(skills)} skills with external upstream sources...")
+    
+    updates = []
+    for skill in skills:
+        print(f"  Checking: {skill['name']} ({skill['source']})")
+        update = check_upstream_changes(skill, token)
+        if update:
+            updates.append(update)
+            print(f"    → Update available!")
+    
+    print(f"\n{'='*60}")
+    print(f"Results: {len(updates)} updates available out of {len(skills)} checked")
+    
+    if not updates:
+        print("All skills are up to date.")
+        return
+    
+    print("\nSkills with available updates:")
+    for u in updates:
+        s = u["skill"]
+        print(f"  - {s['name']} ({s['category']}) ← {s['source']}")
+    
+    if args.check_only:
+        print("\nRun with --apply to download and apply these updates.")
+        return
+    
+    if args.apply:
+        applied = 0
+        for u in updates:
+            s = u["skill"]
+            print(f"\n  Applying update: {s['name']}")
+            
+            if args.dry_run:
+                print(f"    [DRY RUN] Would merge upstream content into {s['local_path']}")
+                applied += 1
+                continue
+            
+            merged = merge_frontmatter(s["local_content"], u["upstream_content"])
+            s["local_path"].write_text(merged, encoding="utf-8")
+            print(f"    Updated: {s['local_path']}")
+            applied += 1
+        
+        print(f"\nApplied {applied} updates.")
+        if not args.dry_run:
+            print("Run the full pipeline to regenerate views:")
+            print("  python scripts/refresh_repo_views.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auto_curate_skills.py
+++ b/tests/test_auto_curate_skills.py
@@ -1,0 +1,167 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "auto_curate_skills.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("auto_curate_skills", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class AutoCurateSkillsTests(unittest.TestCase):
+    def test_ranked_candidates_prefer_trusted_sources_and_actionable_names(self):
+        module = load_module()
+
+        report = {
+            "discoveries": [
+                {
+                    "name": "infra-automation",
+                    "source": "skills.sh (vercel-labs/agent-skills)",
+                    "url": "https://skills.sh/example/infra-automation",
+                    "repo_stars": 50,
+                    "description": "Production-ready runbooks and CI guidance",
+                },
+                {
+                    "name": "random-helper",
+                    "source": "Unknown",
+                    "url": "https://example.com/random-helper",
+                    "repo_stars": 5000,
+                    "description": "misc",
+                },
+                {
+                    "name": "test-driven-development",
+                    "source": "skills.sh (obra/superpowers)",
+                    "url": "https://skills.sh/example/test-driven-development",
+                    "repo_stars": 100000,
+                    "description": "already in repo",
+                },
+            ]
+        }
+
+        ranked = module.rank_discoveries(
+            report,
+            existing_names={"test-driven-development"},
+            limit=10,
+        )
+
+        self.assertEqual("infra-automation", ranked[0]["name"])
+        self.assertEqual("random-helper", ranked[1]["name"])
+        self.assertNotIn("test-driven-development", [item["name"] for item in ranked])
+        self.assertGreater(ranked[0]["curation_score"], ranked[1]["curation_score"])
+
+    def test_build_execution_plan_syncs_before_discovery_and_pipeline(self):
+        module = load_module()
+
+        plan = module.build_execution_plan(
+            python_cmd=["python"],
+            discovery_output="docs/sources/reports/discovery.json",
+            candidate_output="docs/sources/reports/curation-candidates.json",
+            sync_mode="apply",
+            top=5,
+            min_score=20,
+        )
+
+        rendered = [" ".join(step["cmd"]) for step in plan]
+        self.assertIn("python scripts/sync_upstream.py --apply", rendered[0])
+        self.assertIn("python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json", rendered[1])
+        self.assertTrue(
+            any("python scripts/enrich_frontmatter.py" in command for command in rendered),
+            rendered,
+        )
+        self.assertIn("python -m unittest discover tests -v", rendered[-1])
+
+    def test_curate_dry_run_writes_candidate_report(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            discovery_path = repo / "docs" / "sources" / "reports" / "discovery.json"
+            discovery_path.parent.mkdir(parents=True, exist_ok=True)
+            discovery_path.write_text(
+                json.dumps(
+                    {
+                        "discoveries": [
+                            {
+                                "name": "platform-best-practices",
+                                "source": "skills.sh (vercel-labs/agent-skills)",
+                                "url": "https://skills.sh/example/platform-best-practices",
+                                "repo_stars": 1200,
+                                "description": "Operational patterns with examples",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = module.curate_candidates(
+                repo_root=repo,
+                discovery_output=discovery_path,
+                candidate_output=repo / "docs" / "sources" / "reports" / "curation-candidates.json",
+                top=10,
+                min_score=1,
+            )
+
+            self.assertEqual(1, report["selected_count"])
+            self.assertEqual("platform-best-practices", report["selected"][0]["name"])
+
+    def test_build_branch_name_uses_codex_prefix(self):
+        module = load_module()
+        branch = module.build_branch_name("skills-curation")
+        self.assertTrue(branch.startswith("codex/"))
+        self.assertIn("skills-curation", branch)
+
+    def test_write_pr_summary_includes_candidates_and_results(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "curation-pr.md"
+            module.write_pr_summary(
+                output,
+                candidate_report={
+                    "selected_count": 2,
+                    "selected": [
+                        {"name": "alpha-skill", "curation_score": 42, "recommended_category": "developer-engineering"},
+                        {"name": "beta-skill", "curation_score": 35, "recommended_category": "devops-sre"},
+                    ],
+                },
+                ingest_result={
+                    "ingested": [{"name": "alpha-skill", "path": "skills/developer-engineering/alpha-skill"}],
+                    "skipped": [{"name": "beta-skill", "reason": "upstream_markdown_not_found"}],
+                },
+                sync_mode="apply",
+                branch_name="codex/skills-curation-20260327-120000",
+                base_branch="main",
+            )
+
+            body = output.read_text(encoding="utf-8")
+            self.assertIn("Skills curation automation", body)
+            self.assertIn("alpha-skill", body)
+            self.assertIn("upstream_markdown_not_found", body)
+            self.assertIn("codex/skills-curation-20260327-120000", body)
+
+    def test_assert_clean_worktree_raises_when_repo_is_dirty(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            (repo / ".git").mkdir()
+            dirty = repo / "dirty.txt"
+            dirty.write_text("changed", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "dirty worktree"):
+                module.assert_clean_worktree(repo, status_output=" M dirty.txt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bootstrap_in_house_sources.py
+++ b/tests/test_bootstrap_in_house_sources.py
@@ -1,0 +1,105 @@
+import importlib.util
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "bootstrap_in_house_sources.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("bootstrap_in_house_sources", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BootstrapInHouseSourcesTests(unittest.TestCase):
+    def test_build_mapping_preserves_existing_external_sources(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            existing_skill = repo / "skills" / "developer-engineering" / "systematic-debugging"
+            local_only_skill = repo / "skills" / "operations-general" / "summary-helper"
+            existing_skill.mkdir(parents=True)
+            local_only_skill.mkdir(parents=True)
+
+            (existing_skill / "SKILL.md").write_text(
+                textwrap.dedent(
+                    """\
+                    ---
+                    name: systematic-debugging
+                    description: Systematic debugging.
+                    ---
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (local_only_skill / "SKILL.md").write_text(
+                textwrap.dedent(
+                    """\
+                    ---
+                    name: summary-helper
+                    description: Internal helper.
+                    ---
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            existing_payload = {
+                "video": {"url": "https://example.com", "checked_at": "2026-03-01"},
+                "official_references": [],
+                "skills": [
+                    {
+                        "video_name": "systematic-debugging",
+                        "normalized_slug": "systematic-debugging",
+                        "status": "verified_in_repo",
+                        "repo_skill": "skills/developer-engineering/systematic-debugging/SKILL.md",
+                        "source": "https://github.com/obra/superpowers",
+                        "notes": "Tracked from upstream.",
+                        "upstream": {
+                            "repo": "obra/superpowers",
+                            "path": "systematic-debugging/SKILL.md",
+                            "ref": "main",
+                            "last_checked_at": "2026-03-20",
+                            "last_synced_at": "2026-03-20",
+                            "last_synced_commit": "abc123",
+                        },
+                    }
+                ],
+            }
+
+            payload = module.build_in_house_mapping(
+                repo_root=repo,
+                repo_url="https://github.com/example/repo",
+                existing_payload=existing_payload,
+                today="2026-03-27",
+            )
+
+            skills = {item["video_name"]: item for item in payload["skills"]}
+            self.assertEqual("verified_in_repo", skills["systematic-debugging"]["status"])
+            self.assertEqual("https://github.com/obra/superpowers", skills["systematic-debugging"]["source"])
+            self.assertEqual("obra/superpowers", skills["systematic-debugging"]["upstream"]["repo"])
+            self.assertEqual("in_house", skills["summary-helper"]["status"])
+            self.assertEqual(
+                "https://github.com/example/repo",
+                skills["summary-helper"]["source"],
+            )
+
+    def test_load_existing_payload_returns_none_for_missing_file(self):
+        module = load_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            payload = module.load_existing_payload(Path(tmpdir) / "missing.json")
+            self.assertIsNone(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_pipeline.py
+++ b/tests/test_provenance_pipeline.py
@@ -1,5 +1,7 @@
 import json
+import importlib.util
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
@@ -8,6 +10,15 @@ class ProvenancePipelineTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.root = Path(__file__).resolve().parents[1]
+        cls.script_path = cls.root / "scripts" / "provenance_pipeline.py"
+
+    def load_module(self):
+        spec = importlib.util.spec_from_file_location("provenance_pipeline", self.script_path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Failed to load module from {self.script_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
     def test_config_has_required_keys(self):
         cfg = json.loads((self.root / "docs/sources/provenance.config.json").read_text(encoding="utf-8"))
@@ -27,7 +38,7 @@ class ProvenancePipelineTests(unittest.TestCase):
     def test_quick_pipeline_runs(self):
         result = subprocess.run(
             [
-                "python3",
+                sys.executable,
                 "scripts/provenance_pipeline.py",
                 "--mode",
                 "quick",
@@ -41,6 +52,12 @@ class ProvenancePipelineTests(unittest.TestCase):
         )
         if result.returncode != 0:
             self.fail(f"quick pipeline failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
+
+    def test_resolve_python_cmd_uses_current_interpreter(self):
+        module = self.load_module()
+        cmd = module.resolve_python_cmd()
+        self.assertTrue(cmd)
+        self.assertEqual(Path(sys.executable).name.lower(), Path(cmd[0]).name.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a unified `auto_curate_skills.py` orchestrator for sync, discovery, scoring, ingestion, pipeline execution, and optional PR prep
- preserve external provenance during `bootstrap_in_house_sources.py` refresh instead of rewriting every skill as `in_house`
- make `provenance_pipeline.py` use the current Python interpreter so the quick pipeline works cross-platform
- add `ingest_skill.py` and `sync_upstream.py` to support automated ingestion and upstream updates
- expand test coverage for the new automation flow and provenance behavior

## Verification
- `python -m unittest discover tests -v`
- `python scripts/auto_curate_skills.py --curate-only --discovery-output docs/sources/reports/discovery.json --candidate-output docs/sources/reports/curation-candidates.json --top 20 --min-score 20`

## Notes
- auto-PR mode now refuses to run from a dirty worktree to avoid mixing unrelated local changes into generated branches
- candidate auto-ingestion is still best-effort and intentionally skips sources where raw upstream `SKILL.md` content cannot be resolved safely
