### PR TITLE
fix: retain missing simota skill snapshots

### DIFF
--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -1,7 +1,7 @@
 {
   "video": {
     "url": "https://github.com/your-org/Commonly-used-high-value-skills",
-    "checked_at": "2026-07-20",
+    "checked_at": "2026-07-27",
     "note": "Auto-generated provenance mapping for all local skills."
   },
   "official_references": [
@@ -28,7 +28,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/agent-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -44,7 +44,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/agent-workflow-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -60,7 +60,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/agile-product-owner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -76,7 +76,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/algorithmic-art",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -92,7 +92,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/andrej-karpathy-skills",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -108,7 +108,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-design-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -124,7 +124,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-test-suite-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -140,7 +140,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/app-store-optimization",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -156,7 +156,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/aws-solution-architect",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -172,7 +172,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/azure-kubernetes",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -188,7 +188,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/brainstorming",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -204,7 +204,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/brand-guidelines",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -220,7 +220,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/campaign-analytics",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -236,7 +236,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/canvas-design",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -252,7 +252,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/capture-screen",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -268,7 +268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/cc-devops-skills",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -284,7 +284,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/changelog-generator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -300,7 +300,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/chatgpt-apps",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -316,7 +316,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/ci-cd-pipeline-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -332,7 +332,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/cli-demo-generator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -348,7 +348,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/cloudflare-deploy",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -364,7 +364,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/cloudflare-troubleshooting",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -380,7 +380,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/codebase-onboarding",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -396,7 +396,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/codeql-security-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -412,7 +412,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/competitive-teardown",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -428,7 +428,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/competitors-analysis",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -444,7 +444,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/comps-valuation-analyst",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -460,7 +460,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/confidence-check",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -476,7 +476,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/content-creator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -492,7 +492,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -508,7 +508,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-schema-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -524,7 +524,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/deep-research",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -540,7 +540,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/dependency-auditor",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -556,7 +556,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/develop-web-game",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -572,7 +572,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/doc",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -588,7 +588,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/doc-coauthoring",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -604,7 +604,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/docker-expert",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -620,7 +620,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/docs-cleaner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -636,7 +636,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/docx",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -652,7 +652,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/earnings-call-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -668,7 +668,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/env-secrets-manager",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -684,7 +684,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/event-driven-tracker",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -700,7 +700,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/excel-automation",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -716,7 +716,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/fact-checker",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -732,7 +732,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/factor-backtester",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -748,7 +748,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -764,7 +764,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma-implement-design",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -780,7 +780,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-analyst",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -796,7 +796,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-data-collector",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -812,7 +812,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/frontend-design",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -828,7 +828,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-address-comments",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -844,7 +844,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-fix-ci",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -860,7 +860,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/gha-security-review",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-21",
         "last_synced_commit": null
       }
@@ -876,7 +876,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/git-worktree-manager",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -892,7 +892,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/github",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -908,7 +908,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/github-contributor",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -924,7 +924,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/github-ops",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -940,7 +940,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/gog",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -956,7 +956,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/gpt-image2",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-24",
         "last_synced_commit": null
       }
@@ -972,7 +972,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/graphql-expert",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -988,7 +988,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/grype-syft-sbom-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -1004,7 +1004,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gsd-graphify-brownfield-bootstrap",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-16",
         "last_synced_commit": null
       }
@@ -1020,7 +1020,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-15",
         "last_synced_commit": null
       }
@@ -1036,7 +1036,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-15",
         "last_synced_commit": null
       }
@@ -1052,7 +1052,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/hermes-graphify-gsd-runtime-operator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-16",
         "last_synced_commit": null
       }
@@ -1068,7 +1068,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/i18n-expert",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1084,7 +1084,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/imagegen",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1100,7 +1100,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/incident-commander",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1116,7 +1116,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/input-guard",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1132,7 +1132,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/internal-comms",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1148,7 +1148,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/interview-system-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1164,7 +1164,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/investment-memo-writer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1180,7 +1180,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/jupyter-notebook",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1196,7 +1196,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/kubernetes-specialist",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1212,7 +1212,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/link-checker",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1228,7 +1228,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/macro-regime-monitor",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1244,7 +1244,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/markdown-tools",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1260,7 +1260,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1276,7 +1276,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1292,7 +1292,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/mcp-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1308,7 +1308,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/mcp-server-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1324,7 +1324,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/meeting-minutes-taker",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1340,7 +1340,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/mermaid-tools",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1356,7 +1356,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/migration-architect",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1372,7 +1372,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/monorepo-navigator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1388,7 +1388,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/neon-postgres",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -1404,7 +1404,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/neon-postgres-egress-optimizer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-29",
         "last_synced_commit": null
       }
