### PR TITLE
fix: reconcile recurring automation issues

### DIFF
--- a/.github/workflows/dead-links.yml
+++ b/.github/workflows/dead-links.yml
@@ -61,13 +61,84 @@ jobs:
               print("- No dead links detected.")
           PY
 
-      - name: Open issue
-        if: steps.probe.outputs.dead_count != '0'
-        uses: peter-evans/create-issue-from-file@v5
+      - name: Reconcile dead-link issue
+        if: steps.probe.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          DEAD_COUNT: ${{ steps.probe.outputs.dead_count }}
+          REPORT_PATH: dead-links-issue.md
         with:
-          title: "[Monthly] Dead link report: ${{ steps.probe.outputs.dead_count }} URLs unreachable"
-          content-filepath: dead-links-issue.md
-          labels: auto-sync,dead-links
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const titlePrefix = '[Monthly] Dead link report';
+            const labels = ['auto-sync', 'dead-links'];
+            const deadCount = Number(process.env.DEAD_COUNT || '0');
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: labels.join(','),
+              per_page: 100,
+            });
+            const matching = openIssues
+              .filter(issue => !issue.pull_request && issue.title.startsWith(titlePrefix))
+              .sort((a, b) => b.number - a.number);
+
+            if (deadCount > 0) {
+              const title = `${titlePrefix}: ${deadCount} URLs unreachable`;
+              const body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+              let primary = matching.shift();
+              if (primary) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: primary.number,
+                  title,
+                  body,
+                });
+              } else {
+                primary = (await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title,
+                  body,
+                  labels,
+                })).data;
+              }
+              for (const duplicate of matching) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: duplicate.number,
+                  body: `Superseded by #${primary.number}; future runs update one canonical report.`,
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: duplicate.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            } else {
+              for (const issue of matching) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: 'The latest monthly scan found no unreachable links. Closing automatically.',
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -22,10 +22,12 @@ jobs:
           python-version: '3.13'
 
       - name: Discover new skills from external sources
+        id: discovery
         run: python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json
         continue-on-error: true
 
       - name: Check upstream GitHub updates
+        id: upstream
         run: python scripts/check_upstream_github_updates.py --online --write-json docs/sources/reports/upstream-check.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,13 +37,83 @@ jobs:
         id: report
         run: python scripts/generate_sync_report.py --discovery docs/sources/reports/discovery.json --upstream docs/sources/reports/upstream-check.json --output docs/sources/reports/sync-report.md
 
-      - name: Create issue if updates found
-        if: steps.report.outputs.has_updates == 'true'
-        uses: peter-evans/create-issue-from-file@v5
+      - name: Reconcile weekly sync issue
+        if: steps.discovery.outcome == 'success' && steps.upstream.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          HAS_UPDATES: ${{ steps.report.outputs.has_updates }}
+          REPORT_PATH: docs/sources/reports/sync-report.md
         with:
-          title: "[Auto Sync] Weekly skill discovery report — ${{ github.event.schedule && 'scheduled' || 'manual' }}"
-          content-filepath: docs/sources/reports/sync-report.md
-          labels: auto-sync,skill-discovery
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = '[Auto Sync] Weekly skill discovery report';
+            const labels = ['auto-sync', 'skill-discovery'];
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const hasUpdates = process.env.HAS_UPDATES === 'true';
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: labels.join(','),
+              per_page: 100,
+            });
+            const matching = openIssues
+              .filter(issue => !issue.pull_request && issue.title.startsWith(title))
+              .sort((a, b) => b.number - a.number);
+
+            if (hasUpdates) {
+              let primary = matching.shift();
+              if (primary) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: primary.number,
+                  title,
+                  body: report,
+                });
+              } else {
+                primary = (await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title,
+                  body: report,
+                  labels,
+                })).data;
+              }
+              for (const duplicate of matching) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: duplicate.number,
+                  body: `Superseded by #${primary.number}; future runs update one canonical report.`,
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: duplicate.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            } else {
+              for (const issue of matching) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: 'The latest weekly scan found no meaningful discovery or upstream drift. Closing automatically.',
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
 
       - name: Upload reports as artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/check_dead_links.py
+++ b/scripts/check_dead_links.py
@@ -81,6 +81,7 @@ IGNORE_URL_SNIPPETS = (
     "hermes-agent.nousresearch.com/docs/developer-guide/",
     "ifrs-sustainability-standards-vector/ifrs-s2-climate-related-disclosures/",
     "x.com/user/status/",
+    "linkedin.com/posts/username_activity-",
 )
 # Treat these codes as ok; some servers block HEAD or require cookies.
 ACCEPTED_CODES = {200, 201, 202, 203, 204, 301, 302, 303, 307, 308, 400, 401, 403, 405, 429}
@@ -172,6 +173,11 @@ def curl_probe(url: str, method: str, timeout: int) -> tuple[int | None, str]:
         "skills-deadlink-bot/1.0",
         "--max-time",
         str(timeout),
+        "--retry",
+        "2",
+        "--retry-all-errors",
+        "--retry-delay",
+        "1",
         "--request",
         method,
         url,

--- a/scripts/check_upstream_github_updates.py
+++ b/scripts/check_upstream_github_updates.py
@@ -1,22 +1,51 @@
 #!/usr/bin/env python3
-"""Check upstream GitHub changes for mapped skills.
+"""Check mapped GitHub skills for meaningful upstream changes.
 
-By default runs in offline-safe mode (no network) and reports missing metadata.
-Use --online to query GitHub commits API and detect true upstream drift.
+Replacement-mode skills are compared after repository adaptations and local
+supplements are removed. Monitor-mode skills use their reviewed repository
+commit checkpoint. This avoids reporting an update merely because a mapping
+stores a repository-head SHA while GitHub's path history returns another SHA.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-def github_latest_commit(repo: str, path: str, ref: str) -> tuple[str | None, str | None, str | None]:
-    api = f"https://api.github.com/repos/{repo}/commits?path={urllib.parse.quote(path)}&sha={urllib.parse.quote(ref)}&per_page=1"
-    req = urllib.request.Request(api, headers={"User-Agent": "skills-provenance-bot"})
+from sync_upstream import (  # noqa: E402
+    check_upstream_changes,
+    github_commit_sha,
+    load_skills_with_upstream,
+    resolve_github_token,
+)
+
+
+def github_latest_path_commit(
+    repo: str,
+    path: str,
+    ref: str,
+    token: str | None,
+) -> tuple[str | None, str | None, str | None]:
+    api = (
+        f"https://api.github.com/repos/{repo}/commits"
+        f"?path={urllib.parse.quote(path)}"
+        f"&sha={urllib.parse.quote(ref)}&per_page=1"
+    )
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "skills-provenance-bot",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+    req = urllib.request.Request(api, headers=headers)
     with urllib.request.urlopen(req, timeout=20) as resp:
         payload = json.loads(resp.read().decode("utf-8"))
     if not payload:
@@ -27,78 +56,107 @@ def github_latest_commit(repo: str, path: str, ref: str) -> tuple[str | None, st
     return sha, date, None
 
 
+def online_result(skill: dict, token: str | None) -> dict:
+    """Return meaningful drift state plus display metadata for one skill."""
+    checked = check_upstream_changes(skill, token)
+    if checked is None:
+        return {
+            "needs_update": False,
+            "latest_commit": None,
+            "latest_commit_date": None,
+            "check_error": "upstream_content_unavailable",
+            "change_type": "unavailable",
+        }
+
+    change_type = checked.get("changes", "none")
+    latest_commit = None
+    latest_commit_date = None
+    check_error = None
+    try:
+        if skill.get("sync_mode") == "monitor":
+            latest_commit = checked.get("current_commit") or github_commit_sha(
+                skill["repo"],
+                skill.get("ref", "main"),
+                token,
+            )
+        else:
+            latest_commit, latest_commit_date, check_error = github_latest_path_commit(
+                skill["repo"],
+                checked.get("upstream_path") or skill.get("upstream_path") or "",
+                skill.get("ref", "main"),
+                token,
+            )
+    except Exception as exc:
+        check_error = f"commit_metadata: {exc}"
+
+    return {
+        "needs_update": change_type == "body_changed",
+        "latest_commit": latest_commit,
+        "latest_commit_date": latest_commit_date,
+        "check_error": check_error,
+        "change_type": change_type,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--online", action="store_true", help="Query GitHub API for real-time upstream checks")
+    parser.add_argument("--online", action="store_true", help="Query GitHub for meaningful upstream drift")
     parser.add_argument("--write-json", default="docs/sources/reports/upstream-check.json")
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
-    mappings = sorted((root / "docs/sources").glob("*.skills.json"))
-
+    skills = load_skills_with_upstream()
+    token = resolve_github_token() if args.online else None
     rows = []
-    for mapping in mappings:
-        data = json.loads(mapping.read_text(encoding="utf-8"))
-        for s in data.get("skills", []):
-            upstream = s.get("upstream") or {}
-            repo = upstream.get("repo")
-            path = upstream.get("path")
-            ref = upstream.get("ref") or "main"
-            last_synced = upstream.get("last_synced_commit")
-            status = s.get("status")
 
-            if not repo or repo == "local-repo/in-house":
-                continue
+    for skill in skills:
+        item = {
+            "mapping": Path(skill.get("mapping_path", "")).name or None,
+            "video_name": skill.get("name"),
+            "slug": skill.get("name"),
+            "repo_skill": str(skill["local_path"].relative_to(root)),
+            "status": "verified_in_repo",
+            "upstream_repo": skill["repo"],
+            "upstream_path": skill.get("upstream_path"),
+            "upstream_ref": skill.get("ref", "main"),
+            "sync_mode": skill.get("sync_mode", "replace"),
+            "last_synced_commit": skill.get("last_synced_commit"),
+            "needs_update": False,
+            "latest_commit": None,
+            "latest_commit_date": None,
+            "check_error": None,
+            "change_type": "offline",
+            "check_mode": "online" if args.online else "offline",
+        }
 
-            item = {
-                "mapping": mapping.name,
-                "video_name": s.get("video_name"),
-                "slug": s.get("normalized_slug"),
-                "repo_skill": s.get("repo_skill"),
-                "status": status,
-                "upstream_repo": repo,
-                "upstream_path": path,
-                "upstream_ref": ref,
-                "last_synced_commit": last_synced,
-                "needs_update": False,
-                "latest_commit": None,
-                "latest_commit_date": None,
-                "check_error": None,
-                "check_mode": "online" if args.online else "offline",
-            }
-
-            if not args.online:
-                if not last_synced:
-                    item["check_error"] = "missing_last_synced_commit"
-                rows.append(item)
-                continue
-
-            try:
-                sha, d, err = github_latest_commit(repo, path or "", ref)
-                item["latest_commit"] = sha
-                item["latest_commit_date"] = d
-                item["check_error"] = err
-                if sha and last_synced and sha != last_synced:
-                    item["needs_update"] = True
-                if sha and not last_synced:
-                    item["needs_update"] = True
-            except Exception as e:  # network/runtime errors are reported, not fatal
-                item["check_error"] = str(e)
-            rows.append(item)
+        if args.online:
+            item.update(online_result(skill, token))
+        elif not skill.get("last_synced_commit"):
+            item["check_error"] = "missing_last_synced_commit"
+        rows.append(item)
 
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "mode": "online" if args.online else "offline",
         "total_checked": len(rows),
-        "needs_update_count": sum(1 for r in rows if r.get("needs_update")),
+        "needs_update_count": sum(1 for row in rows if row["needs_update"]),
+        "check_error_count": sum(1 for row in rows if row["check_error"]),
         "rows": rows,
     }
 
     out = root / args.write_json
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote upstream check report: {out.relative_to(root)}")
-    print(f"Checked rows: {payload['total_checked']}, needs_update: {payload['needs_update_count']}")
+    try:
+        display_path = out.relative_to(root)
+    except ValueError:
+        display_path = out
+    print(f"Wrote upstream check report: {display_path}")
+    print(
+        f"Checked rows: {payload['total_checked']}, "
+        f"needs_update: {payload['needs_update_count']}, "
+        f"errors: {payload['check_error_count']}"
+    )
     return 0
 
 

--- a/tests/test_check_dead_links.py
+++ b/tests/test_check_dead_links.py
@@ -38,6 +38,7 @@ class CheckDeadLinksTests(unittest.TestCase):
             "http://www.larkoffice.com/sml/2.0",
             "https://api.semanticscholar.org/recommendations/v1/papers/",
             "https://x.com/user/status/456",
+            "https://www.linkedin.com/posts/username_activity-123",
         ]
         for url in urls:
             self.assertTrue(self.module.should_ignore_url(url), url)
@@ -50,6 +51,35 @@ class CheckDeadLinksTests(unittest.TestCase):
         ]
         for url in urls:
             self.assertFalse(self.module.should_ignore_url(url), url)
