### PR TITLE
docs: capture skill curation automation runbook

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,7 @@ Welcome to the documentation directory for the Commonly Used High-Value Skills r
 - [nlpm-audit Usage Guide](./nlpm-audit-usage.md)
 - [Optimization Roadmap](./OPTIMIZATION-ROADMAP.md)
 - [Skill Provenance & Governance](./skill-provenance-governance.md)
+- [Skill Curation & Automation Runbook](./skill-curation-and-automation-runbook.md)
 - [Repo Maintenance Runbook](./repo-maintenance-runbook.md)
 - [Sources](./sources/)
 - [Implementation Plans](./plans/)

--- a/docs/repo-maintenance-runbook.md
+++ b/docs/repo-maintenance-runbook.md
@@ -8,6 +8,8 @@
 - 外源技能必须带可解释的 `source` / `source_url` / `license`
 - 生成物不手改，统一通过脚本刷新
 - 仓库健康度以 `repo-health` 报告为总览入口
+- 技能组合质量以 `audit_skill_portfolio.py` 为长期精选入口
+- 每周自动化维护细则见 [Skill Curation and Automation Runbook](./skill-curation-and-automation-runbook.md)
 
 ## 2. 关键报告与它们回答的问题
 
@@ -55,6 +57,19 @@
 - 用途：
   - 判断哪些来源映射已经变陈旧，需要下一轮巡检
 
+### Skill Portfolio Audit
+
+- 文件：
+  - `docs/sources/reports/skill-quality-audit.json`
+  - `docs/sources/reports/skill-quality-audit.md`
+- 用途：
+  - 判断技能是否仍然适合留在高价值精选组合中
+  - 重点关注：
+    - `replace_or_archive`：优先人工复核，必要时替换或剔除
+    - `improve`：同轮补强正文、示例、触发描述或边界
+    - `review`：解释保留理由或列入下一轮队列
+    - `keep`：可保留，但仍需满足 frontmatter 和 license 规则
+
 ## 3. 本地推荐维护流程
 
 ### 快速检查
@@ -69,6 +84,7 @@ python3 scripts/check_dead_links.py \
 
 python3 scripts/generate_repo_health_report.py
 python3 scripts/evaluate_repo_health.py
