### PR TITLE
fix: reuse gh auth for discovery and sync

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -2031,7 +2031,7 @@
       "complexity": "intermediate",
       "created_at": "2026-06-03",
       "updated_at": "2026-06-03",
-      "line_count": 277,
+      "line_count": 311,
       "path": "skills/developer-engineering/neon-postgres/SKILL.md"
     },
     {
@@ -2520,7 +2520,7 @@
       "complexity": "intermediate",
       "created_at": "2026-06-03",
       "updated_at": "2026-06-03",
-      "line_count": 162,
+      "line_count": 181,
       "path": "skills/devops-sre/azure-kubernetes/SKILL.md"
     },
     {

--- a/openclaw-skills/azure-kubernetes/SKILL.md
+++ b/openclaw-skills/azure-kubernetes/SKILL.md
@@ -65,6 +65,25 @@ If the user is unsure, use safe defaults.
 - **AKS Automatic** (default): Best for most production workloads, provides a curated experience with pre-configured best practices for security, reliability, and performance. Use unless you have specific custom requirements for networking, autoscaling, or node pool configurations not supported by Node Auto-Provisioning (NAP).
 - **AKS Standard**: Use if you need full control over environment configuration, which requires additional overhead to set up and manage.
 
+### Example Starter Commands
+
+Use these only after the Day-0 decisions are explicit:
+
+```bash
+az aks create \
+  --resource-group <rg> \
+  --name <cluster-name> \
+  --tier standard \
+  --network-plugin azure \
+  --network-plugin-mode overlay \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --zones 1 2 3
+
+az aks show --resource-group <rg> --name <cluster-name>
+kubectl get nodes -o wide
+```
+
 ### 2. Networking (Pod IP, Egress, Ingress, Dataplane)
 
 **Pod IP Model** (Key Day-0 decision):

--- a/openclaw-skills/azure-kubernetes/azure-kubernetes-automatic-readiness/SKILL.md
+++ b/openclaw-skills/azure-kubernetes/azure-kubernetes-automatic-readiness/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: azure-kubernetes-automatic-readiness
 description: 'Assess Kubernetes workloads and cluster configuration for AKS Automatic compatibility. Identifies incompatibilities, generates fixes, and guides migration from AKS Standard to AKS Automatic. WHEN: migrate to AKS Automatic, check AKS Automatic readiness, validate manifests for Automatic, assess cluster for Automatic compatibility, fix deployment for Automatic compatibility, identify AKS Automatic migration blockers, is my cluster ready for AKS Automatic.'
+version: "1.0.0"
+author: "seaworld008"
+source: "github:microsoft/azure-skills"
+source_url: "https://skills.sh/microsoft/azure-skills/azure-kubernetes-automatic-readiness"
 license: MIT
+tags: '["azure", "aks", "kubernetes", "readiness", "migration"]'
+created_at: "2026-06-03"
+updated_at: "2026-06-08"
+quality: 4
+complexity: "intermediate"
 metadata:
   author: Microsoft
   version: "1.0.1"

--- a/openclaw-skills/neon-postgres/SKILL.md
+++ b/openclaw-skills/neon-postgres/SKILL.md
@@ -19,6 +19,14 @@ Guide the user through any Neon-related task: setup, connections, branching, and
 
 Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
 
+## Usage
+
+Use this skill when the user needs a current, practical Neon answer that ends in one of three outcomes:
+
+- a working Neon connection string and environment setup
+- a concrete Neon feature configuration such as branching, pooling, autoscaling, or auth
+- an official-docs-grounded explanation of how a Neon capability behaves
+
 ## Neon Documentation
 
 The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
@@ -275,3 +283,29 @@ Key points:
 - Useful for replicating to/from external Postgres systems.
 
 Link: https://neon.com/docs/guides/logical-replication-guide.md
+
+## Common Patterns
+
+### Pattern: existing app already has Postgres
+
+- inspect current ORM, driver, and `.env` usage first
+- swap only the connection string and driver-specific config needed for Neon
+- validate migrations and pooling behavior before changing any runtime code
+
+### Pattern: new project needs fastest Neon bootstrap
+
+- initialize Neon tooling with `neonctl` or the MCP server first
+- store `DATABASE_URL` in environment variables before adding ORM glue
+- choose the simplest driver compatible with the target runtime
+
+### Pattern: preview or branch-based workflows
+
+- create isolated branches for migrations and preview deployments
+- verify each branch has the correct compute endpoint before testing
+- document branch cleanup rules so temporary environments do not linger
+
+## Boundaries
+
+- Do not invent Neon product behavior when a current docs page can answer it directly.
+- Do not overwrite existing database credentials or `.env` values without first reading the file and preserving unrelated entries.
+- Do not recommend a single driver or auth path blindly; choose based on runtime constraints, auth needs, and deployment model.

--- a/scripts/discover_new_skills.py
+++ b/scripts/discover_new_skills.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import urllib.error
 import urllib.parse
@@ -77,6 +78,26 @@ def utc_day() -> str:
 
 def utc_timestamp() -> str:
     return utc_now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def resolve_github_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+    candidate = result.stdout.strip()
+    if result.returncode == 0 and candidate:
+        return candidate
+    return None
 
 
 def get_local_skill_names(skills_dir: Path) -> set[str]:
@@ -511,7 +532,7 @@ def main() -> None:
     output_path = REPO_ROOT / args.output
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    token = os.environ.get("GITHUB_TOKEN")
+    token = resolve_github_token()
     local_names = get_local_skill_names(skills_dir)
     rejected_names, rejected_urls = load_rejected_keys(REPO_ROOT / args.rejected_file)
     print(f"Local skills indexed: {len(local_names)}")

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -25,6 +25,7 @@ import http.client
 import json
 import os
 import re
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -42,7 +43,27 @@ def github_raw_url(repo: str, path: str, ref: str = "main") -> str:
     return f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
 
 
-def fetch_url(url: str, token: str | None = None) -> str | None:
+def resolve_github_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+    candidate = result.stdout.strip()
+    if result.returncode == 0 and candidate:
+        return candidate
+    return None
+
+
+def fetch_url(url: str, token: str | None = None, *, quiet_404: bool = False) -> str | None:
     """Fetch content from a URL."""
     headers = {"User-Agent": "skills-sync-bot"}
     if token:
@@ -52,7 +73,12 @@ def fetch_url(url: str, token: str | None = None) -> str | None:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return resp.read().decode("utf-8", errors="replace")
     except (urllib.error.URLError, urllib.error.HTTPError, http.client.RemoteDisconnected, TimeoutError) as e:
-        print(f"    Warning: fetch failed for {url}: {e}", file=sys.stderr)
+        if not (
+            quiet_404
+            and isinstance(e, urllib.error.HTTPError)
+            and e.code == 404
+        ):
+            print(f"    Warning: fetch failed for {url}: {e}", file=sys.stderr)
         fallback = fetch_github_raw_via_api(url, token)
         if fallback is not None:
             return fallback
@@ -360,7 +386,14 @@ def check_upstream_changes(skill: dict, token: str | None) -> dict | None:
     
     for path in candidate_paths:
         url = github_raw_url(repo, path, skill.get("ref", "main"))
-        upstream_content = fetch_url(url, token)
+        try:
+            upstream_content = fetch_url(
+                url,
+                token,
+                quiet_404=len(candidate_paths) > 1 and path != candidate_paths[-1],
+            )
+        except TypeError:
+            upstream_content = fetch_url(url, token)
         if upstream_content:
             # Compare content (ignore frontmatter for diff)
             local_body = comparable_body(skill["local_content"])
@@ -440,7 +473,7 @@ def main() -> None:
                         help="Exclude a source/repo (can be passed multiple times; accepts github:owner/repo or owner/repo)")
     args = parser.parse_args()
 
