### PR TITLE
docs: simplify AI installation prompt

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -40,23 +40,19 @@ This repository currently contains **15 categories / 163 skills**.
 
 ### Option 1: Give This Prompt to Your AI Tool (Recommended)
 
-If you want your AI tool to install the skills for you, send it the prompt below and replace the local path:
+If you want your AI tool to install the skills for you, start with this short prompt:
 
 ```text
-You are my local installation assistant. Please install the skills from this repository into the current AI tool and follow these rules:
-
-1. The local repository path is: `<replace with your local repo path>`
-2. If the current tool is `Codex`, `Claude Code`, `Cursor`, or another source-browsing AI coding assistant, use the repository `skills/` directory
-3. If the current tool is `OpenClaw`, first run `python scripts/export_openclaw_skills.py`, then use `openclaw-skills/`
-4. If this machine already has a local Codex skills directory, run `python scripts/sync_codex_skills.py --source-root "<repo path>/skills" --codex-root "<Codex skills path>"` to sync it
-5. When finished, tell me:
-   - which directory you used
-   - which local files or settings you changed
-   - how I should verify the installation worked
-   - where it failed if anything did not work
+You are my local installation assistant. Please install the skills from this repository into the current AI tool: https://github.com/seaworld008/Commonly-used-high-value-skills
 ```
 
-If you are unsure which directory your tool should use, this is the easiest and safest way to start.
+If the AI tool cannot infer enough context, add one more line:
+
+```text
+The current tool is `<Codex / Claude Code / Cursor / OpenClaw>`, and the local repository path is `<your local repo path>`.
+```
+
+This works because the repository already includes AI-readable installation rules and directory conventions, so users usually do not need to spell out the full install workflow in the prompt.
 
 ### Option 2: Manual Setup
 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,19 @@
 
 ### 方式一：直接发给 AI 工具的安装提示词（推荐）
 
-如果你希望让 AI 工具直接帮你安装，可以把下面这段提示词原样发给它，只需要把本地路径改成你自己的：
+如果你希望让 AI 工具直接帮你安装，优先发这段短提示词：
 
 ```
-你现在是我的本地安装助手，请把这个仓库里的 Skills 安装到当前 AI 工具中，并按下面规则执行：
-
-1. 仓库本地路径是：`<替换成你的本地仓库路径>`
-2. 如果当前工具是 `Codex`、`Claude Code`、`Cursor` 或其他按源码浏览技能目录的 AI coding assistant，请使用仓库里的 `skills/`
-3. 如果当前工具是 `OpenClaw`，请先运行 `python scripts/export_openclaw_skills.py`，然后使用 `openclaw-skills/`
-4. 如果当前机器已经有本地 `Codex` skills 目录，请运行 `python scripts/sync_codex_skills.py --source-root "<仓库路径>\\skills" --codex-root "<Codex skills 路径>"` 进行同步
-5. 安装完成后，请明确告诉我：
-   - 你为当前工具使用了哪个目录
-   - 你改了哪些本地配置或文件
-   - 应该如何验证安装成功
-   - 如果失败，失败点在哪里
+你现在是我的本地安装助手，请把这个仓库 https://github.com/seaworld008/Commonly-used-high-value-skills 里的 Skills 安装到当前 AI 工具中。
 ```
 
-如果你不确定自己的工具该用哪个目录，就直接把上面的提示词发给 AI 工具，它会按客户端类型自动选择。
+如果 AI 工具没有自动识别出来，再补一句即可：
+
+```text
+当前工具是 `<Codex / Claude Code / Cursor / OpenClaw>`，本地仓库路径是 `<你的本地仓库路径>`。
+```
+
+之所以可以这样简化，是因为仓库里已经包含给 AI 工具读取的安装规则与目录约定文档，通常不需要你手动把安装逻辑全部写进提示词里。
 
 ### 方式二：手动安装步骤
 


### PR DESCRIPTION
## Summary
- simplify the AI installation prompt in README.md and README.en.md
- switch from a long rule-heavy prompt to a short default prompt plus a one-line fallback context hint
- keep the manual setup steps intact for users who prefer direct installation

## Verification
- read the updated Quick Start section in both README files

## Notes
- this PR only contains the README prompt simplification commit `0989d53`
