### PR TITLE
docs: clarify manual skill installation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -27,16 +27,18 @@ This repository currently contains **16 categories / 301 skills**.
 - It is suitable both for daily usage and long-term team knowledge accumulation
 - The repo now supports automated discovery, upstream sync, candidate ranking, quality checks, and generated view refreshes, so it can be maintained as a living skill system rather than a static dump
 - Curation is policy-driven: trusted sources can be preferred, noisy sources can be denied, and minimum quality thresholds can be enforced in one place
-- `scripts/sync_codex_skills.py` lets you sync the latest repository skills into a local Codex skill directory without manual copying
+- `scripts/sync_codex_skills.py` lets you sync the latest repository skills into local Codex, Claude Code, or similar skills directories without manual copying
 - The repository also emphasizes trust and safety through provenance tracking, curated source controls, and built-in security-review skills such as `skill-vetter`, `skill-security-auditor`, `input-guard`, and `link-checker`
 - The repository now also includes license auditing and scheduled dead-link checks: `repo-validation` blocks external skills that are missing license metadata, while the monthly `dead-links` workflow produces a link health report instead of silently drifting.
 - `Hermes Agent` is also treated as a first-class supported client: it uses the same categorized `skills/` tree and already has dedicated Hermes runtime, MCP, and Hermes + graphify + GSD workflow skills in the repository.
 
 ## Which Directory Should You Use
 
-| Client | Directory |
-|--------|-----------|
-| `Codex` / `Claude Code` / `Hermes Agent` / source-browsing AI coding assistants | `skills/` |
+| Usage | Directory |
+|-------|-----------|
+| Let `Codex` / `Claude Code` / `Hermes Agent` / `Cursor` browse this repository directly | `skills/` |
+| Install into a local `Codex` skills directory | Sync `skills/` into `~/.codex/skills` |
+| Install into a local `Claude Code` skills directory | Sync `skills/` into `~/.claude/skills` or project `.claude/skills` |
 | `OpenClaw` | `openclaw-skills/` |
 
 ## Quick Start
@@ -59,18 +61,54 @@ This works because the repository already includes AI-readable installation rule
 
 ### Option 2: Manual Setup
 
-1. Clone the repository.
-2. Choose the correct directory for your client:
-   - `Codex` / `Claude Code` / `Hermes Agent` / `Cursor` / other source-browsing assistants: use `skills/`
-   - `OpenClaw`: use `openclaw-skills/`
-3. If you use OpenClaw, generate the flat export first:
+1. Clone the repository and enter it:
+
+```bash
+git clone https://github.com/seaworld008/Commonly-used-high-value-skills.git
+cd Commonly-used-high-value-skills
+```
+
+2. If you use `Codex`, sync the skills into your local Codex skills directory:
+
+```bash
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.codex/skills
+```
+
+Windows PowerShell example:
+
+```powershell
+python scripts/sync_codex_skills.py --source-root ".\skills" --codex-root "$env:USERPROFILE\.codex\skills"
+```
+
+3. If you use `Claude Code`, sync the skills into your personal or project skills directory:
+
+```bash
+# Personal: available across projects
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.claude/skills
+
+# Project: available only in the current project
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ./.claude/skills
+```
+
+Windows PowerShell example:
+
+```powershell
+python scripts/sync_codex_skills.py --source-root ".\skills" --codex-root "$env:USERPROFILE\.claude\skills"
+```
+
+The `--codex-root` option is the existing sync script's destination parameter. It can point to a Claude Code skills directory too.
+
+4. If you use `Hermes Agent`, `Cursor`, or another source-browsing AI coding assistant, point the tool at this repository's `skills/` directory. If the tool requires a flat one-level skill directory, reuse the sync command above and set `--codex-root` to that tool's skills directory.
+
+5. If you use `OpenClaw`, generate the flat export first:
 
 ```bash
 python3 scripts/export_openclaw_skills.py
 ```
 
-4. Point your AI tool to the correct directory.
-5. Verify by opening a few known skills, for example:
+Then point OpenClaw at `openclaw-skills/`. Do not point OpenClaw at the repository root or `skills/`.
+
+6. Verify by opening a few known skills, for example:
    - `skills/developer-engineering/codebase-onboarding`
    - `skills/security-and-reliability/skill-vetter`
    - `openclaw-skills/codebase-onboarding`
@@ -142,7 +180,7 @@ python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.code
 
 This repository does not just happen to include a few Hermes-related skills. It explicitly supports `Hermes Agent` as one of the maintained consumption targets:
 