@@ -1420,7 +1420,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/netlify-deploy",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1436,7 +1436,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/nextjs-app-router",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1452,7 +1452,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1468,7 +1468,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1484,7 +1484,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-research-documentation",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1500,7 +1500,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1516,7 +1516,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/observability-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1532,7 +1532,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/openai-docs",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1548,7 +1548,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/options-strategy-evaluator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1564,7 +1564,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/osv-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -1580,7 +1580,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pdf",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1596,7 +1596,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pdf-creator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1612,7 +1612,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/performance-profiler",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1628,7 +1628,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1644,7 +1644,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright-pro",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -1660,7 +1660,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/portfolio-risk-manager",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1676,7 +1676,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/ppt-creator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1692,7 +1692,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pptx",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1708,7 +1708,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/pr-review-expert",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1724,7 +1724,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-analysis",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1740,7 +1740,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-manager-toolkit",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1756,7 +1756,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-strategist",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1772,7 +1772,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/prompt-engineer-toolkit",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1788,7 +1788,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/prompt-optimizer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1804,7 +1804,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/promptfoo-evaluation",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1820,7 +1820,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/python-performance",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1836,7 +1836,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/qa-expert",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1852,7 +1852,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/rag-architect",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1868,7 +1868,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/task-understanding-decomposition/reflect-learn",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1884,7 +1884,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/release-manager",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1900,7 +1900,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/render-deploy",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1916,7 +1916,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/repomix-safe-mixer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1932,7 +1932,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/runbook-generator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1948,7 +1948,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/rust-engineer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1964,7 +1964,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/saas-scaffolder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1980,7 +1980,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/screenshot",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -1996,7 +1996,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/sec-filing-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2012,7 +2012,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-auditor",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -2028,7 +2028,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2044,7 +2044,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-ownership-map",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2060,7 +2060,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-review",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-21",
         "last_synced_commit": null
       }
@@ -2076,7 +2076,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-threat-model",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2092,7 +2092,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/semgrep-appsec-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -2108,7 +2108,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/senior-devops",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2124,7 +2124,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/sentry",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2140,7 +2140,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/seo-audit",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2156,7 +2156,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/skill-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2172,7 +2172,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/skill-tester",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2188,7 +2188,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/skill-vetter",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2204,7 +2204,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/skills-search",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2220,7 +2220,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/slack-gif-creator",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2236,7 +2236,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/social-media-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2252,7 +2252,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/sora",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2268,7 +2268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/speech",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2284,7 +2284,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/spreadsheet",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2300,7 +2300,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/stock-screener-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2316,7 +2316,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/supabase",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -2332,7 +2332,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/supabase-postgres",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2348,7 +2348,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/supabase-postgres-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-05",
         "last_synced_commit": null
       }
@@ -2364,7 +2364,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/supermemory",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2380,7 +2380,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/tailwind-design-system",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2396,7 +2396,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/teams-channel-post-writer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2412,7 +2412,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/tech-debt-tracker",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2428,7 +2428,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/terraform-engineer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2444,7 +2444,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/theme-factory",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2460,7 +2460,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/transcribe",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2476,7 +2476,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/transcript-fixer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2492,7 +2492,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/trivy-vulnerability-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -2508,7 +2508,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/tweetclaw-source-research",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-08",
         "last_synced_commit": null
       }
@@ -2524,7 +2524,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/twitter-reader",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2540,7 +2540,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/typescript-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2556,7 +2556,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-design-system",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2572,7 +2572,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-ux-pro-max",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null
       }
@@ -2588,7 +2588,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ux-researcher-designer",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2604,7 +2604,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/vercel-deploy",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2620,7 +2620,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/vercel-react-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-05",
         "last_synced_commit": null
       }
@@ -2636,7 +2636,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/vercel-react-view-transitions",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-08",
         "last_synced_commit": null
       }
@@ -2652,7 +2652,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/vuls-linux-cve-scanner",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null
       }
@@ -2668,7 +2668,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/weather",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2684,7 +2684,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/web-artifacts-builder",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2700,7 +2700,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/web-scraper",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2716,7 +2716,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/webapp-testing",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2732,7 +2732,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/writing-plans",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2748,7 +2748,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/x-twitter-scraper",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-06-22",
         "last_synced_commit": null
       }
