### PR TITLE
chore: harden recurring skills maintenance workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,29 @@ docs/TAGS-INDEX.md                    ← Cross-category tag-based index
 6. **Source provenance must be tracked** — every skill has an entry in `docs/sources/*.skills.json`.
 7. **Keep bilingual READMEs synchronized** — when updating `README.md`, update `README.en.md` in the same change and run `python scripts/check_readme_sync.py`.
 8. **Keep all public counts generated from one source of truth** — skill totals in README badges/text, `docs/catalog.json`, and `.github/assets/repo-banner.svg` must match the actual `skills/*/*/SKILL.md` tree. Run `python scripts/refresh_repo_views.py`, `python scripts/build_catalog_json.py`, and `python scripts/check_readme_sync.py`; never hand-edit counts or banner numbers.
+9. **Prefer authenticated GitHub access for automation** — before running discovery or upstream sync, verify `gh auth status`. If `GITHUB_TOKEN` / `GH_TOKEN` are unset, repository automation should fall back to the locally authenticated `gh` token instead of running unauthenticated searches that cause `401` or premature rate limiting.
+10. **Treat warning sources differently** — distinguish between actionable repository regressions (quality lint, missing frontmatter, generated diff drift) and external-state noise (GitHub API rate limits, exploratory `404` upstream paths, temporary DNS failures). Fix the former in the same run; report the latter with enough detail to retry or repair provenance later.
+11. **Prefer staged pull requests for recurring maintenance** — if the run includes both a focused additive change (for example a new skill) and a broad upstream sync, split them into separate `codex/` branches and PRs so review and rollback stay manageable.
 
 ---
 
 ## Automated Operations (SOP for AI Agents)
+
+### Recurring Run Preflight (每周例行前置检查)
+
+Run this before Operation 1/2/3:
+
+```bash
+git fetch origin --prune
+gh auth status
+git status --short --branch
+```
+
+Interpretation:
+
+- If `gh auth status` fails, fix GitHub authentication before discovery/sync work.
+- If the worktree is dirty, either stop or isolate the maintenance work on a fresh `codex/` branch after understanding the existing changes.
+- If network or DNS is down, do not trust `0 updates found` as a complete freshness result; record it as a partial check and retry once connectivity is restored.
 
 ### Operation 1: Discover & Add New Skills (全网搜集优秀技能)
 
@@ -42,6 +61,7 @@ docs/TAGS-INDEX.md                    ← Cross-category tag-based index
 ```
 Step 1: DISCOVER — Search all platforms for candidate skills
   ├── Run: python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json
+  │   (Uses `GITHUB_TOKEN` / `GH_TOKEN` when present, otherwise should reuse local `gh` authentication)
   ├── Additionally search manually via:
   │   ├── npx skills find "<keyword>"          (skills.sh)
   │   ├── clawhub search "<keyword>"           (ClawHub)
@@ -89,7 +109,8 @@ Step 4: PIPELINE — Run full refresh and validation
 Step 5: COMMIT & PUSH
   ├── git add -A
   ├── git commit -m "feat: add N new skills from <sources>"
-  └── git push
+  ├── git push
+  └── Prefer a focused PR if the run also includes bulk upstream sync changes
 ```
 
 ### Operation 2: Check & Update Existing Skills (检查并更新现有技能)