+python3 scripts/audit_skill_portfolio.py
 ```
 
 ### 完整刷新
@@ -121,6 +137,26 @@ python3 -m unittest \
 2. 优先更新 `docs/sources/*.skills.json`
 3. 再跑 `bootstrap_in_house_sources.py` / `validate_skill_sources.py`
 
+### 情况 D：组合审计出现 `improve` 或 `replace_or_archive`
+
+处理顺序：
+
+1. 先人工复核，不要只按分数删除
+2. 能补强的优先补 `description`、`zh_description`、结构、示例和边界
+3. 与现有技能高度重复且价值低的，寻找更优 permissive 替代
+4. 上游消失但本地仍有价值的，标记 `sync_mode: archived` 或改为 `source: in-house`
+5. 删除或替换后跑完整 pipeline，确认生成视图、catalog、README 同步
+
+### 情况 E：缺失 `zh_description`
+
+处理顺序：
+
+1. 新增或更新技能时手写简洁中文说明
+2. 历史批量缺口使用 `python scripts/backfill_zh_descriptions.py --dry-run` 先预览
+3. 确认后运行 `python scripts/backfill_zh_descriptions.py`
+4. 如果描述过于泛化，再使用 `--refresh-generated` 刷新脚本识别到的生成描述
+5. 跑完整 pipeline，确保中文 README 和分类 README 从源文件再生成
+
 ## 5. CI 中当前已经自动做的事
 
 `repo-validation.yml` 现在会自动执行：
@@ -145,6 +181,8 @@ python3 -m unittest \
 - 证据不足时，不要为了“看起来干净”乱填元数据
 - 如果技能已经经过明显的中文化、扩写和结构重写，且无法唯一对应上游，应考虑改为 `in-house`
 - 统一健康报告优先于零散脚本输出，先看总览，再钻细节
+- 外部 SSL、TLS、rate limit、旧 raw path `404` 要和仓库质量回归分开记录
+- 没有更优替代时，不要为了清空 warning 删除仍有独特价值的技能
 
 ## 7. 目标状态
 

--- a/docs/skill-curation-and-automation-runbook.md
+++ b/docs/skill-curation-and-automation-runbook.md
@@ -1,0 +1,226 @@
+# Skill Curation and Automation Runbook
+
+这份 runbook 沉淀每周精选技能、上游同步、组合审计和自动化持续更新的实践经验。目标不是“尽可能多收集”，而是长期保持高价值、可追溯、可验证、可自动刷新的技能组合。
+
+## 1. 维护目标
+
+- 全库技能必须值得保留：低质技能要补强、替换或剔除。
+- 外部来源必须可追溯：复制外部文本前先确认 permissive license。
+- 未授权但高信号的候选只能做原创 in-house rewrite，不能复制 upstream 文本。
+- 生成文件只能通过 pipeline 更新，不能手工改。
+- 每周自动化必须使用强推理模型运行：`gpt-5.5`，`reasoning_effort = high`。
+- 维护输出必须能回答：新增了什么、更新了什么、为什么没有删除、哪些外部源被阻塞、验证是否干净。
+
+## 2. 每周推荐顺序
+
+先更新已有技能，再发现新技能，最后做组合审计。这样可以避免在陈旧基线上重复引入已经被上游改进的能力。
+
+```bash
+git fetch origin --prune
+gh auth status
+git status --short --branch
+
+python scripts/sync_upstream.py --check-only
+python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json
+python scripts/audit_skill_portfolio.py
+```
+
+如果发现有可应用的上游更新：
+
+```bash
+python scripts/sync_upstream.py --apply
+```
+
+如果发现新候选，先核验 license 和重复覆盖，再通过 ingestion 流程纳入：
+
+```bash
+python scripts/ingest_skill.py --dir skills/<category>/<skill-name> --source "<source_url>"
+```
+
+任何技能变更后都跑完整 pipeline：
+
+```bash
+python scripts/enrich_frontmatter.py && \
+python scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json && \
+python scripts/refresh_repo_views.py && \
+python scripts/generate_tags_index.py && \
+python scripts/build_catalog_json.py && \
+python scripts/check_readme_sync.py && \
+python scripts/lint_skill_quality.py --min-lines 50 && \
+python scripts/audit_licenses.py && \
+python -m unittest discover tests -v
+```
+
+## 3. 技能组合审计
+
+`lint_skill_quality.py` 回答“能不能提交”，`audit_skill_portfolio.py` 回答“是否值得在高价值组合里保留”。每轮维护都应看组合审计，而不是只看 lint。
+
+```bash
+python scripts/audit_skill_portfolio.py
+```
+
+审计结果按 action 处理：
+
+| Action | 含义 | 处理方式 |
+|---|---|---|
+| `keep` | 当前质量足够 | 保留；如有元数据小缺口则顺手修 |
+| `review` | 组合价值或触发描述需要人工判断 | 优先补 `description`、`zh_description`、结构、示例、边界 |
+| `improve` | 内容深度或可执行性不足 | 在同 PR 中补强；补不强则寻找替代 |
+| `replace_or_archive` | 不适合继续作为高价值技能 | 找更优质 permissive 替代；没有替代则归档或删除 |
+
+删除或替换前必须人工复核，不要只按分数机械删除。高质量但 upstream 消失的技能可以保留为本地维护快照，并在 provenance 中标记 `sync_mode: archived` 或改为 `source: in-house`。
+
+## 4. 精选新技能准入标准
+
+新技能必须同时满足：
+
+- 明确触发场景：frontmatter `description` 能让 Agent 判断何时使用。
+- 内容可执行：不少于 50 行，优先不少于 100 行，有步骤、命令、模板或代码块。
+- 覆盖不重复：不是现有技能的薄包装或同义复制。
+- 作用域清楚：解决一个明确任务，不是泛泛的“提升效率”。
+- 来源可追溯：`source`、`source_url`、license、provenance JSON 均完整。
+- 中文公开面完整：必须有短且准确的 `zh_description`。
+
+外部候选 license 决策：
+
+| 上游状态 | 可做动作 |
+|---|---|
+| MIT / Apache-2.0 / BSD / ISC 等 permissive license | 可复制或同步，保留 license 与来源 |
+| 无 license / license unknown | 不复制文本；只可原创 in-house rewrite |
+| copyleft / commercial / unclear terms | 默认不纳入，除非仓库策略明确允许 |
+| repo archived 但内容仍高价值 | 可保留本地快照，标记 archived，不再自动同步 |
+
+## 5. 中文 frontmatter 完整性
+
+`zh_description` 是中文 README、分类 README 和用户扫描体验的基础字段。新增或更新技能时不要只写英文描述。
+
+检查缺失：
+
+```bash
+python - <<'PY'
+from pathlib import Path
+missing = []
+for p in sorted(Path("skills").glob("*/*/SKILL.md")):
+    parts = p.read_text(encoding="utf-8", errors="replace").split("---", 2)
+    if len(parts) < 3 or "\nzh_description:" not in "\n" + parts[1]:
+        missing.append(str(p))
+print("missing_zh_description", len(missing))
+if missing:
+    print("\n".join(missing[:50]))
+PY
+```
+
+批量补齐历史缺口时使用脚本，不要手写生成物：
+
+```bash
+python scripts/backfill_zh_descriptions.py --dry-run
+python scripts/backfill_zh_descriptions.py
+```
+
+如果早期机器生成描述过于泛化，可刷新脚本识别到的生成描述：
+
+```bash
+python scripts/backfill_zh_descriptions.py --refresh-generated
+```
+
+补齐后必须跑完整 pipeline，让分类 README、OpenClaw export、catalog 和 tags index 保持一致。
+
+## 6. 外部阻塞源处理规则
+
+每周自动化会遇到网络和上游状态噪声。不要把外部噪声误判成仓库回归，也不要把真实元数据问题当成噪声忽略。
+
+| 信号 | 分类 | 处理 |
+|---|---|---|
+| ClawHub 偶发 SSL EOF | 外部临时噪声 | 重试；若 discovery 仍部分失败，在总结中记录 source health |
+| GitHub raw 旧路径 `404` | 可能是 provenance 陈旧 | 先尝试用 GitHub API / source_url 精确路径修复；确认消失后标记 archived 或 local-only |
+| `IncompleteRead` / TLS handshake 超时 | 外部临时噪声 | 脚本应短重试，不应中断整轮维护 |
+| GitHub API `403` rate limit | 外部限流 | 优先使用 `gh auth status` 和本地 gh token；记录 partial check |
+| license missing / unknown | 仓库治理问题 | 必须修复或改 in-house，不能只记录 |
+| generated diff drift | 仓库生成链路问题 | 重新跑 pipeline 并提交生成结果 |
+
+同步脚本应优先使用 provenance 中的精确 upstream path。对已归档或本地维护的来源，用以下字段阻止无意义 404 噪声：
+
+```json
+{
+  "upstream": {
+    "sync_mode": "archived",
+    "archived_at": "2026-06-29"
+  }
+}
+```
+
+或：
+
+```json
+{
+  "upstream": {
+    "sync_mode": "local-only"
+  }
+}
+```
+
+## 7. 替换和剔除策略
+
+只有同时满足以下条件时才剔除技能：
+
+- 组合审计为 `replace_or_archive` 或人工确认低价值。
+- 内容无法通过合理补强达到本仓库标准。
+- 没有独特触发场景，或与现有技能高度重复。
+- 删除不会破坏一个重要类别的能力覆盖。
+- provenance、README、OpenClaw export 和 catalog 可通过 pipeline 收敛。
+
+优先替换而不是直接删除。替换候选必须比原技能在至少两个维度上更好：更清晰触发、更深内容、更好示例、更可信来源、更活跃维护、更明确 license。
+
+如果没有更优替代，但本地版本仍有价值，应保留并改为 in-house 维护快照，而不是为了“清空 warning”删除。
+
+## 8. PR 和分支策略
+
+每周维护尽量拆成可审查 PR：
+
+- 上游同步 PR：只包含 upstream sync 和必要质量修复。
+- 新增技能 PR：只包含少量精选新增技能。
+- 审计/治理 PR：脚本、frontmatter、文档、生成视图收敛。
+
+分支命名使用 `codex/` 前缀。PR 标签优先加 `codex`；自动化发起的 PR 还应加 `codex-automation`。
+
+合并前必须满足：
+
+- `git diff --exit-code` 干净。
+- 完整 pipeline 通过。
+- `python scripts/audit_skill_portfolio.py` 没有 `improve` 或 `replace_or_archive`；如果仍有 `review`，PR 摘要必须解释原因和后续计划。
+- license audit 中 `MISSING = 0`，`UNKNOWN = 0`，除非有明确的暂存说明且不涉及复制外部文本。
+
+## 9. 自动化配置要求
+
+每周技能维护任务需要高推理预算，避免低模型把外部噪声误判为“无变化”或错误复制无 license 内容。
+
+推荐配置：
+
+```toml
+model = "gpt-5.5"
+reasoning_effort = "high"
+```
+
+自动化运行结束必须更新 memory，至少记录：
+
+- 运行时间。
+- 已合并 PR 和 merge commit。
+- 新增、更新、删除或保留的技能。
+- 组合审计 action mix。
+- 完整 pipeline 和测试结果。
+- 外部阻塞源：ClawHub、GitHub rate limit、旧 raw path 404、DNS/TLS 问题。
+- 是否有下一轮待办，尤其是 `review` 队列、license 缺口或 missing `zh_description`。
+
+## 10. 最终健康目标
+
+每周维护结束时，理想状态是：
+
+- `missing_zh_description 0`
+- `audit_skill_portfolio.py`: 全部 `keep`，或剩余 `review` 有明确解释
+- `lint_skill_quality.py --min-lines 50`: 0 FAIL / 0 WARN
+- `audit_licenses.py`: missing 0 / unknown 0
+- `check_readme_sync.py`: OK
+- `python -m unittest discover tests -v`: OK
+- `git status --short --branch`: 干净并同步 `origin/main`
+
+这组指标比单独的“发现了多少新技能”更重要。仓库的核心价值来自长期精选和可维护性，而不是数量增长。

--- a/docs/skill-provenance-governance.md
+++ b/docs/skill-provenance-governance.md
@@ -2,6 +2,8 @@
 
 > 目标：让仓库长期可持续“收藏 + 同步 + 优化”全网优质 skills，同时可追溯来源、可自动检查、可定期更新。
 
+每周精选、替换/剔除判断、外部阻塞源分类和自动化模型要求见 [Skill Curation and Automation Runbook](./skill-curation-and-automation-runbook.md)。
+
 ## 1) 基本原则
 
 1. **每个外部来源都要有机器可读记录**（JSON 映射）。

--- a/docs/upstream-sync-runbook.md
+++ b/docs/upstream-sync-runbook.md
@@ -2,6 +2,10 @@
 
 This repository supports two levels of automated upstream refresh.
 
+For the full weekly curation workflow, including portfolio audit, external
+blocker triage, replacement decisions, and automation model settings, see
+[Skill Curation and Automation Runbook](./skill-curation-and-automation-runbook.md).
+
 ## Sync Everything
 
 Use this for routine maintenance when upstream repositories may have changed:
@@ -59,3 +63,33 @@ An external skill is auto-upgradeable when its source mapping contains:
 ```
 
 The generic sync reads those exact paths from `docs/sources/*.skills.json`, fetches upstream content, keeps local enriched frontmatter, replaces the body, updates timestamps, and syncs same-directory auxiliary files when available.