@@ -2764,7 +2764,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/xlsx",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -2780,7 +2780,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/yeet",
         "ref": "main",
-        "last_checked_at": "2026-07-20",
+        "last_checked_at": "2026-07-27",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null
       }
@@ -3041,6 +3041,13 @@
     },
     {
       "date": "2026-07-20",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 173 local skills"
+    },
+    {
+      "date": "2026-07-27",
       "method": "local-scan",
       "target": "skills/*/*/SKILL.md",
       "result": "success",

--- a/scripts/sync_simota_agent_skills.py
+++ b/scripts/sync_simota_agent_skills.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from copy import deepcopy
 from datetime import date
 from pathlib import Path
 
@@ -15,7 +16,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_REPO = "simota/agent-skills"
 SOURCE_URL = f"https://github.com/{SOURCE_REPO}"
-SOURCE_FILE = REPO_ROOT / "docs" / "sources" / "simota-agent-skills-2026-04.skills.json"
+SOURCE_MAPPING_REL = Path("docs/sources/simota-agent-skills-2026-04.skills.json")
+SOURCE_FILE = REPO_ROOT / SOURCE_MAPPING_REL
 
 
 SELECTED_SKILLS: dict[str, list[tuple[str, str]]] = {
@@ -229,19 +231,51 @@ def normalize_text_tree(root: Path) -> None:
             path.write_text(normalized, encoding="utf-8")
 
 
-def import_selected(source_dir: Path, repo_root: Path, apply: bool) -> list[dict]:
+def load_existing_entries(repo_root: Path) -> dict[str, dict]:
+    mapping_path = repo_root / SOURCE_MAPPING_REL
+    if not mapping_path.exists():
+        return {}
+    payload = json.loads(mapping_path.read_text(encoding="utf-8"))
+    return {
+        entry["normalized_slug"]: entry
+        for entry in payload.get("skills", [])
+        if entry.get("normalized_slug")
+    }
+
+
+def import_selected(source_dir: Path, repo_root: Path, apply: bool) -> tuple[list[dict], list[str]]:
     today = date.today().isoformat()
     commit = source_commit(source_dir)
     imported: list[dict] = []
+    missing_upstream: list[str] = []
+    existing_entries = load_existing_entries(repo_root)
 
     for category, skills in SELECTED_SKILLS.items():
         for name, description in skills:
             source_skill_dir = source_dir / name
             source_skill_md = source_skill_dir / "SKILL.md"
-            if not source_skill_md.exists():
-                raise FileNotFoundError(f"Missing upstream skill: {source_skill_md}")
-
             destination = repo_root / "skills" / category / name
+            if not source_skill_md.exists():
+                existing = existing_entries.get(name)
+                if existing is None or not (destination / "SKILL.md").exists():
+                    raise FileNotFoundError(
+                        f"Missing upstream skill and no retained local snapshot: {source_skill_md}"
+                    )
+                retained = deepcopy(existing)
+                upstream = retained.setdefault("upstream", {})
+                upstream["last_checked_at"] = today
+                upstream["sync_mode"] = "local-only"
+                upstream["availability"] = "missing"
+                upstream.setdefault("missing_since", today)
+                retained["notes"] = (
+                    "Retained from the last permissively licensed upstream snapshot because "
+                    f"{name}/SKILL.md is no longer present in simota/agent-skills."
+                )
+                imported.append(retained)
+                missing_upstream.append(name)
+                print(f"WARNING: retaining local snapshot; upstream path missing: {name}/SKILL.md")
+                continue
+
             raw = source_skill_md.read_text(encoding="utf-8", errors="replace")
             _, body = split_frontmatter(raw)
             skill_text = render_frontmatter(category, name, description, today) + body.lstrip()
@@ -276,7 +310,7 @@ def import_selected(source_dir: Path, repo_root: Path, apply: bool) -> list[dict
                 }
             )
 
-    return imported
+    return imported, missing_upstream
 
 
 def write_source_mapping(entries: list[dict], repo_root: Path) -> None:
@@ -296,8 +330,9 @@ def write_source_mapping(entries: list[dict], repo_root: Path) -> None:
         ],
         "skills": entries,
     }