+
+    def test_curl_probe_retries_transient_failures(self) -> None:
+        command = {}
+
+        class Result:
+            returncode = 0
+            stdout = "200"
+            stderr = ""
+
+        original_which = self.module.shutil.which
+        original_run = self.module.subprocess.run
+        self.module.shutil.which = lambda _name: "/usr/bin/curl"
+
+        def fake_run(cmd, **_kwargs):
+            command["argv"] = cmd
+            return Result()
+
+        self.module.subprocess.run = fake_run
+        try:
+            status, error = self.module.curl_probe("https://example.test", "HEAD", 10)
+        finally:
+            self.module.shutil.which = original_which
+            self.module.subprocess.run = original_run
+
+        self.assertEqual(200, status)
+        self.assertEqual("", error)
+        self.assertIn("--retry-all-errors", command["argv"])
+        retry_index = command["argv"].index("--retry")
+        self.assertEqual("2", command["argv"][retry_index + 1])
 
 
 if __name__ == "__main__":

--- a/tests/test_check_upstream_github_updates.py
+++ b/tests/test_check_upstream_github_updates.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_upstream_github_updates.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_upstream_github_updates", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckUpstreamGitHubUpdatesTests(unittest.TestCase):
+    def test_equal_adapted_body_is_not_reported_when_commit_sha_differs(self):
+        module = load_module()
+        skill = {
+            "name": "demo",
+            "repo": "owner/repo",
+            "ref": "main",
+            "sync_mode": "replace",
+            "upstream_path": "skills/demo/SKILL.md",
+            "last_synced_commit": "repository-head-checkpoint",
+        }
+
+        original_check = module.check_upstream_changes
+        original_latest = module.github_latest_path_commit
+        module.check_upstream_changes = lambda _skill, _token: {
+            "changes": "none",
+            "upstream_path": "skills/demo/SKILL.md",
+        }
+        module.github_latest_path_commit = lambda *_args: (
+            "different-path-commit",
+            "2026-08-18T00:00:00Z",
+            None,
+        )
+        try:
+            result = module.online_result(skill, token="token")
+        finally:
+            module.check_upstream_changes = original_check
+            module.github_latest_path_commit = original_latest
+
+        self.assertFalse(result["needs_update"])
+        self.assertEqual("none", result["change_type"])
+        self.assertEqual("different-path-commit", result["latest_commit"])
+
+    def test_monitor_rollback_is_not_reported_as_update(self):
+        module = load_module()
+        skill = {
+            "name": "curated",
+            "repo": "owner/repo",
+            "ref": "main",
+            "sync_mode": "monitor",
+            "last_synced_commit": "reviewed-checkpoint",
+        }
+
+        original_check = module.check_upstream_changes
+        module.check_upstream_changes = lambda _skill, _token: {
+            "changes": "upstream_rollback",
+            "current_commit": "older-head",
+        }
+        try:
+            result = module.online_result(skill, token="token")
+        finally:
+            module.check_upstream_changes = original_check
+
+        self.assertFalse(result["needs_update"])
+        self.assertEqual("upstream_rollback", result["change_type"])
+        self.assertEqual("older-head", result["latest_commit"])
+
+    def test_main_accepts_absolute_output_path(self):
+        module = load_module()
+        original_load = module.load_skills_with_upstream
+        original_argv = sys.argv
+        module.load_skills_with_upstream = lambda: []
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output = Path(tmpdir) / "upstream.json"
+                sys.argv = [
+                    "check_upstream_github_updates.py",
+                    "--write-json",
+                    str(output),
+                ]
+                self.assertEqual(0, module.main())
+                self.assertEqual(0, json.loads(output.read_text())["total_checked"])
+        finally:
+            module.load_skills_with_upstream = original_load
+            sys.argv = original_argv
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dead_links_workflow.py
+++ b/tests/test_dead_links_workflow.py
@@ -31,6 +31,13 @@ class DeadLinksWorkflowTests(unittest.TestCase):
         ]
         self.assertTrue(upload_steps, "dead-links workflow should upload an artifact")
 
