### PR TITLE
fix: use latest ClawHub installer for agent-hub

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -74,7 +74,7 @@
       "name": "agent-hub",
       "category": "ai-agent-platform",
       "description": "Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "author": "seaworld008",
       "source": "github:alirezarezvani/claude-skills",
       "source_url": "",
@@ -86,7 +86,7 @@
       "quality": 4,
       "complexity": "intermediate",
       "created_at": "2026-03-27",
-      "updated_at": "2026-07-20",
+      "updated_at": "2026-07-27",
       "line_count": 288,
       "path": "skills/ai-agent-platform/agent-hub/SKILL.md"
     },

--- a/openclaw-skills/agent-hub/SKILL.md
+++ b/openclaw-skills/agent-hub/SKILL.md
@@ -2,14 +2,14 @@
 name: agent-hub
 description: 'Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.'
 zh_description: "用于管理 Agent 能力中心、技能发现、路由和协作工作流。"
-version: "1.0.5"
+version: "1.0.6"
 author: "seaworld008"
 source: "github:alirezarezvani/claude-skills"
 source_url: ""
 license: MIT
 tags: '["agent", "ai", "hub"]'
 created_at: "2026-03-27"
-updated_at: "2026-07-20"
+updated_at: "2026-07-27"
 quality: 4
 complexity: "intermediate"
 ---
@@ -242,7 +242,7 @@ The coordinator should act when:
 cp -r engineering/agenthub ~/.claude/skills/agenthub
 
 # Or install via ClawHub
-clawhub install agenthub
+npx clawhub@latest install agenthub
 ```
 
 ## Scripts

--- a/skills/ai-agent-platform/agent-hub/SKILL.md
+++ b/skills/ai-agent-platform/agent-hub/SKILL.md
@@ -2,14 +2,14 @@
 name: agent-hub
 description: 'Multi-agent collaboration plugin that spawns N parallel subagents competing on the same task via git worktree isolation. Agents work independently, results are evaluated by metric or LLM judge, and the best branch is merged. Use when: user wants multiple approaches tried in parallel — code optimization, content variation, research exploration, or any task that benefits from parallel competition. Requires: a git repo.'
 zh_description: "用于管理 Agent 能力中心、技能发现、路由和协作工作流。"
-version: "1.0.5"
+version: "1.0.6"
 author: "seaworld008"
 source: "github:alirezarezvani/claude-skills"
 source_url: ""
 license: MIT
 tags: '["agent", "ai", "hub"]'
 created_at: "2026-03-27"
-updated_at: "2026-07-20"
+updated_at: "2026-07-27"
 quality: 4
 complexity: "intermediate"
 ---
@@ -242,7 +242,7 @@ The coordinator should act when:
 cp -r engineering/agenthub ~/.claude/skills/agenthub
 
 # Or install via ClawHub
-clawhub install agenthub
+npx clawhub@latest install agenthub
 ```
 
 ## Scripts


### PR DESCRIPTION
## Summary
- replace the remaining plain `clawhub install` command with `npx clawhub@latest install`
- bump agent-hub patch version and refresh generated catalog/export

## Validation
- freshness audit: 12 latest-installer commands, 0 plain install commands
- quality lint: 318 PASS, 0 WARN, 0 FAIL
- strict license audit: 0 missing, 0 unknown
- source coverage: 316/316
- unit tests: 91 passed
- git diff --check: clean