-    token = os.environ.get("GITHUB_TOKEN")
+    token = resolve_github_token()
     skills = load_skills_with_upstream()
     
     if args.source:

--- a/skills/developer-engineering/neon-postgres/SKILL.md
+++ b/skills/developer-engineering/neon-postgres/SKILL.md
@@ -19,6 +19,14 @@ Guide the user through any Neon-related task: setup, connections, branching, and
 
 Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
 
+## Usage
+
+Use this skill when the user needs a current, practical Neon answer that ends in one of three outcomes:
+
+- a working Neon connection string and environment setup
+- a concrete Neon feature configuration such as branching, pooling, autoscaling, or auth
+- an official-docs-grounded explanation of how a Neon capability behaves
+
 ## Neon Documentation
 
 The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
@@ -275,3 +283,29 @@ Key points:
 - Useful for replicating to/from external Postgres systems.
 
 Link: https://neon.com/docs/guides/logical-replication-guide.md
+
+## Common Patterns
+
+### Pattern: existing app already has Postgres
+
+- inspect current ORM, driver, and `.env` usage first
+- swap only the connection string and driver-specific config needed for Neon
+- validate migrations and pooling behavior before changing any runtime code
+
+### Pattern: new project needs fastest Neon bootstrap
+
+- initialize Neon tooling with `neonctl` or the MCP server first
+- store `DATABASE_URL` in environment variables before adding ORM glue
+- choose the simplest driver compatible with the target runtime
+
+### Pattern: preview or branch-based workflows
+
+- create isolated branches for migrations and preview deployments
+- verify each branch has the correct compute endpoint before testing
+- document branch cleanup rules so temporary environments do not linger
+
+## Boundaries
+
+- Do not invent Neon product behavior when a current docs page can answer it directly.
+- Do not overwrite existing database credentials or `.env` values without first reading the file and preserving unrelated entries.
+- Do not recommend a single driver or auth path blindly; choose based on runtime constraints, auth needs, and deployment model.