-- installation layout matches `Codex` / `Claude Code`, using the categorized `skills/` tree
+- source-browsing usage reads the categorized `skills/` tree; local `Codex` / `Claude Code` installs sync into their own skills directories
 - it includes the dedicated [`hermes-agent`](./skills/ai-agent-platform/hermes-agent/) skill covering CLI usage, gateway setup, profiles, memory, skills, MCP, and contributor guidance
 - it includes [`native-mcp`](./skills/ai-agent-platform/native-mcp/) for Hermes MCP usage
 - it includes the `hermes-graphify-gsd-*` workflow skills for graph-aware and autonomous development loops
@@ -175,7 +213,8 @@ This repository exposes two consumption surfaces for different AI clients:
 
 | Client | Directory | Why |
 |--------|-----------|-----|
-| `Codex` / `Claude Code` / `Hermes Agent` / source-browsing coding assistants | `skills/` | Keeps category structure for browsing, maintenance, and editing |
+| `Codex` / `Claude Code` local skills directories | `~/.codex/skills` / `~/.claude/skills` / `.claude/skills` | Installed as a flat skill directory so clients can discover skills |
+| `Hermes Agent` / `Cursor` / source-browsing coding assistants | `skills/` | Keeps category structure for browsing, maintenance, and editing |
 | `OpenClaw` | `openclaw-skills/` | OpenClaw expects a flat one-level skill directory |
 
 ### AI-Readable Rules
@@ -183,7 +222,7 @@ This repository exposes two consumption surfaces for different AI clients:
 The repository-level [AGENTS.md](./AGENTS.md) defines these rules for future agents:
 
 - `OpenClaw` installations must use `openclaw-skills/`.
-- `Codex`, `Claude Code`, `Hermes Agent`, and similar clients should use `skills/`.
+- `Codex` and `Claude Code` local installs should sync into their own skills directories; source-browsing clients can use `skills/` directly.
 - Do not point OpenClaw at the repository root or the categorized `skills/` tree.
 - Do not manually edit `openclaw-skills/`; regenerate it from source scripts.
 - When updating `README.md`, update `README.en.md` in the same change.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - 很多技能不只是文档，还带 `scripts/`、`references/`、`assets/`，可以直接复用。
 - 仓库已经具备发现新 Skill、同步上游更新、候选优选、质量校验和生成视图的自动化链路，适合持续运营而不是一次性收集。
 - 现在支持用策略文件对白名单来源、黑名单来源、优先来源和基础门槛做统一治理，优选结果更稳定、更可控。
-- 已提供 `scripts/sync_codex_skills.py`，可以把仓库中的最新技能一键同步到本地 `Codex` 技能目录，减少手工拷贝和版本漂移。
+- 已提供 `scripts/sync_codex_skills.py`，可以把仓库中的最新技能一键同步到 `Codex`、`Claude Code` 等本机技能目录，减少手工拷贝和版本漂移。
 - 除了功能覆盖，仓库也重视安全与可信度：既有来源追踪、候选筛选与安装前风险识别能力，也内置 `skill-vetter`、`skill-security-auditor`、`input-guard`、`link-checker` 等安全审查类技能。
 - 现在还内置了许可证审计与月度死链巡检：`repo-validation` 会阻止缺失 license 元数据的外源技能进入主分支，`dead-links` 工作流会按月生成外链巡检报告。
 - `Hermes Agent` 也被作为一等支持对象维护：可直接使用 `skills/` 分类目录，并且仓库已包含 `hermes-agent`、`native-mcp`、`hermes-graphify-gsd-*` 等 Hermes 生态专用技能。
@@ -36,7 +36,9 @@
 
 | 使用场景 | 应使用的目录 |
 |----------|---------------|
-| `Codex` / `Claude Code` / `Hermes Agent` / 按源码浏览的 AI coding assistants | `skills/` |
+| 直接让 `Codex` / `Claude Code` / `Hermes Agent` / `Cursor` 等工具浏览仓库源码 | `skills/` |
+| 安装到 `Codex` 本机技能目录 | 将 `skills/` 同步到 `~/.codex/skills` |
+| 安装到 `Claude Code` 本机技能目录 | 将 `skills/` 同步到 `~/.claude/skills` 或项目内 `.claude/skills` |
 | `OpenClaw` | `openclaw-skills/` |
 
 ### 方式一：直接发给 AI 工具的安装提示词（推荐）
