### PR TITLE
feat: add npx multi-client skill installer

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install test dependency
         run: python -m pip install pyyaml
 
@@ -39,6 +44,13 @@ jobs:
 
       - name: Check README sync
         run: python scripts/check_readme_sync.py
+
+      - name: Validate npx installer package
+        run: |
+          node --check bin/install-skills.js
+          node bin/install-skills.js --help
+          node bin/install-skills.js list-targets
+          npm pack --dry-run --silent
 
       - name: Generate repo health report
         run: python scripts/generate_repo_health_report.py

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ __pycache__/
 .vscode/
 .idea/
 
+# Local AI client skill installs
+.agents/
+.claude/
+.cursor/
+
 # Generated provenance artifacts (reproducible via scripts/provenance_pipeline.py)
 docs/sources/index.json
 docs/sources/reports/*.json

--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,47 @@ This repository currently contains **16 categories / 309 skills**.
 
 ## Quick Start
 
-### Option 1: Give This Prompt to Your AI Tool (Recommended)
+### Option 1: Install With npx
+
+If you do not want to clone and copy directories manually, run the installer directly from GitHub:
+
+```bash
+npx github:seaworld008/Commonly-used-high-value-skills install
+```
+
+By default, this installs skills into the current project's `.agents/skills` directory, which is a safe project-local target for agent skill consumers. You can also install into multiple client directories in one command:
+
+```bash
+# Install into Codex and Claude Code user-level skills directories
+npx github:seaworld008/Commonly-used-high-value-skills install --target codex,claude
+
+# Install into project .agents, Codex, Claude Code, Claude project, and OpenClaw default directories
+npx github:seaworld008/Commonly-used-high-value-skills install --all
+
+# Install into a custom directory for another AI agent client
+npx github:seaworld008/Commonly-used-high-value-skills install --target custom --dir ./vendor/agent-skills
+```
+
+Available targets:
+
+| Target | Install Directory |
+|--------|-------------------|
+| `agents-project` | `./.agents/skills` |
+| `codex` | `~/.codex/skills` |
+| `claude` | `~/.claude/skills` |
+| `claude-project` | `./.claude/skills` |
+| `openclaw` | `~/.openclaw/skills`; local clones prefer `openclaw-skills/`, while npx packages flatten `skills/` |
+| `custom` | selected with `--dir` |
+
+If you already use the `skills.sh` ecosystem, you can also try the standard installer:
+
+```bash
+npx skills add seaworld008/Commonly-used-high-value-skills --all -a codex -a claude-code --copy
+```
+
+This repository's own `high-value-skills` installer is the more explicit option when you need to choose Codex, Claude, OpenClaw, or a custom target directory.
+
+### Option 2: Give This Prompt to Your AI Tool
 
 If you want your AI tool to install the skills for you, start with this short prompt:
 
@@ -59,7 +99,7 @@ The current tool is `<Codex / Claude Code / Hermes Agent / Cursor / OpenClaw>`, 
 
 This works because the repository already includes AI-readable installation rules and directory conventions, so users usually do not need to spell out the full install workflow in the prompt.
 
-### Option 2: Manual Setup
+### Option 3: Manual Setup
 
 1. Clone the repository and enter it:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,47 @@
 | 安装到 `Claude Code` 本机技能目录 | 将 `skills/` 同步到 `~/.claude/skills` 或项目内 `.claude/skills` |
 | `OpenClaw` | `openclaw-skills/` |
 
-### 方式一：直接发给 AI 工具的安装提示词（推荐）
+### 方式一：npx 一键安装（推荐给命令行用户）
+
+不想手动 clone 和复制目录时，可以直接用 GitHub 源运行安装器：
+
+```bash
+npx github:seaworld008/Commonly-used-high-value-skills install
+```
+
+默认会把技能安装到当前项目的 `.agents/skills`，适合多种支持 Agent Skills 约定的工具读取。你也可以一次安装到多个客户端目录：
+
+```bash
+# 安装到 Codex 和 Claude Code 的用户级 skills 目录
+npx github:seaworld008/Commonly-used-high-value-skills install --target codex,claude
+
+# 安装到项目 .agents、Codex、Claude Code、Claude 项目级和 OpenClaw 默认目录
+npx github:seaworld008/Commonly-used-high-value-skills install --all
+
+# 安装到自定义目录，适配其他 AI Agent 客户端
+npx github:seaworld008/Commonly-used-high-value-skills install --target custom --dir ./vendor/agent-skills
+```
+
+可用目标：
+
+| 目标 | 安装目录 |
+|------|----------|
+| `agents-project` | `./.agents/skills` |
+| `codex` | `~/.codex/skills` |
+| `claude` | `~/.claude/skills` |
+| `claude-project` | `./.claude/skills` |
+| `openclaw` | `~/.openclaw/skills`，本地仓库优先使用 `openclaw-skills/`，npx 包会从 `skills/` 平铺安装 |
+| `custom` | 通过 `--dir` 指定 |
+
+如果你已经在使用 `skills.sh` 生态，也可以尝试标准安装入口：
+
+```bash
+npx skills add seaworld008/Commonly-used-high-value-skills --all -a codex -a claude-code --copy
+```
+
+本仓库自带的 `high-value-skills` 安装器更适合需要明确选择 Codex / Claude / OpenClaw / 自定义目录的场景。
+
+### 方式二：直接发给 AI 工具的安装提示词
 
 如果你希望让 AI 工具直接帮你安装，优先发这段短提示词：
 
@@ -57,7 +97,7 @@
 
 之所以可以这样简化，是因为仓库里已经包含给 AI 工具读取的安装规则与目录约定文档，通常不需要你手动把安装逻辑全部写进提示词里。
 
-### 方式二：手动安装步骤
+### 方式三：手动安装步骤
 
 1. 克隆本仓库到本地并进入目录：
 

--- a/bin/install-skills.js
+++ b/bin/install-skills.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_TARGET = "agents-project";
+const TARGETS = {
+  "agents-project": {
+    label: "project .agents skills",
+    dest: () => path.resolve(process.cwd(), ".agents", "skills"),
+    source: "skills",
+  },
+  codex: {
+    label: "Codex user skills",
+    dest: () => path.join(os.homedir(), ".codex", "skills"),
+    source: "skills",
+  },
+  claude: {
+    label: "Claude Code user skills",
+    dest: () => path.join(os.homedir(), ".claude", "skills"),
+    source: "skills",
+  },
+  "claude-project": {
+    label: "Claude Code project skills",
+    dest: () => path.resolve(process.cwd(), ".claude", "skills"),
+    source: "skills",
+  },
+  openclaw: {
+    label: "OpenClaw flat skills",
+    dest: () => path.join(os.homedir(), ".openclaw", "skills"),
+    source: "openclaw",
+  },
+};
+
+function printHelp() {
+  console.log(`Common High-Value Skills installer
+
+Usage:
+  high-value-skills install [options]
+  high-value-skills list-targets
+
+Examples:
+  npx github:seaworld008/Commonly-used-high-value-skills install
+  npx github:seaworld008/Commonly-used-high-value-skills install --target codex,claude
+  npx github:seaworld008/Commonly-used-high-value-skills install --all
+  npx github:seaworld008/Commonly-used-high-value-skills install --target custom --dir ./vendor/skills
+
+Options:
+  --target <names>       Comma-separated targets: agents-project, codex, claude, claude-project, openclaw, custom.
+                         Default: ${DEFAULT_TARGET}
+  --all                  Install to agents-project, codex, claude, claude-project, and openclaw.
+  --dir <path>           Destination directory. Required for --target custom; overrides destination for one target.
+  --source-root <path>   Override categorized source skills root. Mainly useful for tests or local forks.
+  --openclaw-root <path> Override flat OpenClaw source skills root. If unavailable, categorized skills are flattened.
+  --dry-run              Print what would be installed without writing files.
+  --help, -h             Show this help.
+
+Notes:
+  - Categorized skills are flattened during install so clients can discover each skill by name.
+  - Existing skills with the same name are replaced; unrelated existing skills in the destination are preserved.
+  - OpenClaw uses openclaw-skills/ when available; npm installs fall back to flattening skills/.
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    command: "install",
+    targets: [DEFAULT_TARGET],
+    all: false,
+    destDir: null,
+    sourceRoot: path.join(REPO_ROOT, "skills"),
+    openclawRoot: path.join(REPO_ROOT, "openclaw-skills"),
+    dryRun: false,
+  };
+
+  const input = [...argv];
+  if (input[0] && !input[0].startsWith("-")) {
+    args.command = input.shift();
+  }
+
+  for (let i = 0; i < input.length; i += 1) {
+    const flag = input[i];
+    if (flag === "--help" || flag === "-h") {
+      args.command = "help";
+    } else if (flag === "--all") {
+      args.all = true;
+    } else if (flag === "--dry-run") {
+      args.dryRun = true;
+    } else if (flag === "--target") {
+      args.targets = parseTargetList(requireValue(input, ++i, flag));
+    } else if (flag.startsWith("--target=")) {
+      args.targets = parseTargetList(flag.slice("--target=".length));
+    } else if (flag === "--dir") {
+      args.destDir = expandPath(requireValue(input, ++i, flag));
+    } else if (flag.startsWith("--dir=")) {
+      args.destDir = expandPath(flag.slice("--dir=".length));
+    } else if (flag === "--source-root") {
+      args.sourceRoot = expandPath(requireValue(input, ++i, flag));
+    } else if (flag.startsWith("--source-root=")) {
+      args.sourceRoot = expandPath(flag.slice("--source-root=".length));
+    } else if (flag === "--openclaw-root") {
+      args.openclawRoot = expandPath(requireValue(input, ++i, flag));
+    } else if (flag.startsWith("--openclaw-root=")) {
+      args.openclawRoot = expandPath(flag.slice("--openclaw-root=".length));
+    } else {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+
+  if (args.all) {
+    args.targets = ["agents-project", "codex", "claude", "claude-project", "openclaw"];
+  }
+  return args;
+}
+
+function requireValue(input, index, flag) {
+  const value = input[index];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseTargetList(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function expandPath(value) {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return path.resolve(process.cwd(), value);
+}
+
+function listTargets() {
+  console.log("Available targets:");
+  for (const [name, config] of Object.entries(TARGETS)) {
+    console.log(`  ${name.padEnd(15)} ${config.label} -> ${config.dest()}`);
+  }
+  console.log("  custom          custom destination selected with --dir");
+}
+
+function discoverCategorizedSkills(sourceRoot) {
+  const skills = [];
+  for (const category of safeReaddir(sourceRoot)) {
+    const categoryPath = path.join(sourceRoot, category);
+    if (!fs.statSync(categoryPath).isDirectory()) {
+      continue;
+    }
+    for (const skillName of safeReaddir(categoryPath)) {
+      const skillPath = path.join(categoryPath, skillName);
+      if (fs.statSync(skillPath).isDirectory() && fs.existsSync(path.join(skillPath, "SKILL.md"))) {
+        skills.push({ name: skillName, sourceDir: skillPath });
+      }
+    }
+  }
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function discoverFlatSkills(sourceRoot) {
+  return safeReaddir(sourceRoot)
+    .map((skillName) => ({ name: skillName, sourceDir: path.join(sourceRoot, skillName) }))
+    .filter((skill) => fs.statSync(skill.sourceDir).isDirectory() && fs.existsSync(path.join(skill.sourceDir, "SKILL.md")))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function safeReaddir(dir) {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Source directory does not exist: ${dir}`);
+  }
+  return fs.readdirSync(dir).filter((name) => !name.startsWith("."));
+}
+
+function resolveInstallPlan(args, target) {
+  if (target === "custom") {
+    if (!args.destDir) {
+      throw new Error("--target custom requires --dir <path>");
+    }
+    return {
+      target,
+      label: "custom skills directory",
+      destRoot: args.destDir,
+      skills: discoverCategorizedSkills(args.sourceRoot),
+    };
+  }
+
+  const config = TARGETS[target];
+  if (!config) {
+    throw new Error(`Unknown target '${target}'. Run 'high-value-skills list-targets'.`);
+  }
+  if (args.destDir && args.targets.length > 1) {
+    throw new Error("--dir can only override a single target at a time");
+  }
+
+  const hasOpenClawExport = config.source === "openclaw" && fs.existsSync(args.openclawRoot);
+  const sourceRoot = hasOpenClawExport ? args.openclawRoot : args.sourceRoot;
+  const skills = hasOpenClawExport ? discoverFlatSkills(sourceRoot) : discoverCategorizedSkills(sourceRoot);
+  return {
+    target,
+    label: config.label,
+    destRoot: args.destDir || config.dest(),
+    skills,
+  };
+}
+
+function copySkill(sourceDir, destDir) {
+  fs.rmSync(destDir, { recursive: true, force: true });
+  fs.cpSync(sourceDir, destDir, {
+    recursive: true,
+    filter: (source) => !source.split(path.sep).includes("__pycache__"),
+  });
+}
+
+function installPlan(plan, dryRun) {
+  const existing = fs.existsSync(plan.destRoot)
+    ? new Set(
+        fs
+          .readdirSync(plan.destRoot)
+          .filter((name) => fs.statSync(path.join(plan.destRoot, name)).isDirectory())
+      )
+    : new Set();
+
+  let added = 0;
+  let updated = 0;
+  if (!dryRun) {
+    fs.mkdirSync(plan.destRoot, { recursive: true });
+  }
+
+  for (const skill of plan.skills) {
+    const destDir = path.join(plan.destRoot, skill.name);
+    if (existing.has(skill.name)) {
+      updated += 1;
+    } else {
+      added += 1;
+    }
+    if (!dryRun) {
+      copySkill(skill.sourceDir, destDir);
+    }
+  }
+
+  const preserved = [...existing].filter((name) => !plan.skills.some((skill) => skill.name === name)).sort();
+  return {
+    target: plan.target,
+    label: plan.label,
+    destRoot: plan.destRoot,
+    skillCount: plan.skills.length,
+    added,
+    updated,
+    preserved: preserved.length,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.command === "help") {
+    printHelp();
+    return 0;
+  }
+  if (args.command === "list-targets") {
+    listTargets();
+    return 0;
+  }
+  if (args.command !== "install") {
+    throw new Error(`Unknown command: ${args.command}`);
+  }
+
+  const summaries = [];
+  for (const target of args.targets) {
+    const plan = resolveInstallPlan(args, target);
+    summaries.push(installPlan(plan, args.dryRun));
+  }
+
+  for (const summary of summaries) {
+    const prefix = args.dryRun ? "[dry-run] Would install" : "Installed";
+    console.log(
+      `${prefix} ${summary.skillCount} skills to ${summary.label} (${summary.destRoot}). ` +
+        `Added: ${summary.added}, Updated: ${summary.updated}, Preserved extras: ${summary.preserved}.`
+    );
+  }
+  return 0;
+}
+
+try {
+  process.exitCode = main();
+} catch (error) {
+  console.error(`error: ${error.message}`);
+  process.exitCode = 1;
+}

--- a/docs/client-install-guides.md
+++ b/docs/client-install-guides.md
@@ -20,7 +20,55 @@
 
 ---
 
-## 1. Codex
+## 1. npx 一键安装
+
+本仓库提供 npm package 入口，可以通过 GitHub 源直接运行，不需要先手动 clone：
+
+```bash
+npx github:seaworld008/Commonly-used-high-value-skills install
+```
+
+默认目标是当前项目的 `.agents/skills`，适合需要项目级安装、又希望多种 Agent 工具都能读取的场景。
+
+常用目标：
+
+```bash
+# 安装到 Codex 用户级目录
+npx github:seaworld008/Commonly-used-high-value-skills install --target codex
+
+# 安装到 Claude Code 用户级目录
+npx github:seaworld008/Commonly-used-high-value-skills install --target claude
+
+# 安装到 Claude Code 项目级目录
+npx github:seaworld008/Commonly-used-high-value-skills install --target claude-project
+
+# 安装到 OpenClaw 默认目录；本地仓库优先使用 openclaw-skills/，npx 包会从 skills/ 平铺
+npx github:seaworld008/Commonly-used-high-value-skills install --target openclaw
+
+# 一次安装到多个默认目标
+npx github:seaworld008/Commonly-used-high-value-skills install --target agents-project,codex,claude
+
+# 自定义目录，适配其他客户端
+npx github:seaworld008/Commonly-used-high-value-skills install --target custom --dir ./vendor/agent-skills
+```
+
+查看所有目标：
+
+```bash
+npx github:seaworld008/Commonly-used-high-value-skills list-targets
+```
+
+如果你已经使用 `skills.sh`，也可以用它的通用入口安装：
+
+```bash
+npx skills add seaworld008/Commonly-used-high-value-skills --all -a codex -a claude-code --copy
+```
+
+仓库自带的安装器更明确地处理本仓库的双目录结构：本地 clone 里 `openclaw` 目标会优先使用 `openclaw-skills/`；通过 npx 安装时，为避免重复打包生成文件，会从 `skills/` 平铺安装。
+
+---
+
+## 2. Codex
 
 ### 推荐目录
 
@@ -53,7 +101,7 @@ python3 scripts/normalize_codex_skills.py ~/.codex/skills
 
 ---
 
-## 2. Claude Code
+## 3. Claude Code
 
 ### 推荐目录
 
@@ -87,7 +135,7 @@ python3 scripts/sync_codex_skills.py \
 
 ---
 
-## 3. Hermes Agent
+## 4. Hermes Agent
 
 ### 推荐目录
 
@@ -124,7 +172,7 @@ python3 scripts/sync_codex_skills.py \
 
 ---
 
-## 4. OpenClaw
+## 5. OpenClaw
 
 ### 推荐目录
 
@@ -167,7 +215,7 @@ openclaw skills check
 
 ---
 
-## 5. 给 AI 工具的最短安装提示词
+## 6. 给 AI 工具的最短安装提示词
 
 如果你希望让 AI 工具自己完成安装，可以先发这一段：
 
@@ -183,7 +231,7 @@ openclaw skills check
 
 ---
 
-## 6. 维护时推荐顺序
+## 7. 维护时推荐顺序
 
 如果你对仓库做了修改，建议按这个顺序刷新：
 
@@ -202,7 +250,7 @@ python3 scripts/export_openclaw_skills.py
 
 ---
 
-## 7. 什么时候该看哪份文档
+## 8. 什么时候该看哪份文档
 
 - 想快速开始：看根目录 `README.md` / `README.en.md`
 - 想按客户端接入：看本文件

--- a/docs/skill-curation-and-automation-runbook.md
+++ b/docs/skill-curation-and-automation-runbook.md
@@ -189,6 +189,7 @@ python scripts/backfill_zh_descriptions.py --refresh-generated
 - 完整 pipeline 通过。
 - `python scripts/audit_skill_portfolio.py` 没有 `improve` 或 `replace_or_archive`；如果仍有 `review`，PR 摘要必须解释原因和后续计划。
 - license audit 中 `MISSING = 0`，`UNKNOWN = 0`，除非有明确的暂存说明且不涉及复制外部文本。
+- 如果改动影响安装体验，必须验证 `node --check bin/install-skills.js`、`node bin/install-skills.js --help` 和 `npm pack --dry-run`。
 
 ## 9. 自动化配置要求
 
@@ -220,6 +221,8 @@ reasoning_effort = "high"
 - `lint_skill_quality.py --min-lines 50`: 0 FAIL / 0 WARN
 - `audit_licenses.py`: missing 0 / unknown 0
 - `check_readme_sync.py`: OK
+- `node bin/install-skills.js --help`: OK
+- `npm pack --dry-run`: OK
 - `python -m unittest discover tests -v`: OK
 - `git status --short --branch`: 干净并同步 `origin/main`
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "common-high-value-skills",
+  "version": "0.1.0",
+  "description": "Cross-agent installer for the Commonly Used High-Value Skills repository.",
+  "license": "MIT",
+  "type": "commonjs",
+  "bin": {
+    "high-value-skills": "bin/install-skills.js",
+    "common-high-value-skills": "bin/install-skills.js"
+  },
+  "files": [
+    "bin/",
+    "skills/",
+    "docs/client-install-guides.md",
+    "README.md",
+    "README.en.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --check bin/install-skills.js && node bin/install-skills.js --help && npm pack --dry-run --silent"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "ai",
+    "agent",
+    "skills",
+    "codex",
+    "claude",
+    "openclaw"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/seaworld008/Commonly-used-high-value-skills.git"
+  }
+}

--- a/tests/test_npx_installer.py
+++ b/tests/test_npx_installer.py
@@ -1,0 +1,80 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = REPO_ROOT / "bin" / "install-skills.js"
+PACKAGE_JSON = REPO_ROOT / "package.json"
+
+
+class NpxInstallerTests(unittest.TestCase):
+    def test_package_exposes_installer_bin_and_skill_files(self):
+        data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+
+        self.assertEqual("common-high-value-skills", data["name"])
+        self.assertEqual("bin/install-skills.js", data["bin"]["high-value-skills"])
+        self.assertIn("skills/", data["files"])
+        self.assertNotIn("openclaw-skills/", data["files"])
+
+    def test_installer_help_and_target_listing_work(self):
+        help_result = subprocess.run(
+            ["node", str(INSTALLER), "--help"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertIn("high-value-skills install", help_result.stdout)
+
+        targets_result = subprocess.run(
+            ["node", str(INSTALLER), "list-targets"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertIn("agents-project", targets_result.stdout)
+        self.assertIn("codex", targets_result.stdout)
+        self.assertIn("openclaw", targets_result.stdout)
+
+    def test_installer_flattens_categorized_skills_to_custom_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source" / "developer-engineering" / "sample-skill"
+            source.mkdir(parents=True)
+            (source / "SKILL.md").write_text(
+                "---\nname: sample-skill\ndescription: test skill\n---\n\n# Sample\n",
+                encoding="utf-8",
+            )
+            (source / "references").mkdir()
+            (source / "references" / "note.md").write_text("reference\n", encoding="utf-8")
+            dest = root / "installed"
+
+            result = subprocess.run(
+                [
+                    "node",
+                    str(INSTALLER),
+                    "install",
+                    "--target",
+                    "custom",
+                    "--source-root",
+                    str(root / "source"),
+                    "--dir",
+                    str(dest),
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertIn("Installed 1 skills", result.stdout)
+            self.assertTrue((dest / "sample-skill" / "SKILL.md").exists())
+            self.assertTrue((dest / "sample-skill" / "references" / "note.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repo_validation_workflow.py
+++ b/tests/test_repo_validation_workflow.py
@@ -32,6 +32,8 @@ class RepoValidationWorkflowTests(unittest.TestCase):
         self.assertIn("python scripts/evaluate_repo_health.py", commands)
         self.assertIn("python scripts/refresh_repo_views.py", commands)
         self.assertIn("python scripts/check_readme_sync.py", commands)
+        self.assertIn("node --check bin/install-skills.js", commands)
+        self.assertIn("npm pack --dry-run --silent", commands)
         self.assertIn("tests.test_check_readme_sync", commands)
         self.assertIn("GITHUB_STEP_SUMMARY", commands)
         self.assertIn("python -m unittest", commands)


### PR DESCRIPTION
## Summary
- add a package.json and npx-compatible installer for project .agents, Codex, Claude Code, OpenClaw, and custom skill directories
- document npx install flows in Chinese/English README and client install guide
- keep npm package size reasonable by shipping source skills only and flattening during install
- add CI and unit tests for the installer/package entry

## Validation
- full repository pipeline: enrich frontmatter, bootstrap sources, refresh views, tags, catalog, README sync, quality lint, license audit
- npm test
- python -m unittest discover tests -v
- audit_skill_portfolio.py: 309 keep / 0 review / 0 improve / 0 replace_or_archive
- npm pack dry-run: ~10.3MB package, ~36.8MB unpacked