+        workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("actions/github-script@v7", workflow_text)
+        self.assertIn("if: steps.probe.outcome == 'success'", workflow_text)
+        self.assertIn("state_reason: 'completed'", workflow_text)
+        self.assertIn("latest monthly scan found no unreachable links", workflow_text)
+        self.assertNotIn("peter-evans/create-issue-from-file", workflow_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upstream_sync_workflow.py
+++ b/tests/test_upstream_sync_workflow.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "upstream-sync.yml"
+
+
+class UpstreamSyncWorkflowTests(unittest.TestCase):
+    def test_workflow_reconciles_one_canonical_issue(self):
+        data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+        job = data["jobs"]["discover-and-sync"]
+        steps = job["steps"]
+
+        reconcile = next(
+            step
+            for step in steps
+            if isinstance(step, dict) and step.get("name") == "Reconcile weekly sync issue"
+        )
+        self.assertEqual("actions/github-script@v7", reconcile["uses"])
+        self.assertEqual(
+            "steps.discovery.outcome == 'success' && steps.upstream.outcome == 'success'",
+            reconcile["if"],
+        )
+
+        script = reconcile["with"]["script"]
+        self.assertIn("github.rest.issues.create", script)
+        self.assertIn("github.rest.issues.update", script)
+        self.assertIn("state_reason: 'completed'", script)
+        self.assertIn("latest weekly scan found no meaningful", script)
+        self.assertNotIn(
+            "peter-evans/create-issue-from-file",
+            WORKFLOW_PATH.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect meaningful upstream body drift instead of comparing incompatible commit checkpoints
- use authenticated GitHub access and commit-aware monitor semantics
- update one canonical weekly/dead-link issue and close it automatically after a successful clean scan
- avoid closing reports when the underlying discovery or probe step failed
- ignore documented LinkedIn placeholders and retry transient link probe failures

## Live evidence
- upstream: 122 checked, 0 meaningful updates, 0 errors
- dead links: 360 checked, 0 unreachable

## Validation
- 117 unit tests passed
- strict quality, portfolio policy, licenses, source mappings, OpenClaw mappings, repository health, Python compile, Node installer/help/targets, npm pack, generator idempotency, and git diff --check passed

Resolves #80
Resolves #85