@@ -57,20 +59,54 @@
 
 ### 方式二：手动安装步骤
 
-1. 克隆本仓库到本地。
-2. 判断你当前使用的是哪类工具：
-   - 如果是 `Codex` / `Claude Code` / `Hermes Agent` / `Cursor` / 其他源码浏览型 AI coding assistant，直接使用 `skills/`
-   - 如果是 `OpenClaw`，使用 `openclaw-skills/`
-3. 如果你使用 `OpenClaw`，先生成扁平导出目录：
+1. 克隆本仓库到本地并进入目录：
+
+```bash
+git clone https://github.com/seaworld008/Commonly-used-high-value-skills.git
+cd Commonly-used-high-value-skills
+```
+
+2. 如果你使用 `Codex`，同步到本机 Codex skills 目录：
+
+```bash
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.codex/skills
+```
+
+Windows PowerShell 示例：
+
+```powershell
+python scripts/sync_codex_skills.py --source-root ".\skills" --codex-root "$env:USERPROFILE\.codex\skills"
+```
+
+3. 如果你使用 `Claude Code`，同步到个人或项目级 skills 目录：
+
+```bash
+# 个人级，所有项目可用
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.claude/skills
+
+# 项目级，只在当前项目可用
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ./.claude/skills
+```
+
+Windows PowerShell 示例：
+
+```powershell
+python scripts/sync_codex_skills.py --source-root ".\skills" --codex-root "$env:USERPROFILE\.claude\skills"
+```
+
+这里的 `--codex-root` 是同步脚本沿用的参数名，实际含义是“目标技能目录”，也可以指向 `Claude Code` 的 skills 目录。
+
+4. 如果你使用 `Hermes Agent`、`Cursor` 或其他能浏览源码目录的 AI coding assistant，优先把工具指向仓库内的 `skills/`；如果目标工具要求一层扁平技能目录，可以复用上面的同步命令，把 `--codex-root` 改成该工具自己的 skills 目录。
+
+5. 如果你使用 `OpenClaw`，先生成扁平导出目录：
 
 ```bash
 python3 scripts/export_openclaw_skills.py
 ```
 
-4. 把对应目录配置到你的 AI 工具里：
-   - `Codex` / `Claude Code` / `Hermes Agent` / `Cursor`：配置 `skills/`
-   - `OpenClaw`：配置 `openclaw-skills/`
-5. 任选几个技能目录检查是否能正常读取，例如：
+然后把 `openclaw-skills/` 配置到 OpenClaw 的技能加载目录，不要把 OpenClaw 指向仓库根目录或 `skills/`。
+
+6. 任选几个技能目录检查是否能正常读取，例如：
    - `skills/developer-engineering/codebase-onboarding`
    - `skills/security-and-reliability/skill-vetter`
    - `openclaw-skills/codebase-onboarding`
@@ -112,10 +148,10 @@ Windows 示例：
 python scripts/normalize_codex_skills.py "C:\Users\admin\.codex\skills"
 ```
 
-如果你想把仓库里的最新技能同步到本地 Codex 目录，可以运行：
+如果你想把仓库里的最新技能重新同步到本地 Codex 目录，可以运行：
 
-```powershell
-python scripts/sync_codex_skills.py --source-root "E:\AI-codex\003-Commonly-used-high-value-skills\skills" --codex-root "C:\Users\admin\.codex\skills"
+```bash
+python3 scripts/sync_codex_skills.py --source-root ./skills --codex-root ~/.codex/skills
 ```
 
 ## 分类快速跳转
@@ -175,7 +211,7 @@ python scripts/sync_codex_skills.py --source-root "E:\AI-codex\003-Commonly-used
 
 这个仓库不只是“包含几个 Hermes 相关技能”，而是把 `Hermes Agent` 作为正式支持的消费端之一来维护：
 
-- 安装目录与 `Codex` / `Claude Code` 一致，统一使用 `skills/`
+- 源码浏览时统一使用 `skills/`；本机安装到 `Codex` / `Claude Code` 时同步到各自 skills 目录
 - 已内置 [`hermes-agent`](./skills/ai-agent-platform/hermes-agent/) 技能，覆盖 CLI、gateway、profiles、memory、skills、MCP 与贡献开发说明
 - 已内置 [`native-mcp`](./skills/ai-agent-platform/native-mcp/) 技能，方便 Hermes 连接外部 MCP server
 - 已内置 `hermes-graphify-gsd-*` 系列技能，支持把 Hermes 与 graphify、GSD 组合成自动化开发工作流