-    SOURCE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SOURCE_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    source_file = repo_root / SOURCE_MAPPING_REL
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def main() -> int:
@@ -310,15 +345,20 @@ def main() -> int:
     repo_root = Path(args.repo_root).resolve()
     source_dir, tempdir = resolve_source_dir(args.source_dir)
     try:
-        entries = import_selected(source_dir, repo_root, args.apply)
+        entries, missing_upstream = import_selected(source_dir, repo_root, args.apply)
         if args.apply:
             write_source_mapping(entries, repo_root)
         print(
             f"{'Imported' if args.apply else 'Would import'} "
             f"{len(entries)} simota skills across {len(SELECTED_SKILLS)} categories."
         )
+        if missing_upstream:
+            print(
+                "Retained local snapshots for missing upstream skills: "
+                + ", ".join(sorted(missing_upstream))
+            )
         if args.apply:
-            print(f"Mapping: {SOURCE_FILE}")
+            print(f"Mapping: {repo_root / SOURCE_MAPPING_REL}")
     finally:
         if tempdir is not None:
             tempdir.cleanup()

--- a/tests/test_sync_simota_agent_skills.py
+++ b/tests/test_sync_simota_agent_skills.py
@@ -1,0 +1,83 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import sync_simota_agent_skills as sync_simota
+
+
+class SyncSimotaAgentSkillsTests(unittest.TestCase):
+    def test_retains_local_snapshot_when_selected_upstream_skill_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_dir = root / "upstream"
+            source_dir.mkdir()
+            local_skill = root / "repo/skills/ai-agent-platform/arena/SKILL.md"
+            local_skill.parent.mkdir(parents=True)
+            local_skill.write_text("# Arena\n", encoding="utf-8")
+            mapping = root / "repo" / sync_simota.SOURCE_MAPPING_REL
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "normalized_slug": "arena",
+                                "repo_skill": "skills/ai-agent-platform/arena/SKILL.md",
+                                "notes": "Original note.",
+                                "upstream": {
+                                    "repo": sync_simota.SOURCE_REPO,
+                                    "path": "arena/SKILL.md",
+                                    "last_synced_commit": "abc123",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(
+                sync_simota,
+                "SELECTED_SKILLS",
+                {"ai-agent-platform": [("arena", "Arena description.")]},
+            ):
+                entries, missing = sync_simota.import_selected(
+                    source_dir,
+                    root / "repo",
+                    apply=False,
+                )
+
+            self.assertEqual(missing, ["arena"])
+            self.assertEqual(entries[0]["upstream"]["sync_mode"], "local-only")
+            self.assertEqual(entries[0]["upstream"]["availability"], "missing")
+            self.assertEqual(entries[0]["upstream"]["last_synced_commit"], "abc123")
+            self.assertIn("Retained from the last permissively licensed", entries[0]["notes"])
+
+    def test_missing_upstream_without_local_snapshot_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_dir = root / "upstream"
+            source_dir.mkdir()
+
+            with patch.object(
+                sync_simota,
+                "SELECTED_SKILLS",
+                {"ai-agent-platform": [("arena", "Arena description.")]},
+            ):
+                with self.assertRaisesRegex(FileNotFoundError, "no retained local snapshot"):
+                    sync_simota.import_selected(source_dir, root / "repo", apply=False)
+
+    def test_source_mapping_is_written_under_requested_repo_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            repo_root = Path(temp) / "repo"
+            sync_simota.write_source_mapping([], repo_root)
+
+            mapping = repo_root / sync_simota.SOURCE_MAPPING_REL
+            self.assertTrue(mapping.exists())
+            self.assertEqual(json.loads(mapping.read_text(encoding="utf-8"))["skills"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the unified upstream sync running when curated simota paths disappear
- retain permissively licensed local snapshots and mark them local-only in provenance
- add regression tests for retention, hard failure without a snapshot, and repo-root mapping writes
- refresh the generated in-house provenance check date through the repository pipeline

## Validation
- python3 scripts/enrich_frontmatter.py
- python3 scripts/bootstrap_in_house_sources.py --write-json docs/sources/in-house.skills.json
- python3 scripts/refresh_repo_views.py
- python3 scripts/generate_tags_index.py
- python3 scripts/build_catalog_json.py
- python3 scripts/check_readme_sync.py
- python3 scripts/lint_skill_quality.py --min-lines 50
- python3 scripts/audit_licenses.py
- python3 -m unittest discover tests -v
- python3 scripts/sync_simota_agent_skills.py