--- a/skills/devops-sre/azure-kubernetes/SKILL.md
+++ b/skills/devops-sre/azure-kubernetes/SKILL.md
@@ -65,6 +65,25 @@ If the user is unsure, use safe defaults.
 - **AKS Automatic** (default): Best for most production workloads, provides a curated experience with pre-configured best practices for security, reliability, and performance. Use unless you have specific custom requirements for networking, autoscaling, or node pool configurations not supported by Node Auto-Provisioning (NAP).
 - **AKS Standard**: Use if you need full control over environment configuration, which requires additional overhead to set up and manage.
 
+### Example Starter Commands
+
+Use these only after the Day-0 decisions are explicit:
+
+```bash
+az aks create \
+  --resource-group <rg> \
+  --name <cluster-name> \
+  --tier standard \
+  --network-plugin azure \
+  --network-plugin-mode overlay \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --zones 1 2 3
+
+az aks show --resource-group <rg> --name <cluster-name>
+kubectl get nodes -o wide
+```
+
 ### 2. Networking (Pod IP, Egress, Ingress, Dataplane)
 
 **Pod IP Model** (Key Day-0 decision):

--- a/skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/SKILL.md
+++ b/skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: azure-kubernetes-automatic-readiness
 description: 'Assess Kubernetes workloads and cluster configuration for AKS Automatic compatibility. Identifies incompatibilities, generates fixes, and guides migration from AKS Standard to AKS Automatic. WHEN: migrate to AKS Automatic, check AKS Automatic readiness, validate manifests for Automatic, assess cluster for Automatic compatibility, fix deployment for Automatic compatibility, identify AKS Automatic migration blockers, is my cluster ready for AKS Automatic.'
+version: "1.0.0"
+author: "seaworld008"
+source: "github:microsoft/azure-skills"
+source_url: "https://skills.sh/microsoft/azure-skills/azure-kubernetes-automatic-readiness"
 license: MIT
+tags: '["azure", "aks", "kubernetes", "readiness", "migration"]'
+created_at: "2026-06-03"
+updated_at: "2026-06-08"
+quality: 4
+complexity: "intermediate"
 metadata:
   author: Microsoft
   version: "1.0.1"


### PR DESCRIPTION
## Summary
- make `discover_new_skills.py` and `sync_upstream.py` reuse the local `gh` authentication token when `GITHUB_TOKEN`/`GH_TOKEN` are unset
- reduce sync warning noise by suppressing exploratory `404` logs for non-final fallback path probes
- clear the remaining repository lint warnings in `azure-kubernetes`, `azure-kubernetes-automatic-readiness`, and `neon-postgres`

## What changed
- `scripts/discover_new_skills.py`
  - add `resolve_github_token()` with fallback to `gh auth token`
- `scripts/sync_upstream.py`
  - add the same token fallback
  - allow quiet handling for exploratory `404` fallback path checks
  - keep backward compatibility with tests that monkeypatch `fetch_url()`
- skills
  - add an example command block to `azure-kubernetes`
  - add missing recommended frontmatter fields to `azure-kubernetes-automatic-readiness`
  - add `Usage`, `Common Patterns`, and `Boundaries` sections to `neon-postgres`

## Validation
- `python scripts/discover_new_skills.py --output /tmp/discovery-check.json`
  - report errors reduced to `{}`
- `python scripts/sync_upstream.py --check-only`
  - completes with 3 real update candidates instead of auth/rate-limit warning noise
- full pipeline:
  - `python scripts/enrich_frontmatter.py`
  - `python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json`
  - `python scripts/refresh_repo_views.py`
  - `python scripts/generate_tags_index.py`
  - `python scripts/build_catalog_json.py`
  - `python scripts/check_readme_sync.py`
  - `python scripts/lint_skill_quality.py --min-lines 50`
  - `python scripts/audit_licenses.py`
  - `python -m unittest discover tests -v`

## Result
- lint is now `304 PASS / 0 WARN / 0 FAIL`
- unit tests: `73 passed`