@@ -236,7 +272,8 @@ python scripts/sync_codex_skills.py --source-root "E:\AI-codex\003-Commonly-used
 
 | 客户端 | 应使用的目录 | 原因 |
 |--------|---------------|------|
-| `Codex` / `Claude Code` / `Hermes Agent` / 其他按源码浏览的 coding assistants | `skills/` | 保留分类结构，便于检索、维护与编辑 |
+| `Codex` / `Claude Code` 本机技能目录 | `~/.codex/skills` / `~/.claude/skills` / `.claude/skills` | 通过同步命令安装为一层技能目录，便于客户端发现 |
+| `Hermes Agent` / `Cursor` / 其他按源码浏览的 coding assistants | `skills/` | 保留分类结构，便于检索、维护与编辑 |
 | `OpenClaw` | `openclaw-skills/` | OpenClaw 需要扁平的一层技能目录，不能直接识别 `skills/<分类>/<skill>` |
 
 ### 给 AI 机器人看的规则
@@ -244,7 +281,7 @@ python scripts/sync_codex_skills.py --source-root "E:\AI-codex\003-Commonly-used
 仓库根目录的 [AGENTS.md](./AGENTS.md) 明确约束如下：
 
 - `OpenClaw` 安装时必须使用 `openclaw-skills/`
-- `Codex`、`Claude Code`、`Hermes Agent` 等按原方式使用 `skills/`
+- `Codex`、`Claude Code` 本机安装时应同步到各自 skills 目录；源码浏览型工具可直接使用 `skills/`
 - 不要把 `OpenClaw` 指向仓库根目录或 `skills/`
 - `openclaw-skills/` 不手改，统一通过脚本生成
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-06-03",
+  "generated_at": "2026-06-04",
   "total_skills": 301,
   "total_categories": 16,
   "categories": [

--- a/docs/client-install-guides.md
+++ b/docs/client-install-guides.md
@@ -5,17 +5,18 @@
 ## 总原则
 
 - `skills/` 是分类源码目录，适用于：
-  - `Codex`
-  - `Claude Code`
+  - 直接浏览仓库源码的 `Codex`
+  - 直接浏览仓库源码的 `Claude Code`
   - `Hermes Agent`
   - 其他按源码浏览技能目录的 AI coding assistants
+- `~/.codex/skills`、`~/.claude/skills` 和项目内 `.claude/skills` 是本机安装目录，适合让客户端自动发现技能。
 - `openclaw-skills/` 是扁平导出目录，适用于：
   - `OpenClaw`
 
 如果你不确定，默认先看目标工具是否支持多级目录：
 
 - 支持多级目录：优先 `skills/`
-- 只支持一层平铺目录：优先 `openclaw-skills/`
+- 只支持一层平铺目录：优先同步到对应客户端的本机 skills 目录；`OpenClaw` 使用 `openclaw-skills/`
 
 ---
 
@@ -59,8 +60,22 @@ python3 scripts/normalize_codex_skills.py ~/.codex/skills
 
 ### 常见接入方式
 
-把本仓库中的 `skills/` 目录纳入 Claude Code 可发现的技能路径即可。  
-如果你是通过项目级技能目录管理，可以把所需技能复制或链接到项目技能目录；如果你使用全局技能目录，也可以直接同步过去。
+如果你想让 Claude Code 自动发现这些技能，推荐同步到个人或项目级 skills 目录：
+
+```bash
+# 个人级，所有项目可用
+python3 scripts/sync_codex_skills.py \
+  --source-root ./skills \
+  --codex-root ~/.claude/skills
+
+# 项目级，只在当前项目可用
+python3 scripts/sync_codex_skills.py \
+  --source-root ./skills \
+  --codex-root ./.claude/skills
+```
+
+这里的 `--codex-root` 是同步脚本沿用的目标目录参数名，也可以指向 Claude Code 的 skills 目录。
+如果你只是让 Claude Code 浏览当前仓库源码，也可以直接阅读 `skills/` 分类目录。
 
 ### 建议先试的技能
 


### PR DESCRIPTION
## Summary
- Add concrete manual install commands for Codex and Claude Code skills directories.
- Clarify when to use `skills/`, `~/.codex/skills`, `~/.claude/skills`, project `.claude/skills`, and `openclaw-skills/`.
- Keep Chinese README, English README, and client install guide aligned.

## Verification
- `python3 scripts/check_readme_sync.py`
- `git diff --check -- README.md README.en.md docs/client-install-guides.md`