+
+## Handling Noisy Or Retired Upstreams
+
+Do not treat every upstream fetch failure as a repository regression.
+
+- ClawHub SSL EOF, TLS handshake timeouts, and transient `IncompleteRead` errors are external noise. Retry briefly, record source health, and avoid marking the run as fully fresh if discovery was partial.
+- Old GitHub raw-path `404` responses usually mean the provenance path is stale. First repair the exact upstream path from `source_url` or the GitHub API.
+- If the upstream skill has genuinely disappeared but the local skill remains valuable, keep the local version and mark the mapping as archived or local-only instead of repeatedly failing future sync runs.
+- License gaps are not noise. Missing or unknown license metadata must be fixed, or the skill must become an original in-house rewrite before copying any upstream text.
+
+Example archived mapping:
+
+```json
+{
+  "upstream": {
+    "sync_mode": "archived",
+    "archived_at": "2026-06-29"
+  }
+}
+```
+
+Example local-only mapping:
+
+```json
+{
+  "upstream": {
+    "sync_mode": "local-only"
+  }
+}
+```


### PR DESCRIPTION
## Summary
- add a skill curation and automation runbook for weekly high-value skill maintenance
- document portfolio audit actions, external blocker triage, zh_description hygiene, replacement/removal rules, PR strategy, and required gpt-5.5 high automation setting
- link the new runbook from docs index, repo maintenance, provenance, and upstream sync docs

## Validation
- git diff --check
- python scripts/check_readme_sync.py
- python -m unittest discover tests -v