@@ -101,7 +122,7 @@ Step 5: COMMIT & PUSH
 ```
 Step 1: CHECK UPSTREAM — Scan for updated skills
   ├── Run: python scripts/sync_upstream.py --check-only
-  │   (Reads docs/sources/in-house.skills.json, checks upstream repos for new commits)
+  │   (Reads docs/sources/in-house.skills.json, checks upstream repos for new commits, and should reuse local `gh` auth if env tokens are absent)
   └── Output: list of skills with available updates and their diffs
 
 Step 2: APPLY UPDATES
@@ -110,12 +131,14 @@ Step 2: APPLY UPDATES
   ├── For each updated skill:
   │   ├── Preserve local frontmatter enrichments (tags, quality, etc.)
   │   ├── Update: updated_at, version (bump patch)
-  │   └── Verify content quality after merge
+  │   ├── Verify content quality after merge
+  │   └── If upstream becomes too thin for repository standards, add a local quality supplement instead of reverting the upstream body wholesale
   └── If conflicts exist, prefer upstream content but keep local frontmatter
 
 Step 3: QUALITY CHECK
   ├── python scripts/lint_skill_quality.py --min-lines 50
-  └── Manually review any WARN/FAIL results
+  ├── Fix WARN/FAIL items caused by repository quality policy in the same branch
+  └── Record external-state blockers separately (e.g. raw-path `404`, GitHub API `403 rate limit exceeded`)
 
 Step 4: PIPELINE — Same as Operation 1, Step 4
 
@@ -130,6 +153,12 @@ Step 5: COMMIT & PUSH
 **Trigger**: User says "add new and update existing", "全面更新", "搜集新的并更新旧的" or similar.
 
 **Procedure**: Execute Operation 2 first (update existing), then Operation 1 (add new). This ensures the baseline is current before adding new skills.
+
+**Preferred PR strategy**:
+
+- PR 1: small, focused additions or warning fixes
+- PR 2: bulk upstream sync
+- Merge only after each PR has passed the local full pipeline cleanly
 
 ---
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -2937,8 +2937,8 @@
       "quality": 2,
       "complexity": "intermediate",
       "created_at": "2026-03-15",
-      "updated_at": "2026-03-20",
-      "line_count": 122,
+      "updated_at": "2026-06-08",
+      "line_count": 145,
       "path": "skills/engineering-workflow-automation/github/SKILL.md"
     },
     {

--- a/openclaw-skills/github/SKILL.md
+++ b/openclaw-skills/github/SKILL.md
@@ -7,7 +7,7 @@ source: "in-house"
 source_url: ""
 tags: '["automation", "github", "workflow"]'
 created_at: "2026-03-15"
-updated_at: "2026-03-20"
+updated_at: "2026-06-08"
 quality: 2
 complexity: "intermediate"
 ---
@@ -38,6 +38,20 @@ npx clawhub@latest install github
 3. **策略生成 (Planning)**：执行动作前先生成“变更预览”（Preview），描述将要修改的标签、关闭的 Issue 或触发的 Action，避免大规模误操作。
 4. **动作执行 (Execution)**：调用 `gh` 指令执行具体动作。
 5. **状态同步 (Sync)**：执行后回写结果（如回复评论、添加标签、同步状态到 `MEMORY.md`）。
+
+### 本机 `gh` 认证优先
+
+在任何 GitHub 自动化前，先执行：
+
+```bash
+gh auth status
+```
+
+如果仓库脚本需要 GitHub API，但环境里没有显式的 `GITHUB_TOKEN` / `GH_TOKEN`，优先复用本机 `gh auth token`，而不是直接走未认证请求。这样可以显著减少：
+
+- `401 Unauthorized`
+- 过早触发的 API rate limit
+- 因匿名搜索受限导致的“误以为没有更新”
 
 ## 触发条件 / When to Use
 
@@ -75,6 +89,13 @@ npx clawhub@latest install github
   1. 使用 `gh api` 调用更底层的 GraphQL 或 REST API 获取历史统计数据。
   2. 统计 PR 合并周期（Lead Time）、Issue 关闭率等指标。
 
+### 5. 周期性仓库维护 (Recurring Maintenance)
+
+- 先 `git fetch origin --prune`，再做 discovery / upstream sync。
+- 如果同时存在“小而确定的修复”和“大批量同步”，拆成两个 `codex/` 分支与两个 PR。
+- 先合并聚焦 PR，再合并批量同步 PR，避免回滚时把不相关内容绑在一起。
+- 对 warning 做分类：仓库质量回归要当场修，外部 API `403` / 上游路径 `404` 要单独记录并在 PR 里说明。
+
 ## 常用命令/模板 / Common Patterns
 
 ### 自动 Issue 转换模板 (Issue from Discussion)
@@ -109,6 +130,7 @@ gh run view $RUN_ID --log > /tmp/ci-failure.log
 - **认证安全 (Auth Scopes)**：默认使用最小权限 Token。严禁在非受信任环境中显式导出 `GITHUB_TOKEN` 环境变量。
 - **破坏性操作红线**：删除分支、强制推送 (`--force`)、删除 Release 或批量关闭 Issue 必须经过人类二次确认。
 - **API 速率限制 (Rate Limiting)**：短时间内大规模调用 `gh api` 或 `gh search` 可能触发 GitHub 的 Secondary Rate Limit。
+- **告警解释**：不要把匿名 API 的 `401`、上游 fallback 探测时的中间 `404`、或短时网络故障误报成“仓库本身异常”；这类告警要和真实仓库回归分开汇报。
 - **合并冲突 (Conflicts)**：GitHub CLI 无法直接处理复杂的代码行冲突，此时必须回退到本地 `git` 环境进行人工 rebase。
 - **Workflow 自定义权限**：部分 Repo 限制了通过 CLI 触发 Actions 的权限。
 
@@ -120,3 +142,4 @@ gh run view $RUN_ID --log > /tmp/ci-failure.log
 4. **自动化与人工的边界**：代码审查（Review）建议主要由 LLM 提供参考，但最终的 `Approve` 动作应由人类执行。
 5. **日志可追溯**：记录每一次 `gh` 操作的输出，方便事后审计。
 6. **模板化管理**：充分利用 GitHub 仓库自带的 `.github/ISSUE_TEMPLATE` 提高规范度。
+7. **分阶段合并**：周期性维护优先拆成“聚焦修复 PR”和“批量同步 PR”，降低审查与回滚成本。

--- a/scripts/auto_curate_skills.py
+++ b/scripts/auto_curate_skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import re
 import subprocess
 import sys
@@ -103,6 +104,26 @@ DEFAULT_POLICY = {
 
 def resolve_python_cmd() -> list[str]:
     return [sys.executable] if sys.executable else ["python"]
+
+
+def resolve_github_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+    candidate = result.stdout.strip()
+    if result.returncode == 0 and candidate:
+        return candidate
+    return None
 
 
 def load_curation_policy(path: Path | None = None) -> dict:
@@ -395,6 +416,7 @@ def build_execution_plan(
     policy_path: str,
 ) -> list[dict]:
     steps: list[dict] = []
+    steps.append({"name": "github-auth-status", "cmd": ["gh", "auth", "status"]})
     if sync_mode == "check":
         steps.append({"name": "sync-upstream-check", "cmd": python_cmd + ["scripts/sync_upstream.py", "--check-only"]})
     elif sync_mode == "apply":
@@ -552,6 +574,10 @@ def create_pull_request(
             "create",
             "--base",
             base_branch,
+            "--label",
+            "codex",
+            "--label",
+            "codex-automation",
             "--title",
             title,
             "--body-file",
@@ -862,7 +888,7 @@ def ingest_candidates(
     python_cmd: list[str],
     policy: dict | None = None,
 ) -> dict:
-    token = None
+    token = resolve_github_token()
     ingested = []
     skipped = []
     unlicensed_rewrites = []

--- a/skills/engineering-workflow-automation/github/SKILL.md
+++ b/skills/engineering-workflow-automation/github/SKILL.md
@@ -7,7 +7,7 @@ source: "in-house"
 source_url: ""
 tags: '["automation", "github", "workflow"]'
 created_at: "2026-03-15"
-updated_at: "2026-03-20"
+updated_at: "2026-06-08"
 quality: 2
 complexity: "intermediate"
 ---
@@ -38,6 +38,20 @@ npx clawhub@latest install github
 3. **策略生成 (Planning)**：执行动作前先生成“变更预览”（Preview），描述将要修改的标签、关闭的 Issue 或触发的 Action，避免大规模误操作。
 4. **动作执行 (Execution)**：调用 `gh` 指令执行具体动作。
 5. **状态同步 (Sync)**：执行后回写结果（如回复评论、添加标签、同步状态到 `MEMORY.md`）。
+
+### 本机 `gh` 认证优先
+
+在任何 GitHub 自动化前，先执行：
+
+```bash
+gh auth status
+```
+
+如果仓库脚本需要 GitHub API，但环境里没有显式的 `GITHUB_TOKEN` / `GH_TOKEN`，优先复用本机 `gh auth token`，而不是直接走未认证请求。这样可以显著减少：
+
+- `401 Unauthorized`
+- 过早触发的 API rate limit
+- 因匿名搜索受限导致的“误以为没有更新”
 
 ## 触发条件 / When to Use
 
@@ -75,6 +89,13 @@ npx clawhub@latest install github
   1. 使用 `gh api` 调用更底层的 GraphQL 或 REST API 获取历史统计数据。
   2. 统计 PR 合并周期（Lead Time）、Issue 关闭率等指标。
 
+### 5. 周期性仓库维护 (Recurring Maintenance)
+
+- 先 `git fetch origin --prune`，再做 discovery / upstream sync。
+- 如果同时存在“小而确定的修复”和“大批量同步”，拆成两个 `codex/` 分支与两个 PR。
+- 先合并聚焦 PR，再合并批量同步 PR，避免回滚时把不相关内容绑在一起。
+- 对 warning 做分类：仓库质量回归要当场修，外部 API `403` / 上游路径 `404` 要单独记录并在 PR 里说明。
+
 ## 常用命令/模板 / Common Patterns
 
 ### 自动 Issue 转换模板 (Issue from Discussion)
@@ -109,6 +130,7 @@ gh run view $RUN_ID --log > /tmp/ci-failure.log
 - **认证安全 (Auth Scopes)**：默认使用最小权限 Token。严禁在非受信任环境中显式导出 `GITHUB_TOKEN` 环境变量。
 - **破坏性操作红线**：删除分支、强制推送 (`--force`)、删除 Release 或批量关闭 Issue 必须经过人类二次确认。
 - **API 速率限制 (Rate Limiting)**：短时间内大规模调用 `gh api` 或 `gh search` 可能触发 GitHub 的 Secondary Rate Limit。
+- **告警解释**：不要把匿名 API 的 `401`、上游 fallback 探测时的中间 `404`、或短时网络故障误报成“仓库本身异常”；这类告警要和真实仓库回归分开汇报。
 - **合并冲突 (Conflicts)**：GitHub CLI 无法直接处理复杂的代码行冲突，此时必须回退到本地 `git` 环境进行人工 rebase。
 - **Workflow 自定义权限**：部分 Repo 限制了通过 CLI 触发 Actions 的权限。
 
@@ -120,3 +142,4 @@ gh run view $RUN_ID --log > /tmp/ci-failure.log
 4. **自动化与人工的边界**：代码审查（Review）建议主要由 LLM 提供参考，但最终的 `Approve` 动作应由人类执行。
 5. **日志可追溯**：记录每一次 `gh` 操作的输出，方便事后审计。
 6. **模板化管理**：充分利用 GitHub 仓库自带的 `.github/ISSUE_TEMPLATE` 提高规范度。
+7. **分阶段合并**：周期性维护优先拆成“聚焦修复 PR”和“批量同步 PR”，降低审查与回滚成本。

--- a/tests/test_auto_curate_skills.py
+++ b/tests/test_auto_curate_skills.py
@@ -75,8 +75,9 @@ class AutoCurateSkillsTests(unittest.TestCase):
         )
 
         rendered = [" ".join(step["cmd"]) for step in plan]
-        self.assertIn("python scripts/sync_upstream.py --apply", rendered[0])
-        self.assertIn("python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json", rendered[1])
+        self.assertEqual("gh auth status", rendered[0])
+        self.assertIn("python scripts/sync_upstream.py --apply", rendered[1])
+        self.assertIn("python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json", rendered[2])
         self.assertTrue(
             any("python scripts/enrich_frontmatter.py" in command for command in rendered),
             rendered,
@@ -86,6 +87,17 @@ class AutoCurateSkillsTests(unittest.TestCase):
             rendered,
         )
         self.assertIn("python -m unittest discover tests -v", rendered[-1])
+
+    def test_resolve_github_token_falls_back_to_gh_cli(self):
+        module = load_module()
+
+        with mock.patch.dict(module.os.environ, {}, clear=True):
+            completed = mock.Mock(returncode=0, stdout="gho_example_token\n")
+            with mock.patch.object(module.subprocess, "run", return_value=completed) as run:
+                token = module.resolve_github_token()
+
+        self.assertEqual("gho_example_token", token)
+        run.assert_called_once()
 
     def test_curate_dry_run_writes_candidate_report(self):
         module = load_module()


### PR DESCRIPTION
## Summary
- codify recurring maintenance lessons in `AGENTS.md`
- make `auto_curate_skills.py` reuse local `gh` authentication and perform GitHub auth preflight
- improve the in-repo GitHub skill with recurring maintenance guidance and authenticated CLI best practices
- ensure automation-created PRs default to `codex` and `codex-automation` labels

## Changes
- `AGENTS.md`
  - add recurring-run preflight steps
  - distinguish actionable repository warnings from external-state noise
  - document staged PR strategy for weekly maintenance
- `scripts/auto_curate_skills.py`
  - add `resolve_github_token()` with `gh auth token` fallback
  - add `gh auth status` as the first execution-plan step
  - default generated PRs to labels `codex` and `codex-automation`
- `skills/engineering-workflow-automation/github/SKILL.md`
  - add local `gh` auth-first guidance
  - add recurring maintenance workflow advice
  - add warning interpretation guidance
- `tests/test_auto_curate_skills.py`
  - cover the new auth preflight step
  - cover token fallback behavior

## Validation
- `python -m unittest tests.test_auto_curate_skills -v`
- `python scripts/enrich_frontmatter.py`
- `python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json`
- `python scripts/refresh_repo_views.py`
- `python scripts/generate_tags_index.py`
- `python scripts/build_catalog_json.py`
- `python scripts/check_readme_sync.py`
- `python scripts/lint_skill_quality.py --min-lines 50`
- `python scripts/audit_licenses.py`
- `python -m unittest discover tests -v`

## Result
- repository validation: `304 PASS / 0 WARN / 0 FAIL`
- unit tests: `74 passed`
