### PR TITLE
feat: add crash-safe artifact-set upstream sync

### DIFF
--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Validate provenance v2 after normalization
         run: |
           python scripts/validate_skill_sources.py
+          python scripts/reconcile_artifact_inventory.py --offline --check-clean --quiet
           python scripts/check_source_coverage.py --min-percent 100
 
       - name: Check README sync

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Discover new skills from external sources
         id: discovery
         run: python scripts/discover_new_skills.py --output docs/sources/reports/discovery.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Check upstream GitHub updates
@@ -38,10 +40,12 @@ jobs:
         run: python scripts/generate_sync_report.py --discovery docs/sources/reports/discovery.json --upstream docs/sources/reports/upstream-check.json --output docs/sources/reports/sync-report.md
 
       - name: Reconcile weekly sync issue
-        if: steps.discovery.outcome == 'success' && steps.upstream.outcome == 'success'
+        if: always()
         uses: actions/github-script@v7
         env:
-          HAS_UPDATES: ${{ steps.report.outputs.has_updates }}
+          NEEDS_ATTENTION: ${{ steps.report.outputs.needs_attention }}
+          SYNC_STATE: ${{ steps.report.outputs.sync_state }}
+          REPORT_OUTCOME: ${{ steps.report.outcome }}
           REPORT_PATH: docs/sources/reports/sync-report.md
         with:
           script: |
@@ -50,8 +54,17 @@ jobs:
             const repo = context.repo.repo;
             const title = '[Auto Sync] Weekly skill discovery report';
             const labels = ['auto-sync', 'skill-discovery'];
-            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
-            const hasUpdates = process.env.HAS_UPDATES === 'true';
+            const reportSucceeded = process.env.REPORT_OUTCOME === 'success';
+            const reportExists = fs.existsSync(process.env.REPORT_PATH);
+            const report = reportExists
+              ? fs.readFileSync(process.env.REPORT_PATH, 'utf8')
+              : '# Weekly Skill Sync Report\n\nReport rendering failed before an artifact was written.';
+            const needsAttention = reportSucceeded
+              ? process.env.NEEDS_ATTENTION === 'true'
+              : true;
+            const syncState = reportSucceeded
+              ? (process.env.SYNC_STATE || 'failed')
+              : 'failed';
             const openIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
@@ -60,10 +73,31 @@ jobs:
               per_page: 100,
             });
             const matching = openIssues
-              .filter(issue => !issue.pull_request && issue.title.startsWith(title))
+              .filter(issue => !issue.pull_request && issue.title === title)
               .sort((a, b) => b.number - a.number);
 
-            if (hasUpdates) {
+            if (syncState !== 'complete') {
+              const primary = matching.shift();
+              if (primary) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: primary.number,
+                  title,
+                  body: report,
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title,
+                  body: report,
+                  labels,
+                });
+              }
+              // A degraded or failed scan is not authoritative enough to close
+              // duplicates. Preserve every additional issue for human review.
+            } else if (needsAttention) {
               let primary = matching.shift();
               if (primary) {
                 await github.rest.issues.update({
@@ -103,7 +137,7 @@ jobs:
                   owner,
                   repo,
                   issue_number: issue.number,
-                  body: 'The latest weekly scan found no meaningful discovery or upstream drift. Closing automatically.',
+                  body: `The latest weekly scan completed with state ${syncState} and found no meaningful discovery or upstream drift. Closing automatically.`,
                 });
                 await github.rest.issues.update({
                   owner,
@@ -116,8 +150,32 @@ jobs:
             }
 
       - name: Upload reports as artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sync-reports
           path: docs/sources/reports/
           retention-days: 30
+
+      - name: Enforce sync automation state
+        if: always()
+        env:
+          SYNC_STATE: ${{ steps.report.outputs.sync_state }}
+          REPORT_OUTCOME: ${{ steps.report.outcome }}
+        run: |
+          if [ "$REPORT_OUTCOME" != "success" ]; then
+            echo "::error::Sync report rendering failed; refusing to trust or reconcile its outputs."
+            exit 1
+          fi
+          case "$SYNC_STATE" in
+            complete)
+              echo "Upstream automation completed."
+              ;;
+            degraded)
+              echo "::warning::Upstream automation is degraded; the canonical issue records required review."
+              ;;
+            *)
+              echo "::error::Upstream automation failed or produced no trustworthy state."
+              exit 1
+              ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ __pycache__/
 .agents/
 .claude/
 .cursor/
+.hvs-transactions/
+
+# Canonical managed artifact bundle; this is source data, not a local install.
+!skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/
+!skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/**
+!openclaw-skills/using-agent-skills/upstream-bundle/.claude/
+!openclaw-skills/using-agent-skills/upstream-bundle/.claude/**
 
 # Generated provenance artifacts (reproducible via scripts/provenance_pipeline.py)
 docs/sources/index.json

--- a/docs/ai-workflow-agent-skills-sync.md
+++ b/docs/ai-workflow-agent-skills-sync.md
@@ -5,36 +5,38 @@
 ## Refresh From Upstream
 
 ```bash
-python scripts/sync_addyosmani_agent_skills.py --apply --run-pipeline
+python scripts/sync_upstream.py --check-only \
+  --source github:addyosmani/agent-skills \
+  --report-json /tmp/addyosmani-upstream.json
 ```
 
-The sync script:
+This source follows a default branch, so it is deliberately monitor-only. The
+check inspects every declared artifact at one immutable commit and reports a
+commit-range review; it does not overwrite the curated collection.
 
-- clones `addyosmani/agent-skills` from `main`
-- imports every upstream `skills/*/SKILL.md` into `skills/ai-workflow/`
-- copies upstream shared `references/` into imported skills
-- stores Claude commands, plugin metadata, personas, hooks, docs, and references under `skills/ai-workflow/using-agent-skills/upstream-bundle/`
-- updates `docs/sources/addyosmani-agent-skills-2026-04.skills.json`
-- moves existing local workflow skills from `task-understanding-decomposition` into `ai-workflow`
+After reviewing the upstream commit range, update exact external artifacts and
+local curation overlays in a focused PR, then verify ownership:
+
+```bash
+python scripts/reconcile_artifact_inventory.py \
+  --mapping docs/sources/addyosmani-agent-skills-2026-04.skills.json \
+  --output /tmp/addyosmani-inventory.json
+```
+
+Do not use the historical bulk importer to bypass the monitor policy.
+
+For all upstream-backed canonical skills across the whole repository, use:
+
+```bash
+python scripts/sync_all_upstream_skills.py --apply --run-pipeline
+```
 
 ## Install Locally For Codex
 
 After the repository pipeline has run, sync the curated skills into the local Codex skill root:
 
 ```bash
-python scripts/sync_codex_skills.py --source-root skills --codex-root ~/.codex/skills
-```
-
-Or do the upstream refresh, repository pipeline, and local Codex sync in one command:
-
-```bash
-python scripts/sync_addyosmani_agent_skills.py --apply --run-pipeline --sync-codex-root ~/.codex/skills
-```
-
-For all upstream-backed skills across the whole repository, use:
-
-```bash
-python scripts/sync_all_upstream_skills.py --apply --run-pipeline
+node bin/install-skills.js install --target codex
 ```
 
 OpenClaw should continue to use the generated flat export:
@@ -45,10 +47,14 @@ openclaw-skills/
 
 ## Upstream Bundle
 
-The upstream project includes Claude Code slash commands, plugin metadata, specialist personas, hooks, and setup docs. These are preserved under:
+The upstream project includes Claude Code slash commands, plugin metadata,
+specialist personas, hooks, and setup docs. The retained historical bundle and
+repository-specific supplements live under:
 
 ```text
 skills/ai-workflow/using-agent-skills/upstream-bundle/
 ```
 
-Keep this bundle source-driven. Do not hand-edit those copied files; refresh with `scripts/sync_addyosmani_agent_skills.py --apply`.
+Its files are explicitly owned as external exact artifacts or
+`local-repo/curation` overlays. Do not change ownership by refreshing hashes;
+review the source range and update the provenance artifact mapping instead.

--- a/docs/skill-curation-and-automation-runbook.md
+++ b/docs/skill-curation-and-automation-runbook.md
@@ -8,7 +8,8 @@
 - 外部来源必须可追溯：复制外部文本前先确认 permissive license。
 - 未授权但高信号的候选只能做原创 in-house rewrite，不能复制 upstream 文本。
 - 生成文件只能通过 pipeline 更新，不能手工改。
-- 每周自动化必须使用强推理模型运行：`gpt-5.5`，`reasoning_effort = high`。
+- 每周自动化必须使用当期可用的强推理 agentic coding 模型，并设置
+  `reasoning_effort = high`；不要在治理规则中固定会过期的模型版本。
 - 维护输出必须能回答：新增了什么、更新了什么、为什么没有删除、哪些外部源被阻塞、验证是否干净。
 
 ## 2. 每周推荐顺序
@@ -33,6 +34,15 @@ python scripts/sync_upstream.py --check-only --record-check
 
 同步通道遵循以下边界：稳定 release 或不可变 fixed ref 可在门禁通过后自动更新；默认分支、canary 和组合依赖只做 monitor，必须按 commit range 人工复核。
 
+周期检查以机器报告为准，不以日志中的“0 updates”作为成功证明：
+
+```bash
+python scripts/sync_upstream.py --check-only \
+  --report-json /tmp/upstream-report.json
+```
+
+`complete`/`degraded`/`failed` 分别使用退出码 `0`/`2`/`1`。`degraded` 必须保留或更新复核 Issue；`failed` 必须使自动化失败，不能关闭既有 Issue。报告的七项计数必须守恒。
+
 如果发现有可应用的上游更新：
 
 ```bash
@@ -45,6 +55,18 @@ python scripts/sync_upstream.py --apply
 python scripts/ingest_skill.py --dir skills/<category>/<skill-name> --source "<source_url>"
 ```
 
+外部接入会先写独立 provenance v2 mapping，再执行 in-house bootstrap，避免外部技能被误登记为自研。GitHub 来源应同时给出精确路径；接入后用 artifact inventory 检查所有 sidecar 的所有权：
+
+```bash
+python scripts/ingest_skill.py \
+  --dir skills/<category>/<skill-name> \
+  --source "github:<owner>/<repo>" \
+  --source-url "https://github.com/<owner>/<repo>" \
+  --upstream-path "path/to/SKILL.md"
+python scripts/reconcile_artifact_inventory.py \
+  --output /tmp/artifact-inventory.json
+```
+
 任何技能变更后都跑完整 pipeline：
 
 ```bash
@@ -55,7 +77,9 @@ python scripts/generate_tags_index.py && \
 python scripts/build_catalog_json.py && \
 python scripts/check_readme_sync.py && \
 python scripts/lint_skill_quality.py --min-lines 50 && \
+python scripts/audit_skill_portfolio.py --check-policy && \
 python scripts/validate_skill_sources.py && \
+python scripts/reconcile_artifact_inventory.py --offline --check-clean --quiet && \
 python scripts/check_source_coverage.py --min-percent 100 && \
 python scripts/audit_licenses.py && \
 python -m pytest -q tests
@@ -78,7 +102,11 @@ python scripts/audit_skill_portfolio.py
 | `improve` | 内容深度或可执行性不足 | 在同 PR 中补强；补不强则寻找替代 |
 | `replace_or_archive` | 不适合继续作为高价值技能 | 找更优质 permissive 替代；没有替代则归档或删除 |
 
-删除或替换前必须人工复核，不要只按分数机械删除。高质量但 upstream 消失的技能可以保留为本地维护快照，并在 provenance 中标记 `sync_mode: archived` 或改为 `source: in-house`。
+删除或替换前必须人工复核，不要只按分数机械删除。高质量但 upstream
+消失的外部技能可以保留为 licensed `snapshot`，并在 v2 entry 与 origin
+中标记 `sync_mode: archived` 或 `local-only`。不能把已复制的外部内容
+简单改写成 `source: in-house` 来丢弃许可证 lineage；只有真正独立创作、
+不再复制上游表达的重写版才可转为 in-house。
 
 退役必须记录 decision ledger：替代项、独有资产、外部契约、许可证和安装端清理动作。只有替代技能完全覆盖意图，并且原技能没有独有脚本、高风险 guardrail、外部契约或验收标准时，才允许删除活动副本。
 
@@ -150,14 +178,30 @@ python scripts/backfill_zh_descriptions.py --refresh-generated
 | license missing / unknown | 仓库治理问题 | 必须修复或改 in-house，不能只记录 |
 | generated diff drift | 仓库生成链路问题 | 重新跑 pipeline 并提交生成结果 |
 
-同步脚本应优先使用 provenance 中的精确 upstream path。对已归档或本地维护的来源，用以下字段阻止无意义 404 噪声：
+同步脚本应优先使用 provenance 中的精确 upstream path。对已归档或本地维护
+的来源，要同时更新 v2 entry、origin 和兼容层 `upstream`，不能只改 legacy
+字段。例如：
+
+下面两个片段只展示状态迁移时必须同步修改的字段；未展示的 provenance
+v2 必填字段仍须保留并通过 schema 与 repository validator。
 
 ```json
 {
+  "kind": "snapshot",
+  "sync_mode": "archived",
   "upstream": {
     "sync_mode": "archived",
     "archived_at": "2026-06-29"
-  }
+  },
+  "origins": [{
+    "repo": "owner/repo",
+    "sync_mode": "archived",
+    "tracking": {
+      "channel": "fixed_ref",
+      "ref": "<immutable-commit>",
+      "resolved_commit": "<immutable-commit>"
+    }
+  }]
 }
 ```
 
@@ -165,9 +209,20 @@ python scripts/backfill_zh_descriptions.py --refresh-generated
 
 ```json
 {
+  "kind": "snapshot",
+  "sync_mode": "local-only",
   "upstream": {
     "sync_mode": "local-only"
-  }
+  },
+  "origins": [{
+    "repo": "owner/repo",
+    "sync_mode": "local-only",
+    "tracking": {
+      "channel": "fixed_ref",
+      "ref": "<immutable-commit>",
+      "resolved_commit": "<immutable-commit>"
+    }
+  }]
 }
 ```
 
@@ -183,7 +238,9 @@ python scripts/backfill_zh_descriptions.py --refresh-generated
 
 优先替换而不是直接删除。替换候选必须比原技能在至少两个维度上更好：更清晰触发、更深内容、更好示例、更可信来源、更活跃维护、更明确 license。
 
-如果没有更优替代，但本地版本仍有价值，应保留并改为 in-house 维护快照，而不是为了“清空 warning”删除。
+如果没有更优替代，但本地版本仍有价值，应保留为带原许可证 lineage 的
+`snapshot`；只有完全原创重写的内容才改为 `in_house`。不能为了“清空
+warning”删除仍有独有价值的能力。
 
 ## 8. PR 和分支策略
 

--- a/docs/skill-provenance-governance.md
+++ b/docs/skill-provenance-governance.md
@@ -31,6 +31,9 @@
 - `scripts/check_upstream_github_updates.py`：检查 GitHub upstream 是否有更新（支持 offline/online 模式）
 - `scripts/provenance_pipeline.py`：统一执行入口（一条命令跑完整流程）
 - `scripts/migrate_provenance_v2.py`：来源映射 v1→v2 迁移与显式受管哈希刷新
+- `scripts/reconcile_artifact_inventory.py`：逐文件判定外部 exact artifact 与本地 curation overlay
+- `scripts/artifact_set_sync.py`：受管 artifact-set 的事务式暂存、替换、回滚与安全删除
+- `scripts/github_artifact_provider.py`：按不可变 commit 读取 GitHub tree/blob 与移动候选
 - `scripts/provenance_v2.schema.json`：provenance v2 的机器可读契约
 - `docs/sources/provenance.config.json`：统一配置（阈值/输出路径）
 
@@ -47,6 +50,26 @@
 
 所有活动 mapping 默认必须是 `schema_version: 2`。只有兼容旧 fixture 或迁移排障时才允许显式使用 `validate_skill_sources.py --allow-v1`。
 
+`managed_files` 不是“当前目录文件列表”的同义词，而是覆盖、更新和删除授权。只有以下两类文件可进入：
+
+- 在锁定 commit 上与上游 blob 字节完全一致的 external artifact；
+- 明确归属于 `local-repo/curation`、永不被外部 origin 覆盖的本地 overlay。
+
+首次治理或历史目录补录时先只读盘点，再显式写入：
+
+```bash
+python scripts/reconcile_artifact_inventory.py \
+  --output /tmp/artifact-inventory.json
+python scripts/reconcile_artifact_inventory.py \
+  --write --output /tmp/artifact-inventory-write.json
+python scripts/reconcile_artifact_inventory.py \
+  --offline --output /tmp/artifact-inventory-idempotence.json
+python scripts/reconcile_artifact_inventory.py \
+  --offline --check-clean --quiet
+```
+
+只要出现 `unavailable`、所有权冲突、受管哈希漂移、symlink 或扫描错误，写入必须停止；不能通过刷新 digest 消除用户修改证据。
+
 迁移默认只读：
 
 ```bash
@@ -62,7 +85,9 @@ python scripts/migrate_provenance_v2.py --refresh-managed-digests --write
 
 ### Release channel 策略
 
-- `latest_release`：可在许可证、签名/制品和 inventory 门禁通过后自动同步。
+- `latest_release`：canonical skill 只有在解析后的不可变 commit 上通过
+  许可证与 artifact inventory 门禁后才可自动同步；包签名、SLSA 与制品
+  完整性属于 bundle-specific tooling，不能由普通 skill sync 冒充。
 - `fixed_ref`：只有不可变 ref 才可自动同步。
 - `default_branch`、`canary`：一律 `monitor`，进入人工复核，不能自动覆盖 canonical 内容。
 - `local`：仅允许 `local-only`。
@@ -109,12 +134,32 @@ python scripts/migrate_provenance_v2.py --refresh-managed-digests --write
    - 验证命令与结果
    - 是否为原创（`in_house`）或外部来源
 
-检查上游时，`--check-only` 保证零写入；只有明确需要记录检查时间时才使用 `--record-check`：
+检查上游时，普通 `--check-only` 不修改 canonical skill 或 provenance
+mapping。显式 `--report-json` 会写报告，显式 `--record-check` 会更新
+mapping 的检查 checkpoint：
 
 ```bash
 python scripts/sync_upstream.py --check-only
 python scripts/sync_upstream.py --check-only --record-check
+python scripts/sync_upstream.py --check-only \
+  --report-json /tmp/upstream-report.json
 ```
+
+机器报告采用三态：
+
+- `complete`（退出码 `0`）：检查可信完成；可能包含可自动吸收的 `changed` 或显式 `expected_skipped`。
+- `degraded`（退出码 `2`）：存在 `monitor_review` 或上游 rollback，必须人工处理。
+- `failed`（退出码 `1`）：存在未预期 unavailable、空输入、记录失败或事务失败，禁止声称“全部最新”。
+
+报告必须满足：
+
+```text
+total = equal + changed + monitor_review + unavailable + rollback + expected_skipped
+```
+
+artifact apply 只覆盖所选 external origin 已有且 digest 未被用户修改的受管目标。其他 origin 的文件受到保护；上游删除只会 prune manifest 授权且当前 hash 仍匹配的文件。技能目录和 mapping 使用两阶段事务，mapping 未成功提交时必须恢复原 artifact set。
+
+跨 mapping/skill 的写入使用仓库私有状态目录 `.hvs-transactions/` 保存崩溃恢复 journal。该目录已被 Git 忽略；固定 `batch.lock` 可以长期存在。不要手工删除 `pending/` 或其中的原始文件：下一次受管写操作会在取得全局锁后自动判定完成或回滚，无法安全判定时会保留 recovery 路径并失败关闭。`--check-only`、`--dry-run` 和 inventory 只读检查既不会创建事务状态，也不会恢复或删除已有 journal；若只读路径发现待恢复事务，应先运行相应的受管写操作完成恢复。
 
 ## 6) 定期更新策略（建议）
 
@@ -125,7 +170,12 @@ python scripts/sync_upstream.py --check-only --record-check
   - `python3 scripts/skills_refresh_planner.py --stale-days 30 --write-json docs/sources/reports/refresh-queue.json`
   - `python3 scripts/build_skills_catalog.py --write-json docs/sources/reports/catalog.json`
   - `python3 scripts/generate_sources_index.py --write-json docs/sources/index.json`
-  - `python3 scripts/check_upstream_github_updates.py --write-json docs/sources/reports/upstream-check.json`
+  - `python3 scripts/check_upstream_github_updates.py --online --write-json docs/sources/reports/upstream-check.json`
+
+不带 `--online` 的检查只用于确定性 inventory/CI 结构验证，永远不能
+返回 `complete`；有效离线盘点为 `degraded`，空输入、inventory 错误或
+unavailable 仍必须是 `failed`。它不能作为“当前上游已是最新”的新鲜度
+证据。
 - 通过 refresh queue 的 `priority` 字段批量处理最紧急条目。
 - 通过 catalog 的 `conflicts` 字段快速发现跨来源 slug 冲突。
 - 通过 sources index 快速查看全局覆盖率与状态分布。
@@ -155,6 +205,9 @@ python scripts/sync_upstream.py --check-only --record-check
 - [x] 增加来源覆盖率门禁
 - [x] provenance v2 来源、artifact、许可证与依赖 DAG 门禁
 - [x] `--check-only` 零写入与显式 `--record-check`
+- [x] artifact-set 全文件同步、二进制安全与安全 prune
+- [x] external/local overlay 唯一所有权与历史 sidecar 全量纳管
+- [x] 周期任务 `complete/degraded/failed` 三态与守恒报告
 
 
 ## 9) 阶段收敛（告一段落）

--- a/docs/skill-provenance-governance.md
+++ b/docs/skill-provenance-governance.md
@@ -50,7 +50,7 @@
 
 所有活动 mapping 默认必须是 `schema_version: 2`。只有兼容旧 fixture 或迁移排障时才允许显式使用 `validate_skill_sources.py --allow-v1`。
 
-`managed_files` 不是“当前目录文件列表”的同义词，而是覆盖、更新和删除授权。只有以下两类文件可进入：
+`managed_files` 不是“当前目录文件列表”的同义词，而是覆盖、更新和删除授权。每条记录同时锁定 `sha256` 与 Git 可移植模式 `100644`/`100755`；仅执行位变化也属于必须复核或受管修复的状态变化。只有以下两类文件可进入：
 
 - 在锁定 commit 上与上游 blob 字节完全一致的 external artifact；
 - 明确归属于 `local-repo/curation`、永不被外部 origin 覆盖的本地 overlay。

--- a/docs/sources/addyosmani-agent-skills-2026-04.skills.json
+++ b/docs/sources/addyosmani-agent-skills-2026-04.skills.json
@@ -115,42 +115,50 @@
         {
           "path": "skills/ai-workflow/api-and-interface-design/SKILL.md",
           "sha256": "3468e0faecccd949ad7fd68780aac30ac770d51bc0c3258e7dce54d01640bf37",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/api-and-interface-design/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "api-and-interface-design"
+          "owner": "api-and-interface-design",
+          "mode": "100644"
         }
       ]
     },
@@ -251,42 +259,50 @@
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/SKILL.md",
           "sha256": "8cec167f87a7724bdd892494963481a4a6b40bf923ba6186e2d49854e6025c99",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "browser-testing-with-devtools"
+          "owner": "browser-testing-with-devtools",
+          "mode": "100644"
         }
       ]
     },
@@ -387,42 +403,50 @@
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/SKILL.md",
           "sha256": "3bad8c5989a0a1b2a2f49ddb6d26009010ef73378f024a6d517c98cfafb267be",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "ci-cd-and-automation"
+          "owner": "ci-cd-and-automation",
+          "mode": "100644"
         }
       ]
     },
@@ -523,42 +547,50 @@
         {
           "path": "skills/ai-workflow/code-review-and-quality/SKILL.md",
           "sha256": "b2d7e0bb79266f0326ec5336e8a6ef8f462a8314cc9dd4c66f9c90f6a66d1c86",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-review-and-quality/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "code-review-and-quality"
+          "owner": "code-review-and-quality",
+          "mode": "100644"
         }
       ]
     },
@@ -659,42 +691,50 @@
         {
           "path": "skills/ai-workflow/code-simplification/SKILL.md",
           "sha256": "a3d0674b7caea304f6047c0dd5f9efac499e821731aa54e0138b2d29adf89ac1",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/code-simplification/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "code-simplification"
+          "owner": "code-simplification",
+          "mode": "100644"
         }
       ]
     },
@@ -795,42 +835,50 @@
         {
           "path": "skills/ai-workflow/context-engineering/SKILL.md",
           "sha256": "4a31be187fc8e58e925c26f76d58db88a0dce2ca0055ae9ccb2ef1a4c5403c9f",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/context-engineering/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "context-engineering"
+          "owner": "context-engineering",
+          "mode": "100644"
         }
       ]
     },
@@ -931,42 +979,50 @@
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/SKILL.md",
           "sha256": "acf148e9bb8893787526d1663c6d9eef66f243328867833a43e1d015d9460b4e",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "debugging-and-error-recovery"
+          "owner": "debugging-and-error-recovery",
+          "mode": "100644"
         }
       ]
     },
@@ -1067,42 +1123,50 @@
         {
           "path": "skills/ai-workflow/deprecation-and-migration/SKILL.md",
           "sha256": "c48510a6b6f8fee4aca9d8581342d6212787237daa96fb3bab4eef7071f8e4ee",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deprecation-and-migration/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "deprecation-and-migration"
+          "owner": "deprecation-and-migration",
+          "mode": "100644"
         }
       ]
     },
@@ -1203,42 +1267,50 @@
         {
           "path": "skills/ai-workflow/documentation-and-adrs/SKILL.md",
           "sha256": "6a77f1f3153351da13d5b3a8a510c9c988627ad8072fa1c5254448f94d750cca",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/documentation-and-adrs/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "documentation-and-adrs"
+          "owner": "documentation-and-adrs",
+          "mode": "100644"
         }
       ]
     },
@@ -1339,42 +1411,50 @@
         {
           "path": "skills/ai-workflow/doubt-driven-development/SKILL.md",
           "sha256": "2e2b245c80c7cb03f475efa1153e257018e6e2e3092806a7acd8c279f5097b2e",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/doubt-driven-development/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "doubt-driven-development"
+          "owner": "doubt-driven-development",
+          "mode": "100644"
         }
       ]
     },
@@ -1475,42 +1555,50 @@
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/SKILL.md",
           "sha256": "966c423b383c8e6ec08a3d0c8da33b1ed21859f561ef3dc662cdaaf86a08a9a6",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "frontend-ui-engineering"
+          "owner": "frontend-ui-engineering",
+          "mode": "100644"
         }
       ]
     },
@@ -1611,42 +1699,50 @@
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/SKILL.md",
           "sha256": "b346d65a6f821f4ce91ac2d9e1494c6e1c0d991c06003d9e3c1138abd0c86199",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "git-workflow-and-versioning"
+          "owner": "git-workflow-and-versioning",
+          "mode": "100644"
         }
       ]
     },
@@ -1767,62 +1863,74 @@
         {
           "path": "skills/ai-workflow/idea-refine/SKILL.md",
           "sha256": "7b702aa564b22144e902e7c58954e9d230da31610649def250662a43fa30e1c2",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/examples.md",
           "sha256": "563204bfbf2f80a444151695205af4cb759e722b3d1e5460e08f278a69c89ba1",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/frameworks.md",
           "sha256": "161ebc18fdf2d996bc62a87a2d747cf1bf53548354f8925de25c732c27f00309",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/refinement-criteria.md",
           "sha256": "1ca2973a4d01b5cb37ab7ddb2eff77fa4e792634a33d0ce44961c068fc88d51a",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/idea-refine/scripts/idea-refine.sh",
           "sha256": "f02a52408a4218047c032d221483abfbb48d11f090bb4915965c7419bf2e0e47",
-          "owner": "idea-refine"
+          "owner": "idea-refine",
+          "mode": "100755"
         }
       ]
     },
@@ -1923,42 +2031,50 @@
         {
           "path": "skills/ai-workflow/incremental-implementation/SKILL.md",
           "sha256": "d0e039e6d9b50354f77cce5e082aa6e2bb45830d6c6c79f33b90e6a4ec13c4f3",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/incremental-implementation/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "incremental-implementation"
+          "owner": "incremental-implementation",
+          "mode": "100644"
         }
       ]
     },
@@ -2059,42 +2175,50 @@
         {
           "path": "skills/ai-workflow/interview-me/SKILL.md",
           "sha256": "53b1f74b1a9a6c3946d0681c3164f03316ccc8c70e07606a9fc6d895fe74f556",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/interview-me/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "interview-me"
+          "owner": "interview-me",
+          "mode": "100644"
         }
       ]
     },
@@ -2195,42 +2319,50 @@
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/SKILL.md",
           "sha256": "d814e7fb3ef08f46d8695bbd9cd1c16a5f5c7302842db3b4f9331a38f3405bfd",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "observability-and-instrumentation"
+          "owner": "observability-and-instrumentation",
+          "mode": "100644"
         }
       ]
     },
@@ -2331,42 +2463,50 @@
         {
           "path": "skills/ai-workflow/performance-optimization/SKILL.md",
           "sha256": "0367fdd12d2f2d0fdabd96a7171cf1559cca39979fc3e4cc09cff186485a0b09",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/performance-optimization/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "performance-optimization"
+          "owner": "performance-optimization",
+          "mode": "100644"
         }
       ]
     },
@@ -2467,42 +2607,50 @@
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/SKILL.md",
           "sha256": "875b99c85ce53a28a1be3e1ec8b537fff814669bb3f4d2d9eb5b431b213519c3",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "planning-and-task-breakdown"
+          "owner": "planning-and-task-breakdown",
+          "mode": "100644"
         }
       ]
     },
@@ -2603,42 +2751,50 @@
         {
           "path": "skills/ai-workflow/security-and-hardening/SKILL.md",
           "sha256": "b7f215bb94cbe8e242e0498b32c1f90b25b4fc258c0dbfd6dc9f5b2746f56887",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/security-and-hardening/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "security-and-hardening"
+          "owner": "security-and-hardening",
+          "mode": "100644"
         }
       ]
     },
@@ -2739,42 +2895,50 @@
         {
           "path": "skills/ai-workflow/shipping-and-launch/SKILL.md",
           "sha256": "ecd93feeb1506e38d7fc94618747e11dde83c0bb05c40d16e8569527188d609f",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/shipping-and-launch/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "shipping-and-launch"
+          "owner": "shipping-and-launch",
+          "mode": "100644"
         }
       ]
     },
@@ -2875,42 +3039,50 @@
         {
           "path": "skills/ai-workflow/source-driven-development/SKILL.md",
           "sha256": "f3493584ceb70bc53cae8a35a4bf83cce778a378ab25846bd6a6e19242fa71aa",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/source-driven-development/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "source-driven-development"
+          "owner": "source-driven-development",
+          "mode": "100644"
         }
       ]
     },
@@ -3011,42 +3183,50 @@
         {
           "path": "skills/ai-workflow/spec-driven-development/SKILL.md",
           "sha256": "34abface7e80405844850662245170a58dc80693604913796198d000ee76b3b5",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/spec-driven-development/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "spec-driven-development"
+          "owner": "spec-driven-development",
+          "mode": "100644"
         }
       ]
     },
@@ -3147,42 +3327,50 @@
         {
           "path": "skills/ai-workflow/test-driven-development/SKILL.md",
           "sha256": "946d6f569f9379fe8125ee7b417d821203599adb1650a17a71dc0e8c4fa118db",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/test-driven-development/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "test-driven-development"
+          "owner": "test-driven-development",
+          "mode": "100644"
         }
       ]
     },
@@ -3498,257 +3686,308 @@
         {
           "path": "skills/ai-workflow/using-agent-skills/SKILL.md",
           "sha256": "15cce8043d59a97651d5d7c234c311fd295095d81ffe9fee19c3a8a365e482ad",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/marketplace.json",
           "sha256": "49d1e650a25265c1cea43d3b82b673fa8bbadc86be95e58d6d4ef903835fc9c2",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/plugin.json",
           "sha256": "c7c604d3e6bc3ed516bb84f5845685536bda1c0aba1443aefabe2585bd287d38",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/build.md",
           "sha256": "74cc85b5092f8e209bcda36441a4ce17a5cd9efd2a7d8ce76ba202816088e277",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/code-simplify.md",
           "sha256": "71e9e8d38c5cbab5b7ecff324ed4ea0f1aaa4fd053ea6c2b717f2fbadfb65a91",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/plan.md",
           "sha256": "4a14758a45963c4c43b239f405dcdf0cf70778fc0de8c90953fd86177f952832",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/review.md",
           "sha256": "8ad7da75873b430b737328d1bdd95fc8d2de4a4866737087feb4d218abe4e88f",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/ship.md",
           "sha256": "02d2d0fc10bfb58bb62dcfe22ed396cd2b9f55dced7d5cd92fce6d29f0da4ace",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/spec.md",
           "sha256": "ac359a9ad030dee29e54bd0db64b96cadaab00daf8eb900043956930f23e17e5",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/test.md",
           "sha256": "62f72b64cfac6db984db072fdc987a23e6049876191297da5f37367def986ff2",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md",
           "sha256": "74c0c1335f1397a5138a78eda4275e4e5deba16c4537f3a4b4971c3280d0ba27",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/code-reviewer.md",
           "sha256": "74667b052cb6a75079791cee8f6e465a248e28fd82178505aaaec8db95c40ccf",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/security-auditor.md",
           "sha256": "66a3f68f1c691b600ddb44e88afb138e239d0572df37be84e1f9a427c887dd0a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/test-engineer.md",
           "sha256": "c4acde91d6307d88515387344a129a2d0679134e587596c3517d73faffcd5aa6",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/web-performance-auditor.md",
           "sha256": "0928b1cf8103262a364bce0c1fc689a918852e2275441f1b2e687adfa1e607e9",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/adoption-guide.md",
           "sha256": "21bff9ad02144ff2860243f9d71ad45e90294db6b9066149af74b2f97a1908f6",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/agents.md",
           "sha256": "e03481592a725146ed48ee22010086dcfebd1faf1373cb99e7f2ed4d2100275c",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/antigravity-setup.md",
           "sha256": "cd3b7ddf7eb42af069f43cecbddceb98faaa2717fa184568e5e6bccda6612ef0",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/codex-setup.md",
           "sha256": "a99892641e69e5dee19b7236054d1f18d2759fd854b98f4dfa15fe60f401c47f",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/comparison.md",
           "sha256": "7edc3360fc5ee5a4fcacdeb8f4d19cd8174f4bed7436b1c04c0369d8c3b72fb8",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/copilot-setup.md",
           "sha256": "c8fb9c61c286ea2fb0358de0fb2e3cd4cab2b5e356dbc455386fe349fae8a469",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/cursor-setup.md",
           "sha256": "1ce79da3cddb3217e53b1815c62ddc75dfa740f4965c8d56a5014c2395d15352",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/developer-onboarding.md",
           "sha256": "59a35b68045f34aa42161bc5901892489e6ecdac4b5bbfcf311fde65f8255eea",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/gemini-cli-setup.md",
           "sha256": "982d9cdc469fb26cbd4dd6a2d26d1894f2b93e2f821dd8646c188dacb8150803",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/getting-started.md",
           "sha256": "64021c41172dce3741b262b8b1df87cb6ab4ea5a3a46c08d062f1f5e4c7000a9",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/opencode-setup.md",
           "sha256": "4ea73ec1e4a46e5fc1a7984a6a15e64b6289522c4d8927147e34d4abdf0030f4",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/skill-anatomy.md",
           "sha256": "5026d3ade4cec780a6d4c372cc11403ca1014ac369f72791f8c5ebe063519343",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/windsurf-setup.md",
           "sha256": "1410af016060047d1a265365f8d98aadd00a58bcfa2a048edec06d61d337cd97",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SDD-CACHE.md",
           "sha256": "8c1d337a11ed7fd4f3f0e965856cb86a97cdf8b3de0b29b63345ad0133b3db12",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SIMPLIFY-IGNORE.md",
           "sha256": "a7121b0505c960a8a7a7f09600c9fa81464fc403ab297b95d23f5109b13ea52a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/hooks.json",
           "sha256": "870c97c9cb6f526b66cc1d684e261ad2f7b45066a41e56ca5cb3fa6784df8888",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-post.sh",
           "sha256": "cf60a60fd475cceaf8cefdf0462393b1be0d7a4a5a4ea54508172f36ec0883e5",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-pre.sh",
           "sha256": "853ad36f5e17e977060b92313e34b848ec1d321f2ac4aa657e9f3b9281cc0473",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start-test.sh",
           "sha256": "db35bb3e69a98900dddb0c5b1c9ceb8e738cdeb17613ed50177fff7924d350d2",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start.sh",
           "sha256": "9f3ab636c164463b26bc93af82626d42b184ce323a6b64c9a9aec873dd2c7cb7",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore-test.sh",
           "sha256": "8f93c89e46c5a7478c01fa8531fa45e594fc5105411eaa7bd7c9f3ca8343926e",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore.sh",
           "sha256": "1256c677adbce33f3c361793d7dae2405fb02a7efc07b19cc8f42134def8a5cd",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100755"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/accessibility-checklist.md",
           "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/definition-of-done.md",
           "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/observability-checklist.md",
           "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/orchestration-patterns.md",
           "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/performance-checklist.md",
           "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/security-checklist.md",
           "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/testing-patterns.md",
           "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
-          "owner": "using-agent-skills"
+          "owner": "using-agent-skills",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/addyosmani-agent-skills-2026-04.skills.json
+++ b/docs/sources/addyosmani-agent-skills-2026-04.skills.json
@@ -34,7 +34,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -57,13 +57,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/api-and-interface-design",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/definition-of-done.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/observability-checklist.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/performance-checklist.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/security-checklist.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/api-and-interface-design/references/testing-patterns.md",
+              "target": "skills/ai-workflow/api-and-interface-design/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/api-and-interface-design/SKILL.md",
-          "owner": "api-and-interface-design",
-          "sha256": "3468e0faecccd949ad7fd68780aac30ac770d51bc0c3258e7dce54d01640bf37"
+          "sha256": "3468e0faecccd949ad7fd68780aac30ac770d51bc0c3258e7dce54d01640bf37",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "api-and-interface-design"
+        },
+        {
+          "path": "skills/ai-workflow/api-and-interface-design/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "api-and-interface-design"
         }
       ]
     },
@@ -83,7 +170,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -106,13 +193,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/browser-testing-with-devtools",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/definition-of-done.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/observability-checklist.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/performance-checklist.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/security-checklist.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/browser-testing-with-devtools/references/testing-patterns.md",
+              "target": "skills/ai-workflow/browser-testing-with-devtools/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/browser-testing-with-devtools/SKILL.md",
-          "owner": "browser-testing-with-devtools",
-          "sha256": "8cec167f87a7724bdd892494963481a4a6b40bf923ba6186e2d49854e6025c99"
+          "sha256": "8cec167f87a7724bdd892494963481a4a6b40bf923ba6186e2d49854e6025c99",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "browser-testing-with-devtools"
+        },
+        {
+          "path": "skills/ai-workflow/browser-testing-with-devtools/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "browser-testing-with-devtools"
         }
       ]
     },
@@ -132,7 +306,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -155,13 +329,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/ci-cd-and-automation",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/definition-of-done.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/observability-checklist.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/performance-checklist.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/security-checklist.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/ci-cd-and-automation/references/testing-patterns.md",
+              "target": "skills/ai-workflow/ci-cd-and-automation/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/ci-cd-and-automation/SKILL.md",
-          "owner": "ci-cd-and-automation",
-          "sha256": "3bad8c5989a0a1b2a2f49ddb6d26009010ef73378f024a6d517c98cfafb267be"
+          "sha256": "3bad8c5989a0a1b2a2f49ddb6d26009010ef73378f024a6d517c98cfafb267be",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "ci-cd-and-automation"
+        },
+        {
+          "path": "skills/ai-workflow/ci-cd-and-automation/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "ci-cd-and-automation"
         }
       ]
     },
@@ -181,7 +442,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -204,13 +465,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/code-review-and-quality",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/definition-of-done.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/observability-checklist.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/performance-checklist.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/security-checklist.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-review-and-quality/references/testing-patterns.md",
+              "target": "skills/ai-workflow/code-review-and-quality/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/code-review-and-quality/SKILL.md",
-          "owner": "code-review-and-quality",
-          "sha256": "b2d7e0bb79266f0326ec5336e8a6ef8f462a8314cc9dd4c66f9c90f6a66d1c86"
+          "sha256": "b2d7e0bb79266f0326ec5336e8a6ef8f462a8314cc9dd4c66f9c90f6a66d1c86",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "code-review-and-quality"
+        },
+        {
+          "path": "skills/ai-workflow/code-review-and-quality/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "code-review-and-quality"
         }
       ]
     },
@@ -230,7 +578,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -253,13 +601,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/code-simplification",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/code-simplification/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/code-simplification/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/definition-of-done.md",
+              "target": "skills/ai-workflow/code-simplification/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/observability-checklist.md",
+              "target": "skills/ai-workflow/code-simplification/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/code-simplification/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/performance-checklist.md",
+              "target": "skills/ai-workflow/code-simplification/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/security-checklist.md",
+              "target": "skills/ai-workflow/code-simplification/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/code-simplification/references/testing-patterns.md",
+              "target": "skills/ai-workflow/code-simplification/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/code-simplification/SKILL.md",
-          "owner": "code-simplification",
-          "sha256": "a3d0674b7caea304f6047c0dd5f9efac499e821731aa54e0138b2d29adf89ac1"
+          "sha256": "a3d0674b7caea304f6047c0dd5f9efac499e821731aa54e0138b2d29adf89ac1",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "code-simplification"
+        },
+        {
+          "path": "skills/ai-workflow/code-simplification/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "code-simplification"
         }
       ]
     },
@@ -279,7 +714,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -302,13 +737,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/context-engineering",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/context-engineering/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/context-engineering/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/definition-of-done.md",
+              "target": "skills/ai-workflow/context-engineering/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/observability-checklist.md",
+              "target": "skills/ai-workflow/context-engineering/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/context-engineering/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/performance-checklist.md",
+              "target": "skills/ai-workflow/context-engineering/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/security-checklist.md",
+              "target": "skills/ai-workflow/context-engineering/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/context-engineering/references/testing-patterns.md",
+              "target": "skills/ai-workflow/context-engineering/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/context-engineering/SKILL.md",
-          "owner": "context-engineering",
-          "sha256": "4a31be187fc8e58e925c26f76d58db88a0dce2ca0055ae9ccb2ef1a4c5403c9f"
+          "sha256": "4a31be187fc8e58e925c26f76d58db88a0dce2ca0055ae9ccb2ef1a4c5403c9f",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "context-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/context-engineering/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "context-engineering"
         }
       ]
     },
@@ -328,7 +850,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -351,13 +873,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/debugging-and-error-recovery",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/definition-of-done.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/observability-checklist.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/performance-checklist.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/security-checklist.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/debugging-and-error-recovery/references/testing-patterns.md",
+              "target": "skills/ai-workflow/debugging-and-error-recovery/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/debugging-and-error-recovery/SKILL.md",
-          "owner": "debugging-and-error-recovery",
-          "sha256": "acf148e9bb8893787526d1663c6d9eef66f243328867833a43e1d015d9460b4e"
+          "sha256": "acf148e9bb8893787526d1663c6d9eef66f243328867833a43e1d015d9460b4e",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "debugging-and-error-recovery"
+        },
+        {
+          "path": "skills/ai-workflow/debugging-and-error-recovery/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "debugging-and-error-recovery"
         }
       ]
     },
@@ -377,7 +986,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -400,13 +1009,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/deprecation-and-migration",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/definition-of-done.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/observability-checklist.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/performance-checklist.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/security-checklist.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/deprecation-and-migration/references/testing-patterns.md",
+              "target": "skills/ai-workflow/deprecation-and-migration/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/deprecation-and-migration/SKILL.md",
-          "owner": "deprecation-and-migration",
-          "sha256": "c48510a6b6f8fee4aca9d8581342d6212787237daa96fb3bab4eef7071f8e4ee"
+          "sha256": "c48510a6b6f8fee4aca9d8581342d6212787237daa96fb3bab4eef7071f8e4ee",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "deprecation-and-migration"
+        },
+        {
+          "path": "skills/ai-workflow/deprecation-and-migration/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "deprecation-and-migration"
         }
       ]
     },
@@ -426,7 +1122,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -449,13 +1145,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/documentation-and-adrs",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/definition-of-done.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/observability-checklist.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/performance-checklist.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/security-checklist.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/documentation-and-adrs/references/testing-patterns.md",
+              "target": "skills/ai-workflow/documentation-and-adrs/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/documentation-and-adrs/SKILL.md",
-          "owner": "documentation-and-adrs",
-          "sha256": "6a77f1f3153351da13d5b3a8a510c9c988627ad8072fa1c5254448f94d750cca"
+          "sha256": "6a77f1f3153351da13d5b3a8a510c9c988627ad8072fa1c5254448f94d750cca",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "documentation-and-adrs"
+        },
+        {
+          "path": "skills/ai-workflow/documentation-and-adrs/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "documentation-and-adrs"
         }
       ]
     },
@@ -475,7 +1258,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -498,13 +1281,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/doubt-driven-development",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/definition-of-done.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/observability-checklist.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/performance-checklist.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/security-checklist.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/doubt-driven-development/references/testing-patterns.md",
+              "target": "skills/ai-workflow/doubt-driven-development/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/doubt-driven-development/SKILL.md",
-          "owner": "doubt-driven-development",
-          "sha256": "2e2b245c80c7cb03f475efa1153e257018e6e2e3092806a7acd8c279f5097b2e"
+          "sha256": "2e2b245c80c7cb03f475efa1153e257018e6e2e3092806a7acd8c279f5097b2e",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "doubt-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/doubt-driven-development/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "doubt-driven-development"
         }
       ]
     },
@@ -524,7 +1394,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -547,13 +1417,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/frontend-ui-engineering",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/definition-of-done.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/observability-checklist.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/performance-checklist.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/security-checklist.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/frontend-ui-engineering/references/testing-patterns.md",
+              "target": "skills/ai-workflow/frontend-ui-engineering/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/frontend-ui-engineering/SKILL.md",
-          "owner": "frontend-ui-engineering",
-          "sha256": "966c423b383c8e6ec08a3d0c8da33b1ed21859f561ef3dc662cdaaf86a08a9a6"
+          "sha256": "966c423b383c8e6ec08a3d0c8da33b1ed21859f561ef3dc662cdaaf86a08a9a6",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "frontend-ui-engineering"
+        },
+        {
+          "path": "skills/ai-workflow/frontend-ui-engineering/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "frontend-ui-engineering"
         }
       ]
     },
@@ -573,7 +1530,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -596,13 +1553,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/git-workflow-and-versioning",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/definition-of-done.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/observability-checklist.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/performance-checklist.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/security-checklist.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/git-workflow-and-versioning/references/testing-patterns.md",
+              "target": "skills/ai-workflow/git-workflow-and-versioning/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/git-workflow-and-versioning/SKILL.md",
-          "owner": "git-workflow-and-versioning",
-          "sha256": "b346d65a6f821f4ce91ac2d9e1494c6e1c0d991c06003d9e3c1138abd0c86199"
+          "sha256": "b346d65a6f821f4ce91ac2d9e1494c6e1c0d991c06003d9e3c1138abd0c86199",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "git-workflow-and-versioning"
+        },
+        {
+          "path": "skills/ai-workflow/git-workflow-and-versioning/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "git-workflow-and-versioning"
         }
       ]
     },
@@ -622,7 +1666,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -634,6 +1678,26 @@
             {
               "source": "skills/idea-refine/SKILL.md",
               "target": "skills/ai-workflow/idea-refine/SKILL.md"
+            },
+            {
+              "source": "skills/idea-refine/examples.md",
+              "target": "skills/ai-workflow/idea-refine/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/idea-refine/frameworks.md",
+              "target": "skills/ai-workflow/idea-refine/frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/idea-refine/refinement-criteria.md",
+              "target": "skills/ai-workflow/idea-refine/refinement-criteria.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/idea-refine/scripts/idea-refine.sh",
+              "target": "skills/ai-workflow/idea-refine/scripts/idea-refine.sh",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -645,13 +1709,120 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/idea-refine",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/idea-refine/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/idea-refine/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/definition-of-done.md",
+              "target": "skills/ai-workflow/idea-refine/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/observability-checklist.md",
+              "target": "skills/ai-workflow/idea-refine/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/idea-refine/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/performance-checklist.md",
+              "target": "skills/ai-workflow/idea-refine/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/security-checklist.md",
+              "target": "skills/ai-workflow/idea-refine/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/idea-refine/references/testing-patterns.md",
+              "target": "skills/ai-workflow/idea-refine/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/idea-refine/SKILL.md",
-          "owner": "idea-refine",
-          "sha256": "7b702aa564b22144e902e7c58954e9d230da31610649def250662a43fa30e1c2"
+          "sha256": "7b702aa564b22144e902e7c58954e9d230da31610649def250662a43fa30e1c2",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/examples.md",
+          "sha256": "563204bfbf2f80a444151695205af4cb759e722b3d1e5460e08f278a69c89ba1",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/frameworks.md",
+          "sha256": "161ebc18fdf2d996bc62a87a2d747cf1bf53548354f8925de25c732c27f00309",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/refinement-criteria.md",
+          "sha256": "1ca2973a4d01b5cb37ab7ddb2eff77fa4e792634a33d0ce44961c068fc88d51a",
+          "owner": "idea-refine"
+        },
+        {
+          "path": "skills/ai-workflow/idea-refine/scripts/idea-refine.sh",
+          "sha256": "f02a52408a4218047c032d221483abfbb48d11f090bb4915965c7419bf2e0e47",
+          "owner": "idea-refine"
         }
       ]
     },
@@ -671,7 +1842,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -694,13 +1865,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/incremental-implementation",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/definition-of-done.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/observability-checklist.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/performance-checklist.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/security-checklist.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/incremental-implementation/references/testing-patterns.md",
+              "target": "skills/ai-workflow/incremental-implementation/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/incremental-implementation/SKILL.md",
-          "owner": "incremental-implementation",
-          "sha256": "d0e039e6d9b50354f77cce5e082aa6e2bb45830d6c6c79f33b90e6a4ec13c4f3"
+          "sha256": "d0e039e6d9b50354f77cce5e082aa6e2bb45830d6c6c79f33b90e6a4ec13c4f3",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "incremental-implementation"
+        },
+        {
+          "path": "skills/ai-workflow/incremental-implementation/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "incremental-implementation"
         }
       ]
     },
@@ -720,7 +1978,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -743,13 +2001,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/interview-me",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/interview-me/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/interview-me/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/definition-of-done.md",
+              "target": "skills/ai-workflow/interview-me/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/observability-checklist.md",
+              "target": "skills/ai-workflow/interview-me/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/interview-me/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/performance-checklist.md",
+              "target": "skills/ai-workflow/interview-me/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/security-checklist.md",
+              "target": "skills/ai-workflow/interview-me/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/interview-me/references/testing-patterns.md",
+              "target": "skills/ai-workflow/interview-me/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/interview-me/SKILL.md",
-          "owner": "interview-me",
-          "sha256": "53b1f74b1a9a6c3946d0681c3164f03316ccc8c70e07606a9fc6d895fe74f556"
+          "sha256": "53b1f74b1a9a6c3946d0681c3164f03316ccc8c70e07606a9fc6d895fe74f556",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "interview-me"
+        },
+        {
+          "path": "skills/ai-workflow/interview-me/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "interview-me"
         }
       ]
     },
@@ -769,7 +2114,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -792,13 +2137,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/observability-and-instrumentation",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/definition-of-done.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/observability-checklist.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/performance-checklist.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/security-checklist.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/observability-and-instrumentation/references/testing-patterns.md",
+              "target": "skills/ai-workflow/observability-and-instrumentation/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/observability-and-instrumentation/SKILL.md",
-          "owner": "observability-and-instrumentation",
-          "sha256": "d814e7fb3ef08f46d8695bbd9cd1c16a5f5c7302842db3b4f9331a38f3405bfd"
+          "sha256": "d814e7fb3ef08f46d8695bbd9cd1c16a5f5c7302842db3b4f9331a38f3405bfd",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "observability-and-instrumentation"
+        },
+        {
+          "path": "skills/ai-workflow/observability-and-instrumentation/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "observability-and-instrumentation"
         }
       ]
     },
@@ -818,7 +2250,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -841,13 +2273,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/performance-optimization",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/performance-optimization/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/definition-of-done.md",
+              "target": "skills/ai-workflow/performance-optimization/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/observability-checklist.md",
+              "target": "skills/ai-workflow/performance-optimization/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/performance-optimization/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/performance-checklist.md",
+              "target": "skills/ai-workflow/performance-optimization/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/security-checklist.md",
+              "target": "skills/ai-workflow/performance-optimization/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/performance-optimization/references/testing-patterns.md",
+              "target": "skills/ai-workflow/performance-optimization/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/performance-optimization/SKILL.md",
-          "owner": "performance-optimization",
-          "sha256": "0367fdd12d2f2d0fdabd96a7171cf1559cca39979fc3e4cc09cff186485a0b09"
+          "sha256": "0367fdd12d2f2d0fdabd96a7171cf1559cca39979fc3e4cc09cff186485a0b09",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "performance-optimization"
+        },
+        {
+          "path": "skills/ai-workflow/performance-optimization/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "performance-optimization"
         }
       ]
     },
@@ -867,7 +2386,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -890,13 +2409,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/planning-and-task-breakdown",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/definition-of-done.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/observability-checklist.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/performance-checklist.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/security-checklist.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/planning-and-task-breakdown/references/testing-patterns.md",
+              "target": "skills/ai-workflow/planning-and-task-breakdown/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/planning-and-task-breakdown/SKILL.md",
-          "owner": "planning-and-task-breakdown",
-          "sha256": "875b99c85ce53a28a1be3e1ec8b537fff814669bb3f4d2d9eb5b431b213519c3"
+          "sha256": "875b99c85ce53a28a1be3e1ec8b537fff814669bb3f4d2d9eb5b431b213519c3",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "planning-and-task-breakdown"
+        },
+        {
+          "path": "skills/ai-workflow/planning-and-task-breakdown/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "planning-and-task-breakdown"
         }
       ]
     },
@@ -916,7 +2522,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -939,13 +2545,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/security-and-hardening",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/definition-of-done.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/observability-checklist.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/performance-checklist.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/security-checklist.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/security-and-hardening/references/testing-patterns.md",
+              "target": "skills/ai-workflow/security-and-hardening/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/security-and-hardening/SKILL.md",
-          "owner": "security-and-hardening",
-          "sha256": "b7f215bb94cbe8e242e0498b32c1f90b25b4fc258c0dbfd6dc9f5b2746f56887"
+          "sha256": "b7f215bb94cbe8e242e0498b32c1f90b25b4fc258c0dbfd6dc9f5b2746f56887",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "security-and-hardening"
+        },
+        {
+          "path": "skills/ai-workflow/security-and-hardening/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "security-and-hardening"
         }
       ]
     },
@@ -965,7 +2658,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -988,13 +2681,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/shipping-and-launch",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/definition-of-done.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/observability-checklist.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/performance-checklist.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/security-checklist.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/shipping-and-launch/references/testing-patterns.md",
+              "target": "skills/ai-workflow/shipping-and-launch/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/shipping-and-launch/SKILL.md",
-          "owner": "shipping-and-launch",
-          "sha256": "ecd93feeb1506e38d7fc94618747e11dde83c0bb05c40d16e8569527188d609f"
+          "sha256": "ecd93feeb1506e38d7fc94618747e11dde83c0bb05c40d16e8569527188d609f",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "shipping-and-launch"
+        },
+        {
+          "path": "skills/ai-workflow/shipping-and-launch/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "shipping-and-launch"
         }
       ]
     },
@@ -1014,7 +2794,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1037,13 +2817,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/source-driven-development",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/source-driven-development/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/definition-of-done.md",
+              "target": "skills/ai-workflow/source-driven-development/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/observability-checklist.md",
+              "target": "skills/ai-workflow/source-driven-development/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/source-driven-development/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/performance-checklist.md",
+              "target": "skills/ai-workflow/source-driven-development/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/security-checklist.md",
+              "target": "skills/ai-workflow/source-driven-development/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/source-driven-development/references/testing-patterns.md",
+              "target": "skills/ai-workflow/source-driven-development/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/source-driven-development/SKILL.md",
-          "owner": "source-driven-development",
-          "sha256": "f3493584ceb70bc53cae8a35a4bf83cce778a378ab25846bd6a6e19242fa71aa"
+          "sha256": "f3493584ceb70bc53cae8a35a4bf83cce778a378ab25846bd6a6e19242fa71aa",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "source-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/source-driven-development/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "source-driven-development"
         }
       ]
     },
@@ -1063,7 +2930,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1086,13 +2953,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/spec-driven-development",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/definition-of-done.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/observability-checklist.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/performance-checklist.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/security-checklist.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/spec-driven-development/references/testing-patterns.md",
+              "target": "skills/ai-workflow/spec-driven-development/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/spec-driven-development/SKILL.md",
-          "owner": "spec-driven-development",
-          "sha256": "34abface7e80405844850662245170a58dc80693604913796198d000ee76b3b5"
+          "sha256": "34abface7e80405844850662245170a58dc80693604913796198d000ee76b3b5",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "spec-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/spec-driven-development/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "spec-driven-development"
         }
       ]
     },
@@ -1112,7 +3066,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1135,13 +3089,100 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/test-driven-development",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/test-driven-development/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/definition-of-done.md",
+              "target": "skills/ai-workflow/test-driven-development/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/observability-checklist.md",
+              "target": "skills/ai-workflow/test-driven-development/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/test-driven-development/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/performance-checklist.md",
+              "target": "skills/ai-workflow/test-driven-development/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/security-checklist.md",
+              "target": "skills/ai-workflow/test-driven-development/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/test-driven-development/references/testing-patterns.md",
+              "target": "skills/ai-workflow/test-driven-development/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/test-driven-development/SKILL.md",
-          "owner": "test-driven-development",
-          "sha256": "946d6f569f9379fe8125ee7b417d821203599adb1650a17a71dc0e8c4fa118db"
+          "sha256": "946d6f569f9379fe8125ee7b417d821203599adb1650a17a71dc0e8c4fa118db",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "test-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/test-driven-development/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "test-driven-development"
         }
       ]
     },
@@ -1161,7 +3202,7 @@
         "last_synced_commit": "7829ffd90d973b6325f5f12f1b1226dcace74443",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1184,13 +3225,530 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/using-agent-skills",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/definition-of-done.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/observability-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/performance-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/security-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/references/testing-patterns.md",
+              "target": "skills/ai-workflow/using-agent-skills/references/testing-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/marketplace.json",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/marketplace.json",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/plugin.json",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/plugin.json",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/build.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/build.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/code-simplify.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/code-simplify.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/plan.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/plan.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/review.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/review.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/ship.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/ship.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/spec.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/spec.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/test.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/test.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/code-reviewer.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/code-reviewer.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/security-auditor.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/security-auditor.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/test-engineer.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/test-engineer.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/web-performance-auditor.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/web-performance-auditor.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/adoption-guide.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/adoption-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/agents.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/agents.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/antigravity-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/antigravity-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/codex-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/codex-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/comparison.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/comparison.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/copilot-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/copilot-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/cursor-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/cursor-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/developer-onboarding.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/developer-onboarding.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/gemini-cli-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/gemini-cli-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/getting-started.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/getting-started.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/opencode-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/opencode-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/skill-anatomy.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/skill-anatomy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/windsurf-setup.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/windsurf-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SDD-CACHE.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SDD-CACHE.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SIMPLIFY-IGNORE.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SIMPLIFY-IGNORE.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/hooks.json",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/hooks.json",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-post.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-post.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-pre.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-pre.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start-test.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start-test.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore-test.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore-test.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore.sh",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/accessibility-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/accessibility-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/definition-of-done.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/definition-of-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/observability-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/observability-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/performance-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/performance-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/security-checklist.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/security-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/testing-patterns.md",
+              "target": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/testing-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/using-agent-skills/SKILL.md",
-          "owner": "using-agent-skills",
-          "sha256": "15cce8043d59a97651d5d7c234c311fd295095d81ffe9fee19c3a8a365e482ad"
+          "sha256": "15cce8043d59a97651d5d7c234c311fd295095d81ffe9fee19c3a8a365e482ad",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/marketplace.json",
+          "sha256": "49d1e650a25265c1cea43d3b82b673fa8bbadc86be95e58d6d4ef903835fc9c2",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude-plugin/plugin.json",
+          "sha256": "c7c604d3e6bc3ed516bb84f5845685536bda1c0aba1443aefabe2585bd287d38",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/build.md",
+          "sha256": "74cc85b5092f8e209bcda36441a4ce17a5cd9efd2a7d8ce76ba202816088e277",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/code-simplify.md",
+          "sha256": "71e9e8d38c5cbab5b7ecff324ed4ea0f1aaa4fd053ea6c2b717f2fbadfb65a91",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/plan.md",
+          "sha256": "4a14758a45963c4c43b239f405dcdf0cf70778fc0de8c90953fd86177f952832",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/review.md",
+          "sha256": "8ad7da75873b430b737328d1bdd95fc8d2de4a4866737087feb4d218abe4e88f",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/ship.md",
+          "sha256": "02d2d0fc10bfb58bb62dcfe22ed396cd2b9f55dced7d5cd92fce6d29f0da4ace",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/spec.md",
+          "sha256": "ac359a9ad030dee29e54bd0db64b96cadaab00daf8eb900043956930f23e17e5",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/test.md",
+          "sha256": "62f72b64cfac6db984db072fdc987a23e6049876191297da5f37367def986ff2",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md",
+          "sha256": "74c0c1335f1397a5138a78eda4275e4e5deba16c4537f3a4b4971c3280d0ba27",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/code-reviewer.md",
+          "sha256": "74667b052cb6a75079791cee8f6e465a248e28fd82178505aaaec8db95c40ccf",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/security-auditor.md",
+          "sha256": "66a3f68f1c691b600ddb44e88afb138e239d0572df37be84e1f9a427c887dd0a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/test-engineer.md",
+          "sha256": "c4acde91d6307d88515387344a129a2d0679134e587596c3517d73faffcd5aa6",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/agents/web-performance-auditor.md",
+          "sha256": "0928b1cf8103262a364bce0c1fc689a918852e2275441f1b2e687adfa1e607e9",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/adoption-guide.md",
+          "sha256": "21bff9ad02144ff2860243f9d71ad45e90294db6b9066149af74b2f97a1908f6",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/agents.md",
+          "sha256": "e03481592a725146ed48ee22010086dcfebd1faf1373cb99e7f2ed4d2100275c",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/antigravity-setup.md",
+          "sha256": "cd3b7ddf7eb42af069f43cecbddceb98faaa2717fa184568e5e6bccda6612ef0",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/codex-setup.md",
+          "sha256": "a99892641e69e5dee19b7236054d1f18d2759fd854b98f4dfa15fe60f401c47f",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/comparison.md",
+          "sha256": "7edc3360fc5ee5a4fcacdeb8f4d19cd8174f4bed7436b1c04c0369d8c3b72fb8",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/copilot-setup.md",
+          "sha256": "c8fb9c61c286ea2fb0358de0fb2e3cd4cab2b5e356dbc455386fe349fae8a469",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/cursor-setup.md",
+          "sha256": "1ce79da3cddb3217e53b1815c62ddc75dfa740f4965c8d56a5014c2395d15352",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/developer-onboarding.md",
+          "sha256": "59a35b68045f34aa42161bc5901892489e6ecdac4b5bbfcf311fde65f8255eea",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/gemini-cli-setup.md",
+          "sha256": "982d9cdc469fb26cbd4dd6a2d26d1894f2b93e2f821dd8646c188dacb8150803",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/getting-started.md",
+          "sha256": "64021c41172dce3741b262b8b1df87cb6ab4ea5a3a46c08d062f1f5e4c7000a9",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/opencode-setup.md",
+          "sha256": "4ea73ec1e4a46e5fc1a7984a6a15e64b6289522c4d8927147e34d4abdf0030f4",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/skill-anatomy.md",
+          "sha256": "5026d3ade4cec780a6d4c372cc11403ca1014ac369f72791f8c5ebe063519343",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/docs/windsurf-setup.md",
+          "sha256": "1410af016060047d1a265365f8d98aadd00a58bcfa2a048edec06d61d337cd97",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SDD-CACHE.md",
+          "sha256": "8c1d337a11ed7fd4f3f0e965856cb86a97cdf8b3de0b29b63345ad0133b3db12",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/SIMPLIFY-IGNORE.md",
+          "sha256": "a7121b0505c960a8a7a7f09600c9fa81464fc403ab297b95d23f5109b13ea52a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/hooks.json",
+          "sha256": "870c97c9cb6f526b66cc1d684e261ad2f7b45066a41e56ca5cb3fa6784df8888",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-post.sh",
+          "sha256": "cf60a60fd475cceaf8cefdf0462393b1be0d7a4a5a4ea54508172f36ec0883e5",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/sdd-cache-pre.sh",
+          "sha256": "853ad36f5e17e977060b92313e34b848ec1d321f2ac4aa657e9f3b9281cc0473",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start-test.sh",
+          "sha256": "db35bb3e69a98900dddb0c5b1c9ceb8e738cdeb17613ed50177fff7924d350d2",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/session-start.sh",
+          "sha256": "9f3ab636c164463b26bc93af82626d42b184ce323a6b64c9a9aec873dd2c7cb7",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore-test.sh",
+          "sha256": "8f93c89e46c5a7478c01fa8531fa45e594fc5105411eaa7bd7c9f3ca8343926e",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/hooks/simplify-ignore.sh",
+          "sha256": "1256c677adbce33f3c361793d7dae2405fb02a7efc07b19cc8f42134def8a5cd",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/accessibility-checklist.md",
+          "sha256": "61c759d94d52296231f5f310b92b401f56c44e4430dc3cc95ebac5d7b1d5ffac",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/definition-of-done.md",
+          "sha256": "d1c75d2ae65d2c7a9cd01f93fa8de63e00e75f2fe5d08be224d576157054dcee",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/observability-checklist.md",
+          "sha256": "28659e0a4b9625a434285fa9ede632802afa909f768d0f8d839dca227e53d8fe",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/orchestration-patterns.md",
+          "sha256": "61e543d86f19f86b83074f8c1c769455c7085a2c72dd47b1da21a8c63785be4a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/performance-checklist.md",
+          "sha256": "628539583b7f515f84d0b8e4f4210ccdc0449afd31901149a078209f0769e654",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/security-checklist.md",
+          "sha256": "a8bbff3b1ac9122985e98fbe9a8fa09cd8ad53b190bac7f8f0f63687900f7d7a",
+          "owner": "using-agent-skills"
+        },
+        {
+          "path": "skills/ai-workflow/using-agent-skills/upstream-bundle/references/testing-patterns.md",
+          "sha256": "f0bf05acd0edcadc27297ad5b74f104c8103ccfedba1a05cd6d6ae4af8364c56",
+          "owner": "using-agent-skills"
         }
       ]
     }

--- a/docs/sources/alirezarezvani-claude-skills-2026-04.skills.json
+++ b/docs/sources/alirezarezvani-claude-skills-2026-04.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://github.com/alirezarezvani/claude-skills",
-    "checked_at": "2026-08-18",
+    "checked_at": "2026-08-20",
     "note": "Curated from alirezarezvani/claude-skills with upstream tracking enabled."
   },
   "official_references": [
@@ -25,11 +25,12 @@
         "path": "engineering/agenthub/skills/agenthub/SKILL.md",
         "ref": "main",
         "sync_mode": "monitor",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
-        "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc"
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
+        "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+        "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -47,18 +48,73 @@
             "channel": "default_branch",
             "ref": "main",
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-            "path_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+            "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850",
             "content_sha256": "387d7d7ea145c1779276f316313d89ac62c469f900b5dfb8e4e55aa0a765f7a3",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-agent-platform/agent-hub",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-agent-platform/agent-hub/CLAUDE.md",
+              "target": "skills/ai-agent-platform/agent-hub/CLAUDE.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/agent-hub/README.md",
+              "target": "skills/ai-agent-platform/agent-hub/README.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/agent-hub/settings.json",
+              "target": "skills/ai-agent-platform/agent-hub/settings.json",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
           }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/ai-agent-platform/agent-hub/CLAUDE.md",
+          "sha256": "002a900117ade74f8dea66bb1dca3179536c324d592527c01152b11139fc49d5",
+          "owner": "agent-hub"
+        },
+        {
+          "path": "skills/ai-agent-platform/agent-hub/README.md",
+          "sha256": "a555836eacdc116ddb76e8bf9cb0c91466806c7b41091586f493826cdea1536c",
+          "owner": "agent-hub"
+        },
+        {
           "path": "skills/ai-agent-platform/agent-hub/SKILL.md",
-          "owner": "agent-hub",
-          "sha256": "387d7d7ea145c1779276f316313d89ac62c469f900b5dfb8e4e55aa0a765f7a3"
+          "sha256": "387d7d7ea145c1779276f316313d89ac62c469f900b5dfb8e4e55aa0a765f7a3",
+          "owner": "agent-hub"
+        },
+        {
+          "path": "skills/ai-agent-platform/agent-hub/settings.json",
+          "sha256": "1bf3fcb93594d44bbd1cc30af78ac5da4c9bb32d7cb17ad163ad6787867fb760",
+          "owner": "agent-hub"
         }
       ]
     },
@@ -73,10 +129,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "engineering-team/skills/security-pen-testing/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "b99505446a787228e776bf51b49d8f4b5939e203"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -98,8 +155,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "b99505446a787228e776bf51b49d8f4b5939e203",
             "content_sha256": "3d5f04c0e983706af28bab77938a3b4e0b312d74dccf1c28ff80cc805955eb57",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -122,10 +187,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "ra-qm-team/skills/information-security-manager-iso27001/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "aecfb8e0bb71dbf1413082f86b33a5c4c9b8f416"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -147,8 +213,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "aecfb8e0bb71dbf1413082f86b33a5c4c9b8f416",
             "content_sha256": "4c4a0abe72a34ebb8c14fd70ec4e89e0028698555aa73ac4cf11103772cca2b7",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -171,10 +245,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "product-team/skills/landing-page-generator/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "a088c8ba778319fea026c8a25e9e98b15754f379"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -196,8 +271,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "a088c8ba778319fea026c8a25e9e98b15754f379",
             "content_sha256": "d39df0b84a8c5124f8d96f48a67cb4dbb282266a46fbacc699c23f0225d95d62",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -220,10 +303,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "finance/skills/saas-metrics-coach/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -245,8 +329,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850",
             "content_sha256": "d96b366ece56d6001694d33d6b959a9d4541230a6d82e3623b54bd88e8e9ab81",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -269,10 +361,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "engineering-team/skills/senior-architect/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -294,8 +387,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850",
             "content_sha256": "506b0a94794848e0ac86c5437b2fea177bafa958a60df08c2b35f050a162708d",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -318,10 +419,11 @@
         "repo": "alirezarezvani/claude-skills",
         "path": "engineering/skills/skill-security-auditor/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "a088c8ba778319fea026c8a25e9e98b15754f379"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -343,8 +445,16 @@
             "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
             "path_commit": "a088c8ba778319fea026c8a25e9e98b15754f379",
             "content_sha256": "2907b6beba027e9e23c6e05395eb01ad4cd5c167b9ebb925712a6195591da3c6",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],

--- a/docs/sources/alirezarezvani-claude-skills-2026-04.skills.json
+++ b/docs/sources/alirezarezvani-claude-skills-2026-04.skills.json
@@ -99,22 +99,26 @@
         {
           "path": "skills/ai-agent-platform/agent-hub/CLAUDE.md",
           "sha256": "002a900117ade74f8dea66bb1dca3179536c324d592527c01152b11139fc49d5",
-          "owner": "agent-hub"
+          "owner": "agent-hub",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/agent-hub/README.md",
           "sha256": "a555836eacdc116ddb76e8bf9cb0c91466806c7b41091586f493826cdea1536c",
-          "owner": "agent-hub"
+          "owner": "agent-hub",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/agent-hub/SKILL.md",
           "sha256": "387d7d7ea145c1779276f316313d89ac62c469f900b5dfb8e4e55aa0a765f7a3",
-          "owner": "agent-hub"
+          "owner": "agent-hub",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/agent-hub/settings.json",
           "sha256": "1bf3fcb93594d44bbd1cc30af78ac5da4c9bb32d7cb17ad163ad6787867fb760",
-          "owner": "agent-hub"
+          "owner": "agent-hub",
+          "mode": "100644"
         }
       ]
     },
@@ -172,7 +176,8 @@
         {
           "path": "skills/security-and-reliability/security-pen-testing/SKILL.md",
           "owner": "security-pen-testing",
-          "sha256": "3d5f04c0e983706af28bab77938a3b4e0b312d74dccf1c28ff80cc805955eb57"
+          "sha256": "3d5f04c0e983706af28bab77938a3b4e0b312d74dccf1c28ff80cc805955eb57",
+          "mode": "100644"
         }
       ]
     },
@@ -230,7 +235,8 @@
         {
           "path": "skills/security-and-reliability/information-security-manager-iso27001/SKILL.md",
           "owner": "information-security-manager-iso27001",
-          "sha256": "4c4a0abe72a34ebb8c14fd70ec4e89e0028698555aa73ac4cf11103772cca2b7"
+          "sha256": "4c4a0abe72a34ebb8c14fd70ec4e89e0028698555aa73ac4cf11103772cca2b7",
+          "mode": "100644"
         }
       ]
     },
@@ -288,7 +294,8 @@
         {
           "path": "skills/product-design/landing-page-generator/SKILL.md",
           "owner": "landing-page-generator",
-          "sha256": "d39df0b84a8c5124f8d96f48a67cb4dbb282266a46fbacc699c23f0225d95d62"
+          "sha256": "d39df0b84a8c5124f8d96f48a67cb4dbb282266a46fbacc699c23f0225d95d62",
+          "mode": "100644"
         }
       ]
     },
@@ -346,7 +353,8 @@
         {
           "path": "skills/finance-investing/saas-metrics-coach/SKILL.md",
           "owner": "saas-metrics-coach",
-          "sha256": "d96b366ece56d6001694d33d6b959a9d4541230a6d82e3623b54bd88e8e9ab81"
+          "sha256": "d96b366ece56d6001694d33d6b959a9d4541230a6d82e3623b54bd88e8e9ab81",
+          "mode": "100644"
         }
       ]
     },
@@ -404,7 +412,8 @@
         {
           "path": "skills/devops-sre/senior-architect/SKILL.md",
           "owner": "senior-architect",
-          "sha256": "506b0a94794848e0ac86c5437b2fea177bafa958a60df08c2b35f050a162708d"
+          "sha256": "506b0a94794848e0ac86c5437b2fea177bafa958a60df08c2b35f050a162708d",
+          "mode": "100644"
         }
       ]
     },
@@ -462,7 +471,8 @@
         {
           "path": "skills/security-and-reliability/skill-security-auditor/SKILL.md",
           "owner": "skill-security-auditor",
-          "sha256": "2907b6beba027e9e23c6e05395eb01ad4cd5c167b9ebb925712a6195591da3c6"
+          "sha256": "2907b6beba027e9e23c6e05395eb01ad4cd5c167b9ebb925712a6195591da3c6",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/cloudflare-security-audit-skill-2026-07.skills.json
+++ b/docs/sources/cloudflare-security-audit-skill-2026-07.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://github.com/cloudflare/security-audit-skill",
-    "checked_at": "2026-08-18",
+    "checked_at": "2026-08-20",
     "note": "Cloudflare security audit skill imported with companion methodology files under MIT."
   },
   "official_references": [
@@ -34,10 +34,11 @@
         "repo": "cloudflare/security-audit-skill",
         "path": "skills/security-audit/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "8bac42001ddd90a4dcd8d5a5045199283a8eba75",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "c1239b903704f5ea063b6dc0de3ba905f4cca3e4"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -49,26 +50,134 @@
           "sync_mode": "monitor",
           "artifacts": [
             {
+              "source": "skills/security-audit/AI-AND-LLM.md",
+              "target": "skills/security-and-reliability/security-audit/AI-AND-LLM.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/ATTACK-CLASSES.md",
+              "target": "skills/security-and-reliability/security-audit/ATTACK-CLASSES.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/CLIENT-SIDE.md",
+              "target": "skills/security-and-reliability/security-audit/CLIENT-SIDE.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/HUNTING.md",
+              "target": "skills/security-and-reliability/security-audit/HUNTING.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/MEMORY-SAFETY-AND-BINARY.md",
+              "target": "skills/security-and-reliability/security-audit/MEMORY-SAFETY-AND-BINARY.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/RECONNAISSANCE.md",
+              "target": "skills/security-and-reliability/security-audit/RECONNAISSANCE.md",
+              "type": "file"
+            },
+            {
               "source": "skills/security-audit/SKILL.md",
               "target": "skills/security-and-reliability/security-audit/SKILL.md"
+            },
+            {
+              "source": "skills/security-audit/VALIDATION-AND-REPORTING.md",
+              "target": "skills/security-and-reliability/security-audit/VALIDATION-AND-REPORTING.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/WEB-PROTOCOL-AND-AUTH.md",
+              "target": "skills/security-and-reliability/security-audit/WEB-PROTOCOL-AND-AUTH.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/report-schema.json",
+              "target": "skills/security-and-reliability/security-audit/report-schema.json",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-audit/validate-findings.cjs",
+              "target": "skills/security-and-reliability/security-audit/validate-findings.cjs",
+              "type": "file"
             }
           ],
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
             "resolved_commit": "8bac42001ddd90a4dcd8d5a5045199283a8eba75",
-            "path_commit": "8bac42001ddd90a4dcd8d5a5045199283a8eba75",
+            "path_commit": "c1239b903704f5ea063b6dc0de3ba905f4cca3e4",
             "content_sha256": "f534330a3098552529d9d8a4d3edde15bd7545db42b4af955b469d72592e8710",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "6dbc9ecb3a5b9080e95b962869e8c7ab16cfdc20",
+              "content_sha256": "e598e694aa506650c7192d5ea3be0e50aca0d356ea00551c53429f0b01eb6391",
+              "spdx": "MIT",
+              "resolved_commit": "8bac42001ddd90a4dcd8d5a5045199283a8eba75",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/security-and-reliability/security-audit/AI-AND-LLM.md",
+          "sha256": "e3f1f732de2bdd469023a6ac591849a1285abe9b0d12de11fb7d9fd13f6c108e",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/ATTACK-CLASSES.md",
+          "sha256": "f3fab5e6a113553f357e3586f488b9c7e047d48c2ee5443c77724ec1d1d5fdb0",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/CLIENT-SIDE.md",
+          "sha256": "14a0bef183b95e62de4945b886fbfd677c53c68d77f8fdf4c7e2d42e9815f883",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/HUNTING.md",
+          "sha256": "735caebbc3bfed31d2c9fbbf61f383060305774708e0d0ac38050a7eac7ac679",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/MEMORY-SAFETY-AND-BINARY.md",
+          "sha256": "8e1f8e8d9029941083fd5739fec493de7f2699a13fec23d0d0a9a3aae85f7e55",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/RECONNAISSANCE.md",
+          "sha256": "89e2f899107335467716f06bc0bb175e87ccfb662dd9878b9a0f155d8005343f",
+          "owner": "security-audit"
+        },
+        {
           "path": "skills/security-and-reliability/security-audit/SKILL.md",
-          "owner": "security-audit",
-          "sha256": "f534330a3098552529d9d8a4d3edde15bd7545db42b4af955b469d72592e8710"
+          "sha256": "f534330a3098552529d9d8a4d3edde15bd7545db42b4af955b469d72592e8710",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/VALIDATION-AND-REPORTING.md",
+          "sha256": "049dea0289689c66fd913aafa7d6d6df3d5b38d5d9d8e571825ba58f4308c2bd",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/WEB-PROTOCOL-AND-AUTH.md",
+          "sha256": "b8f9a0e29ad6685a3d96cf42a538be7012c4a18925a4871a475291aae497ed04",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/report-schema.json",
+          "sha256": "05c24d50f3314b025dbfb28dfee550d9dec9775602d51fc5c891013a3ab8b273",
+          "owner": "security-audit"
+        },
+        {
+          "path": "skills/security-and-reliability/security-audit/validate-findings.cjs",
+          "sha256": "36d445209703d838c320c6366935f6476823e96e6b76d99a64f3aaf9beb51f2e",
+          "owner": "security-audit"
         }
       ]
     }

--- a/docs/sources/cloudflare-security-audit-skill-2026-07.skills.json
+++ b/docs/sources/cloudflare-security-audit-skill-2026-07.skills.json
@@ -127,57 +127,68 @@
         {
           "path": "skills/security-and-reliability/security-audit/AI-AND-LLM.md",
           "sha256": "e3f1f732de2bdd469023a6ac591849a1285abe9b0d12de11fb7d9fd13f6c108e",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/ATTACK-CLASSES.md",
           "sha256": "f3fab5e6a113553f357e3586f488b9c7e047d48c2ee5443c77724ec1d1d5fdb0",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/CLIENT-SIDE.md",
           "sha256": "14a0bef183b95e62de4945b886fbfd677c53c68d77f8fdf4c7e2d42e9815f883",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/HUNTING.md",
           "sha256": "735caebbc3bfed31d2c9fbbf61f383060305774708e0d0ac38050a7eac7ac679",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/MEMORY-SAFETY-AND-BINARY.md",
           "sha256": "8e1f8e8d9029941083fd5739fec493de7f2699a13fec23d0d0a9a3aae85f7e55",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/RECONNAISSANCE.md",
           "sha256": "89e2f899107335467716f06bc0bb175e87ccfb662dd9878b9a0f155d8005343f",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/SKILL.md",
           "sha256": "f534330a3098552529d9d8a4d3edde15bd7545db42b4af955b469d72592e8710",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/VALIDATION-AND-REPORTING.md",
           "sha256": "049dea0289689c66fd913aafa7d6d6df3d5b38d5d9d8e571825ba58f4308c2bd",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/WEB-PROTOCOL-AND-AUTH.md",
           "sha256": "b8f9a0e29ad6685a3d96cf42a538be7012c4a18925a4871a475291aae497ed04",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/report-schema.json",
           "sha256": "05c24d50f3314b025dbfb28dfee550d9dec9775602d51fc5c891013a3ab8b273",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-audit/validate-findings.cjs",
           "sha256": "36d445209703d838c320c6366935f6476823e96e6b76d99a64f3aaf9beb51f2e",
-          "owner": "security-audit"
+          "owner": "security-audit",
+          "mode": "100755"
         }
       ]
     }

--- a/docs/sources/firebase-agent-skills-2026-07.skills.json
+++ b/docs/sources/firebase-agent-skills-2026-07.skills.json
@@ -68,7 +68,8 @@
         {
           "path": "skills/security-and-reliability/firebase-security-rules-auditor/SKILL.md",
           "owner": "firebase-security-rules-auditor",
-          "sha256": "91b3a59f6e981e5eab000eafc1ba17d209eab0d3eab1b213f134f5a4a3b162a7"
+          "sha256": "91b3a59f6e981e5eab000eafc1ba17d209eab0d3eab1b213f134f5a4a3b162a7",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/graphify-2026-04.skills.json
+++ b/docs/sources/graphify-2026-04.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://github.com/Graphify-Labs/graphify",
-    "checked_at": "2026-08-18",
+    "checked_at": "2026-08-20",
     "note": "Curated from graphify as a codebase-and-corpus knowledge graph workflow aligned with the Karpathy-style wiki pattern. Updated from the graphifyy 0.5.0 PyPI wheel Codex skill variant."
   },
   "official_references": [
@@ -28,13 +28,14 @@
       "upstream": {
         "repo": "Graphify-Labs/graphify",
         "path": "graphify/skill-codex.md",
-        "ref": "v8",
-        "last_checked_at": "2026-08-18",
-        "last_synced_at": "2026-08-18",
+        "ref": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
+        "last_checked_at": "2026-08-20",
+        "last_synced_at": "2026-08-20",
         "last_synced_commit": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
-      "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "8658cc31059111dd914d247301e3d999b4935cf0"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -50,20 +51,685 @@
           ],
           "tracking": {
             "channel": "fixed_ref",
-            "ref": "v8",
+            "ref": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
             "resolved_commit": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
-            "path_commit": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
+            "path_commit": "8658cc31059111dd914d247301e3d999b4935cf0",
             "content_sha256": "9b82b9b92e7144d5bce26f83d2a20ffba20930285f312c2c6851eaa566bd8951",
-            "last_checked_at": "2026-08-18",
-            "last_synced_at": "2026-08-18"
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
+              "content_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+              "spdx": "Apache-2.0",
+              "resolved_commit": "62b1d4370b8f8d61dea9a1d952393ae63ad53fa4",
+              "api_spdx": "NOASSERTION"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/developer-engineering/graphify",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/developer-engineering/graphify/__init__.py",
+              "target": "skills/developer-engineering/graphify/__init__.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/__main__.py",
+              "target": "skills/developer-engineering/graphify/__main__.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/_minhash.py",
+              "target": "skills/developer-engineering/graphify/_minhash.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/affected.py",
+              "target": "skills/developer-engineering/graphify/affected.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/analyze.py",
+              "target": "skills/developer-engineering/graphify/analyze.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/benchmark.py",
+              "target": "skills/developer-engineering/graphify/benchmark.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/build.py",
+              "target": "skills/developer-engineering/graphify/build.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/cache.py",
+              "target": "skills/developer-engineering/graphify/cache.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/callflow_html.py",
+              "target": "skills/developer-engineering/graphify/callflow_html.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/cargo_introspect.py",
+              "target": "skills/developer-engineering/graphify/cargo_introspect.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/cli.py",
+              "target": "skills/developer-engineering/graphify/cli.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/cluster.py",
+              "target": "skills/developer-engineering/graphify/cluster.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/command-kilo.md",
+              "target": "skills/developer-engineering/graphify/command-kilo.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/dedup.py",
+              "target": "skills/developer-engineering/graphify/dedup.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/detect.py",
+              "target": "skills/developer-engineering/graphify/detect.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/diagnostics.py",
+              "target": "skills/developer-engineering/graphify/diagnostics.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/export.py",
+              "target": "skills/developer-engineering/graphify/export.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/extract.py",
+              "target": "skills/developer-engineering/graphify/extract.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/file_slice.py",
+              "target": "skills/developer-engineering/graphify/file_slice.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/global_graph.py",
+              "target": "skills/developer-engineering/graphify/global_graph.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/google_workspace.py",
+              "target": "skills/developer-engineering/graphify/google_workspace.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/hooks.py",
+              "target": "skills/developer-engineering/graphify/hooks.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/ids.py",
+              "target": "skills/developer-engineering/graphify/ids.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/ingest.py",
+              "target": "skills/developer-engineering/graphify/ingest.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/install.py",
+              "target": "skills/developer-engineering/graphify/install.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/llm.py",
+              "target": "skills/developer-engineering/graphify/llm.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/manifest.py",
+              "target": "skills/developer-engineering/graphify/manifest.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/manifest_ingest.py",
+              "target": "skills/developer-engineering/graphify/manifest_ingest.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/mcp_ingest.py",
+              "target": "skills/developer-engineering/graphify/mcp_ingest.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/multigraph_compat.py",
+              "target": "skills/developer-engineering/graphify/multigraph_compat.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/pascal_resolution.py",
+              "target": "skills/developer-engineering/graphify/pascal_resolution.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/paths.py",
+              "target": "skills/developer-engineering/graphify/paths.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/pg_introspect.py",
+              "target": "skills/developer-engineering/graphify/pg_introspect.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/prs.py",
+              "target": "skills/developer-engineering/graphify/prs.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/querylog.py",
+              "target": "skills/developer-engineering/graphify/querylog.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/reflect.py",
+              "target": "skills/developer-engineering/graphify/reflect.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/report.py",
+              "target": "skills/developer-engineering/graphify/report.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/resolver_registry.py",
+              "target": "skills/developer-engineering/graphify/resolver_registry.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/ruby_resolution.py",
+              "target": "skills/developer-engineering/graphify/ruby_resolution.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/scip_ingest.py",
+              "target": "skills/developer-engineering/graphify/scip_ingest.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/security.py",
+              "target": "skills/developer-engineering/graphify/security.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/semantic_cleanup.py",
+              "target": "skills/developer-engineering/graphify/semantic_cleanup.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/serve.py",
+              "target": "skills/developer-engineering/graphify/serve.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-agents.md",
+              "target": "skills/developer-engineering/graphify/skill-agents.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-aider.md",
+              "target": "skills/developer-engineering/graphify/skill-aider.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-amp.md",
+              "target": "skills/developer-engineering/graphify/skill-amp.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-claw.md",
+              "target": "skills/developer-engineering/graphify/skill-claw.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-codex.md",
+              "target": "skills/developer-engineering/graphify/skill-codex.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-copilot.md",
+              "target": "skills/developer-engineering/graphify/skill-copilot.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-devin.md",
+              "target": "skills/developer-engineering/graphify/skill-devin.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-droid.md",
+              "target": "skills/developer-engineering/graphify/skill-droid.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-kilo.md",
+              "target": "skills/developer-engineering/graphify/skill-kilo.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-kiro.md",
+              "target": "skills/developer-engineering/graphify/skill-kiro.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-opencode.md",
+              "target": "skills/developer-engineering/graphify/skill-opencode.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-pi.md",
+              "target": "skills/developer-engineering/graphify/skill-pi.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-trae.md",
+              "target": "skills/developer-engineering/graphify/skill-trae.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-vscode.md",
+              "target": "skills/developer-engineering/graphify/skill-vscode.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/skill-windows.md",
+              "target": "skills/developer-engineering/graphify/skill-windows.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/symbol_resolution.py",
+              "target": "skills/developer-engineering/graphify/symbol_resolution.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/transcribe.py",
+              "target": "skills/developer-engineering/graphify/transcribe.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/tree_html.py",
+              "target": "skills/developer-engineering/graphify/tree_html.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/validate.py",
+              "target": "skills/developer-engineering/graphify/validate.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/watch.py",
+              "target": "skills/developer-engineering/graphify/watch.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/graphify/wiki.py",
+              "target": "skills/developer-engineering/graphify/wiki.py",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
           }
         }
       ],
       "managed_files": [
         {
           "path": "skills/developer-engineering/graphify/SKILL.md",
-          "owner": "graphify",
-          "sha256": "9b82b9b92e7144d5bce26f83d2a20ffba20930285f312c2c6851eaa566bd8951"
+          "sha256": "9b82b9b92e7144d5bce26f83d2a20ffba20930285f312c2c6851eaa566bd8951",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/__init__.py",
+          "sha256": "5afcd670aa65337ae49735582a9bc482a721abdfbfc063fcad1d0ccc90b0838a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/__main__.py",
+          "sha256": "a388ae6c903eb8b753ed6afdd63e4258df3980e347b3441669f3d402e7ca7ccf",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/_minhash.py",
+          "sha256": "eea373a21d8f9c97beecb08ca06f0e2d273cd40e2e91dfbcaec4972bd45fdf0c",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/affected.py",
+          "sha256": "f772e52e3fc6919042919d89ad67d0407679721a8850955253ebc6a538a91c53",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/analyze.py",
+          "sha256": "8b2bd5cb4c1ee1174265361d3a746877ab4dc65f3b25334d54c98f62e4755ef2",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/benchmark.py",
+          "sha256": "6bf7084c9a7da62c7b5ec46e2ca8280fded842d8c23a023aaaa4a62dfea61829",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/build.py",
+          "sha256": "77c56872ccff475dcb39707f621958019f50e8bacef49c2c10c50ac9dfdeadfd",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/cache.py",
+          "sha256": "0955b389fb0a57e004990f812b6badc67b1bfd0d7a8905efb8bf458e87068a0b",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/callflow_html.py",
+          "sha256": "83d0667c3fd4d2a981a2b9b30fea340f3773b61a4aa0e44b7f68652c0ab4785c",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/cargo_introspect.py",
+          "sha256": "a5b97dd1df4b364354b2cb5a7eb7b1e756e487216d03ac6a0fca00b80bcfbf9b",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/cli.py",
+          "sha256": "d68072b4de385662c90560c87a5e424cb2a059397b9b8146468cbb0078bb4401",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/cluster.py",
+          "sha256": "a3920a33cb72c013c355d1a89e304ea90ff4c82e1e0ddaf25c7af3b0cbe6cacd",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/command-kilo.md",
+          "sha256": "5c2332f9e9d9f90e807cff0043f21a05e98e31cfc88777e968eb2249eed80aed",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/dedup.py",
+          "sha256": "39ea5274ac6ea081364c64dc2200afadd1e8f1946a2fa702065bd0ff7178f386",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/detect.py",
+          "sha256": "38696a6498cdb9b320e6c5cca169470de0fac8ab13f4e09e312a2560e35b80a0",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/diagnostics.py",
+          "sha256": "4cab48ec7db79a703498f6b3c8f936a52b804dba249893b9383a6bece04ed6e8",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/export.py",
+          "sha256": "12996202aae38157e74f6066de655ba8dedb60f59ed768292136d6ad07604a90",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/extract.py",
+          "sha256": "1554c1d054d063782c0d9e99ba433c92f0fafcacb08dd357ea8b5859a78bc29d",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/file_slice.py",
+          "sha256": "82f05c6b9963de72fa9295ce85e8305a4430ee63800b4dd1000eb429b6d9544e",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/global_graph.py",
+          "sha256": "f1efb88ad523dbc7f0c6c44d575da056ccbbb202c2951095ba0671779b923563",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/google_workspace.py",
+          "sha256": "f5563580450aea0830159ebed58316594161b6bcb9539cd97d161ff529ceae9a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/hooks.py",
+          "sha256": "538d55085e9da0f14e372a54e303d7ab85bbffae1f1772fbcb9b1a96b0fdf52e",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/ids.py",
+          "sha256": "ac9138fccaa369adf0fd110cb2775f77bf6244d6b833d417d5551759a4439f4c",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/ingest.py",
+          "sha256": "34a5103d469774f0981ba741e7b3e883d35d2023e16dbf0c90287f2ac4e775ad",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/install.py",
+          "sha256": "f473bc446ede308e36f74ebb306eff3da12c9dcbf45e87133576dcf7f99e2526",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/llm.py",
+          "sha256": "9c5a1541fa3102369a31266f2ed606f3452b24f46dc2e214ac753d1c658e29d4",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/manifest.py",
+          "sha256": "c865a2c577d4bf618d19d512d1f687ea0c961b8c09879b40d414536f184f7da2",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/manifest_ingest.py",
+          "sha256": "1f79a52f3c7f7a47d3a5006204bc00310c52d72c0b021200d9d5c477cbdc7f7f",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/mcp_ingest.py",
+          "sha256": "7553845a7cae7c310803bf37d992b695b27d21e1b827c1c33dbed2b15971be61",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/multigraph_compat.py",
+          "sha256": "73abcd5293c91f2584ea29539774a126fe99a783e3672887d69b5d70033c798b",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/pascal_resolution.py",
+          "sha256": "e4e9400ee20e6b410e521ad24bfe4c7e09742590ba1b0964cc84b49158d9318f",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/paths.py",
+          "sha256": "98b99e4de7290c6ed4511338ccfb118b15a15304aa00e759b3c186e4776dc705",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/pg_introspect.py",
+          "sha256": "9b31b4759289794407084e226d960aaea7936518dadc9da051e51136aa8b3af6",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/prs.py",
+          "sha256": "0ca28d7af2186c640ce7501b10d501b3498e3a50e14e62964bacedf78a73c30a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/querylog.py",
+          "sha256": "953ad5fece9d380795a70e7dda4b72069ed7a57f56d8648fd339fea959a150a4",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/reflect.py",
+          "sha256": "1133f73a98fda37bcaa7c18e21741a518f855947210a55b90f6bad79c3878497",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/report.py",
+          "sha256": "6bda48f7f1387610b0a68f27a42ed0f1c967baed94737cc15a9bf563db8e30c8",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/resolver_registry.py",
+          "sha256": "bd5904412417ead6104852c1d79c3e8d1aebb7ab3f80a13330f19be7c18f307b",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/ruby_resolution.py",
+          "sha256": "10e799b3605125841740ef71734ac3f4aa9cecefc627669c9aac2b5253a7a897",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/scip_ingest.py",
+          "sha256": "4de62f7da456e5dc28f78a0dc5d97200e036cfb01318a806539582d53e288aa5",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/security.py",
+          "sha256": "26effec8aec27935da8cb60ee060924aa1a1965644a4c9f7dd61f4ae6b90a516",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/semantic_cleanup.py",
+          "sha256": "cae3cc75d203ffc2a23e01d8fedff40ed1316ded1767698bc31b5b59e64673aa",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/serve.py",
+          "sha256": "8b3ea9065bc1aaa7f686162ac9830592a09a147e9cde995b143175f8a5ca889d",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-agents.md",
+          "sha256": "7a6d60d8c3fd4384252c23c69c1c82643c6a86dee967f5dfa9f23169fea2cb1a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-aider.md",
+          "sha256": "482ca401af014b01cc64e8fbe5389515753c792664f955291dd4dc2be470c291",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-amp.md",
+          "sha256": "7a6d60d8c3fd4384252c23c69c1c82643c6a86dee967f5dfa9f23169fea2cb1a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-claw.md",
+          "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-codex.md",
+          "sha256": "3898b1042721cad27d6f87ca44f638415a7f763203aefd86b90f9358ffea3a43",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-copilot.md",
+          "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-devin.md",
+          "sha256": "254dafb67b53b4657815ab53383fa88dd6f4f8a19eb7be6f7c83c927ca7e0576",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-droid.md",
+          "sha256": "06b8b1592469d3605953ce77e9f49dfa08a8d6f39511bed40f6687b465dab49c",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-kilo.md",
+          "sha256": "43b43d22b206cf867fd9e3fdb64f5f4cee190decd69153a6d41e86d61bcaf4af",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-kiro.md",
+          "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-opencode.md",
+          "sha256": "8664d0684e7fa14c47c8cce312a964c1669e44f8c8eea89a5b4fdb593f62ed66",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-pi.md",
+          "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-trae.md",
+          "sha256": "fe5d7ed45cd9260ebe5694275a2d67bb0457bc71bbf85091790a98d4b6ffe405",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-vscode.md",
+          "sha256": "ab190cc8333d30f02692e7b63b0e4dd3140c00f087e5f26e3693feb176cd91cf",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/skill-windows.md",
+          "sha256": "43011be551529ba70b2c3962bece090c591ce1fdc8d05026837ae337972a431a",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/symbol_resolution.py",
+          "sha256": "1da5a99cf41c511102fead3fedefbc42f0dfdbe70b01962c8520652fc2313153",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/transcribe.py",
+          "sha256": "b01c127af5a7bf44865e517848dbb2d3dd88af0b146674c87ea56079cd926d55",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/tree_html.py",
+          "sha256": "dbd109d344de6a9bbfd3b20c62c91c6e5e7dceaf672d1695ae2985e58892d789",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/validate.py",
+          "sha256": "be068c6b2ff4e514f31663e0155a9d63f35096d154b98ab6c9c467a23febd6f7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/watch.py",
+          "sha256": "d91f6bbcba9e5a58b22655182f2dfc890bbda6f8c1bc27b2e73231d480e2e4c7",
+          "owner": "graphify"
+        },
+        {
+          "path": "skills/developer-engineering/graphify/wiki.py",
+          "sha256": "53a2f7d3b2ea6b573bb8aaf28bf256bfeac3ac05c251f381a0531474abf22325",
+          "owner": "graphify"
         }
       ]
     }

--- a/docs/sources/graphify-2026-04.skills.json
+++ b/docs/sources/graphify-2026-04.skills.json
@@ -409,327 +409,392 @@
         {
           "path": "skills/developer-engineering/graphify/SKILL.md",
           "sha256": "9b82b9b92e7144d5bce26f83d2a20ffba20930285f312c2c6851eaa566bd8951",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/__init__.py",
           "sha256": "5afcd670aa65337ae49735582a9bc482a721abdfbfc063fcad1d0ccc90b0838a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/__main__.py",
           "sha256": "a388ae6c903eb8b753ed6afdd63e4258df3980e347b3441669f3d402e7ca7ccf",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/_minhash.py",
           "sha256": "eea373a21d8f9c97beecb08ca06f0e2d273cd40e2e91dfbcaec4972bd45fdf0c",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/affected.py",
           "sha256": "f772e52e3fc6919042919d89ad67d0407679721a8850955253ebc6a538a91c53",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/analyze.py",
           "sha256": "8b2bd5cb4c1ee1174265361d3a746877ab4dc65f3b25334d54c98f62e4755ef2",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/benchmark.py",
           "sha256": "6bf7084c9a7da62c7b5ec46e2ca8280fded842d8c23a023aaaa4a62dfea61829",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/build.py",
           "sha256": "77c56872ccff475dcb39707f621958019f50e8bacef49c2c10c50ac9dfdeadfd",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/cache.py",
           "sha256": "0955b389fb0a57e004990f812b6badc67b1bfd0d7a8905efb8bf458e87068a0b",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/callflow_html.py",
           "sha256": "83d0667c3fd4d2a981a2b9b30fea340f3773b61a4aa0e44b7f68652c0ab4785c",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/cargo_introspect.py",
           "sha256": "a5b97dd1df4b364354b2cb5a7eb7b1e756e487216d03ac6a0fca00b80bcfbf9b",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/cli.py",
           "sha256": "d68072b4de385662c90560c87a5e424cb2a059397b9b8146468cbb0078bb4401",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/cluster.py",
           "sha256": "a3920a33cb72c013c355d1a89e304ea90ff4c82e1e0ddaf25c7af3b0cbe6cacd",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/command-kilo.md",
           "sha256": "5c2332f9e9d9f90e807cff0043f21a05e98e31cfc88777e968eb2249eed80aed",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/dedup.py",
           "sha256": "39ea5274ac6ea081364c64dc2200afadd1e8f1946a2fa702065bd0ff7178f386",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/detect.py",
           "sha256": "38696a6498cdb9b320e6c5cca169470de0fac8ab13f4e09e312a2560e35b80a0",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/diagnostics.py",
           "sha256": "4cab48ec7db79a703498f6b3c8f936a52b804dba249893b9383a6bece04ed6e8",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/export.py",
           "sha256": "12996202aae38157e74f6066de655ba8dedb60f59ed768292136d6ad07604a90",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/extract.py",
           "sha256": "1554c1d054d063782c0d9e99ba433c92f0fafcacb08dd357ea8b5859a78bc29d",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/file_slice.py",
           "sha256": "82f05c6b9963de72fa9295ce85e8305a4430ee63800b4dd1000eb429b6d9544e",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/global_graph.py",
           "sha256": "f1efb88ad523dbc7f0c6c44d575da056ccbbb202c2951095ba0671779b923563",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/google_workspace.py",
           "sha256": "f5563580450aea0830159ebed58316594161b6bcb9539cd97d161ff529ceae9a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/hooks.py",
           "sha256": "538d55085e9da0f14e372a54e303d7ab85bbffae1f1772fbcb9b1a96b0fdf52e",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/ids.py",
           "sha256": "ac9138fccaa369adf0fd110cb2775f77bf6244d6b833d417d5551759a4439f4c",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/ingest.py",
           "sha256": "34a5103d469774f0981ba741e7b3e883d35d2023e16dbf0c90287f2ac4e775ad",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/install.py",
           "sha256": "f473bc446ede308e36f74ebb306eff3da12c9dcbf45e87133576dcf7f99e2526",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/llm.py",
           "sha256": "9c5a1541fa3102369a31266f2ed606f3452b24f46dc2e214ac753d1c658e29d4",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/manifest.py",
           "sha256": "c865a2c577d4bf618d19d512d1f687ea0c961b8c09879b40d414536f184f7da2",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/manifest_ingest.py",
           "sha256": "1f79a52f3c7f7a47d3a5006204bc00310c52d72c0b021200d9d5c477cbdc7f7f",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/mcp_ingest.py",
           "sha256": "7553845a7cae7c310803bf37d992b695b27d21e1b827c1c33dbed2b15971be61",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/multigraph_compat.py",
           "sha256": "73abcd5293c91f2584ea29539774a126fe99a783e3672887d69b5d70033c798b",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/pascal_resolution.py",
           "sha256": "e4e9400ee20e6b410e521ad24bfe4c7e09742590ba1b0964cc84b49158d9318f",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/paths.py",
           "sha256": "98b99e4de7290c6ed4511338ccfb118b15a15304aa00e759b3c186e4776dc705",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/pg_introspect.py",
           "sha256": "9b31b4759289794407084e226d960aaea7936518dadc9da051e51136aa8b3af6",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/prs.py",
           "sha256": "0ca28d7af2186c640ce7501b10d501b3498e3a50e14e62964bacedf78a73c30a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/querylog.py",
           "sha256": "953ad5fece9d380795a70e7dda4b72069ed7a57f56d8648fd339fea959a150a4",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/reflect.py",
           "sha256": "1133f73a98fda37bcaa7c18e21741a518f855947210a55b90f6bad79c3878497",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/report.py",
           "sha256": "6bda48f7f1387610b0a68f27a42ed0f1c967baed94737cc15a9bf563db8e30c8",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/resolver_registry.py",
           "sha256": "bd5904412417ead6104852c1d79c3e8d1aebb7ab3f80a13330f19be7c18f307b",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/ruby_resolution.py",
           "sha256": "10e799b3605125841740ef71734ac3f4aa9cecefc627669c9aac2b5253a7a897",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/scip_ingest.py",
           "sha256": "4de62f7da456e5dc28f78a0dc5d97200e036cfb01318a806539582d53e288aa5",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/security.py",
           "sha256": "26effec8aec27935da8cb60ee060924aa1a1965644a4c9f7dd61f4ae6b90a516",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/semantic_cleanup.py",
           "sha256": "cae3cc75d203ffc2a23e01d8fedff40ed1316ded1767698bc31b5b59e64673aa",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/serve.py",
           "sha256": "8b3ea9065bc1aaa7f686162ac9830592a09a147e9cde995b143175f8a5ca889d",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-agents.md",
           "sha256": "7a6d60d8c3fd4384252c23c69c1c82643c6a86dee967f5dfa9f23169fea2cb1a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-aider.md",
           "sha256": "482ca401af014b01cc64e8fbe5389515753c792664f955291dd4dc2be470c291",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-amp.md",
           "sha256": "7a6d60d8c3fd4384252c23c69c1c82643c6a86dee967f5dfa9f23169fea2cb1a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-claw.md",
           "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-codex.md",
           "sha256": "3898b1042721cad27d6f87ca44f638415a7f763203aefd86b90f9358ffea3a43",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-copilot.md",
           "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-devin.md",
           "sha256": "254dafb67b53b4657815ab53383fa88dd6f4f8a19eb7be6f7c83c927ca7e0576",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-droid.md",
           "sha256": "06b8b1592469d3605953ce77e9f49dfa08a8d6f39511bed40f6687b465dab49c",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-kilo.md",
           "sha256": "43b43d22b206cf867fd9e3fdb64f5f4cee190decd69153a6d41e86d61bcaf4af",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-kiro.md",
           "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-opencode.md",
           "sha256": "8664d0684e7fa14c47c8cce312a964c1669e44f8c8eea89a5b4fdb593f62ed66",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-pi.md",
           "sha256": "3e4d30df5a936965acaa25117230a6f3ff44353c137e63030e85e3bc3a391fb7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-trae.md",
           "sha256": "fe5d7ed45cd9260ebe5694275a2d67bb0457bc71bbf85091790a98d4b6ffe405",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-vscode.md",
           "sha256": "ab190cc8333d30f02692e7b63b0e4dd3140c00f087e5f26e3693feb176cd91cf",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/skill-windows.md",
           "sha256": "43011be551529ba70b2c3962bece090c591ce1fdc8d05026837ae337972a431a",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/symbol_resolution.py",
           "sha256": "1da5a99cf41c511102fead3fedefbc42f0dfdbe70b01962c8520652fc2313153",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/transcribe.py",
           "sha256": "b01c127af5a7bf44865e517848dbb2d3dd88af0b146674c87ea56079cd926d55",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/tree_html.py",
           "sha256": "dbd109d344de6a9bbfd3b20c62c91c6e5e7dceaf672d1695ae2985e58892d789",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/validate.py",
           "sha256": "be068c6b2ff4e514f31663e0155a9d63f35096d154b98ab6c9c467a23febd6f7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/watch.py",
           "sha256": "d91f6bbcba9e5a58b22655182f2dfc890bbda6f8c1bc27b2e73231d480e2e4c7",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/graphify/wiki.py",
           "sha256": "53a2f7d3b2ea6b573bb8aaf28bf256bfeac3ac05c251f381a0531474abf22325",
-          "owner": "graphify"
+          "owner": "graphify",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -123,72 +123,86 @@
         {
           "path": "skills/developer-engineering/agent-designer/README.md",
           "owner": "agent-designer",
-          "sha256": "c825124b0a6ae2649c335933657fef765b9911b79fa838b4969683588c175bfa"
+          "sha256": "c825124b0a6ae2649c335933657fef765b9911b79fa838b4969683588c175bfa",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/SKILL.md",
           "owner": "agent-designer",
-          "sha256": "8563d0a91d425107bfdf2cfb3c870366ae5eef5ee0aad9985a07d53b5f3d7bee"
+          "sha256": "8563d0a91d425107bfdf2cfb3c870366ae5eef5ee0aad9985a07d53b5f3d7bee",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/agent_evaluator.py",
           "owner": "agent-designer",
-          "sha256": "a63895a6bc66c94a68e9d1faa8beec843691a6cade9063ed3af144a3149b62b9"
+          "sha256": "a63895a6bc66c94a68e9d1faa8beec843691a6cade9063ed3af144a3149b62b9",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/agent_planner.py",
           "owner": "agent-designer",
-          "sha256": "0770a4041483e58e4869ed379820f366c1bac56045a06d4b7c218ea649718791"
+          "sha256": "0770a4041483e58e4869ed379820f366c1bac56045a06d4b7c218ea649718791",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/assets/sample_execution_logs.json",
           "owner": "agent-designer",
-          "sha256": "5389957c0ea136f99d1e005308c853251e7ea06089766babbd4c734ce1fbf764"
+          "sha256": "5389957c0ea136f99d1e005308c853251e7ea06089766babbd4c734ce1fbf764",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/assets/sample_system_requirements.json",
           "owner": "agent-designer",
-          "sha256": "ae67d58ba0687d7f3e2f4cad9c03d956a6254a32375e17a95ef455a6322d226a"
+          "sha256": "ae67d58ba0687d7f3e2f4cad9c03d956a6254a32375e17a95ef455a6322d226a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/assets/sample_tool_descriptions.json",
           "owner": "agent-designer",
-          "sha256": "e29f18bed083565e2d2825398facf4991d5b642ad7ed65ff9c3b703266f99d04"
+          "sha256": "e29f18bed083565e2d2825398facf4991d5b642ad7ed65ff9c3b703266f99d04",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/expected_outputs/sample_agent_architecture.json",
           "owner": "agent-designer",
-          "sha256": "8614a27c80939024f3aee2d28f6643ffe9f2ef73b57e2fc83d08c1d00c2d78d5"
+          "sha256": "8614a27c80939024f3aee2d28f6643ffe9f2ef73b57e2fc83d08c1d00c2d78d5",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/expected_outputs/sample_evaluation_report.json",
           "owner": "agent-designer",
-          "sha256": "dda807023b53ebc4eb239b1534b9a9489172ca4f7ae5746ee2e21684e76f7e67"
+          "sha256": "dda807023b53ebc4eb239b1534b9a9489172ca4f7ae5746ee2e21684e76f7e67",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/expected_outputs/sample_tool_schemas.json",
           "owner": "agent-designer",
-          "sha256": "c861155bd4251a715599f75121f9f12965973812e268b73ab7aad6dd94623c91"
+          "sha256": "c861155bd4251a715599f75121f9f12965973812e268b73ab7aad6dd94623c91",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/references/agent_architecture_patterns.md",
           "owner": "agent-designer",
-          "sha256": "8d73a2c9e3618491fb5813b1ec59af0cb7410011690369c056986adada34b4c6"
+          "sha256": "8d73a2c9e3618491fb5813b1ec59af0cb7410011690369c056986adada34b4c6",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/references/evaluation_methodology.md",
           "owner": "agent-designer",
-          "sha256": "053f836da08a6b4d1a2dd16a7bb57ee0c48341615cf05fdff4933e4bd0c0c7d8"
+          "sha256": "053f836da08a6b4d1a2dd16a7bb57ee0c48341615cf05fdff4933e4bd0c0c7d8",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/references/tool_design_best_practices.md",
           "owner": "agent-designer",
-          "sha256": "ff2aac14b86a32133f5aebb5e2486da04f9911c903466f6c317b273735f6206d"
+          "sha256": "ff2aac14b86a32133f5aebb5e2486da04f9911c903466f6c317b273735f6206d",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/agent-designer/tool_schema_generator.py",
           "owner": "agent-designer",
-          "sha256": "a95369bd7132c83e210a51c1357788d478e3acbccc4a58f36ceb3cfb1e5fe087"
+          "sha256": "a95369bd7132c83e210a51c1357788d478e3acbccc4a58f36ceb3cfb1e5fe087",
+          "mode": "100644"
         }
       ]
     },
@@ -238,7 +252,8 @@
         {
           "path": "skills/ai-workflow/agent-workflow-designer/SKILL.md",
           "owner": "agent-workflow-designer",
-          "sha256": "266ed347532728354663764c33b9441b107915a28e8d0bddd8cfae3a95eda79c"
+          "sha256": "266ed347532728354663764c33b9441b107915a28e8d0bddd8cfae3a95eda79c",
+          "mode": "100644"
         }
       ]
     },
@@ -303,22 +318,26 @@
         {
           "path": "skills/product-design/agile-product-owner/SKILL.md",
           "owner": "agile-product-owner",
-          "sha256": "628294b52558c5f1b7884bd86c0bb06fed923343908cff2797166665bc86a7fe"
+          "sha256": "628294b52558c5f1b7884bd86c0bb06fed923343908cff2797166665bc86a7fe",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/agile-product-owner/references/sprint-planning-guide.md",
           "owner": "agile-product-owner",
-          "sha256": "2ae5bb3c6ae2013621d81a13df3f595a9828026f655c0c663e1bee2a87791354"
+          "sha256": "2ae5bb3c6ae2013621d81a13df3f595a9828026f655c0c663e1bee2a87791354",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/agile-product-owner/references/user-story-templates.md",
           "owner": "agile-product-owner",
-          "sha256": "2c5cc3626566c66e85c35d34da1784dfc10ce05f840fd38d5556f6bcce46dc08"
+          "sha256": "2c5cc3626566c66e85c35d34da1784dfc10ce05f840fd38d5556f6bcce46dc08",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/agile-product-owner/scripts/user_story_generator.py",
           "owner": "agile-product-owner",
-          "sha256": "529e731d998829c4162226e4dc3225d3916c925d54b575c520c92cbec14cf7be"
+          "sha256": "529e731d998829c4162226e4dc3225d3916c925d54b575c520c92cbec14cf7be",
+          "mode": "100644"
         }
       ]
     },
@@ -383,22 +402,26 @@
         {
           "path": "skills/growth-operations-xiaohongshu/algorithmic-art/LICENSE.txt",
           "owner": "algorithmic-art",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/algorithmic-art/SKILL.md",
           "owner": "algorithmic-art",
-          "sha256": "3a19e1c1a25507c5f6d8b93b73e068e3b0e931bdc52c5e56bee1ca2eb5fc9a63"
+          "sha256": "3a19e1c1a25507c5f6d8b93b73e068e3b0e931bdc52c5e56bee1ca2eb5fc9a63",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/algorithmic-art/templates/generator_template.js",
           "owner": "algorithmic-art",
-          "sha256": "9ee0f1da52ef8f7bbfde1917123654880890d43f2d388642d71eab6dd78f94c4"
+          "sha256": "9ee0f1da52ef8f7bbfde1917123654880890d43f2d388642d71eab6dd78f94c4",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/algorithmic-art/templates/viewer.html",
           "owner": "algorithmic-art",
-          "sha256": "86c79d7ce97d2599ebe4bd9b97fdeb7295c9d3ed61ceeb513cbe1b2bb5d1ce29"
+          "sha256": "86c79d7ce97d2599ebe4bd9b97fdeb7295c9d3ed61ceeb513cbe1b2bb5d1ce29",
+          "mode": "100644"
         }
       ]
     },
@@ -448,7 +471,8 @@
         {
           "path": "skills/ai-workflow/andrej-karpathy-skills/SKILL.md",
           "owner": "andrej-karpathy-skills",
-          "sha256": "c766537eecfb66b685104596ea29be912e8dded1507c09d1b5894f685bc15d9d"
+          "sha256": "c766537eecfb66b685104596ea29be912e8dded1507c09d1b5894f685bc15d9d",
+          "mode": "100644"
         }
       ]
     },
@@ -523,32 +547,38 @@
         {
           "path": "skills/developer-engineering/api-design-reviewer/SKILL.md",
           "owner": "api-design-reviewer",
-          "sha256": "ed235881cfc758c7a705861cb279d266dc43ade63ee124eb585d3ca0a4f4fd20"
+          "sha256": "ed235881cfc758c7a705861cb279d266dc43ade63ee124eb585d3ca0a4f4fd20",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/api-design-reviewer/references/api_antipatterns.md",
           "owner": "api-design-reviewer",
-          "sha256": "60901c132668746265cc74779ad36b9faf8fa3fe11787a68fa6e128a159d38a9"
+          "sha256": "60901c132668746265cc74779ad36b9faf8fa3fe11787a68fa6e128a159d38a9",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/api-design-reviewer/references/rest_design_rules.md",
           "owner": "api-design-reviewer",
-          "sha256": "a69236c8fa395100146c74255f3e43101021b7730acfeb03aa17872d02b05bb2"
+          "sha256": "a69236c8fa395100146c74255f3e43101021b7730acfeb03aa17872d02b05bb2",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/api-design-reviewer/scripts/api_linter.py",
           "owner": "api-design-reviewer",
-          "sha256": "0a0fcdeaf067ddfb6b530f4a8ec27d5e7b8f1aab2e7686792ace1967e0b0a5b0"
+          "sha256": "0a0fcdeaf067ddfb6b530f4a8ec27d5e7b8f1aab2e7686792ace1967e0b0a5b0",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/api-design-reviewer/scripts/api_scorecard.py",
           "owner": "api-design-reviewer",
-          "sha256": "b96aacbcf99c1ad8a1940fac5fdcfd22749a7378176714cd50e15bf99750e52e"
+          "sha256": "b96aacbcf99c1ad8a1940fac5fdcfd22749a7378176714cd50e15bf99750e52e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/api-design-reviewer/scripts/breaking_change_detector.py",
           "owner": "api-design-reviewer",
-          "sha256": "4e6be80751d58aa88f27acd8d610e68b6f189233995ba8d0342e19ae3ac90db2"
+          "sha256": "4e6be80751d58aa88f27acd8d610e68b6f189233995ba8d0342e19ae3ac90db2",
+          "mode": "100644"
         }
       ]
     },
@@ -598,7 +628,8 @@
         {
           "path": "skills/developer-engineering/api-test-suite-builder/SKILL.md",
           "owner": "api-test-suite-builder",
-          "sha256": "0ddf470115c9ee8fa5ab0177c46b7444749cab5a961e25773cb1909b24c1200a"
+          "sha256": "0ddf470115c9ee8fa5ab0177c46b7444749cab5a961e25773cb1909b24c1200a",
+          "mode": "100644"
         }
       ]
     },
@@ -728,87 +759,104 @@
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/HOW_TO_USE.md",
           "owner": "app-store-optimization",
-          "sha256": "88163da94aff5fd03196f635f7e1640e14cf7be8e76fa3086473cbc41e03f18e"
+          "sha256": "88163da94aff5fd03196f635f7e1640e14cf7be8e76fa3086473cbc41e03f18e",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/README.md",
           "owner": "app-store-optimization",
-          "sha256": "4c3289588110cbb07049b15e05b22a3e3c251e62305be94e3952195c36d701d2"
+          "sha256": "4c3289588110cbb07049b15e05b22a3e3c251e62305be94e3952195c36d701d2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/SKILL.md",
           "owner": "app-store-optimization",
-          "sha256": "b3f21e562511dee6ddfdac0e616626be43ee2ecc56a8afc0ed5d70ca08da2318"
+          "sha256": "b3f21e562511dee6ddfdac0e616626be43ee2ecc56a8afc0ed5d70ca08da2318",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/assets/aso-audit-template.md",
           "owner": "app-store-optimization",
-          "sha256": "3a96bbc323bf420b59219c0d0e223393850a923c94c4a52df0acf992739ee010"
+          "sha256": "3a96bbc323bf420b59219c0d0e223393850a923c94c4a52df0acf992739ee010",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/expected_output.json",
           "owner": "app-store-optimization",
-          "sha256": "59db04fda533c3f2e0e0aa6387afd5bdd09b8278234af22ef4b40c85dcf92c47"
+          "sha256": "59db04fda533c3f2e0e0aa6387afd5bdd09b8278234af22ef4b40c85dcf92c47",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/references/aso-best-practices.md",
           "owner": "app-store-optimization",
-          "sha256": "e86e9710a8dcdd5034c19113eb41a232104531c71f1339e7135dfe0c1aa33c82"
+          "sha256": "e86e9710a8dcdd5034c19113eb41a232104531c71f1339e7135dfe0c1aa33c82",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/references/keyword-research-guide.md",
           "owner": "app-store-optimization",
-          "sha256": "631a6206414ab908f3e09c218a83a6deaec5dfec3b869336d8420da9b072f833"
+          "sha256": "631a6206414ab908f3e09c218a83a6deaec5dfec3b869336d8420da9b072f833",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/references/platform-requirements.md",
           "owner": "app-store-optimization",
-          "sha256": "686604daedaf48e0f6bc70a9ad4b327069c54ee524c1104c56e45f6a1d45fe34"
+          "sha256": "686604daedaf48e0f6bc70a9ad4b327069c54ee524c1104c56e45f6a1d45fe34",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/sample_input.json",
           "owner": "app-store-optimization",
-          "sha256": "e4abb74979b21e8707e0026b77d76bfa882416710a49d35b9985b7ca692de585"
+          "sha256": "e4abb74979b21e8707e0026b77d76bfa882416710a49d35b9985b7ca692de585",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/ab_test_planner.py",
           "owner": "app-store-optimization",
-          "sha256": "bc65f41e0fe84170b02e83b4648d3d2dbb460e9588acb1e1bea4d7d9e63d1a95"
+          "sha256": "bc65f41e0fe84170b02e83b4648d3d2dbb460e9588acb1e1bea4d7d9e63d1a95",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/aso_scorer.py",
           "owner": "app-store-optimization",
-          "sha256": "df2854642b889a55877f2420563a22a753dc157723a3c7fe40d3dfcfc16b7892"
+          "sha256": "df2854642b889a55877f2420563a22a753dc157723a3c7fe40d3dfcfc16b7892",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/competitor_analyzer.py",
           "owner": "app-store-optimization",
-          "sha256": "df64cf5b9c863afabebca1461230039287c6075806895e21541f8471c10f47c8"
+          "sha256": "df64cf5b9c863afabebca1461230039287c6075806895e21541f8471c10f47c8",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/keyword_analyzer.py",
           "owner": "app-store-optimization",
-          "sha256": "7d66b1043a859eecfe919649c82f693ac841a18361cffffc5a8faf92e2c432f4"
+          "sha256": "7d66b1043a859eecfe919649c82f693ac841a18361cffffc5a8faf92e2c432f4",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/launch_checklist.py",
           "owner": "app-store-optimization",
-          "sha256": "4d820f097856c612b7f41bd02319f5003384af237318ad0139e0f62c723587a1"
+          "sha256": "4d820f097856c612b7f41bd02319f5003384af237318ad0139e0f62c723587a1",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/localization_helper.py",
           "owner": "app-store-optimization",
-          "sha256": "1c6c26fc2c8c87867d02777bcd90753ed461319573df7961ccaf38bb2c29726b"
+          "sha256": "1c6c26fc2c8c87867d02777bcd90753ed461319573df7961ccaf38bb2c29726b",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/metadata_optimizer.py",
           "owner": "app-store-optimization",
-          "sha256": "e689b3521cad59b510b89e5e6d9536519286e521079f805fe016d7546d68702f"
+          "sha256": "e689b3521cad59b510b89e5e6d9536519286e521079f805fe016d7546d68702f",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/app-store-optimization/scripts/review_analyzer.py",
           "owner": "app-store-optimization",
-          "sha256": "395f675845886fd88b28c94c445b7450e60522c1acf0e0cd26a7465cfef8560f"
+          "sha256": "395f675845886fd88b28c94c445b7450e60522c1acf0e0cd26a7465cfef8560f",
+          "mode": "100644"
         }
       ]
     },
@@ -858,7 +906,8 @@
         {
           "path": "skills/ai-workflow/brainstorming/SKILL.md",
           "owner": "brainstorming",
-          "sha256": "b186b164309e49806f1249b4b41a1de307c1b7d5400a7260a5c306fe7c9154f6"
+          "sha256": "b186b164309e49806f1249b4b41a1de307c1b7d5400a7260a5c306fe7c9154f6",
+          "mode": "100644"
         }
       ]
     },
@@ -913,12 +962,14 @@
         {
           "path": "skills/operations-general/brand-guidelines/LICENSE.txt",
           "owner": "brand-guidelines",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/brand-guidelines/SKILL.md",
           "owner": "brand-guidelines",
-          "sha256": "59b81f971c363a849236c928a444883da29381b933e86e9deb436d1223d06f44"
+          "sha256": "59b81f971c363a849236c928a444883da29381b933e86e9deb436d1223d06f44",
+          "mode": "100644"
         }
       ]
     },
@@ -1023,62 +1074,74 @@
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/SKILL.md",
           "owner": "campaign-analytics",
-          "sha256": "b7831870e5ecf3e811a439f0dbf328de3a3fe7533621813b7f72e23b30ee42a2"
+          "sha256": "b7831870e5ecf3e811a439f0dbf328de3a3fe7533621813b7f72e23b30ee42a2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/assets/ab_test_template.md",
           "owner": "campaign-analytics",
-          "sha256": "3df619680783ba97bc6aec7f109291fe2f190d0b9eb0125b0e13b269ca220d43"
+          "sha256": "3df619680783ba97bc6aec7f109291fe2f190d0b9eb0125b0e13b269ca220d43",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/assets/campaign_report_template.md",
           "owner": "campaign-analytics",
-          "sha256": "448ef109e333b351b0fbc2b2a087352d6abc89d125620585e6518b6aa91e631c"
+          "sha256": "448ef109e333b351b0fbc2b2a087352d6abc89d125620585e6518b6aa91e631c",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/assets/channel_comparison_template.md",
           "owner": "campaign-analytics",
-          "sha256": "5c6b30fccafa570192907ad7ff83f1d4b16b83519ab06ceccadbfa195fae69ba"
+          "sha256": "5c6b30fccafa570192907ad7ff83f1d4b16b83519ab06ceccadbfa195fae69ba",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/assets/expected_output.json",
           "owner": "campaign-analytics",
-          "sha256": "5214cc084d57938e4b92ba592305355597e9f2298c76520ace8d46d4a325c4d7"
+          "sha256": "5214cc084d57938e4b92ba592305355597e9f2298c76520ace8d46d4a325c4d7",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/assets/sample_campaign_data.json",
           "owner": "campaign-analytics",
-          "sha256": "6e8604e35126d012d34272e9de8094a1f69e9f21b9ab2c1054ee0c52ab061156"
+          "sha256": "6e8604e35126d012d34272e9de8094a1f69e9f21b9ab2c1054ee0c52ab061156",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/references/attribution-models-guide.md",
           "owner": "campaign-analytics",
-          "sha256": "7909ca8534cf68bab00c1f2e2035fa3b6b0dbfd6fb94da2db88948b8616058e5"
+          "sha256": "7909ca8534cf68bab00c1f2e2035fa3b6b0dbfd6fb94da2db88948b8616058e5",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/references/campaign-metrics-benchmarks.md",
           "owner": "campaign-analytics",
-          "sha256": "5f83037ed8d13db1febfa5490ad3f21698043057ad859a70c323912091e30cd7"
+          "sha256": "5f83037ed8d13db1febfa5490ad3f21698043057ad859a70c323912091e30cd7",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/references/funnel-optimization-framework.md",
           "owner": "campaign-analytics",
-          "sha256": "9a95040212cf0df227ec40079da50db34b909b7f4ca7ad5c3711a6d0f517d612"
+          "sha256": "9a95040212cf0df227ec40079da50db34b909b7f4ca7ad5c3711a6d0f517d612",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/scripts/attribution_analyzer.py",
           "owner": "campaign-analytics",
-          "sha256": "cc01b84dcd0d2d0659dbb4603ea8499a129d43c38ea5bcf727d12399af74f3e5"
+          "sha256": "cc01b84dcd0d2d0659dbb4603ea8499a129d43c38ea5bcf727d12399af74f3e5",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/scripts/campaign_roi_calculator.py",
           "owner": "campaign-analytics",
-          "sha256": "503809b68fc7754cc903e633dbcc8da87d147e8b61160f1b399c445cb94f5782"
+          "sha256": "503809b68fc7754cc903e633dbcc8da87d147e8b61160f1b399c445cb94f5782",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/campaign-analytics/scripts/funnel_analyzer.py",
           "owner": "campaign-analytics",
-          "sha256": "c9d31b4142512aa31e5965ebe7d6222893e78b19f653fbcc3f404e4122fe0463"
+          "sha256": "c9d31b4142512aa31e5965ebe7d6222893e78b19f653fbcc3f404e4122fe0463",
+          "mode": "100644"
         }
       ]
     },
@@ -1538,417 +1601,500 @@
         {
           "path": "skills/product-design/canvas-design/LICENSE.txt",
           "owner": "canvas-design",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/SKILL.md",
           "owner": "canvas-design",
-          "sha256": "6c87a6965e5e1beb2dd304674ddfcc029acf0b8758855f5247aa885dc6e996ca"
+          "sha256": "6c87a6965e5e1beb2dd304674ddfcc029acf0b8758855f5247aa885dc6e996ca",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/ArsenalSC-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "8ddd61b18ba2c0d0dbe4a691cf5f1a0673f473d02fa0546e67ee88c006aeff6e"
+          "sha256": "8ddd61b18ba2c0d0dbe4a691cf5f1a0673f473d02fa0546e67ee88c006aeff6e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/ArsenalSC-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "65e6f89df58f68fd905b3add34a79dd6106aa3b3044df0dad9676fff53d504b9"
+          "sha256": "65e6f89df58f68fd905b3add34a79dd6106aa3b3044df0dad9676fff53d504b9",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BigShoulders-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "b43bcd198b9fdf717dd42aa61a34dba32e01aceaeae659d689afd0ca52c37ea2"
+          "sha256": "b43bcd198b9fdf717dd42aa61a34dba32e01aceaeae659d689afd0ca52c37ea2",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BigShoulders-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "fbc746aabf0eb1847dfd92e2efc4596d79fa897d60b8e64062a22f585508fb3f"
+          "sha256": "fbc746aabf0eb1847dfd92e2efc4596d79fa897d60b8e64062a22f585508fb3f",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BigShoulders-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "18a879fc71978a4447150705caf880a9da3860083c259fd29e6dc03057b6842a"
+          "sha256": "18a879fc71978a4447150705caf880a9da3860083c259fd29e6dc03057b6842a",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Boldonse-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "45cc82ab4032273c0924025ffcf8f0665a68e1a5955e3f7247e5daf1deeb1326"
+          "sha256": "45cc82ab4032273c0924025ffcf8f0665a68e1a5955e3f7247e5daf1deeb1326",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Boldonse-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "cc2e540604565c0f90a7d8d46194a2f42fc9c45512cd2e39bf03b50eb68c35a4"
+          "sha256": "cc2e540604565c0f90a7d8d46194a2f42fc9c45512cd2e39bf03b50eb68c35a4",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BricolageGrotesque-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "a737b146fe0d77ffe8a86e3cd16700dd431d3b1e420d4fd80e142cd68a1cb50d"
+          "sha256": "a737b146fe0d77ffe8a86e3cd16700dd431d3b1e420d4fd80e142cd68a1cb50d",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BricolageGrotesque-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "0e4f4eb8534bc66a76aca13dd19c1f9731b2008866b29ccff182b764649df9b4"
+          "sha256": "0e4f4eb8534bc66a76aca13dd19c1f9731b2008866b29ccff182b764649df9b4",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/BricolageGrotesque-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "972a6d098c9867ae131d0ea99e221e63976b11a19d4b931c2c7ace525674e4f6"
+          "sha256": "972a6d098c9867ae131d0ea99e221e63976b11a19d4b931c2c7ace525674e4f6",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/CrimsonPro-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "48f191e38355c8db100eb3ce157c20f9302a3b9a37b44a660f77ecfce3986609"
+          "sha256": "48f191e38355c8db100eb3ce157c20f9302a3b9a37b44a660f77ecfce3986609",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/CrimsonPro-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "52318db3526b644e6efa60be0b3ca5a50e40fbe8bd026c261e0aa206f0772267"
+          "sha256": "52318db3526b644e6efa60be0b3ca5a50e40fbe8bd026c261e0aa206f0772267",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/CrimsonPro-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "35680d14547b6748b6f362a052a46d22764ce5eccf96e18b74f567bb2ee58114"
+          "sha256": "35680d14547b6748b6f362a052a46d22764ce5eccf96e18b74f567bb2ee58114",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/CrimsonPro-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "48fad08cb1917a7b2f2c6fe5135d6c07743a6663cf7631ec4481108aaf081422"
+          "sha256": "48fad08cb1917a7b2f2c6fe5135d6c07743a6663cf7631ec4481108aaf081422",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/DMMono-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "bfe7842fcb88323e2981e24710c25202677385a8c75fb6a87217b275a0247ae3"
+          "sha256": "bfe7842fcb88323e2981e24710c25202677385a8c75fb6a87217b275a0247ae3",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/DMMono-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "f98ada968dc3b6b2c08d3f5caaf266977df0bfe0929372b93df5a06cf2ace450"
+          "sha256": "f98ada968dc3b6b2c08d3f5caaf266977df0bfe0929372b93df5a06cf2ace450",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/EricaOne-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "e0de629968b52255548d5fafcf30b24ff9edae0eda362380755a75816404d0fa"
+          "sha256": "e0de629968b52255548d5fafcf30b24ff9edae0eda362380755a75816404d0fa",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/EricaOne-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "db1d89e80e33a8a01beaaac7a85df582857d24a43f1e181461aa7ff5d701476a"
+          "sha256": "db1d89e80e33a8a01beaaac7a85df582857d24a43f1e181461aa7ff5d701476a",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/GeistMono-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "75c0828d5c1ee44b9ef9f4df577bf41595ec362e2ea3f1e558590c9e92c7949d"
+          "sha256": "75c0828d5c1ee44b9ef9f4df577bf41595ec362e2ea3f1e558590c9e92c7949d",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/GeistMono-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "6a873c900f584109b13ae0aaf81d6e3cf0a68751a216b03f7b6c68d547057bb4"
+          "sha256": "6a873c900f584109b13ae0aaf81d6e3cf0a68751a216b03f7b6c68d547057bb4",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/GeistMono-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "a55c1b51cda4afeab9e471e7947b85a20f7c8831d7e6b1470c1b7fbdc0f0f15e"
+          "sha256": "a55c1b51cda4afeab9e471e7947b85a20f7c8831d7e6b1470c1b7fbdc0f0f15e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Gloock-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "c0a3f3125ac491ef3d1f09f401be4834c646562f647e44f2bcbc49f0466c656d"
+          "sha256": "c0a3f3125ac491ef3d1f09f401be4834c646562f647e44f2bcbc49f0466c656d",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Gloock-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "e86b4ce66dbd3f1f83eee8db99ec96e0da1128c3f53df0e9b3b7472025dfe960"
+          "sha256": "e86b4ce66dbd3f1f83eee8db99ec96e0da1128c3f53df0e9b3b7472025dfe960",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexMono-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "dbd2a2fb024579438d6400a84e57579bfd2dbe67c306c8fd9fde92a61e4f2eea"
+          "sha256": "dbd2a2fb024579438d6400a84e57579bfd2dbe67c306c8fd9fde92a61e4f2eea",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexMono-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "5294ce778857e1eb02e830b6ab06435537d38f43055327e73d03a2d4d57d5123"
+          "sha256": "5294ce778857e1eb02e830b6ab06435537d38f43055327e73d03a2d4d57d5123",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexMono-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "ab08018ccd276b79fb2c636bb95b9c543598f9d50505fe92506fcb4dae7810cd"
+          "sha256": "ab08018ccd276b79fb2c636bb95b9c543598f9d50505fe92506fcb4dae7810cd",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexSerif-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "b8d294e9b5c5a0940f167c3ced0f7ef2e3f57082ca3ff096ef30e86e26c1c159"
+          "sha256": "b8d294e9b5c5a0940f167c3ced0f7ef2e3f57082ca3ff096ef30e86e26c1c159",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexSerif-BoldItalic.ttf",
           "owner": "canvas-design",
-          "sha256": "da64b75f4284f53e7b5c71fa190a35b8bf3494fe19f1804c81c3a53340bca570"
+          "sha256": "da64b75f4284f53e7b5c71fa190a35b8bf3494fe19f1804c81c3a53340bca570",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexSerif-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "b11f1048745e715a55c9d837b3f10226ca3d78867b7db7251ddad8f98dcf0f38"
+          "sha256": "b11f1048745e715a55c9d837b3f10226ca3d78867b7db7251ddad8f98dcf0f38",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/IBMPlexSerif-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "77cd233a2af8dc6b1022faea3bb3b01f3c75af68bcf530cb6aeb15982ff3dbb7"
+          "sha256": "77cd233a2af8dc6b1022faea3bb3b01f3c75af68bcf530cb6aeb15982ff3dbb7",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSans-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "444f85bf1c4b0e1ce1ca624f6be54bcd832207714ccaf4ea99ee531341683bdf"
+          "sha256": "444f85bf1c4b0e1ce1ca624f6be54bcd832207714ccaf4ea99ee531341683bdf",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSans-BoldItalic.ttf",
           "owner": "canvas-design",
-          "sha256": "3762f6cef95d6039489ad5ba5787d4c30f17a1ad01e9ac3c816ed69692722a68"
+          "sha256": "3762f6cef95d6039489ad5ba5787d4c30f17a1ad01e9ac3c816ed69692722a68",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSans-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "78e85858e371b2cb4e18f617c10f0f937c0e12a0887ffee98555b24ed305b3a7"
+          "sha256": "78e85858e371b2cb4e18f617c10f0f937c0e12a0887ffee98555b24ed305b3a7",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSans-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "bf4dc6d13a8cccd4807133c77a1ee9619a16b92cb23322258725ab6731c2f6e5"
+          "sha256": "bf4dc6d13a8cccd4807133c77a1ee9619a16b92cb23322258725ab6731c2f6e5",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSans-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "a22cb26e48fd79bcb01bf2fc92d36785474dce36d9c544ab0a8868c2657c4a87"
+          "sha256": "a22cb26e48fd79bcb01bf2fc92d36785474dce36d9c544ab0a8868c2657c4a87",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSerif-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "9c86e4d5a47b50224a2463a9eca8535835257c8e85c470c2c6b454b1af6f046e"
+          "sha256": "9c86e4d5a47b50224a2463a9eca8535835257c8e85c470c2c6b454b1af6f046e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/InstrumentSerif-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "56ac3be03ac3ba283196b3e77850ab2ffcf56cfb6fd3212c5620109a972f8c99"
+          "sha256": "56ac3be03ac3ba283196b3e77850ab2ffcf56cfb6fd3212c5620109a972f8c99",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Italiana-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "8373b11312ace78c4cec2e8f9f6aa9f2330601107dac7bcf899c6f2dbd40c5a5"
+          "sha256": "8373b11312ace78c4cec2e8f9f6aa9f2330601107dac7bcf899c6f2dbd40c5a5",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Italiana-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "15c4dd6ab8cf4a29ba8826f65edcbe2f6c266c557d34d081f25072dfd5605fd2"
+          "sha256": "15c4dd6ab8cf4a29ba8826f65edcbe2f6c266c557d34d081f25072dfd5605fd2",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/JetBrainsMono-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "a2349098b9e45419e7bf0e2958d6c4937a049dded37387b08be725be4c7615f3"
+          "sha256": "a2349098b9e45419e7bf0e2958d6c4937a049dded37387b08be725be4c7615f3",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/JetBrainsMono-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "a76abf002c49097d146e86740a3105a5d00450b1592e820a1109a8c5680cd697"
+          "sha256": "a76abf002c49097d146e86740a3105a5d00450b1592e820a1109a8c5680cd697",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/JetBrainsMono-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "b6b1ff4ddefe36d7f2a6174e1d001cab374e594519ee9049af028d577b64c5f5"
+          "sha256": "b6b1ff4ddefe36d7f2a6174e1d001cab374e594519ee9049af028d577b64c5f5",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Jura-Light.ttf",
           "owner": "canvas-design",
-          "sha256": "c891a381df056b2c4dfe85841e911bf45da0890fa21a7b2692cbe5ea1f505e1e"
+          "sha256": "c891a381df056b2c4dfe85841e911bf45da0890fa21a7b2692cbe5ea1f505e1e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Jura-Medium.ttf",
           "owner": "canvas-design",
-          "sha256": "c72965cb732a92872643819fd1734128238583cc36b116313859137a51d3368a"
+          "sha256": "c72965cb732a92872643819fd1734128238583cc36b116313859137a51d3368a",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Jura-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "eaf9bdb675f6d87e5feb88199ab3ea581d3bd2082f426e384fa9c394576d7260"
+          "sha256": "eaf9bdb675f6d87e5feb88199ab3ea581d3bd2082f426e384fa9c394576d7260",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/LibreBaskerville-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "55959eef5b0c3b2e3c1c7631b8ff0f9447d75de20f29cfa7db5bcfb026763343"
+          "sha256": "55959eef5b0c3b2e3c1c7631b8ff0f9447d75de20f29cfa7db5bcfb026763343",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/LibreBaskerville-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "2101302538d9e88adb679031c04623e4578b5745e89566284fd2c508d79acae0"
+          "sha256": "2101302538d9e88adb679031c04623e4578b5745e89566284fd2c508d79acae0",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Lora-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "7d74015e950c2fb66519c7295b8155621d22200ae2ca2a4c6b43ce3c490cac87"
+          "sha256": "7d74015e950c2fb66519c7295b8155621d22200ae2ca2a4c6b43ce3c490cac87",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Lora-BoldItalic.ttf",
           "owner": "canvas-design",
-          "sha256": "152f87e71f5ddb60d5c57ecd9132807c947e65c42977193c9164e7c5a6690081"
+          "sha256": "152f87e71f5ddb60d5c57ecd9132807c947e65c42977193c9164e7c5a6690081",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Lora-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "be627e595184e8afe521f08da0607eee613f1997d423bc8dadc5798995581377"
+          "sha256": "be627e595184e8afe521f08da0607eee613f1997d423bc8dadc5798995581377",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Lora-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "62e37a82d3f1ef2a70712885fa8b3144b65fd144d8e748d6196b690a354d792c"
+          "sha256": "62e37a82d3f1ef2a70712885fa8b3144b65fd144d8e748d6196b690a354d792c",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Lora-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "7ed00e7c9cdf16ab7e2fd2361fe45d4f0b61263cd60aae398b27b7ee08108827"
+          "sha256": "7ed00e7c9cdf16ab7e2fd2361fe45d4f0b61263cd60aae398b27b7ee08108827",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/NationalPark-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "69ac4c301c4a7233c6e602d12a92c54d7967b575f4449951c45ce773f7acff53"
+          "sha256": "69ac4c301c4a7233c6e602d12a92c54d7967b575f4449951c45ce773f7acff53",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/NationalPark-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "81c6c71d83b5b45d7344f96df12bb4a2477a5b092a9144757ee1d0f50f855175"
+          "sha256": "81c6c71d83b5b45d7344f96df12bb4a2477a5b092a9144757ee1d0f50f855175",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/NationalPark-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "a477338b7e18308d476650dfe31235ef86a883572665e56ffb5fb80f82009b58"
+          "sha256": "a477338b7e18308d476650dfe31235ef86a883572665e56ffb5fb80f82009b58",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/NothingYouCouldDo-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "7c2a6970584ddad04919816163746f83b378078015899b18468b40f05e9ce128"
+          "sha256": "7c2a6970584ddad04919816163746f83b378078015899b18468b40f05e9ce128",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/NothingYouCouldDo-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "d866f985896d3280f4fce72db7e17302c24a0c1fdb0699b6b5ed3af14f944d57"
+          "sha256": "d866f985896d3280f4fce72db7e17302c24a0c1fdb0699b6b5ed3af14f944d57",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Outfit-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "6654b93d21301ec61887d3cedd6c11d9df1b1dfb63f9cf45ac7995f6e2235ab1"
+          "sha256": "6654b93d21301ec61887d3cedd6c11d9df1b1dfb63f9cf45ac7995f6e2235ab1",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Outfit-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "1945b62cd76da9a3051a1660dde72afaa64ffc2666d30e7a78356d651653ba2f"
+          "sha256": "1945b62cd76da9a3051a1660dde72afaa64ffc2666d30e7a78356d651653ba2f",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Outfit-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "f24945365147c9e783e91d8649959b59be6b00c9ee4ecd2f6b33afbb2dd871fe"
+          "sha256": "f24945365147c9e783e91d8649959b59be6b00c9ee4ecd2f6b33afbb2dd871fe",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/PixelifySans-Medium.ttf",
           "owner": "canvas-design",
-          "sha256": "38397504f71c122b03d234ea6f55118e3d5bdbddffd82bedddbd7755d3b3be82"
+          "sha256": "38397504f71c122b03d234ea6f55118e3d5bdbddffd82bedddbd7755d3b3be82",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/PixelifySans-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "7f54d1d9f1ae1ba9f2722f978145f90324fea34ca3c2304b3a29cfa96ac6037e"
+          "sha256": "7f54d1d9f1ae1ba9f2722f978145f90324fea34ca3c2304b3a29cfa96ac6037e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/PoiretOne-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "2eaf541f7eb8b512e4c757a5212060abf5b6edfef230e9d7640bf736b315c33a"
+          "sha256": "2eaf541f7eb8b512e4c757a5212060abf5b6edfef230e9d7640bf736b315c33a",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/PoiretOne-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "9cf265b139648b36b6c0afdfeb0bf27f7e66db9a16094bc40f644d8da05bc318"
+          "sha256": "9cf265b139648b36b6c0afdfeb0bf27f7e66db9a16094bc40f644d8da05bc318",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/RedHatMono-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "7ef48353f4be5ddb90f000f6fad48f2b62b3e8c27d9818d8d45ff46c201065e0"
+          "sha256": "7ef48353f4be5ddb90f000f6fad48f2b62b3e8c27d9818d8d45ff46c201065e0",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/RedHatMono-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "435fbfb7e66988b2a06686a4cb966faec733f35d8fe100a1601573c27f3e0bb8"
+          "sha256": "435fbfb7e66988b2a06686a4cb966faec733f35d8fe100a1601573c27f3e0bb8",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/RedHatMono-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "452fe826871b37539f5212b20c87cf30f82f58dd2741f1c96edd1dcbdc0db6b4"
+          "sha256": "452fe826871b37539f5212b20c87cf30f82f58dd2741f1c96edd1dcbdc0db6b4",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Silkscreen-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "6b849745119bbe85ec01fd080c9cd50234da9f52ac6e48b55d1a424a0c4d7ca9"
+          "sha256": "6b849745119bbe85ec01fd080c9cd50234da9f52ac6e48b55d1a424a0c4d7ca9",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Silkscreen-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "49567408600809e25147e9225ac4f37f410e2df45a750696c45027531fb65f1b"
+          "sha256": "49567408600809e25147e9225ac4f37f410e2df45a750696c45027531fb65f1b",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/SmoochSans-Medium.ttf",
           "owner": "canvas-design",
-          "sha256": "dd76e6e77cce82f827a8654cd906e9ce58f3aaf78adda63c4a7f655b8ecb41f0"
+          "sha256": "dd76e6e77cce82f827a8654cd906e9ce58f3aaf78adda63c4a7f655b8ecb41f0",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/SmoochSans-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "74c9c4eb88e891483e1b7bc54780b452cbf4f4df66d4e71881d7569aa2130749"
+          "sha256": "74c9c4eb88e891483e1b7bc54780b452cbf4f4df66d4e71881d7569aa2130749",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Tektur-Medium.ttf",
           "owner": "canvas-design",
-          "sha256": "52bbe8c9b057b3d2da4eeace31a524b1ea26a1375ae34319cf6900ccc57a4c82"
+          "sha256": "52bbe8c9b057b3d2da4eeace31a524b1ea26a1375ae34319cf6900ccc57a4c82",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Tektur-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "3f1466cb5438f31782eeb6e895f3a655bc4d090e24263e331f555357d1cb734e"
+          "sha256": "3f1466cb5438f31782eeb6e895f3a655bc4d090e24263e331f555357d1cb734e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/Tektur-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "162e1b36c4718c5b051b36c971ad7e50d341944f35618f480422ebbe72988f98"
+          "sha256": "162e1b36c4718c5b051b36c971ad7e50d341944f35618f480422ebbe72988f98",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/WorkSans-Bold.ttf",
           "owner": "canvas-design",
-          "sha256": "240d125fc9f8561363dc1ea3f513501253bd70942f41468f48f0b0cafb0c82e2"
+          "sha256": "240d125fc9f8561363dc1ea3f513501253bd70942f41468f48f0b0cafb0c82e2",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/WorkSans-BoldItalic.ttf",
           "owner": "canvas-design",
-          "sha256": "a5b2cad813df0aaa7d16621f2e93b5117c25e9bc788bc9a3ad218e9d6348ce34"
+          "sha256": "a5b2cad813df0aaa7d16621f2e93b5117c25e9bc788bc9a3ad218e9d6348ce34",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/WorkSans-Italic.ttf",
           "owner": "canvas-design",
-          "sha256": "6b7f7002e0b0c8b261fe878658ef5551e3e59d9f6b609b04efb90dde1e2c1ada"
+          "sha256": "6b7f7002e0b0c8b261fe878658ef5551e3e59d9f6b609b04efb90dde1e2c1ada",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/WorkSans-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "ace8c22a3326318b54e67c3691857929634205533f454a70ef5a3473ddb2e2ba"
+          "sha256": "ace8c22a3326318b54e67c3691857929634205533f454a70ef5a3473ddb2e2ba",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/WorkSans-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "e67985a843df0d3cdee51a3d0f329eb1774a344ad9ff0c9ab923751f1577e2a4"
+          "sha256": "e67985a843df0d3cdee51a3d0f329eb1774a344ad9ff0c9ab923751f1577e2a4",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/YoungSerif-OFL.txt",
           "owner": "canvas-design",
-          "sha256": "cdcb8039606b40a027a6d24586ec62d5fe29c701343d82a048c829cb28a3dd28"
+          "sha256": "cdcb8039606b40a027a6d24586ec62d5fe29c701343d82a048c829cb28a3dd28",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/canvas-design/canvas-fonts/YoungSerif-Regular.ttf",
           "owner": "canvas-design",
-          "sha256": "f8dc08f77abad753a00670af70756a8ace938e5c3f0b770f4f4c2071c4bd8fc6"
+          "sha256": "f8dc08f77abad753a00670af70756a8ace938e5c3f0b770f4f4c2071c4bd8fc6",
+          "mode": "100644"
         }
       ]
     },
@@ -2048,57 +2194,68 @@
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/LICENSE.txt",
           "owner": "chatgpt-apps",
-          "sha256": "a7f55b2cb68997f729e6199720d4d3cae47633aba0254a84b2d36ab284be9d45"
+          "sha256": "a7f55b2cb68997f729e6199720d4d3cae47633aba0254a84b2d36ab284be9d45",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/SKILL.md",
           "owner": "chatgpt-apps",
-          "sha256": "3d26dfc609f2fce9274097030b6260046bec19a8f5d1d072095d6c3aa4f4792b"
+          "sha256": "3d26dfc609f2fce9274097030b6260046bec19a8f5d1d072095d6c3aa4f4792b",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/agents/openai.yaml",
           "owner": "chatgpt-apps",
-          "sha256": "ebd723c60efd5242c628da61c0f1a91edd3dc106860573ba8f2f96dcdd224fcb"
+          "sha256": "ebd723c60efd5242c628da61c0f1a91edd3dc106860573ba8f2f96dcdd224fcb",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/app-archetypes.md",
           "owner": "chatgpt-apps",
-          "sha256": "ae3bb232c201541303264653518eca8bc59832bc73e511835d66ebd0a3c04f87"
+          "sha256": "ae3bb232c201541303264653518eca8bc59832bc73e511835d66ebd0a3c04f87",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/apps-sdk-docs-workflow.md",
           "owner": "chatgpt-apps",
-          "sha256": "41f0ec23b35c6a66de59de80c13b9be59002a371c8a36d23f96f20e19c656b49"
+          "sha256": "41f0ec23b35c6a66de59de80c13b9be59002a371c8a36d23f96f20e19c656b49",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/interactive-state-sync-patterns.md",
           "owner": "chatgpt-apps",
-          "sha256": "5ca632712be3d75f63a405292184a7867cfc0fa3803b53b2063a94318a8c1278"
+          "sha256": "5ca632712be3d75f63a405292184a7867cfc0fa3803b53b2063a94318a8c1278",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/repo-contract-and-validation.md",
           "owner": "chatgpt-apps",
-          "sha256": "28fb7093b67e29d05322e3fd38cb7ad182e92913aa45051d97dbddca8a627cd6"
+          "sha256": "28fb7093b67e29d05322e3fd38cb7ad182e92913aa45051d97dbddca8a627cd6",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/search-fetch-standard.md",
           "owner": "chatgpt-apps",
-          "sha256": "32c706205035007d1b616bf3eeb6c6c9ce69f6c56493bf0ea942a20abe8b39e6"
+          "sha256": "32c706205035007d1b616bf3eeb6c6c9ce69f6c56493bf0ea942a20abe8b39e6",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/upstream-example-workflow.md",
           "owner": "chatgpt-apps",
-          "sha256": "241f2fc58ff6c3b276325bef70254d8e1a18ec9e7633bd3bd03ef45ff478f727"
+          "sha256": "241f2fc58ff6c3b276325bef70254d8e1a18ec9e7633bd3bd03ef45ff478f727",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/references/window-openai-patterns.md",
           "owner": "chatgpt-apps",
-          "sha256": "940c5308c89d9984c9c07c78d9fddf5fdaed97f106e6b631ed8ae6e6128e5bbf"
+          "sha256": "940c5308c89d9984c9c07c78d9fddf5fdaed97f106e6b631ed8ae6e6128e5bbf",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/chatgpt-apps/scripts/scaffold_node_ext_apps.mjs",
           "owner": "chatgpt-apps",
-          "sha256": "fb12086ca7e37ab7d1fb02418b11623f207b8726aabfcbfb3d5634539479807a"
+          "sha256": "fb12086ca7e37ab7d1fb02418b11623f207b8726aabfcbfb3d5634539479807a",
+          "mode": "100644"
         }
       ]
     },
@@ -2188,47 +2345,56 @@
         {
           "path": "skills/developer-engineering/cli-demo-generator/SKILL.md",
           "owner": "cli-demo-generator",
-          "sha256": "b2ced5f550fe850f802810eea3a1469f8ff14eb439b85020629f3fa531e4b0c3"
+          "sha256": "b2ced5f550fe850f802810eea3a1469f8ff14eb439b85020629f3fa531e4b0c3",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/assets/examples/batch-config.yaml",
           "owner": "cli-demo-generator",
-          "sha256": "181e7d003b1bc14de549f9dd07bf1d36a6943d7810ca183ec3f8b60845a398b5"
+          "sha256": "181e7d003b1bc14de549f9dd07bf1d36a6943d7810ca183ec3f8b60845a398b5",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/assets/templates/basic.tape",
           "owner": "cli-demo-generator",
-          "sha256": "f3fd16bca14aba2b08f91f9bca13ab91291eae3fd9ede46604c03fd20125e3f1"
+          "sha256": "f3fd16bca14aba2b08f91f9bca13ab91291eae3fd9ede46604c03fd20125e3f1",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/assets/templates/interactive.tape",
           "owner": "cli-demo-generator",
-          "sha256": "7af6348a6cfe1915424ab684ed1231bbfb5d1de6d83e6abe0d24a0648266cea7"
+          "sha256": "7af6348a6cfe1915424ab684ed1231bbfb5d1de6d83e6abe0d24a0648266cea7",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/references/best_practices.md",
           "owner": "cli-demo-generator",
-          "sha256": "4f2b5991e8070335fbb6245880e3b1eb02789fc68fafe84d08833f876167c9ae"
+          "sha256": "4f2b5991e8070335fbb6245880e3b1eb02789fc68fafe84d08833f876167c9ae",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/references/vhs_syntax.md",
           "owner": "cli-demo-generator",
-          "sha256": "d49f06de9345b586b0b1755a7d26220aa89a5dd9b4154fbb7c6039b25e8717af"
+          "sha256": "d49f06de9345b586b0b1755a7d26220aa89a5dd9b4154fbb7c6039b25e8717af",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/scripts/auto_generate_demo.py",
           "owner": "cli-demo-generator",
-          "sha256": "ba7d6a1e7c70d76cadd582fc1eae9b279932c9af67834255d26857b7c46ac27d"
+          "sha256": "ba7d6a1e7c70d76cadd582fc1eae9b279932c9af67834255d26857b7c46ac27d",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/scripts/batch_generate.py",
           "owner": "cli-demo-generator",
-          "sha256": "c7275ae65b0f5aa3ecd2813c10b1c316ba2cac2cf7b42a1c8b375ed120d5f87c"
+          "sha256": "c7275ae65b0f5aa3ecd2813c10b1c316ba2cac2cf7b42a1c8b375ed120d5f87c",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/cli-demo-generator/scripts/record_interactive.sh",
           "owner": "cli-demo-generator",
-          "sha256": "cd5807a9edc5774bfe1afca1c31d23b4bea3432ee231bc4a0a06815db9607b8d"
+          "sha256": "cd5807a9edc5774bfe1afca1c31d23b4bea3432ee231bc4a0a06815db9607b8d",
+          "mode": "100644"
         }
       ]
     },
@@ -3833,1562 +3999,1874 @@
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/LICENSE.txt",
           "owner": "cloudflare-deploy",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/SKILL.md",
           "owner": "cloudflare-deploy",
-          "sha256": "79918ba4ded2da748b1b0268bef82d459ddefde3c0a703391c582a67febb0d5e"
+          "sha256": "79918ba4ded2da748b1b0268bef82d459ddefde3c0a703391c582a67febb0d5e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/agents/openai.yaml",
           "owner": "cloudflare-deploy",
-          "sha256": "6dbc46d5027859d1a0ecba153f192dceacc24e620961b6880d28a7ca6d82961a"
+          "sha256": "6dbc46d5027859d1a0ecba153f192dceacc24e620961b6880d28a7ca6d82961a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/assets/cloudflare-small.svg",
           "owner": "cloudflare-deploy",
-          "sha256": "48f68d56ac6c83734e8aa64af35fa3f6a0613a9a2293158153db1402be104f17"
+          "sha256": "48f68d56ac6c83734e8aa64af35fa3f6a0613a9a2293158153db1402be104f17",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/assets/cloudflare.png",
           "owner": "cloudflare-deploy",
-          "sha256": "ccef528d73dfe224cfb4817bcb7e15d63922421249d688031ff48c5eef2a2189"
+          "sha256": "ccef528d73dfe224cfb4817bcb7e15d63922421249d688031ff48c5eef2a2189",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/agents-sdk/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "fbe8e1611f991966dcde842d0281beb76e354e8196b19437ad8fdd672539f277"
+          "sha256": "fbe8e1611f991966dcde842d0281beb76e354e8196b19437ad8fdd672539f277",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/agents-sdk/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "38f9799af72977ac6c344de172dfcc1c55a7a343d8e450786bde4672a30afe97"
+          "sha256": "38f9799af72977ac6c344de172dfcc1c55a7a343d8e450786bde4672a30afe97",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/agents-sdk/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "85216db38cb5eb54889605ed89ca322a320bc3082c20da31a78a35c3dcc9f764"
+          "sha256": "85216db38cb5eb54889605ed89ca322a320bc3082c20da31a78a35c3dcc9f764",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/agents-sdk/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "01e857e317f073cf75909f4054bea3adebecb373799c5630fecd870c410a391b"
+          "sha256": "01e857e317f073cf75909f4054bea3adebecb373799c5630fecd870c410a391b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/agents-sdk/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "891353f30bba3a69c66cd43f4ac1a86884d8c6abc26420ddbc73e6cf65cafaac"
+          "sha256": "891353f30bba3a69c66cd43f4ac1a86884d8c6abc26420ddbc73e6cf65cafaac",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3d1edf888ad79bf599c6b21b66e0ba68c0473c5a2c60be1bf2e5a21b68623089"
+          "sha256": "3d1edf888ad79bf599c6b21b66e0ba68c0473c5a2c60be1bf2e5a21b68623089",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1135a774a42e059942ccb12d8ba514e6479d7f8f5f47400b4053f6da5984b532"
+          "sha256": "1135a774a42e059942ccb12d8ba514e6479d7f8f5f47400b4053f6da5984b532",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/dynamic-routing.md",
           "owner": "cloudflare-deploy",
-          "sha256": "56f3539a61bae2fda7d8a98c81ed14e820caf733f27e6cce2fffeeaf7a6c1db5"
+          "sha256": "56f3539a61bae2fda7d8a98c81ed14e820caf733f27e6cce2fffeeaf7a6c1db5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/features.md",
           "owner": "cloudflare-deploy",
-          "sha256": "efbc7d2d4464c1aab4881f059589439e2979b9967568878c32f7cb3e72cc6ccf"
+          "sha256": "efbc7d2d4464c1aab4881f059589439e2979b9967568878c32f7cb3e72cc6ccf",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/sdk-integration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3633951a1ea8f419d85059dfb98f23e830805f728b516d7d87d1fa11ef9d9101"
+          "sha256": "3633951a1ea8f419d85059dfb98f23e830805f728b516d7d87d1fa11ef9d9101",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-gateway/troubleshooting.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c79d02ce7b9e6cb361f1700eff6e12149fc74547aad3438501863d8cd02b2a79"
+          "sha256": "c79d02ce7b9e6cb361f1700eff6e12149fc74547aad3438501863d8cd02b2a79",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-search/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c8c484ab7723f38b649186e1c70f85a9b492c597cc513fe08876910b5406eff2"
+          "sha256": "c8c484ab7723f38b649186e1c70f85a9b492c597cc513fe08876910b5406eff2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-search/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "cff4ce1bee49988265f176fe5a0bdd69714a1b6e215a65662ddbf305f981d05f"
+          "sha256": "cff4ce1bee49988265f176fe5a0bdd69714a1b6e215a65662ddbf305f981d05f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-search/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "59af92d0c3b196bea13ac72e18b42db528721f8971c7d335b27951b77aa4ddb0"
+          "sha256": "59af92d0c3b196bea13ac72e18b42db528721f8971c7d335b27951b77aa4ddb0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-search/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e548c0f2cba170e81dd3e9e15b7cf430eabd7e73770ed29589b90dc20c3bf452"
+          "sha256": "e548c0f2cba170e81dd3e9e15b7cf430eabd7e73770ed29589b90dc20c3bf452",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ai-search/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1215875bf8a9e6317d31019a84a124aa7ba7e85bac10b92bc445d0ef7383d619"
+          "sha256": "1215875bf8a9e6317d31019a84a124aa7ba7e85bac10b92bc445d0ef7383d619",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/analytics-engine/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "123cb825f034688e3603b5a5fb6b372bbd9d82cabaa047bf787631ecb2026702"
+          "sha256": "123cb825f034688e3603b5a5fb6b372bbd9d82cabaa047bf787631ecb2026702",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/analytics-engine/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ae82c22e055e2edef7078286b7442763e19f70894b95fe310dd7c1709f9a572c"
+          "sha256": "ae82c22e055e2edef7078286b7442763e19f70894b95fe310dd7c1709f9a572c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/analytics-engine/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "86112c2385fe4e44b4825f9962cfe3429e6681de9f051a50a1c70514f1b85131"
+          "sha256": "86112c2385fe4e44b4825f9962cfe3429e6681de9f051a50a1c70514f1b85131",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/analytics-engine/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "08d11a06bc1cc955bdf4ade8d1a523b0e78157434d559169c4bc2d36f886667b"
+          "sha256": "08d11a06bc1cc955bdf4ade8d1a523b0e78157434d559169c4bc2d36f886667b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/analytics-engine/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d294a7ee3ce2d58fbb8413eb6e58faf7af8f699cecc7480b955ceb31e87204b2"
+          "sha256": "d294a7ee3ce2d58fbb8413eb6e58faf7af8f699cecc7480b955ceb31e87204b2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7e5a0b6c299554eb58914d25a0fe98e016229d1c664cc9703e170e89b696a0a5"
+          "sha256": "7e5a0b6c299554eb58914d25a0fe98e016229d1c664cc9703e170e89b696a0a5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "847c33ce18c1a4ff210ce5db75db0694113fe5367bdba983b0e6f0d7dd2742b1"
+          "sha256": "847c33ce18c1a4ff210ce5db75db0694113fe5367bdba983b0e6f0d7dd2742b1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6ea23fb895605fd2a2380580f7cd21ab39c51dde470067ed191fd387f6337cb4"
+          "sha256": "6ea23fb895605fd2a2380580f7cd21ab39c51dde470067ed191fd387f6337cb4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "b721d8e28866f376ca8ac91d8f7f9fa35726f6378f83796baed13687f6eca6e2"
+          "sha256": "b721d8e28866f376ca8ac91d8f7f9fa35726f6378f83796baed13687f6eca6e2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7ea6b294371bc04ffbf0a1fdc71a2e138f3303bfcdd85b91b1e29d0d53f80bc2"
+          "sha256": "7ea6b294371bc04ffbf0a1fdc71a2e138f3303bfcdd85b91b1e29d0d53f80bc2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api-shield/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a032c7160b70c9a200e982bc457acd746760c2960e25b7554dfb315da98f71dc"
+          "sha256": "a032c7160b70c9a200e982bc457acd746760c2960e25b7554dfb315da98f71dc",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api-shield/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2ac3f5be499c1047575dddae5fe10fd9ab93e153eec3bd3fae3e2add82275aaa"
+          "sha256": "2ac3f5be499c1047575dddae5fe10fd9ab93e153eec3bd3fae3e2add82275aaa",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api-shield/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "79acd0a84bdeca4f45ef92d3772e9f403d15266210205700a7fccc313a084418"
+          "sha256": "79acd0a84bdeca4f45ef92d3772e9f403d15266210205700a7fccc313a084418",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api-shield/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6941ecb164f0cd23432029e319cdfd7c999365eca6aa1a1df76b52bb59d565dd"
+          "sha256": "6941ecb164f0cd23432029e319cdfd7c999365eca6aa1a1df76b52bb59d565dd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/api-shield/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "66f0e9bc0d7440d76368f3863b8009cfe80de3a61e91c76727a249e2eb192574"
+          "sha256": "66f0e9bc0d7440d76368f3863b8009cfe80de3a61e91c76727a249e2eb192574",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/argo-smart-routing/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "405ab3a8878c32c95e12fb1c769f6cf79a597def8898b5e291d347a04c3e9052"
+          "sha256": "405ab3a8878c32c95e12fb1c769f6cf79a597def8898b5e291d347a04c3e9052",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/argo-smart-routing/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8c3266518ed0f9f98aefd6702eaf7400c40b0de0f49cc4daa7ff6f763f7e7ede"
+          "sha256": "8c3266518ed0f9f98aefd6702eaf7400c40b0de0f49cc4daa7ff6f763f7e7ede",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/argo-smart-routing/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "9cc0c9f4ce01828e0153baded0393f0569e9aceff2601c16aad71e12e2fa8a39"
+          "sha256": "9cc0c9f4ce01828e0153baded0393f0569e9aceff2601c16aad71e12e2fa8a39",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/argo-smart-routing/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "fc890c1e98c117ac8b6eb5ef39a62059732d9df2642700a8ad9fd2c877107fc7"
+          "sha256": "fc890c1e98c117ac8b6eb5ef39a62059732d9df2642700a8ad9fd2c877107fc7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/argo-smart-routing/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8f0e0d9abdc17971afc802c23a04bf8780365031e5c4241cf084b0ad97c3707e"
+          "sha256": "8f0e0d9abdc17971afc802c23a04bf8780365031e5c4241cf084b0ad97c3707e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bindings/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5ba09af5a3ce0b8ea090f60b87a0660f56d6252e256a36eff86ec1dfcd8c69a0"
+          "sha256": "5ba09af5a3ce0b8ea090f60b87a0660f56d6252e256a36eff86ec1dfcd8c69a0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bindings/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d0567127790ea92ebba3570785363d1752eab1c9570aeda5c7885e8c104677c5"
+          "sha256": "d0567127790ea92ebba3570785363d1752eab1c9570aeda5c7885e8c104677c5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bindings/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d52fdcaee45d9f7fa7279247e09d382f69b5fab60ba8257fdcf92d8b37e14b34"
+          "sha256": "d52fdcaee45d9f7fa7279247e09d382f69b5fab60ba8257fdcf92d8b37e14b34",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bindings/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f14c1ef1d9104df78642cda287ca6ba21e3ef954a6e71e33c7d4e47f75164c28"
+          "sha256": "f14c1ef1d9104df78642cda287ca6ba21e3ef954a6e71e33c7d4e47f75164c28",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bindings/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "189274aa2bdf605781b59b105c347c689d320a09fb62f9ed300d1f64e93281f6"
+          "sha256": "189274aa2bdf605781b59b105c347c689d320a09fb62f9ed300d1f64e93281f6",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bot-management/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4d50475aa586fb08cadbc7067d55b7ef1a6e5556bad3587b23e35ae37d541967"
+          "sha256": "4d50475aa586fb08cadbc7067d55b7ef1a6e5556bad3587b23e35ae37d541967",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bot-management/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a00ceaea1f51f7536829b2f93323d0df5c8f6b7742bfbcf9fcbd489eb910c4e9"
+          "sha256": "a00ceaea1f51f7536829b2f93323d0df5c8f6b7742bfbcf9fcbd489eb910c4e9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bot-management/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "361f709d6561c916b6082afa689ad3e69aa05f2cb4f9ed7bcbdfa62605b95c47"
+          "sha256": "361f709d6561c916b6082afa689ad3e69aa05f2cb4f9ed7bcbdfa62605b95c47",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bot-management/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d26a1b2dee0b92e6e2f4046067e0ba3f9e14f0b548b1d06537232d265e4cbb56"
+          "sha256": "d26a1b2dee0b92e6e2f4046067e0ba3f9e14f0b548b1d06537232d265e4cbb56",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/bot-management/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "daeb6aa87d2c1fe00e7d3ba3ebcb5e782725a6a3e22edde56c03527d1eb1ba63"
+          "sha256": "daeb6aa87d2c1fe00e7d3ba3ebcb5e782725a6a3e22edde56c03527d1eb1ba63",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/browser-rendering/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a0c6e51afc6c19f2a892e3f144b9210f4fe067318ad2550e34ded538a9db9463"
+          "sha256": "a0c6e51afc6c19f2a892e3f144b9210f4fe067318ad2550e34ded538a9db9463",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/browser-rendering/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0f346bfc469d1deb6077523b6ea20f071975c5223267415b2b9398cc6ab566ae"
+          "sha256": "0f346bfc469d1deb6077523b6ea20f071975c5223267415b2b9398cc6ab566ae",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/browser-rendering/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "db9206a7f14bf13d5f8ade9875927662796016c52b0221b54c3e08238890b952"
+          "sha256": "db9206a7f14bf13d5f8ade9875927662796016c52b0221b54c3e08238890b952",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/browser-rendering/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "31c3e69294545b1f7f9aecc80c3809521efe3b8d4c36bbc47ba8a693a81460ea"
+          "sha256": "31c3e69294545b1f7f9aecc80c3809521efe3b8d4c36bbc47ba8a693a81460ea",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/browser-rendering/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ed518864d14d821619b23d0a6e4fe0b39b64c8da98ad17d3da07b4b42d35c161"
+          "sha256": "ed518864d14d821619b23d0a6e4fe0b39b64c8da98ad17d3da07b4b42d35c161",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/c3/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a29848e8c74b2a8055330461f2ffec6ccb14d5d61b97b8214195ee7787c70d20"
+          "sha256": "a29848e8c74b2a8055330461f2ffec6ccb14d5d61b97b8214195ee7787c70d20",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/c3/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1c5429d72d1f5d5dab6d21914f7eb8aded761a828b4190655a2d4a0be6b12592"
+          "sha256": "1c5429d72d1f5d5dab6d21914f7eb8aded761a828b4190655a2d4a0be6b12592",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/c3/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "01e7f90dfbfce4d20a86a41b3ca882dab74d0b540ea07952da2f4ff1c6b6626c"
+          "sha256": "01e7f90dfbfce4d20a86a41b3ca882dab74d0b540ea07952da2f4ff1c6b6626c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/c3/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4acfbc2572326cd0be2bdd76bc7c7fb629a68dabb7c98b3fc6bed234d13e72b0"
+          "sha256": "4acfbc2572326cd0be2bdd76bc7c7fb629a68dabb7c98b3fc6bed234d13e72b0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/c3/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "592e533f9658678bfee0f5e7e65d9cfbf4a23ab4e47a3004543980643ce8826a"
+          "sha256": "592e533f9658678bfee0f5e7e65d9cfbf4a23ab4e47a3004543980643ce8826a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cache-reserve/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "90f848f9b142ddbfd911eea882b46bd45b5062efeda6b22e5be3d526c6155144"
+          "sha256": "90f848f9b142ddbfd911eea882b46bd45b5062efeda6b22e5be3d526c6155144",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cache-reserve/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "21b1448498e35b32fea54786ffa8dec6fff4ff597a3acfa10904ff459082207f"
+          "sha256": "21b1448498e35b32fea54786ffa8dec6fff4ff597a3acfa10904ff459082207f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cache-reserve/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7a033bcbe69e1617d6df25d202c8ecf58fe40a1a06b91c7b71d9ac1964886869"
+          "sha256": "7a033bcbe69e1617d6df25d202c8ecf58fe40a1a06b91c7b71d9ac1964886869",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cache-reserve/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3642800cd57f39fa3841021057a0ab6fb8bbcd8270b45b4acf33d6f1345e0f92"
+          "sha256": "3642800cd57f39fa3841021057a0ab6fb8bbcd8270b45b4acf33d6f1345e0f92",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cache-reserve/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "94b4739cfaa9aa8d805b5d820c5cfe2259ee9a108a574bf5fff8837655647dcb"
+          "sha256": "94b4739cfaa9aa8d805b5d820c5cfe2259ee9a108a574bf5fff8837655647dcb",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/containers/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "84ac21e42da260e8a2a5cbf677b455a7a06e0585dcd56be49895c014a26ae998"
+          "sha256": "84ac21e42da260e8a2a5cbf677b455a7a06e0585dcd56be49895c014a26ae998",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/containers/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d79640924c80decc91ef17011f021fd21fdb8dc97fb2e8dd81f735a06ecb0a1d"
+          "sha256": "d79640924c80decc91ef17011f021fd21fdb8dc97fb2e8dd81f735a06ecb0a1d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/containers/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "00af782c2e2ab7c95cd4491d0269eddc12efcc541ec67a5692ab0b50bc7c6cdd"
+          "sha256": "00af782c2e2ab7c95cd4491d0269eddc12efcc541ec67a5692ab0b50bc7c6cdd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/containers/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5707e264b73f62b30624e3ae14646d5fb7dd889a463376f3123a5424f2dd66d2"
+          "sha256": "5707e264b73f62b30624e3ae14646d5fb7dd889a463376f3123a5424f2dd66d2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/containers/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "129853373101f0a96b3e7ccfe6d840ac93cc089fcfeb8d551fca0af81c74a904"
+          "sha256": "129853373101f0a96b3e7ccfe6d840ac93cc089fcfeb8d551fca0af81c74a904",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cron-triggers/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "97cd7899f085cb1f28b10c7508062a3a614bccfe2e78ea8457d654ff0cc1be4f"
+          "sha256": "97cd7899f085cb1f28b10c7508062a3a614bccfe2e78ea8457d654ff0cc1be4f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cron-triggers/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2768dedd364f5424f5a5b4e6ab579f5d8b9de8c5d7fb32924cee73404450c64c"
+          "sha256": "2768dedd364f5424f5a5b4e6ab579f5d8b9de8c5d7fb32924cee73404450c64c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cron-triggers/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ef4548a7f8f80b1be2c41391a5aba2ce18ef0e02a96ec3b675bb84971dc383a0"
+          "sha256": "ef4548a7f8f80b1be2c41391a5aba2ce18ef0e02a96ec3b675bb84971dc383a0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cron-triggers/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eb66b7b1186d07279cbf1a0b0a477898b32b04a5eca283aa9e8669ddca5e0bd2"
+          "sha256": "eb66b7b1186d07279cbf1a0b0a477898b32b04a5eca283aa9e8669ddca5e0bd2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/cron-triggers/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "99e9e973fee96b3a1c9ff3a896546cc8a498f9831cb168e1cf4e4b4ecff38102"
+          "sha256": "99e9e973fee96b3a1c9ff3a896546cc8a498f9831cb168e1cf4e4b4ecff38102",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/d1/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "61b28faa4348cc80cd1296bc562fcba8205a131e73c9dc19a7da32e5c4b5f724"
+          "sha256": "61b28faa4348cc80cd1296bc562fcba8205a131e73c9dc19a7da32e5c4b5f724",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/d1/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ea957b3260a43c46ab7845303ed34065655b4367683bf502c53b334e5fa4c776"
+          "sha256": "ea957b3260a43c46ab7845303ed34065655b4367683bf502c53b334e5fa4c776",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/d1/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "06bc8baec2affc1d2cb12a0e2b3b3ea766527abd97c2ecf05460822f36feed2d"
+          "sha256": "06bc8baec2affc1d2cb12a0e2b3b3ea766527abd97c2ecf05460822f36feed2d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/d1/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1ffa594d0bdc7e02e64629c999f587119a5453a764bbf6ed69712ffc2c4c1f93"
+          "sha256": "1ffa594d0bdc7e02e64629c999f587119a5453a764bbf6ed69712ffc2c4c1f93",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/d1/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2e548a1267c7efae89fbe77a3627d096b3d77a64af61d8e3f53d36d15d01e48b"
+          "sha256": "2e548a1267c7efae89fbe77a3627d096b3d77a64af61d8e3f53d36d15d01e48b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ddos/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "63018c3c2d25ce26a0f1b80dd60bd2d3c5193a26bf96979ef624030ab766c4a8"
+          "sha256": "63018c3c2d25ce26a0f1b80dd60bd2d3c5193a26bf96979ef624030ab766c4a8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ddos/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eba158f9cca3ce70a07e5050a5586e3c1acd60f69e22069d9d02c8c91ad60cf5"
+          "sha256": "eba158f9cca3ce70a07e5050a5586e3c1acd60f69e22069d9d02c8c91ad60cf5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ddos/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0d0fae2b22edba2d40fddbbcec3f0c63651a25a0115e708edfc8b4e4c584c925"
+          "sha256": "0d0fae2b22edba2d40fddbbcec3f0c63651a25a0115e708edfc8b4e4c584c925",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ddos/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "320f6d383fe22756ae19e3a79fb1c1a5d147d74a493b73eed6dd6644fb9fd1a0"
+          "sha256": "320f6d383fe22756ae19e3a79fb1c1a5d147d74a493b73eed6dd6644fb9fd1a0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/ddos/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "546d722c64d8b1c14bc0a924b38eec24bcd3e639c25bbf424bb8cf73933ac306"
+          "sha256": "546d722c64d8b1c14bc0a924b38eec24bcd3e639c25bbf424bb8cf73933ac306",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2dd7fa0efc7db9a4edb0935b77a48973fe79978b693d29385db0403f1792154a"
+          "sha256": "2dd7fa0efc7db9a4edb0935b77a48973fe79978b693d29385db0403f1792154a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d3a0957cca017ae837bcf891d34404a6faca40a9b4d9b4be26a3f6272c223622"
+          "sha256": "d3a0957cca017ae837bcf891d34404a6faca40a9b4d9b4be26a3f6272c223622",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "b2c7ef2f41948280df468b8d1ed618486fb865ec8bd985706721f9debe472945"
+          "sha256": "b2c7ef2f41948280df468b8d1ed618486fb865ec8bd985706721f9debe472945",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "82c019a3e36341d3d9113b9b30f0d2e6692a59fdd903ed00dce2f7774e6e4f5a"
+          "sha256": "82c019a3e36341d3d9113b9b30f0d2e6692a59fdd903ed00dce2f7774e6e4f5a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a60c80f45d7b13b161a93b5c14771161cf95c4876224a699ba74816207de54ea"
+          "sha256": "a60c80f45d7b13b161a93b5c14771161cf95c4876224a699ba74816207de54ea",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/do-storage/testing.md",
           "owner": "cloudflare-deploy",
-          "sha256": "035b05fed943b2322941d7bd713d4d0e3025f2e514a3ef00642fc53509133472"
+          "sha256": "035b05fed943b2322941d7bd713d4d0e3025f2e514a3ef00642fc53509133472",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/durable-objects/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eeaafe38e5f85b70d5d548735a62181e055121932f98625f7b12d8f364751f4a"
+          "sha256": "eeaafe38e5f85b70d5d548735a62181e055121932f98625f7b12d8f364751f4a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/durable-objects/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ada50c598680f4d1e50d3e0588a1a6c0f4875346e583e34b87956ededff12e22"
+          "sha256": "ada50c598680f4d1e50d3e0588a1a6c0f4875346e583e34b87956ededff12e22",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/durable-objects/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "30486904f250952df8f11b7899f3ebedc46b7f9bb1c28d4695a3bf8acfb87375"
+          "sha256": "30486904f250952df8f11b7899f3ebedc46b7f9bb1c28d4695a3bf8acfb87375",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/durable-objects/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "b7156d2d5415f3670698d2ccae91877852fbebf7868b66412497907901bf1661"
+          "sha256": "b7156d2d5415f3670698d2ccae91877852fbebf7868b66412497907901bf1661",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/durable-objects/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e3ad270b7beaad53f700b4b5f49202ec7d9ea5c95bd22f963f2dc7a9272142a9"
+          "sha256": "e3ad270b7beaad53f700b4b5f49202ec7d9ea5c95bd22f963f2dc7a9272142a9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-routing/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4e28709e319f3912008a2887f9f3d62bdaa98ad9e52cc5ae139b8d220e825479"
+          "sha256": "4e28709e319f3912008a2887f9f3d62bdaa98ad9e52cc5ae139b8d220e825479",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-routing/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bb8355f4ef58ab1577982d1f6e399038538ec5f84e93071cd9f928b5a6832d36"
+          "sha256": "bb8355f4ef58ab1577982d1f6e399038538ec5f84e93071cd9f928b5a6832d36",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-routing/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a9a45e84286ffce8b67cd6a50e72a3a0f169f4414280fd94e5f33f9e9ac4ecd1"
+          "sha256": "a9a45e84286ffce8b67cd6a50e72a3a0f169f4414280fd94e5f33f9e9ac4ecd1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-routing/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8298b63f8e644b5b9de02cf61f031e403c5a363901ec2b470b936ea57f390ea7"
+          "sha256": "8298b63f8e644b5b9de02cf61f031e403c5a363901ec2b470b936ea57f390ea7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-routing/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "507bfca00d2b363d6168ec918fc75829bbf0145402aa3239916ba1bf7e92b6a3"
+          "sha256": "507bfca00d2b363d6168ec918fc75829bbf0145402aa3239916ba1bf7e92b6a3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-workers/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a0bc3bf064ca3c2352e92a16bf81fbdc30691b4afac6503e2b212ee2f336efe4"
+          "sha256": "a0bc3bf064ca3c2352e92a16bf81fbdc30691b4afac6503e2b212ee2f336efe4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-workers/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5e4b0e68fcf88e3332b15a8f6ef22cf706953d51b38456cd0346348543f06754"
+          "sha256": "5e4b0e68fcf88e3332b15a8f6ef22cf706953d51b38456cd0346348543f06754",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-workers/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "984d84d6842f4adda147cb783537ffd51ac887c331a0de3c100374c63c06d33e"
+          "sha256": "984d84d6842f4adda147cb783537ffd51ac887c331a0de3c100374c63c06d33e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-workers/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "135434634be61d82d5567dc20e779e9a807693d9d83ba2a49184d62ec551cb76"
+          "sha256": "135434634be61d82d5567dc20e779e9a807693d9d83ba2a49184d62ec551cb76",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/email-workers/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e8704f7beac19235631b246420c5ce730b054ccf899f43548366d70fe430737d"
+          "sha256": "e8704f7beac19235631b246420c5ce730b054ccf899f43548366d70fe430737d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/hyperdrive/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4d0e1a0e8366975d6ac0dcfd183e8b0a925f582c35917897aace568addff09f6"
+          "sha256": "4d0e1a0e8366975d6ac0dcfd183e8b0a925f582c35917897aace568addff09f6",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/hyperdrive/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7e7bb032dc6151ca8e3c30b278efa19d617362e9225f7a5f77a176585f10f7e5"
+          "sha256": "7e7bb032dc6151ca8e3c30b278efa19d617362e9225f7a5f77a176585f10f7e5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/hyperdrive/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "9c66135e7d5ed7a0e4f6b1395b71387b62aa22166d7eb26ab7d918b1fb5b5e57"
+          "sha256": "9c66135e7d5ed7a0e4f6b1395b71387b62aa22166d7eb26ab7d918b1fb5b5e57",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/hyperdrive/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c0001867d043c37581bc1a0d0ea556b649d7522e965ab2eedd431b1f3b0ca56e"
+          "sha256": "c0001867d043c37581bc1a0d0ea556b649d7522e965ab2eedd431b1f3b0ca56e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/hyperdrive/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e3bcdfb9c42df3ca1a84f175d727e918b638f28759fb5bd38fd3bcfdd21594ff"
+          "sha256": "e3bcdfb9c42df3ca1a84f175d727e918b638f28759fb5bd38fd3bcfdd21594ff",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/images/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2df48cf4d8d5269c55a2c2e94ec331c576200db80cb33bdb3f08f104fee88676"
+          "sha256": "2df48cf4d8d5269c55a2c2e94ec331c576200db80cb33bdb3f08f104fee88676",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/images/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "92c62bd77b133bf58287e93f12dced76725c0dc699b28ecad2acdae709ceea3c"
+          "sha256": "92c62bd77b133bf58287e93f12dced76725c0dc699b28ecad2acdae709ceea3c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/images/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e4c66bfcbf49b9c0cef84d66c7f8b49ce4520c92190661d13c409eaa0825c8f2"
+          "sha256": "e4c66bfcbf49b9c0cef84d66c7f8b49ce4520c92190661d13c409eaa0825c8f2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/images/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "447ec285923c9ab4b29e56ec7ec0318f30a559c05c257d37b02f60e62971b9d2"
+          "sha256": "447ec285923c9ab4b29e56ec7ec0318f30a559c05c257d37b02f60e62971b9d2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/images/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "b1cfebd7afdd7024e581e4a1002a304af0c00e630d4cd4623e97caae1c02fcd1"
+          "sha256": "b1cfebd7afdd7024e581e4a1002a304af0c00e630d4cd4623e97caae1c02fcd1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/kv/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c141ec2f48645a0f0884511baceee0265776075f3073aefbd199f3037b420681"
+          "sha256": "c141ec2f48645a0f0884511baceee0265776075f3073aefbd199f3037b420681",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/kv/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "94a2fc711801bf91b2697d3690ca5b5f6c7732f22ec50965e1eb0eafed204ff4"
+          "sha256": "94a2fc711801bf91b2697d3690ca5b5f6c7732f22ec50965e1eb0eafed204ff4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/kv/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "59138344e7c23b43b360e0df44a23ee56253d013a4a1a9633c5b459b3d4ebac3"
+          "sha256": "59138344e7c23b43b360e0df44a23ee56253d013a4a1a9633c5b459b3d4ebac3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/kv/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "60f1e7577a90acd2e44c65602b25f1f7cbb2cc6321c2fc501bf623484cb1115b"
+          "sha256": "60f1e7577a90acd2e44c65602b25f1f7cbb2cc6321c2fc501bf623484cb1115b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/kv/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4fc5129467ba3e9820609512c3ce9ac0e2db5c125cae6c892c239ad273381754"
+          "sha256": "4fc5129467ba3e9820609512c3ce9ac0e2db5c125cae6c892c239ad273381754",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/miniflare/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "484f0edc585d46559ee0be2bc443da8c7e96d6cde31e2c18ea52a2ae6c73bb95"
+          "sha256": "484f0edc585d46559ee0be2bc443da8c7e96d6cde31e2c18ea52a2ae6c73bb95",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/miniflare/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "468ea31044ec445b89fb54692335f26705ba10ee977f233afb075f340e8a77a2"
+          "sha256": "468ea31044ec445b89fb54692335f26705ba10ee977f233afb075f340e8a77a2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/miniflare/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "54dce11b0189897aae54406b09bfe4f9da89293daafc33898b80ccdc728494f2"
+          "sha256": "54dce11b0189897aae54406b09bfe4f9da89293daafc33898b80ccdc728494f2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/miniflare/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eb42fd5887eccd3b8100a4be7c1ba4209d8e0f169ea080252c4b46d38c745f63"
+          "sha256": "eb42fd5887eccd3b8100a4be7c1ba4209d8e0f169ea080252c4b46d38c745f63",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/miniflare/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3cde456ae68df13ddc6987df3c45c2440409ab7e2574e5e58b2c1f037f902af0"
+          "sha256": "3cde456ae68df13ddc6987df3c45c2440409ab7e2574e5e58b2c1f037f902af0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/network-interconnect/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "00aa27f34cbe4277a1c79624a06bfe3ab8cf910e2c847eb5ba9c5206f1e12b3e"
+          "sha256": "00aa27f34cbe4277a1c79624a06bfe3ab8cf910e2c847eb5ba9c5206f1e12b3e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/network-interconnect/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a4785017781a4b469b1c3e5c94f520a50b89412092b65963dee44bcb6e00b868"
+          "sha256": "a4785017781a4b469b1c3e5c94f520a50b89412092b65963dee44bcb6e00b868",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/network-interconnect/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3edfa1d1642a0aed71121156acd7e4f76258b027b8f3758cbca68ab0ea5a1956"
+          "sha256": "3edfa1d1642a0aed71121156acd7e4f76258b027b8f3758cbca68ab0ea5a1956",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/network-interconnect/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8444d367d9389661e040061c009011263c429b52b72a27f2fb4ff82ad261b7be"
+          "sha256": "8444d367d9389661e040061c009011263c429b52b72a27f2fb4ff82ad261b7be",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/network-interconnect/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e696a628f29643cb7955ed5d0607875188d462dcdff8a2758d287302d6b0fa1f"
+          "sha256": "e696a628f29643cb7955ed5d0607875188d462dcdff8a2758d287302d6b0fa1f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/observability/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5b6085ff9ff70483e47af484f554ed6a0214886bfbb74add0a146d9454514635"
+          "sha256": "5b6085ff9ff70483e47af484f554ed6a0214886bfbb74add0a146d9454514635",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/observability/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0dd66198a6832b3de90b32fabfae0e89b9ad98921181bfa5d77cb31da2c309c5"
+          "sha256": "0dd66198a6832b3de90b32fabfae0e89b9ad98921181bfa5d77cb31da2c309c5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/observability/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8a1b85928d8f146b57d8ef4c9b60f3ccd052e32a32b58b698da28a2483027960"
+          "sha256": "8a1b85928d8f146b57d8ef4c9b60f3ccd052e32a32b58b698da28a2483027960",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/observability/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "569bd59b08317bd6aa85621e7974650e3602a0cc5cbcd0e98dd503d9e879fb9f"
+          "sha256": "569bd59b08317bd6aa85621e7974650e3602a0cc5cbcd0e98dd503d9e879fb9f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/observability/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "df66dce8d14a5887e183dbc1831c3914cdfc731a854f1a12f6833da4b6fc05c7"
+          "sha256": "df66dce8d14a5887e183dbc1831c3914cdfc731a854f1a12f6833da4b6fc05c7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0b79f0e3bd7dd929d03de09ac7c35e006547c99763399f01b64436749085afe8"
+          "sha256": "0b79f0e3bd7dd929d03de09ac7c35e006547c99763399f01b64436749085afe8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "90989f928df3e394e9bc9587ac4eda172bf3735a338a0b1f6edba4d6af3a2652"
+          "sha256": "90989f928df3e394e9bc9587ac4eda172bf3735a338a0b1f6edba4d6af3a2652",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "98607a16fb561f374609bb638a5d05e94c55ebcad29cdec1058cd25800799b85"
+          "sha256": "98607a16fb561f374609bb638a5d05e94c55ebcad29cdec1058cd25800799b85",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5c66190d3a5aaa5864044431811afc31524dec856442504a2bd5caa0640c4af2"
+          "sha256": "5c66190d3a5aaa5864044431811afc31524dec856442504a2bd5caa0640c4af2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5a527102ede2c5b01543f356b0edf2574472251439c08b257ebefa4753eee957"
+          "sha256": "5a527102ede2c5b01543f356b0edf2574472251439c08b257ebefa4753eee957",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages-functions/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "19474e50d4c3c5fda0184f62df8302aef0ba8a09999fc3111d8cb979aa280fd7"
+          "sha256": "19474e50d4c3c5fda0184f62df8302aef0ba8a09999fc3111d8cb979aa280fd7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages-functions/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "edf4ea412a1372e46a704a3c0b7b60d208722b0dbda106d04bab41ab48dda1da"
+          "sha256": "edf4ea412a1372e46a704a3c0b7b60d208722b0dbda106d04bab41ab48dda1da",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages-functions/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "adaf79d53ca4d46ebc1be695314bb67aa42a11f412d9b61a48a765c828dd0d94"
+          "sha256": "adaf79d53ca4d46ebc1be695314bb67aa42a11f412d9b61a48a765c828dd0d94",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages-functions/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c623392e07ba0b90d90a7b30408081f792e5c74faa8fbb7cf799adc4fd4d16b5"
+          "sha256": "c623392e07ba0b90d90a7b30408081f792e5c74faa8fbb7cf799adc4fd4d16b5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pages-functions/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "35f462e5f5681bd317d66a62f7e297cd8395c406e9e52cdb05f8c5b17df6877c"
+          "sha256": "35f462e5f5681bd317d66a62f7e297cd8395c406e9e52cdb05f8c5b17df6877c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pipelines/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "08dc858b6848abbe594e38be62965de409a7769b7f562d17806df9491de36313"
+          "sha256": "08dc858b6848abbe594e38be62965de409a7769b7f562d17806df9491de36313",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pipelines/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1e2d758985524a1e9335a20508909ee73b087e5352c586ab2ddd8daac5f5b665"
+          "sha256": "1e2d758985524a1e9335a20508909ee73b087e5352c586ab2ddd8daac5f5b665",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pipelines/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2b838aaa75b3e304b586799bf07f66d878e1e6ef4911c6f4c0252c597ef2fb14"
+          "sha256": "2b838aaa75b3e304b586799bf07f66d878e1e6ef4911c6f4c0252c597ef2fb14",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pipelines/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c227e49aba59e449ea3f5bb8751bc5c623287ea35f898db2deb873808d326e69"
+          "sha256": "c227e49aba59e449ea3f5bb8751bc5c623287ea35f898db2deb873808d326e69",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pipelines/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "75d05267912d6023aa850316401992131c2ae5ee5dcceea2682328cd4bec71a3"
+          "sha256": "75d05267912d6023aa850316401992131c2ae5ee5dcceea2682328cd4bec71a3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pulumi/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2803dd115110b5f4b8ac414fb78debbe06c3a653d57032aee2374f89eca4d2d5"
+          "sha256": "2803dd115110b5f4b8ac414fb78debbe06c3a653d57032aee2374f89eca4d2d5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pulumi/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5e6459dbe3bcd802965fbc8467c54744671d5a9b3c600fececb2db314295797d"
+          "sha256": "5e6459dbe3bcd802965fbc8467c54744671d5a9b3c600fececb2db314295797d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pulumi/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5c102d4eb4d16a1647b451af42599d6123f6f4f31e4390edd698ba6ad8154eb6"
+          "sha256": "5c102d4eb4d16a1647b451af42599d6123f6f4f31e4390edd698ba6ad8154eb6",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pulumi/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f78cb1104200a53a2bd7c7807189fc59b59f6296c83f998054db1509ed3148ce"
+          "sha256": "f78cb1104200a53a2bd7c7807189fc59b59f6296c83f998054db1509ed3148ce",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/pulumi/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "975cd37cd6735d790624d042982a683f05f96dd6509f9da8ada7e78f8e645f2e"
+          "sha256": "975cd37cd6735d790624d042982a683f05f96dd6509f9da8ada7e78f8e645f2e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/queues/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "faa1106897e0f1b89a0b87040e14955f7594a48ef966d3ee88ece436cbef9359"
+          "sha256": "faa1106897e0f1b89a0b87040e14955f7594a48ef966d3ee88ece436cbef9359",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/queues/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ffe55706d2bcbb14f799d3254631c8b5e77a21534ce8831ddba7cbb325061e8c"
+          "sha256": "ffe55706d2bcbb14f799d3254631c8b5e77a21534ce8831ddba7cbb325061e8c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/queues/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f8730e15875faf99ff444ca6dc198d96a0ebbb2adde14163c1455e754f24197b"
+          "sha256": "f8730e15875faf99ff444ca6dc198d96a0ebbb2adde14163c1455e754f24197b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/queues/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a6adba9ddac675d2c4faa9c42d9aaba06e09a7802184aff22905d3ea135a92b1"
+          "sha256": "a6adba9ddac675d2c4faa9c42d9aaba06e09a7802184aff22905d3ea135a92b1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/queues/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4ce6cecea3ac1beeae91f5f3dca2fad88b4b65159abee4d56c12be8ec731c541"
+          "sha256": "4ce6cecea3ac1beeae91f5f3dca2fad88b4b65159abee4d56c12be8ec731c541",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e7d0e772e34c8fd6fb1d2aadb6a2c07a6d30d8e04ea50ce9a2b8c638836a8bf0"
+          "sha256": "e7d0e772e34c8fd6fb1d2aadb6a2c07a6d30d8e04ea50ce9a2b8c638836a8bf0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d229e1d53595db452fb893ab5053d37781e782bd46f5ead3193599474abbba88"
+          "sha256": "d229e1d53595db452fb893ab5053d37781e782bd46f5ead3193599474abbba88",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c2e3bb6047af5ca71e4e539a3dedaf9c62b7d41d4ef7f41c298495e9e9380fd3"
+          "sha256": "c2e3bb6047af5ca71e4e539a3dedaf9c62b7d41d4ef7f41c298495e9e9380fd3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c9068fb874e3ce0244e11e04c99383f9ca4e314a176e782e3e2cbc3dcef9a0f8"
+          "sha256": "c9068fb874e3ce0244e11e04c99383f9ca4e314a176e782e3e2cbc3dcef9a0f8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "fe0e4caa70e1f1a04d8559b56445b9db0cc51019d03a40a0ef996a1b5298698e"
+          "sha256": "fe0e4caa70e1f1a04d8559b56445b9db0cc51019d03a40a0ef996a1b5298698e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-data-catalog/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e1c0c6bfbdba3cfd2e9ab4d051cc88f947d8656e89d8912b998bfd7fcb80b762"
+          "sha256": "e1c0c6bfbdba3cfd2e9ab4d051cc88f947d8656e89d8912b998bfd7fcb80b762",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-data-catalog/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d5389cca0a4151ba3d400bbb587bdf437cfd8f863f183469ad8457e2133dd46b"
+          "sha256": "d5389cca0a4151ba3d400bbb587bdf437cfd8f863f183469ad8457e2133dd46b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-data-catalog/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4b6f9ede6a838e6d9f3da9dd06e3a637180ad0ef7e2063eb543eca3ff934c319"
+          "sha256": "4b6f9ede6a838e6d9f3da9dd06e3a637180ad0ef7e2063eb543eca3ff934c319",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-data-catalog/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "38cc280708c858e55991687da7a14f27e4f706195875d12cb788c91c0fa70223"
+          "sha256": "38cc280708c858e55991687da7a14f27e4f706195875d12cb788c91c0fa70223",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-data-catalog/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2b3a790749b2a3a31fbbf90c457de9aa05b2cf31ef4428acc6f6e545f80a907a"
+          "sha256": "2b3a790749b2a3a31fbbf90c457de9aa05b2cf31ef4428acc6f6e545f80a907a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-sql/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2e131d74778370969ae905ccc904adee9e4d7ff8abfe7269ebee0a8beda90f36"
+          "sha256": "2e131d74778370969ae905ccc904adee9e4d7ff8abfe7269ebee0a8beda90f36",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-sql/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1750e8f7b6ad5dbba86a05c186b6d8d67afd3674e75e4210c6500c4968c1cae1"
+          "sha256": "1750e8f7b6ad5dbba86a05c186b6d8d67afd3674e75e4210c6500c4968c1cae1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-sql/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c7f20114aad49340e78cf493404fecbe53a8c835b428f3c52900f37c82ba83da"
+          "sha256": "c7f20114aad49340e78cf493404fecbe53a8c835b428f3c52900f37c82ba83da",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-sql/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "9bc7ec882f2b04bdcf1c374b7e5ede67f47e7097b10d61c8b085aa4b35135efd"
+          "sha256": "9bc7ec882f2b04bdcf1c374b7e5ede67f47e7097b10d61c8b085aa4b35135efd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/r2-sql/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bc836b21abaac340720968be103d607b9ee70e81c55505af02d849a8fd62a4c2"
+          "sha256": "bc836b21abaac340720968be103d607b9ee70e81c55505af02d849a8fd62a4c2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtime-sfu/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2c1a23b8c44198e95eabb9f8db96453db61d935f96292932e9a5d1feea31e98c"
+          "sha256": "2c1a23b8c44198e95eabb9f8db96453db61d935f96292932e9a5d1feea31e98c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtime-sfu/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7c6c3d15d77976a87abcba5a8358c29c81e7dbeb15713cf5ccf71374e6017bfb"
+          "sha256": "7c6c3d15d77976a87abcba5a8358c29c81e7dbeb15713cf5ccf71374e6017bfb",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtime-sfu/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6cee79842fdf8fc68b75951a8fa015cbd9276c7babe6e8753f654d3b112c3fb1"
+          "sha256": "6cee79842fdf8fc68b75951a8fa015cbd9276c7babe6e8753f654d3b112c3fb1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtime-sfu/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "9717fbbf38ea4a8adc51631fd093eefacd6d6c7c30a961e54a5d404fa206b259"
+          "sha256": "9717fbbf38ea4a8adc51631fd093eefacd6d6c7c30a961e54a5d404fa206b259",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtime-sfu/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "51a2b40afd609346a367dcf8a626e905dfe895b3309fcb53432290c3da93cf0e"
+          "sha256": "51a2b40afd609346a367dcf8a626e905dfe895b3309fcb53432290c3da93cf0e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtimekit/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "190ecae4bb2ed00795cec6b59df4b0b3045cbc07d09b818abe398c239e97d531"
+          "sha256": "190ecae4bb2ed00795cec6b59df4b0b3045cbc07d09b818abe398c239e97d531",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtimekit/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "37020e6102c6f4f080f430f3de20c83532930e59cdcaaee52752d1fe62190152"
+          "sha256": "37020e6102c6f4f080f430f3de20c83532930e59cdcaaee52752d1fe62190152",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtimekit/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4d4ccf99fa72d8923df1eb3910eade99021cb77c5d9b4aa95310a01aeade0aaf"
+          "sha256": "4d4ccf99fa72d8923df1eb3910eade99021cb77c5d9b4aa95310a01aeade0aaf",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtimekit/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "83cecda63bad4c55c4b375f0b83fd90bcdc9a15a257fc95809ab08fa4c102618"
+          "sha256": "83cecda63bad4c55c4b375f0b83fd90bcdc9a15a257fc95809ab08fa4c102618",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/realtimekit/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2e02421351f5a7ad19887c38ccae65f14c8118956c6763c029072847036ebcd8"
+          "sha256": "2e02421351f5a7ad19887c38ccae65f14c8118956c6763c029072847036ebcd8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/sandbox/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "daef5eaf1d88b2980c8d6053134e991d6b762c8969b3100a3ee4c5c79f43fa26"
+          "sha256": "daef5eaf1d88b2980c8d6053134e991d6b762c8969b3100a3ee4c5c79f43fa26",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/sandbox/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "816b4a3b589a0403ec22b11eef5f68d5fe571661744f844f76f966d4e6724c8b"
+          "sha256": "816b4a3b589a0403ec22b11eef5f68d5fe571661744f844f76f966d4e6724c8b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/sandbox/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "71a892941829a103444fa5dc591da2c6a16ff25c24ace1cdc30e190068922ea4"
+          "sha256": "71a892941829a103444fa5dc591da2c6a16ff25c24ace1cdc30e190068922ea4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/sandbox/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "abca00f4f9b66ac7c34ed3ed6decf2b0cb5455e17b35d4316bee60446b4c52f9"
+          "sha256": "abca00f4f9b66ac7c34ed3ed6decf2b0cb5455e17b35d4316bee60446b4c52f9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/sandbox/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "85a3929971f06e5ebe3e8d93256fffd54231002ed5959dff0e78ca398f16de2d"
+          "sha256": "85a3929971f06e5ebe3e8d93256fffd54231002ed5959dff0e78ca398f16de2d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/secrets-store/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "82c078e9d71d9bd28b2f23535f086e74bec7adad08e3cb6c289326a4a6e14550"
+          "sha256": "82c078e9d71d9bd28b2f23535f086e74bec7adad08e3cb6c289326a4a6e14550",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/secrets-store/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d6453c2646c9b2a7fa74b9a63a7a6aa0707ceb499a06705bdda367cfe3e8a1fd"
+          "sha256": "d6453c2646c9b2a7fa74b9a63a7a6aa0707ceb499a06705bdda367cfe3e8a1fd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/secrets-store/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a7cb7ba5afedecbd005217d6155d85e2800b9f5029bc49f16f15498fc99f17ba"
+          "sha256": "a7cb7ba5afedecbd005217d6155d85e2800b9f5029bc49f16f15498fc99f17ba",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/secrets-store/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "572d2d0464d24d66c4720b52c57f6a3234335cfb2fd18308bba876b72229a296"
+          "sha256": "572d2d0464d24d66c4720b52c57f6a3234335cfb2fd18308bba876b72229a296",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/secrets-store/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "60f60f7ef93d50208629a2e630d24f4758b1b995eab146395fc639844829058a"
+          "sha256": "60f60f7ef93d50208629a2e630d24f4758b1b995eab146395fc639844829058a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/smart-placement/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2a41285bae05a8772a6b52b292c28aa87bd4f65c6b984ba85e2733fec104567d"
+          "sha256": "2a41285bae05a8772a6b52b292c28aa87bd4f65c6b984ba85e2733fec104567d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/smart-placement/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d3d8b440a7e362799d7b02dfc3ce348d7bbe51a760f4c6945f2d93bd82785774"
+          "sha256": "d3d8b440a7e362799d7b02dfc3ce348d7bbe51a760f4c6945f2d93bd82785774",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/smart-placement/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7d29937845c26f42ec568f4a98262bdbfe2e983c45e94c7c6376dda0ea67e856"
+          "sha256": "7d29937845c26f42ec568f4a98262bdbfe2e983c45e94c7c6376dda0ea67e856",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/smart-placement/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8e56c052e6b513b9ab565f0eaf0e7f84bca236dfc30bb77ec6715b70821a5b92"
+          "sha256": "8e56c052e6b513b9ab565f0eaf0e7f84bca236dfc30bb77ec6715b70821a5b92",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/smart-placement/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "693558fe87218c6ee1adca94ca3362eb9cce923e369559f7ff87dca1b9bc5047"
+          "sha256": "693558fe87218c6ee1adca94ca3362eb9cce923e369559f7ff87dca1b9bc5047",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/snippets/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4f66291949e5fb2a66e49a98b392c2d18057ff36ba74906feae3aeef94f9701f"
+          "sha256": "4f66291949e5fb2a66e49a98b392c2d18057ff36ba74906feae3aeef94f9701f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/snippets/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e76a59c5005ad537ea4ad83fab71365995717fb51938797a4dc29af324285755"
+          "sha256": "e76a59c5005ad537ea4ad83fab71365995717fb51938797a4dc29af324285755",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/snippets/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "836c6765b1ca807f46f1a13ca0d8f383fc6f6c4f8fc857a366156cde96ff74ef"
+          "sha256": "836c6765b1ca807f46f1a13ca0d8f383fc6f6c4f8fc857a366156cde96ff74ef",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/snippets/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "301c7167f03075505498f1f6b5fe1c72a393065a8228f42c435fde9f1b694150"
+          "sha256": "301c7167f03075505498f1f6b5fe1c72a393065a8228f42c435fde9f1b694150",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/snippets/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2b06454df89a837e16ae554769ad055e8de90d2c6bc19a81b4aeee0fc423029d"
+          "sha256": "2b06454df89a837e16ae554769ad055e8de90d2c6bc19a81b4aeee0fc423029d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/spectrum/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6dfd516d6e54696accbe6bb499f4e70686061abd0afa192897b32d7fd0c3f32e"
+          "sha256": "6dfd516d6e54696accbe6bb499f4e70686061abd0afa192897b32d7fd0c3f32e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/spectrum/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bef098862434f4c8e253d718d3437091813e45c3bfaa5004e8e86d6ceb83beb2"
+          "sha256": "bef098862434f4c8e253d718d3437091813e45c3bfaa5004e8e86d6ceb83beb2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/spectrum/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2079f33dfe2ef2ed715927c95c2ba5389f5f426745597aef94e5885da5eec403"
+          "sha256": "2079f33dfe2ef2ed715927c95c2ba5389f5f426745597aef94e5885da5eec403",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/spectrum/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "cb07bb56c6c5e2b2f88380772cbaa25143d7f32cce69c8f5bbbb1e77d4fdd216"
+          "sha256": "cb07bb56c6c5e2b2f88380772cbaa25143d7f32cce69c8f5bbbb1e77d4fdd216",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/spectrum/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "087e7d9a1a1a308eb13614332df217137296501cf57082077f05bb3a1f2bf7b0"
+          "sha256": "087e7d9a1a1a308eb13614332df217137296501cf57082077f05bb3a1f2bf7b0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/static-assets/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ef31f6ca300cb5fb1f111a626f6d92ef2b5b48a3ed97c2203874c33a2f38c0e8"
+          "sha256": "ef31f6ca300cb5fb1f111a626f6d92ef2b5b48a3ed97c2203874c33a2f38c0e8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/static-assets/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "619acb0a8d9732395316fc0beeed11e1a10557e08c639338ac92473cea1c5701"
+          "sha256": "619acb0a8d9732395316fc0beeed11e1a10557e08c639338ac92473cea1c5701",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/static-assets/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c35204c02177893d0b8c5b9bf2341d7814ed9d1e8e2ca3fc7c87d05603e9ec50"
+          "sha256": "c35204c02177893d0b8c5b9bf2341d7814ed9d1e8e2ca3fc7c87d05603e9ec50",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/static-assets/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "37b51d4f42e2a685934b7199dc62a0d8fd3d98c9dcf197ca5f5667aee01ea86d"
+          "sha256": "37b51d4f42e2a685934b7199dc62a0d8fd3d98c9dcf197ca5f5667aee01ea86d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/static-assets/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a9b508f7936d8edf7c63c65fb217d27f6aa555209a21e0a65eadf7a32d9ec9c4"
+          "sha256": "a9b508f7936d8edf7c63c65fb217d27f6aa555209a21e0a65eadf7a32d9ec9c4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ead31da7979689bffda222b1b1c20903fb1aca03301b208eff0b3682a422b6ab"
+          "sha256": "ead31da7979689bffda222b1b1c20903fb1aca03301b208eff0b3682a422b6ab",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/api-live.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7c384bb3ee0575f41bcc57cf1d7c6f37741e21de5d4ebb86ee4d1a05f6d671b0"
+          "sha256": "7c384bb3ee0575f41bcc57cf1d7c6f37741e21de5d4ebb86ee4d1a05f6d671b0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5440838fb2fb329fe815aecde94709a3d32be08c917491355709314ff7e3d8f1"
+          "sha256": "5440838fb2fb329fe815aecde94709a3d32be08c917491355709314ff7e3d8f1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "74c156e9c665e9d523bcd7c5d9a763339aba0356b1dc69d723ef6bab41a25328"
+          "sha256": "74c156e9c665e9d523bcd7c5d9a763339aba0356b1dc69d723ef6bab41a25328",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "65ef0e0f81470833dea11179849d5bf78f695720286db5e5eebe7d8dcf77a1d4"
+          "sha256": "65ef0e0f81470833dea11179849d5bf78f695720286db5e5eebe7d8dcf77a1d4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/stream/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1a18c1989fb525c15167126f98246afa27766e701c86150cb60409759a3e08f4"
+          "sha256": "1a18c1989fb525c15167126f98246afa27766e701c86150cb60409759a3e08f4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tail-workers/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "22776dd6348b07d2c7132ee4a52715f49bc61c1bb50d0af81e49281e44bb9799"
+          "sha256": "22776dd6348b07d2c7132ee4a52715f49bc61c1bb50d0af81e49281e44bb9799",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tail-workers/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d8349bfabdfac0d2cd8c911f2314c34ff1045b2a85b6d135cf4f4692940a94b3"
+          "sha256": "d8349bfabdfac0d2cd8c911f2314c34ff1045b2a85b6d135cf4f4692940a94b3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tail-workers/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8efac4877ad572f631f78643712a9c1e151661d4efedd728ee23fe2877669845"
+          "sha256": "8efac4877ad572f631f78643712a9c1e151661d4efedd728ee23fe2877669845",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tail-workers/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4ba9dc553f71ed2422a03c4fe8022aef313761227b88551e07b21496f0c68ac7"
+          "sha256": "4ba9dc553f71ed2422a03c4fe8022aef313761227b88551e07b21496f0c68ac7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tail-workers/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "400bb20063049d802f9b9d97924810817234bba9a12d8fd5ff13e9f0913812e4"
+          "sha256": "400bb20063049d802f9b9d97924810817234bba9a12d8fd5ff13e9f0913812e4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/terraform/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a7070aaa31c8e229b2ebfca6fe66bcf6ead9cdf1ef6d7b494a556080253ec073"
+          "sha256": "a7070aaa31c8e229b2ebfca6fe66bcf6ead9cdf1ef6d7b494a556080253ec073",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/terraform/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5dc812c078d06454d801b0e126d50c48031c1a7b0ffef7ebf77a97cf7b41e768"
+          "sha256": "5dc812c078d06454d801b0e126d50c48031c1a7b0ffef7ebf77a97cf7b41e768",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/terraform/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4d12cad256eaf2b021c1c19e7be29ef79e2d76183e387eefce2d4eb50b8d483e"
+          "sha256": "4d12cad256eaf2b021c1c19e7be29ef79e2d76183e387eefce2d4eb50b8d483e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/terraform/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ede039589518cceb96d40c12b7e22aaf0fbb1a5ec4d806af57940dfcaf9da672"
+          "sha256": "ede039589518cceb96d40c12b7e22aaf0fbb1a5ec4d806af57940dfcaf9da672",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/terraform/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1c5d35e79bdfbb2bfce92b095dbdb4fb08923b651a8f8e40e6e70e2956e6ffef"
+          "sha256": "1c5d35e79bdfbb2bfce92b095dbdb4fb08923b651a8f8e40e6e70e2956e6ffef",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1cbeda06e54ae97dc5db42721579e9b455cc1a2eec61f4756b3d4de29dddf2a0"
+          "sha256": "1cbeda06e54ae97dc5db42721579e9b455cc1a2eec61f4756b3d4de29dddf2a0",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "698055870e668a0827b8bbb83d9016b093e22e4a95f4aabeaca7ef2e0d1e099f"
+          "sha256": "698055870e668a0827b8bbb83d9016b093e22e4a95f4aabeaca7ef2e0d1e099f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "41c67b8a19309f3d626f8ad94bc0d4748be63ad311c220c73f76faaabde461ec"
+          "sha256": "41c67b8a19309f3d626f8ad94bc0d4748be63ad311c220c73f76faaabde461ec",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "267e3fad1f1a328bec1786ce883f7d658ee328ee5e812c2a4ee61739b507c691"
+          "sha256": "267e3fad1f1a328bec1786ce883f7d658ee328ee5e812c2a4ee61739b507c691",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/networking.md",
           "owner": "cloudflare-deploy",
-          "sha256": "99f51bcb065fdd62df94aa116f11effde03d81c4299f369770492346add235ca"
+          "sha256": "99f51bcb065fdd62df94aa116f11effde03d81c4299f369770492346add235ca",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/tunnel/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "696d5fe99640934a94b6facb6e3198d93dc38bfac3c3324fd817e47f620bc40d"
+          "sha256": "696d5fe99640934a94b6facb6e3198d93dc38bfac3c3324fd817e47f620bc40d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turn/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "9b1e36931f40b1faf3c8f24f89acb12c4f4223de0afc83e6b8de636f4730d542"
+          "sha256": "9b1e36931f40b1faf3c8f24f89acb12c4f4223de0afc83e6b8de636f4730d542",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turn/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "912ec9aa734843078db5ceb9c6732f3aa62778aa7ffb836b9798b46152f377ff"
+          "sha256": "912ec9aa734843078db5ceb9c6732f3aa62778aa7ffb836b9798b46152f377ff",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turn/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8df0cf402a41dd2a8205b9fc94f868df48273ef9e85cf1ad690732ac1e2469b7"
+          "sha256": "8df0cf402a41dd2a8205b9fc94f868df48273ef9e85cf1ad690732ac1e2469b7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turn/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7135e3e6e0351bf85fcfd5a914fd499979e7e15540d155810be5bc710e5841d7"
+          "sha256": "7135e3e6e0351bf85fcfd5a914fd499979e7e15540d155810be5bc710e5841d7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turn/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "de0a2e64a0fe6456028cbd0cd8f29195cc8d4da0e8935746357587d5937aa636"
+          "sha256": "de0a2e64a0fe6456028cbd0cd8f29195cc8d4da0e8935746357587d5937aa636",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turnstile/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "137caa7c326b4f57fecaa6174179d140aae4e20770301ac9ee207fa0f5a2cffd"
+          "sha256": "137caa7c326b4f57fecaa6174179d140aae4e20770301ac9ee207fa0f5a2cffd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turnstile/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8d9123ce63066a64d40c7da10ae3251dad64710f8122f3c57f826985d1474d27"
+          "sha256": "8d9123ce63066a64d40c7da10ae3251dad64710f8122f3c57f826985d1474d27",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turnstile/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eac60f420fa7122c275c40e6b7a9a55a672c42027d56d5e187432a1653f221b1"
+          "sha256": "eac60f420fa7122c275c40e6b7a9a55a672c42027d56d5e187432a1653f221b1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turnstile/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3166f9a79a6512310b84a7958dc911906395fd10e3540af7698083ec8e5d8286"
+          "sha256": "3166f9a79a6512310b84a7958dc911906395fd10e3540af7698083ec8e5d8286",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/turnstile/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7d229cb935aaa187796a8667b4d9843c8585a7f90fa30ddc6999240960f12bd8"
+          "sha256": "7d229cb935aaa187796a8667b4d9843c8585a7f90fa30ddc6999240960f12bd8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/vectorize/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "badc6f6e66868e9eaf30e46babf9e5c060fe7e425ed62d29d17161677323b388"
+          "sha256": "badc6f6e66868e9eaf30e46babf9e5c060fe7e425ed62d29d17161677323b388",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/vectorize/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c0aab15c2d7fc72b875b26e9a96a32bb2f899bd64ff3db33107208aacbf7347b"
+          "sha256": "c0aab15c2d7fc72b875b26e9a96a32bb2f899bd64ff3db33107208aacbf7347b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/vectorize/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "057eaef43f53e8bd71699ca17a3d296eb0c165ce1c1a304d71dea53ee9ab0908"
+          "sha256": "057eaef43f53e8bd71699ca17a3d296eb0c165ce1c1a304d71dea53ee9ab0908",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/vectorize/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "41368d07e71f80db6d649b07ed871b9ac463bcc8db8d53563e07d24634fd5633"
+          "sha256": "41368d07e71f80db6d649b07ed871b9ac463bcc8db8d53563e07d24634fd5633",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/vectorize/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "dcc4227997e7a856444a701b9243a9a1c8d1cb38680429ac3047b761f85e71c3"
+          "sha256": "dcc4227997e7a856444a701b9243a9a1c8d1cb38680429ac3047b761f85e71c3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/waf/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "dfcf0ff026f351637a2c7e9321740a24a87a3a5ee9698712677c2914b5d22163"
+          "sha256": "dfcf0ff026f351637a2c7e9321740a24a87a3a5ee9698712677c2914b5d22163",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/waf/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d7f67e1a1ee4096edb8382fa04c610fc933593afb442cec3f2d5e76bf6a604fa"
+          "sha256": "d7f67e1a1ee4096edb8382fa04c610fc933593afb442cec3f2d5e76bf6a604fa",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/waf/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e4fb36ebccdb73eb8be9513d316a7294ab62a6ce355b7e09498a77af91cdb095"
+          "sha256": "e4fb36ebccdb73eb8be9513d316a7294ab62a6ce355b7e09498a77af91cdb095",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/waf/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "d002f5d683577b734b6a1d787b96d04bff5ac47d454e720219ff58a9d850f4cb"
+          "sha256": "d002f5d683577b734b6a1d787b96d04bff5ac47d454e720219ff58a9d850f4cb",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/waf/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8fc5fab71800154d1128725274bcfe1a59b3e667c2c0f841a96f643e5da89ba1"
+          "sha256": "8fc5fab71800154d1128725274bcfe1a59b3e667c2c0f841a96f643e5da89ba1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/web-analytics/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bff5f576b9fc55ee7f3c448a7e5aff30e653bcc214d4040f476f392a69213218"
+          "sha256": "bff5f576b9fc55ee7f3c448a7e5aff30e653bcc214d4040f476f392a69213218",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/web-analytics/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "82a7c2312b3d8d9852d14547ef7771616f0da3cdecaa146afbf6272b77976017"
+          "sha256": "82a7c2312b3d8d9852d14547ef7771616f0da3cdecaa146afbf6272b77976017",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/web-analytics/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e81a0ac61dce03a4890b9950ba06662c16e4b9ddb4eecdff204221501cd8d6d5"
+          "sha256": "e81a0ac61dce03a4890b9950ba06662c16e4b9ddb4eecdff204221501cd8d6d5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/web-analytics/integration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a0dbfd1a658252e25d7ffa86180c691c6976265526b36ab14ce9e4b469d95cba"
+          "sha256": "a0dbfd1a658252e25d7ffa86180c691c6976265526b36ab14ce9e4b469d95cba",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/web-analytics/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6ccd1e334d260b968731f5f613ad28882bc199b72883e3254a52ded8d859f5a8"
+          "sha256": "6ccd1e334d260b968731f5f613ad28882bc199b72883e3254a52ded8d859f5a8",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workerd/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "daed9e582eff91b2c29dc77701c7c18a3d92fde0dc6883b2913df26094c0c597"
+          "sha256": "daed9e582eff91b2c29dc77701c7c18a3d92fde0dc6883b2913df26094c0c597",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workerd/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "7a6652e76e27424b0ce0d7393e1a04595460290d44e5ca937e3b0090a3b61166"
+          "sha256": "7a6652e76e27424b0ce0d7393e1a04595460290d44e5ca937e3b0090a3b61166",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workerd/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "656371e6aa55e315ea02e4304228f5c1151023f68af8058ad60984b90e00a9ad"
+          "sha256": "656371e6aa55e315ea02e4304228f5c1151023f68af8058ad60984b90e00a9ad",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workerd/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "ed3107537e54d440445408131b89db5f81f869902bade11cda7978f31234f74a"
+          "sha256": "ed3107537e54d440445408131b89db5f81f869902bade11cda7978f31234f74a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workerd/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "dc293c43c732adf6e3edfeaf72510904c7e8d097ca26c8b168748dd3d57e4408"
+          "sha256": "dc293c43c732adf6e3edfeaf72510904c7e8d097ca26c8b168748dd3d57e4408",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "4e00df1c6d64cd393c909430769c183b7027b4fe1db0c2dbb31090987baff14c"
+          "sha256": "4e00df1c6d64cd393c909430769c183b7027b4fe1db0c2dbb31090987baff14c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "96dafb63543f3a52a791ba56b0c3fb45efd7bef5b31331ce520cb999b8956c8d"
+          "sha256": "96dafb63543f3a52a791ba56b0c3fb45efd7bef5b31331ce520cb999b8956c8d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "76a1086028fbda8218306771af0c15c53774c40279c5a40a74057e6e9f2b10b4"
+          "sha256": "76a1086028fbda8218306771af0c15c53774c40279c5a40a74057e6e9f2b10b4",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/frameworks.md",
           "owner": "cloudflare-deploy",
-          "sha256": "520538d460fa6a11360163e3ed0725d840946c776feb9e00bd0bafd9f1cff699"
+          "sha256": "520538d460fa6a11360163e3ed0725d840946c776feb9e00bd0bafd9f1cff699",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f9430e9fe0462c5749fb6478f5d29eea18838d71bcb73366c9479ff865dc597f"
+          "sha256": "f9430e9fe0462c5749fb6478f5d29eea18838d71bcb73366c9479ff865dc597f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f408d6db9c13ef192511b506b7f83b15df1a0e736c9d10215fcc1c0c0b3ba439"
+          "sha256": "f408d6db9c13ef192511b506b7f83b15df1a0e736c9d10215fcc1c0c0b3ba439",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-ai/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "e1f1fae0a795cbf975d4751e36f28a2b9eb48ad9cd10a9edf48cc9211581c241"
+          "sha256": "e1f1fae0a795cbf975d4751e36f28a2b9eb48ad9cd10a9edf48cc9211581c241",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-ai/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2b6093736b90376cf9089726eddc580f77d9f719be5031a1552cd05a4f3e991c"
+          "sha256": "2b6093736b90376cf9089726eddc580f77d9f719be5031a1552cd05a4f3e991c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-ai/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "acfe8100a30a006b2b35ba9f81897130402825b062a087984258fa597ea8fa1a"
+          "sha256": "acfe8100a30a006b2b35ba9f81897130402825b062a087984258fa597ea8fa1a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-ai/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "10fe3b26750c2fc92ff6ccdefc1200352cdae88c573071cd7735d0a84ff925da"
+          "sha256": "10fe3b26750c2fc92ff6ccdefc1200352cdae88c573071cd7735d0a84ff925da",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-ai/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "1ebfd949690bd1e8150435c1bd1bf7b5cd3e6ab35eec5442f7af8bf39ea80198"
+          "sha256": "1ebfd949690bd1e8150435c1bd1bf7b5cd3e6ab35eec5442f7af8bf39ea80198",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-for-platforms/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "8c1b123a124f0da9da6ee5944723f6a1fdf39bf753c8bbf5aae23aeab4de6000"
+          "sha256": "8c1b123a124f0da9da6ee5944723f6a1fdf39bf753c8bbf5aae23aeab4de6000",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-for-platforms/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6bc581bf87e21dd9764b88e7658b8cce841491943bd67b0ab8c37e1fcb2b9835"
+          "sha256": "6bc581bf87e21dd9764b88e7658b8cce841491943bd67b0ab8c37e1fcb2b9835",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-for-platforms/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "21e9034f5b014589e05e98eb5fa368e1c4fe4f287215c4b8f38ce12b95fd588a"
+          "sha256": "21e9034f5b014589e05e98eb5fa368e1c4fe4f287215c4b8f38ce12b95fd588a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-for-platforms/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "98904178ec81e30e0503ae512cedf76e0d8bdcc517009984b474a6008243e18f"
+          "sha256": "98904178ec81e30e0503ae512cedf76e0d8bdcc517009984b474a6008243e18f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-for-platforms/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "08ea9e56309bf663fca61a9bb6e5115d23758fcde7112d482944ac510ae43643"
+          "sha256": "08ea9e56309bf663fca61a9bb6e5115d23758fcde7112d482944ac510ae43643",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-playground/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "5429f6fbb3300f1e190e8024ae8fd63f5e345ea22ecdaea4e405766351177496"
+          "sha256": "5429f6fbb3300f1e190e8024ae8fd63f5e345ea22ecdaea4e405766351177496",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-playground/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bf8f93589789b19c0834815dd498d09a0eaf526502d66691c4797b6c2906ad49"
+          "sha256": "bf8f93589789b19c0834815dd498d09a0eaf526502d66691c4797b6c2906ad49",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-playground/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eee7eeb85e60ee4a2b9d91f445448dc93c3d2875a80b35888f93847e990d128f"
+          "sha256": "eee7eeb85e60ee4a2b9d91f445448dc93c3d2875a80b35888f93847e990d128f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-playground/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "85e262f98373f1631dcef3f44a57b6d9e30f8e930e013dc8667fa5993bb6dfae"
+          "sha256": "85e262f98373f1631dcef3f44a57b6d9e30f8e930e013dc8667fa5993bb6dfae",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-playground/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c95d27741ecccbad12386ff4fa9dae6c8ff21438bf83f3edfd177ec156a8da69"
+          "sha256": "c95d27741ecccbad12386ff4fa9dae6c8ff21438bf83f3edfd177ec156a8da69",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-vpc/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6bfab65387d76709296161a0206a1a943f773374c1fb8fa435853693b16902df"
+          "sha256": "6bfab65387d76709296161a0206a1a943f773374c1fb8fa435853693b16902df",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-vpc/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "60bae66d5674a5e54a0077168adfbc5c44a9c87050149381b119941bb4c45f41"
+          "sha256": "60bae66d5674a5e54a0077168adfbc5c44a9c87050149381b119941bb4c45f41",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-vpc/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0a3f90caf7b17158687c6f4ce5a6e2f292c19255eb2bf766d7eec96de926104b"
+          "sha256": "0a3f90caf7b17158687c6f4ce5a6e2f292c19255eb2bf766d7eec96de926104b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-vpc/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "70e2d004800e75ccdbbdcc37623b97d9f5b4592183aae1421e21bad19e111d80"
+          "sha256": "70e2d004800e75ccdbbdcc37623b97d9f5b4592183aae1421e21bad19e111d80",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workers-vpc/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "87dc009bc45b057408dfbeaace374ff169295bba7d9d4d40fa973945848c9ecc"
+          "sha256": "87dc009bc45b057408dfbeaace374ff169295bba7d9d4d40fa973945848c9ecc",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workflows/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "c0a6be8e49bc081474ad24ec4c1f6ec190c2e431c2d30869e0b5a047b4a25c3f"
+          "sha256": "c0a6be8e49bc081474ad24ec4c1f6ec190c2e431c2d30869e0b5a047b4a25c3f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workflows/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "f9daa528ae883afcab07036e1b7c5e341b1b10d579fadaa782553243c41881ee"
+          "sha256": "f9daa528ae883afcab07036e1b7c5e341b1b10d579fadaa782553243c41881ee",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workflows/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "3701f2702b265c517668e24e2dd63417a277e7f601cb52623a9a4e1677553756"
+          "sha256": "3701f2702b265c517668e24e2dd63417a277e7f601cb52623a9a4e1677553756",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workflows/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "21ddf3bdb1987bfbdfc1796e49643bf0f2ef247ccf01a78c03f77e5dc50d695d"
+          "sha256": "21ddf3bdb1987bfbdfc1796e49643bf0f2ef247ccf01a78c03f77e5dc50d695d",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/workflows/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eca20d1dadcf97e7a415603793aec1dbb3a252eb5abf27a35e0b99e242ebe593"
+          "sha256": "eca20d1dadcf97e7a415603793aec1dbb3a252eb5abf27a35e0b99e242ebe593",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a30d1890034e40e50a6f974a6dde4a8337293372aff91d4b79bbe4ecddc69e36"
+          "sha256": "a30d1890034e40e50a6f974a6dde4a8337293372aff91d4b79bbe4ecddc69e36",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "0872bc513368c167efbf8bc16024140963f44fd2cdc8777cd615b15831997d53"
+          "sha256": "0872bc513368c167efbf8bc16024140963f44fd2cdc8777cd615b15831997d53",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/auth.md",
           "owner": "cloudflare-deploy",
-          "sha256": "71ca6291023a9897c376ea03600f7095bc38b3ad5360cffefb4c9bd93f338fdf"
+          "sha256": "71ca6291023a9897c376ea03600f7095bc38b3ad5360cffefb4c9bd93f338fdf",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "a8e042ffe9e399167816920a58c8ce909b6cd784507615e3431729884e1334b2"
+          "sha256": "a8e042ffe9e399167816920a58c8ce909b6cd784507615e3431729884e1334b2",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "bb24bd86adaacf3f1f2e359e6e02ee72e1342e6156ffa3bb8b6d25aa28aba5c6"
+          "sha256": "bb24bd86adaacf3f1f2e359e6e02ee72e1342e6156ffa3bb8b6d25aa28aba5c6",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/wrangler/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eef3fa927fea3594313d72c0107b6552e65c0a86ad0324558d73e579bbd74772"
+          "sha256": "eef3fa927fea3594313d72c0107b6552e65c0a86ad0324558d73e579bbd74772",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/IMPLEMENTATION_SUMMARY.md",
           "owner": "cloudflare-deploy",
-          "sha256": "eba1671fc4ba17fae19d1ff2d1b312d5042b5821e7a4dbc2f6367a4fa8bd5506"
+          "sha256": "eba1671fc4ba17fae19d1ff2d1b312d5042b5821e7a4dbc2f6367a4fa8bd5506",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/README.md",
           "owner": "cloudflare-deploy",
-          "sha256": "929bee8e3efffad15b1a2ee2e20ff87b5d89cc724b4f450f07f6ef15caf4b2f9"
+          "sha256": "929bee8e3efffad15b1a2ee2e20ff87b5d89cc724b4f450f07f6ef15caf4b2f9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/api.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6b28a3e1525d46aad707b1bf4edd2739df9f48ae880f71a705448270b42f8b9e"
+          "sha256": "6b28a3e1525d46aad707b1bf4edd2739df9f48ae880f71a705448270b42f8b9e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/configuration.md",
           "owner": "cloudflare-deploy",
-          "sha256": "6f3666ac64d1b36b4a708b3dea9d3b1d9679b34c58a00e3ca8e254edd602418a"
+          "sha256": "6f3666ac64d1b36b4a708b3dea9d3b1d9679b34c58a00e3ca8e254edd602418a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/gotchas.md",
           "owner": "cloudflare-deploy",
-          "sha256": "30378f48fde6e866780466228a3e698005a9ce23a24188c8ed520195b03eac3e"
+          "sha256": "30378f48fde6e866780466228a3e698005a9ce23a24188c8ed520195b03eac3e",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/cloudflare-deploy/references/zaraz/patterns.md",
           "owner": "cloudflare-deploy",
-          "sha256": "2ea1d00fe81b1e881c00090fd18c96d8c78ebb41fcc55f540b68150320d90d17"
+          "sha256": "2ea1d00fe81b1e881c00090fd18c96d8c78ebb41fcc55f540b68150320d90d17",
+          "mode": "100644"
         }
       ]
     },
@@ -5463,32 +5941,38 @@
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/SKILL.md",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "af5b8d70120fa573ccc586411956e3f9a1ad3b4b7b16e334bec3629900fa3835"
+          "sha256": "af5b8d70120fa573ccc586411956e3f9a1ad3b4b7b16e334bec3629900fa3835",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/references/api_overview.md",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "4dbe6aef7402cd26a30a166252335f64a952ee5ec3b307cb105218a0064fe59d"
+          "sha256": "4dbe6aef7402cd26a30a166252335f64a952ee5ec3b307cb105218a0064fe59d",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/references/common_issues.md",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "6a35f9bec753487a4961a2a9e8b0cf38f329cc1a69b388446aa44ec8d41942b5"
+          "sha256": "6a35f9bec753487a4961a2a9e8b0cf38f329cc1a69b388446aa44ec8d41942b5",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/references/ssl_modes.md",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "5cf6d9d5c76a903fc9e5cc11469a7b1c16fa6f775c00945feb3f15045ecde392"
+          "sha256": "5cf6d9d5c76a903fc9e5cc11469a7b1c16fa6f775c00945feb3f15045ecde392",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/scripts/check_cloudflare_config.py",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "af949f88d1db660125ff9a977bf15fb55796a244a92d00f049123b80decd46c6"
+          "sha256": "af949f88d1db660125ff9a977bf15fb55796a244a92d00f049123b80decd46c6",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/cloudflare-troubleshooting/scripts/fix_ssl_mode.py",
           "owner": "cloudflare-troubleshooting",
-          "sha256": "e9f48e283189137f0402cde63d826afa560a2566c5ed1707fb47597ddd3024d1"
+          "sha256": "e9f48e283189137f0402cde63d826afa560a2566c5ed1707fb47597ddd3024d1",
+          "mode": "100644"
         }
       ]
     },
@@ -5538,7 +6022,8 @@
         {
           "path": "skills/developer-engineering/codebase-onboarding/SKILL.md",
           "owner": "codebase-onboarding",
-          "sha256": "8af53883413a4bbcd55a82916edbdcd42f78a8e2cde78a3cada8932704de3fb5"
+          "sha256": "8af53883413a4bbcd55a82916edbdcd42f78a8e2cde78a3cada8932704de3fb5",
+          "mode": "100644"
         }
       ]
     },
@@ -5588,7 +6073,8 @@
         {
           "path": "skills/security-and-reliability/codeql-security-scanner/SKILL.md",
           "owner": "codeql-security-scanner",
-          "sha256": "601d8a67881a59afe7418fd5ad02b2f232434a39b227e73f11eac83aa0023658"
+          "sha256": "601d8a67881a59afe7418fd5ad02b2f232434a39b227e73f11eac83aa0023658",
+          "mode": "100644"
         }
       ]
     },
@@ -5638,7 +6124,8 @@
         {
           "path": "skills/product-design/competitive-teardown/SKILL.md",
           "owner": "competitive-teardown",
-          "sha256": "aa82b6c902958aaedefbb20a537d19f665b733b4a8f33f6e645b5c25c41bbcfb"
+          "sha256": "aa82b6c902958aaedefbb20a537d19f665b733b4a8f33f6e645b5c25c41bbcfb",
+          "mode": "100644"
         }
       ]
     },
@@ -5708,27 +6195,32 @@
         {
           "path": "skills/growth-operations-xiaohongshu/competitors-analysis/.security-scan-passed",
           "owner": "competitors-analysis",
-          "sha256": "b69a2158300a29194cbaa750712e5c5a0b22c18c37aaa33b9b1cd48b2a95ae11"
+          "sha256": "b69a2158300a29194cbaa750712e5c5a0b22c18c37aaa33b9b1cd48b2a95ae11",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/competitors-analysis/SKILL.md",
           "owner": "competitors-analysis",
-          "sha256": "feb4a4825c79b4998cde9d628898458285f78b9ff6c2acf0d2fd1a2df22744a9"
+          "sha256": "feb4a4825c79b4998cde9d628898458285f78b9ff6c2acf0d2fd1a2df22744a9",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/competitors-analysis/references/analysis_checklist.md",
           "owner": "competitors-analysis",
-          "sha256": "b7ae6b92f7d17180b49b4023d7acf331d57b2de6669ac53490b51ec26682989c"
+          "sha256": "b7ae6b92f7d17180b49b4023d7acf331d57b2de6669ac53490b51ec26682989c",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/competitors-analysis/references/profile_template.md",
           "owner": "competitors-analysis",
-          "sha256": "269fd4294879b5f73079d72a32f337129aeb02e1102552fc4a9835b08982fc4f"
+          "sha256": "269fd4294879b5f73079d72a32f337129aeb02e1102552fc4a9835b08982fc4f",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/competitors-analysis/scripts/update-competitors.sh",
           "owner": "competitors-analysis",
-          "sha256": "ac71139edb1492b505bfac2e8d0e8d96a9074bd9e4db8f8ec523e5e3bae2480f"
+          "sha256": "ac71139edb1492b505bfac2e8d0e8d96a9074bd9e4db8f8ec523e5e3bae2480f",
+          "mode": "100644"
         }
       ]
     },
@@ -5793,22 +6285,26 @@
         {
           "path": "skills/finance-investing/comps-valuation-analyst/SKILL.md",
           "owner": "comps-valuation-analyst",
-          "sha256": "332a81e617abb5070bebe0181d44830a11ea57e848cdbd3a9e128e37ed6a00e8"
+          "sha256": "332a81e617abb5070bebe0181d44830a11ea57e848cdbd3a9e128e37ed6a00e8",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/comps-valuation-analyst/assets/sample_comps_input.json",
           "owner": "comps-valuation-analyst",
-          "sha256": "09af27e01d928ec273324af83fd603d9878eca0fa25f91002dc648e8b7a44ef4"
+          "sha256": "09af27e01d928ec273324af83fd603d9878eca0fa25f91002dc648e8b7a44ef4",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/comps-valuation-analyst/references/comps-methodology.md",
           "owner": "comps-valuation-analyst",
-          "sha256": "e3877acc2f6dc0791d8f3034bb9c521c633528e70eac9d243052b7c8bb45e4a0"
+          "sha256": "e3877acc2f6dc0791d8f3034bb9c521c633528e70eac9d243052b7c8bb45e4a0",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/comps-valuation-analyst/scripts/calculate_comps.py",
           "owner": "comps-valuation-analyst",
-          "sha256": "9d751804830ea21cd585b5f1ac3e1635d373887f3aa17bc2d1b0061c64065b99"
+          "sha256": "9d751804830ea21cd585b5f1ac3e1635d373887f3aa17bc2d1b0061c64065b99",
+          "mode": "100644"
         }
       ]
     },
@@ -5903,52 +6399,62 @@
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/SKILL.md",
           "owner": "content-creator",
-          "sha256": "ae030934dcee65f8554aa99f21025f64955173c58e91b6704a2cdfbae71c58d2"
+          "sha256": "ae030934dcee65f8554aa99f21025f64955173c58e91b6704a2cdfbae71c58d2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/assets/content_calendar_template.md",
           "owner": "content-creator",
-          "sha256": "338d24a0dd5b41e9e5de98d8feda602000211abf09ce41c2b6f2493ceeb2951d"
+          "sha256": "338d24a0dd5b41e9e5de98d8feda602000211abf09ce41c2b6f2493ceeb2951d",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/examples/brand_voice_analysis_example.md",
           "owner": "content-creator",
-          "sha256": "9c87726c7be78f36cf8507f3c5bfd248a75c6c6e572e6b1634eff878688cee86"
+          "sha256": "9c87726c7be78f36cf8507f3c5bfd248a75c6c6e572e6b1634eff878688cee86",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/examples/seo_optimization_example.md",
           "owner": "content-creator",
-          "sha256": "8597e5d3fe37c85073ab491ed6b8d6e7d58ccb91cb01130b9370ac5564346af5"
+          "sha256": "8597e5d3fe37c85073ab491ed6b8d6e7d58ccb91cb01130b9370ac5564346af5",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/references/analytics_guide.md",
           "owner": "content-creator",
-          "sha256": "08d4f5c42b865c484d1efd8a74d6c782136b7b23e82737f10bbc2955eff8b2d2"
+          "sha256": "08d4f5c42b865c484d1efd8a74d6c782136b7b23e82737f10bbc2955eff8b2d2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/references/brand_guidelines.md",
           "owner": "content-creator",
-          "sha256": "6d6e9dc47ae44f80fa18976f2a37b3667de4dae13fdeefaaa4ad219f302fd8d0"
+          "sha256": "6d6e9dc47ae44f80fa18976f2a37b3667de4dae13fdeefaaa4ad219f302fd8d0",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/references/content_frameworks.md",
           "owner": "content-creator",
-          "sha256": "a6696080a7550cba45dd4841312f28f8d62a5f8ba42e893540ea86b2b2052538"
+          "sha256": "a6696080a7550cba45dd4841312f28f8d62a5f8ba42e893540ea86b2b2052538",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/references/social_media_optimization.md",
           "owner": "content-creator",
-          "sha256": "b6c14dc67901d28bea22513b283f715e54f0eccd8b7171f5ec07a2e813ea0901"
+          "sha256": "b6c14dc67901d28bea22513b283f715e54f0eccd8b7171f5ec07a2e813ea0901",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/scripts/brand_voice_analyzer.py",
           "owner": "content-creator",
-          "sha256": "ac1b43b9a76ca63f62005c123ba71d9c98e21a6562ebf9f7f8eae62f0a01b8b0"
+          "sha256": "ac1b43b9a76ca63f62005c123ba71d9c98e21a6562ebf9f7f8eae62f0a01b8b0",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/content-creator/scripts/seo_optimizer.py",
           "owner": "content-creator",
-          "sha256": "285e797a356ba8bb60631c0a123d249ef24468f368c00e3d585ea27f9b5aadc5"
+          "sha256": "285e797a356ba8bb60631c0a123d249ef24468f368c00e3d585ea27f9b5aadc5",
+          "mode": "100644"
         }
       ]
     },
@@ -6063,72 +6569,86 @@
         {
           "path": "skills/developer-engineering/database-designer/README.md",
           "owner": "database-designer",
-          "sha256": "18264cfce2a0cf29a83902a64909944eac6a6d3ae50d6366f307a6fd97c0bbb5"
+          "sha256": "18264cfce2a0cf29a83902a64909944eac6a6d3ae50d6366f307a6fd97c0bbb5",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/SKILL.md",
           "owner": "database-designer",
-          "sha256": "3407b5f86dfdc30fd94450e47cc3f3d39881039fd3166e892446b10a982c3d88"
+          "sha256": "3407b5f86dfdc30fd94450e47cc3f3d39881039fd3166e892446b10a982c3d88",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/assets/sample_query_patterns.json",
           "owner": "database-designer",
-          "sha256": "de9d9fe65e8f8ff9aeac7f055d475e5b742999081caaf50ffdd3ff88aab98d4b"
+          "sha256": "de9d9fe65e8f8ff9aeac7f055d475e5b742999081caaf50ffdd3ff88aab98d4b",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/assets/sample_schema.json",
           "owner": "database-designer",
-          "sha256": "006d510d7807dc1cf7a23710fcfe4b0cf0f6f37a7fafb559e79f91d6c56ed177"
+          "sha256": "006d510d7807dc1cf7a23710fcfe4b0cf0f6f37a7fafb559e79f91d6c56ed177",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/assets/sample_schema.sql",
           "owner": "database-designer",
-          "sha256": "8dfa99c27922537d64243a9dfddcee996d29f1c4d4ef23ce21db6f631bf828d5"
+          "sha256": "8dfa99c27922537d64243a9dfddcee996d29f1c4d4ef23ce21db6f631bf828d5",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/expected_outputs/index_optimization_sample.txt",
           "owner": "database-designer",
-          "sha256": "a31ac7a8eaccc2b1db5701ec025304b12ea5dc82e81df25eb662ccbc0cc48f67"
+          "sha256": "a31ac7a8eaccc2b1db5701ec025304b12ea5dc82e81df25eb662ccbc0cc48f67",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/expected_outputs/migration_sample.txt",
           "owner": "database-designer",
-          "sha256": "bb34e3bf0728810756a184c0f1bd4e1ad61ee5adda2efcbce668f6d1dcadeee9"
+          "sha256": "bb34e3bf0728810756a184c0f1bd4e1ad61ee5adda2efcbce668f6d1dcadeee9",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/expected_outputs/schema_analysis_sample.txt",
           "owner": "database-designer",
-          "sha256": "97335e832292f3687d9e0f576eee50e8b55dc184376cd457ae56578c4802c987"
+          "sha256": "97335e832292f3687d9e0f576eee50e8b55dc184376cd457ae56578c4802c987",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/index_optimizer.py",
           "owner": "database-designer",
-          "sha256": "0c73e6724d02eae6d48a9dd2a626e06e7d551a3fcae3ab5f13a044384b2db485"
+          "sha256": "0c73e6724d02eae6d48a9dd2a626e06e7d551a3fcae3ab5f13a044384b2db485",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/migration_generator.py",
           "owner": "database-designer",
-          "sha256": "420e49cc56fd5a3b1d9ad5983462f539389548dc885142fa0c0b596a44b3ec92"
+          "sha256": "420e49cc56fd5a3b1d9ad5983462f539389548dc885142fa0c0b596a44b3ec92",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/references/database_selection_decision_tree.md",
           "owner": "database-designer",
-          "sha256": "18d1a914c6097e6e7e8fd38da4e5847c24191e24063efb3d39f83526079f20ee"
+          "sha256": "18d1a914c6097e6e7e8fd38da4e5847c24191e24063efb3d39f83526079f20ee",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/references/index_strategy_patterns.md",
           "owner": "database-designer",
-          "sha256": "8d85e83b63c7977ac1cbfd70b2d42ac6fbdbfbeb9219d1dee98f0fafdafaabe8"
+          "sha256": "8d85e83b63c7977ac1cbfd70b2d42ac6fbdbfbeb9219d1dee98f0fafdafaabe8",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/references/normalization_guide.md",
           "owner": "database-designer",
-          "sha256": "30f05dfb9c474203c3377cbd7814f2d61971bde0bbad0807c332ddf2d27a4c30"
+          "sha256": "30f05dfb9c474203c3377cbd7814f2d61971bde0bbad0807c332ddf2d27a4c30",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/database-designer/schema_analyzer.py",
           "owner": "database-designer",
-          "sha256": "4c44912b055045f278c938e6dc90f8559bded16cf6dfa066860d66a3a7a42e42"
+          "sha256": "4c44912b055045f278c938e6dc90f8559bded16cf6dfa066860d66a3a7a42e42",
+          "mode": "100644"
         }
       ]
     },
@@ -6178,7 +6698,8 @@
         {
           "path": "skills/developer-engineering/database-schema-designer/SKILL.md",
           "owner": "database-schema-designer",
-          "sha256": "b03ec657fc54c1d38227d98edb4b95b5d63b339b4a54d45017b1c52e6ae9e5d6"
+          "sha256": "b03ec657fc54c1d38227d98edb4b95b5d63b339b4a54d45017b1c52e6ae9e5d6",
+          "mode": "100644"
         }
       ]
     },
@@ -6258,37 +6779,44 @@
         {
           "path": "skills/ai-workflow/deep-research/.security-scan-passed",
           "owner": "deep-research",
-          "sha256": "8095939e787c6106dfd21ecd2ce4b53fa7298b093b79511dfe1e77da5dfbd00f"
+          "sha256": "8095939e787c6106dfd21ecd2ce4b53fa7298b093b79511dfe1e77da5dfbd00f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/SKILL.md",
           "owner": "deep-research",
-          "sha256": "ba2e0a3e4d26a554ebc37920a2e0c162684ccf5e1088e386e2988080843b270f"
+          "sha256": "ba2e0a3e4d26a554ebc37920a2e0c162684ccf5e1088e386e2988080843b270f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/references/completeness_review_checklist.md",
           "owner": "deep-research",
-          "sha256": "39f4837c0238ca8bb557d52712e0f8205e17024ae266dfdf0d7d83186f4f6384"
+          "sha256": "39f4837c0238ca8bb557d52712e0f8205e17024ae266dfdf0d7d83186f4f6384",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/references/formatting_rules.md",
           "owner": "deep-research",
-          "sha256": "0130e9f20c965662bfd60e223eb39575a998486cc4218a87959ae33638f3f99d"
+          "sha256": "0130e9f20c965662bfd60e223eb39575a998486cc4218a87959ae33638f3f99d",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/references/research_plan_checklist.md",
           "owner": "deep-research",
-          "sha256": "7e9cbc37c08149260eeee22ec25e8dec171d33e7bdd2bed487c132852cac3be8"
+          "sha256": "7e9cbc37c08149260eeee22ec25e8dec171d33e7bdd2bed487c132852cac3be8",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/references/research_report_template.md",
           "owner": "deep-research",
-          "sha256": "7cd26e83197c9823e0a639e4a615c84a9ef25a5396bf3aae45b3e600758a68dc"
+          "sha256": "7cd26e83197c9823e0a639e4a615c84a9ef25a5396bf3aae45b3e600758a68dc",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/deep-research/references/source_quality_rubric.md",
           "owner": "deep-research",
-          "sha256": "2e084d898275d226ae3342accb240c0e2fd1b911cf9370df541aefff8f693ef8"
+          "sha256": "2e084d898275d226ae3342accb240c0e2fd1b911cf9370df541aefff8f693ef8",
+          "mode": "100644"
         }
       ]
     },
@@ -6413,82 +6941,98 @@
         {
           "path": "skills/developer-engineering/dependency-auditor/README.md",
           "owner": "dependency-auditor",
-          "sha256": "023b2506b44dd23c791664e91f1836f9795450333565762cf86267adee8cddbb"
+          "sha256": "023b2506b44dd23c791664e91f1836f9795450333565762cf86267adee8cddbb",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/SKILL.md",
           "owner": "dependency-auditor",
-          "sha256": "f68734aa24262a0f383cf7e5ce693fa9b7411265cc756938cdbe1187f637e963"
+          "sha256": "f68734aa24262a0f383cf7e5ce693fa9b7411265cc756938cdbe1187f637e963",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/assets/sample_go.mod",
           "owner": "dependency-auditor",
-          "sha256": "3da5b13abe39db65446c64bfef8aa7e5216b317f0853e17a3c575382044fc676"
+          "sha256": "3da5b13abe39db65446c64bfef8aa7e5216b317f0853e17a3c575382044fc676",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/assets/sample_package.json",
           "owner": "dependency-auditor",
-          "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032"
+          "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.txt",
           "owner": "dependency-auditor",
-          "sha256": "85ee24f99830b71a59419a181efa52e4f6f5ace9ad92e30d2fb6489d21bb0198"
+          "sha256": "85ee24f99830b71a59419a181efa52e4f6f5ace9ad92e30d2fb6489d21bb0198",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/expected_outputs/sample_license_report.txt",
           "owner": "dependency-auditor",
-          "sha256": "96d4d67bd77d9f0941f9334a563c94cc25557001aa96d390103878c2903b126a"
+          "sha256": "96d4d67bd77d9f0941f9334a563c94cc25557001aa96d390103878c2903b126a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/expected_outputs/sample_upgrade_plan.txt",
           "owner": "dependency-auditor",
-          "sha256": "13cab41ede802c9fe49eb894e86c6ad6a9ced164a64f16a2fff62c2884fd545c"
+          "sha256": "13cab41ede802c9fe49eb894e86c6ad6a9ced164a64f16a2fff62c2884fd545c",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/expected_outputs/sample_vulnerability_report.json",
           "owner": "dependency-auditor",
-          "sha256": "795d7e23d4c5b56c30051371a1ca8f0ab72496f65c0e554e21d3211ca4dca8a4"
+          "sha256": "795d7e23d4c5b56c30051371a1ca8f0ab72496f65c0e554e21d3211ca4dca8a4",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/references/dependency_management_best_practices.md",
           "owner": "dependency-auditor",
-          "sha256": "2eafa69105d7c31bf50b693af656d4181250e241ea110eeba7227ecb29e24f90"
+          "sha256": "2eafa69105d7c31bf50b693af656d4181250e241ea110eeba7227ecb29e24f90",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/references/license_compatibility_matrix.md",
           "owner": "dependency-auditor",
-          "sha256": "9432a2776985d38f5668e5acfa95754e8695d96bfbea01159e1b7d60da6b6035"
+          "sha256": "9432a2776985d38f5668e5acfa95754e8695d96bfbea01159e1b7d60da6b6035",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/references/vulnerability_assessment_guide.md",
           "owner": "dependency-auditor",
-          "sha256": "5e4743618d544cc5903f67572c71aff31180c8f9222c8cfbd4782d7305d482bb"
+          "sha256": "5e4743618d544cc5903f67572c71aff31180c8f9222c8cfbd4782d7305d482bb",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/scripts/dep_scanner.py",
           "owner": "dependency-auditor",
-          "sha256": "309abbb1fb20df6dfcea77ac0e963bd61953cb4b46de8c1a6d10cae6d88546cd"
+          "sha256": "309abbb1fb20df6dfcea77ac0e963bd61953cb4b46de8c1a6d10cae6d88546cd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/scripts/license_checker.py",
           "owner": "dependency-auditor",
-          "sha256": "7fa7b6d19cc8de7d38850c24d1c8970fafac9df6bd4f44f883056745bd410dc8"
+          "sha256": "7fa7b6d19cc8de7d38850c24d1c8970fafac9df6bd4f44f883056745bd410dc8",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/scripts/upgrade_planner.py",
           "owner": "dependency-auditor",
-          "sha256": "fcaf65475a3376c53c345ad27137a06a99c67184a7b328129021d69f48cc870b"
+          "sha256": "fcaf65475a3376c53c345ad27137a06a99c67184a7b328129021d69f48cc870b",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/test-inventory.json",
           "owner": "dependency-auditor",
-          "sha256": "9eb7db72e3c66d324efe411b11f702ebedd42ac8fa89ffe7ead338b902450fd3"
+          "sha256": "9eb7db72e3c66d324efe411b11f702ebedd42ac8fa89ffe7ead338b902450fd3",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/dependency-auditor/test-project/package.json",
           "owner": "dependency-auditor",
-          "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032"
+          "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032",
+          "mode": "100644"
         }
       ]
     },
@@ -6568,37 +7112,44 @@
         {
           "path": "skills/ai-agent-platform/develop-web-game/LICENSE.txt",
           "owner": "develop-web-game",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/SKILL.md",
           "owner": "develop-web-game",
-          "sha256": "eecd17a801d2fd328cfc27015175adb35a1379586bd68668fbfa6ead283902bf"
+          "sha256": "eecd17a801d2fd328cfc27015175adb35a1379586bd68668fbfa6ead283902bf",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/agents/openai.yaml",
           "owner": "develop-web-game",
-          "sha256": "0962a160095830d7c6d7c6983ed023ebce93855f51c3e9a58cbba0c3d9ce07dd"
+          "sha256": "0962a160095830d7c6d7c6983ed023ebce93855f51c3e9a58cbba0c3d9ce07dd",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/assets/game-small.svg",
           "owner": "develop-web-game",
-          "sha256": "c384984085a0d12baadc39ee05c4b3ecf22c8f04fe0a5d8227b00675742c249e"
+          "sha256": "c384984085a0d12baadc39ee05c4b3ecf22c8f04fe0a5d8227b00675742c249e",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/assets/game.png",
           "owner": "develop-web-game",
-          "sha256": "08382df5010120e47f06e6c32e7e990bb8f3bc473c07f7191b7c11484272635d"
+          "sha256": "08382df5010120e47f06e6c32e7e990bb8f3bc473c07f7191b7c11484272635d",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/references/action_payloads.json",
           "owner": "develop-web-game",
-          "sha256": "7c6915472781be9cc704bb12952577bd66ae4c073d294459d564a8d45f98671c"
+          "sha256": "7c6915472781be9cc704bb12952577bd66ae4c073d294459d564a8d45f98671c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/develop-web-game/scripts/web_game_playwright_client.js",
           "owner": "develop-web-game",
-          "sha256": "e95c3bcbdc0d15eb08fd3a6021283ec32f715b51f1e5847d3db20df526be5996"
+          "sha256": "e95c3bcbdc0d15eb08fd3a6021283ec32f715b51f1e5847d3db20df526be5996",
+          "mode": "100644"
         }
       ]
     },
@@ -6658,17 +7209,20 @@
         {
           "path": "skills/operations-general/docs-cleaner/.security-scan-passed",
           "owner": "docs-cleaner",
-          "sha256": "3ffdcc7e18c84317454d70e7f0940ac19fdd08df743ab150f518c48a529450a7"
+          "sha256": "3ffdcc7e18c84317454d70e7f0940ac19fdd08df743ab150f518c48a529450a7",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/docs-cleaner/SKILL.md",
           "owner": "docs-cleaner",
-          "sha256": "ac180796dbabc2b4e1546cfe93e0f57d08d70eba934d4e662742f34f7986ace3"
+          "sha256": "ac180796dbabc2b4e1546cfe93e0f57d08d70eba934d4e662742f34f7986ace3",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/docs-cleaner/references/value_analysis_template.md",
           "owner": "docs-cleaner",
-          "sha256": "1957112c55f4422195f7554bd8893ff1dbf0503c38be99edb018c38ea7dd140a"
+          "sha256": "1957112c55f4422195f7554bd8893ff1dbf0503c38be99edb018c38ea7dd140a",
+          "mode": "100644"
         }
       ]
     },
@@ -7023,312 +7577,374 @@
         {
           "path": "skills/office-white-collar/docx/LICENSE.txt",
           "owner": "docx",
-          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa"
+          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/SKILL.md",
           "owner": "docx",
-          "sha256": "c54ca1e218b29b66af643ba05cc058d633fff26584c0c2dea37090fb5a5a7d50"
+          "sha256": "c54ca1e218b29b66af643ba05cc058d633fff26584c0c2dea37090fb5a5a7d50",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/__init__.py",
           "owner": "docx",
-          "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+          "sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/accept_changes.py",
           "owner": "docx",
-          "sha256": "0c991d2bc7304a1248e9f3bf9b1498f0b6e76641fc457e7cbd73c99b4eef3a74"
+          "sha256": "0c991d2bc7304a1248e9f3bf9b1498f0b6e76641fc457e7cbd73c99b4eef3a74",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/comment.py",
           "owner": "docx",
-          "sha256": "e86e4e17ec5805780325206d20d3ed5a8f7024f1e4641ac8f46ef5df0b564f63"
+          "sha256": "e86e4e17ec5805780325206d20d3ed5a8f7024f1e4641ac8f46ef5df0b564f63",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/helpers/__init__.py",
           "owner": "docx",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/helpers/merge_runs.py",
           "owner": "docx",
-          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7"
+          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/helpers/simplify_redlines.py",
           "owner": "docx",
-          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896"
+          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/pack.py",
           "owner": "docx",
-          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683"
+          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd",
           "owner": "docx",
-          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354"
+          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd",
           "owner": "docx",
-          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412"
+          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd",
           "owner": "docx",
-          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40"
+          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd",
           "owner": "docx",
-          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026"
+          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd",
           "owner": "docx",
-          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9"
+          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd",
           "owner": "docx",
-          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c"
+          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd",
           "owner": "docx",
-          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88"
+          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd",
           "owner": "docx",
-          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614"
+          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd",
           "owner": "docx",
-          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff"
+          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd",
           "owner": "docx",
-          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8"
+          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd",
           "owner": "docx",
-          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2"
+          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd",
           "owner": "docx",
-          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece"
+          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd",
           "owner": "docx",
-          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281"
+          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd",
           "owner": "docx",
-          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4"
+          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd",
           "owner": "docx",
-          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285"
+          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd",
           "owner": "docx",
-          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368"
+          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd",
           "owner": "docx",
-          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b"
+          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd",
           "owner": "docx",
-          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a"
+          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd",
           "owner": "docx",
-          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637"
+          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd",
           "owner": "docx",
-          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578"
+          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd",
           "owner": "docx",
-          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763"
+          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd",
           "owner": "docx",
-          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155"
+          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd",
           "owner": "docx",
-          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e"
+          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd",
           "owner": "docx",
-          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519"
+          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd",
           "owner": "docx",
-          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831"
+          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd",
           "owner": "docx",
-          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd"
+          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd",
           "owner": "docx",
-          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2"
+          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd",
           "owner": "docx",
-          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a"
+          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd",
           "owner": "docx",
-          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8"
+          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd",
           "owner": "docx",
-          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24"
+          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd",
           "owner": "docx",
-          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26"
+          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/mce/mc.xsd",
           "owner": "docx",
-          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413"
+          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-2010.xsd",
           "owner": "docx",
-          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2"
+          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-2012.xsd",
           "owner": "docx",
-          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74"
+          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-2018.xsd",
           "owner": "docx",
-          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad"
+          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-cex-2018.xsd",
           "owner": "docx",
-          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081"
+          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-cid-2016.xsd",
           "owner": "docx",
-          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d"
+          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd",
           "owner": "docx",
-          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604"
+          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/schemas/microsoft/wml-symex-2015.xsd",
           "owner": "docx",
-          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b"
+          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/soffice.py",
           "owner": "docx",
-          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0"
+          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/unpack.py",
           "owner": "docx",
-          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62"
+          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validate.py",
           "owner": "docx",
-          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514"
+          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validators/__init__.py",
           "owner": "docx",
-          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987"
+          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validators/base.py",
           "owner": "docx",
-          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25"
+          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validators/docx.py",
           "owner": "docx",
-          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345"
+          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validators/pptx.py",
           "owner": "docx",
-          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc"
+          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/office/validators/redlining.py",
           "owner": "docx",
-          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40"
+          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/render_docx.py",
           "owner": "docx",
-          "sha256": "52b3c3158913ebcad2ada7b8193970b70453239e255054aa2d60c1683af08751"
+          "sha256": "52b3c3158913ebcad2ada7b8193970b70453239e255054aa2d60c1683af08751",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/templates/comments.xml",
           "owner": "docx",
-          "sha256": "a08ba83ee8790ac9e3dc61921f4988f19edd7e06ac09d6f1897a877c1581818d"
+          "sha256": "a08ba83ee8790ac9e3dc61921f4988f19edd7e06ac09d6f1897a877c1581818d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/templates/commentsExtended.xml",
           "owner": "docx",
-          "sha256": "544eeecfeceed4b468fff163cd9c366d33641c8b8ab691ce002576197846afe8"
+          "sha256": "544eeecfeceed4b468fff163cd9c366d33641c8b8ab691ce002576197846afe8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/templates/commentsExtensible.xml",
           "owner": "docx",
-          "sha256": "bad10b3283e6ad6e7ef6d1ca5169683721ed690ee331282c65df04017e080631"
+          "sha256": "bad10b3283e6ad6e7ef6d1ca5169683721ed690ee331282c65df04017e080631",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/templates/commentsIds.xml",
           "owner": "docx",
-          "sha256": "db20f9616e004ec42ef736e80c2384e45db0f8d1194d31dc8b37c7d6ecdd6420"
+          "sha256": "db20f9616e004ec42ef736e80c2384e45db0f8d1194d31dc8b37c7d6ecdd6420",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/docx/scripts/templates/people.xml",
           "owner": "docx",
-          "sha256": "056f63aa1197fd8c9dda980c9f1b9ff016fd5fa4a462df8aec5f384f39d23e37"
+          "sha256": "056f63aa1197fd8c9dda980c9f1b9ff016fd5fa4a462df8aec5f384f39d23e37",
+          "mode": "100644"
         }
       ]
     },
@@ -7393,22 +8009,26 @@
         {
           "path": "skills/finance-investing/earnings-call-analyzer/SKILL.md",
           "owner": "earnings-call-analyzer",
-          "sha256": "fba3ca2e9d69833dac59fd6ae9ee7e038fe46e8991bca5b9755272e8438d1e92"
+          "sha256": "fba3ca2e9d69833dac59fd6ae9ee7e038fe46e8991bca5b9755272e8438d1e92",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/earnings-call-analyzer/assets/sample_earnings_call.json",
           "owner": "earnings-call-analyzer",
-          "sha256": "572fa41cf8728dd5bf3c8602f16e50c13c210fa3f82445aa5fca914e85ea709a"
+          "sha256": "572fa41cf8728dd5bf3c8602f16e50c13c210fa3f82445aa5fca914e85ea709a",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/earnings-call-analyzer/references/transcript-signals.md",
           "owner": "earnings-call-analyzer",
-          "sha256": "4709f85fc934ff45961e8a63bb07acfe7d1a77142ffa1a6c7d9865f9917211f0"
+          "sha256": "4709f85fc934ff45961e8a63bb07acfe7d1a77142ffa1a6c7d9865f9917211f0",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/earnings-call-analyzer/scripts/analyze_earnings_call.py",
           "owner": "earnings-call-analyzer",
-          "sha256": "6ab6e10413a0b4271207ce611c9972f87293c3580b6acae8629072c11d4d9fba"
+          "sha256": "6ab6e10413a0b4271207ce611c9972f87293c3580b6acae8629072c11d4d9fba",
+          "mode": "100644"
         }
       ]
     },
@@ -7458,7 +8078,8 @@
         {
           "path": "skills/devops-sre/env-secrets-manager/SKILL.md",
           "owner": "env-secrets-manager",
-          "sha256": "daf70ddd63bcda8251e10686dd3bf92eedce65da946cf4d675975ac81f343c2f"
+          "sha256": "daf70ddd63bcda8251e10686dd3bf92eedce65da946cf4d675975ac81f343c2f",
+          "mode": "100644"
         }
       ]
     },
@@ -7523,22 +8144,26 @@
         {
           "path": "skills/finance-investing/event-driven-tracker/SKILL.md",
           "owner": "event-driven-tracker",
-          "sha256": "6053fde009b3d85c62b5849c00e354bb5b30e520828a1d05cbfad11badf96307"
+          "sha256": "6053fde009b3d85c62b5849c00e354bb5b30e520828a1d05cbfad11badf96307",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/event-driven-tracker/assets/sample_events.json",
           "owner": "event-driven-tracker",
-          "sha256": "b68a3f0d0fb7915cec54b21aa9ab3e23a0b8a964d204ab881b3d49970566a14e"
+          "sha256": "b68a3f0d0fb7915cec54b21aa9ab3e23a0b8a964d204ab881b3d49970566a14e",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/event-driven-tracker/references/event-catalog.md",
           "owner": "event-driven-tracker",
-          "sha256": "9d1e59b5b6318aa8cfa179aa2a939bb60f76550b06fbaefcfff324686c187f3d"
+          "sha256": "9d1e59b5b6318aa8cfa179aa2a939bb60f76550b06fbaefcfff324686c187f3d",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/event-driven-tracker/scripts/track_events.py",
           "owner": "event-driven-tracker",
-          "sha256": "24b26e928f3fb68f639fe4a7b75a19db4e7e291d8c4e470ce01dd4c98d2526fb"
+          "sha256": "24b26e928f3fb68f639fe4a7b75a19db4e7e291d8c4e470ce01dd4c98d2526fb",
+          "mode": "100644"
         }
       ]
     },
@@ -7598,17 +8223,20 @@
         {
           "path": "skills/operations-general/fact-checker/.security-scan-passed",
           "owner": "fact-checker",
-          "sha256": "6d24eb87a94ee87a630e879e275ddaf65f565c03dc153e682c583314bfe93bab"
+          "sha256": "6d24eb87a94ee87a630e879e275ddaf65f565c03dc153e682c583314bfe93bab",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/fact-checker/README.md",
           "owner": "fact-checker",
-          "sha256": "d6030c2cdadea2fee9508d69e0f258ff94c95fca9acec77719a6e5dbd33d684e"
+          "sha256": "d6030c2cdadea2fee9508d69e0f258ff94c95fca9acec77719a6e5dbd33d684e",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/fact-checker/SKILL.md",
           "owner": "fact-checker",
-          "sha256": "13b07ae11886c9bed7cd75b251029fe5f70e4e28eef715fae9851bd2ed18a962"
+          "sha256": "13b07ae11886c9bed7cd75b251029fe5f70e4e28eef715fae9851bd2ed18a962",
+          "mode": "100644"
         }
       ]
     },
@@ -7673,22 +8301,26 @@
         {
           "path": "skills/finance-investing/factor-backtester/SKILL.md",
           "owner": "factor-backtester",
-          "sha256": "668913d944c65f28d5e8845afe2b5decbebca8e02ea8d56517fd0b4ad6b9ebbb"
+          "sha256": "668913d944c65f28d5e8845afe2b5decbebca8e02ea8d56517fd0b4ad6b9ebbb",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/factor-backtester/assets/sample_factor_data.json",
           "owner": "factor-backtester",
-          "sha256": "e382aa59d08916b9d9b70f8590841408580c4c8bd6a2e0851a525ec67153363e"
+          "sha256": "e382aa59d08916b9d9b70f8590841408580c4c8bd6a2e0851a525ec67153363e",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/factor-backtester/references/backtest-checklist.md",
           "owner": "factor-backtester",
-          "sha256": "1dc0ea20dfc3e8918d9823da3057cb709a7dfca0b631a36c57b205c92e777ff1"
+          "sha256": "1dc0ea20dfc3e8918d9823da3057cb709a7dfca0b631a36c57b205c92e777ff1",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/factor-backtester/scripts/backtest_factor.py",
           "owner": "factor-backtester",
-          "sha256": "4d2e5ccd50ba5c3b6aeb3266d14d7354386b5784fc856a5b8f87f1301bc35e68"
+          "sha256": "4d2e5ccd50ba5c3b6aeb3266d14d7354386b5784fc856a5b8f87f1301bc35e68",
+          "mode": "100644"
         }
       ]
     },
@@ -7773,42 +8405,50 @@
         {
           "path": "skills/ai-agent-platform/figma/LICENSE.txt",
           "owner": "figma",
-          "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+          "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/SKILL.md",
           "owner": "figma",
-          "sha256": "86867fb69dab78a44802c7eccd933078ae8952241460e29f7144c0150c1e4623"
+          "sha256": "86867fb69dab78a44802c7eccd933078ae8952241460e29f7144c0150c1e4623",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/agents/openai.yaml",
           "owner": "figma",
-          "sha256": "4b732040f73a28c7ab36c1e3417f09fb6cc7558b6d258222c62e90d882104b0e"
+          "sha256": "4b732040f73a28c7ab36c1e3417f09fb6cc7558b6d258222c62e90d882104b0e",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/assets/figma-small.svg",
           "owner": "figma",
-          "sha256": "c933768c03dff033b55d8e3cdabd0ba63efa9d68bd0db346a454b4b7286a2564"
+          "sha256": "c933768c03dff033b55d8e3cdabd0ba63efa9d68bd0db346a454b4b7286a2564",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/assets/figma.png",
           "owner": "figma",
-          "sha256": "4d16e1b19ae7bdac7d601d0b3bf3c0ea4a018a8cb0e38d19e5b00971968ecada"
+          "sha256": "4d16e1b19ae7bdac7d601d0b3bf3c0ea4a018a8cb0e38d19e5b00971968ecada",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/assets/icon.svg",
           "owner": "figma",
-          "sha256": "8936c5dcd619c41f5a27f7c08e8c50b22e428069c36217e4aa872099d6cc2cf7"
+          "sha256": "8936c5dcd619c41f5a27f7c08e8c50b22e428069c36217e4aa872099d6cc2cf7",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/references/figma-mcp-config.md",
           "owner": "figma",
-          "sha256": "3b8bbd016e7cecfe01d096791582da8c9669c18675ec3f201d0d4088051711a9"
+          "sha256": "3b8bbd016e7cecfe01d096791582da8c9669c18675ec3f201d0d4088051711a9",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma/references/figma-tools-and-prompts.md",
           "owner": "figma",
-          "sha256": "428add063f235ffe27fb4b8d092558794f25f7ad69893d5a88621d8174e9c8d6"
+          "sha256": "428add063f235ffe27fb4b8d092558794f25f7ad69893d5a88621d8174e9c8d6",
+          "mode": "100644"
         }
       ]
     },
@@ -7883,32 +8523,38 @@
         {
           "path": "skills/ai-agent-platform/figma-implement-design/LICENSE.txt",
           "owner": "figma-implement-design",
-          "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+          "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma-implement-design/SKILL.md",
           "owner": "figma-implement-design",
-          "sha256": "ddd13c636aa7d4ea3d89cc51d4e54196c65860f80f2004f07645c823ca8ae48c"
+          "sha256": "ddd13c636aa7d4ea3d89cc51d4e54196c65860f80f2004f07645c823ca8ae48c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma-implement-design/agents/openai.yaml",
           "owner": "figma-implement-design",
-          "sha256": "85458037bb2fa5fe85375ceb9535c8eefe14591c4ca2994501e0d89690292c03"
+          "sha256": "85458037bb2fa5fe85375ceb9535c8eefe14591c4ca2994501e0d89690292c03",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma-implement-design/assets/figma-small.svg",
           "owner": "figma-implement-design",
-          "sha256": "6a38267efbd872bbc215d0227a395eb0b0093bc6441c44a39a43f3210549e5e9"
+          "sha256": "6a38267efbd872bbc215d0227a395eb0b0093bc6441c44a39a43f3210549e5e9",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma-implement-design/assets/figma.png",
           "owner": "figma-implement-design",
-          "sha256": "4d16e1b19ae7bdac7d601d0b3bf3c0ea4a018a8cb0e38d19e5b00971968ecada"
+          "sha256": "4d16e1b19ae7bdac7d601d0b3bf3c0ea4a018a8cb0e38d19e5b00971968ecada",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/figma-implement-design/assets/icon.svg",
           "owner": "figma-implement-design",
-          "sha256": "8936c5dcd619c41f5a27f7c08e8c50b22e428069c36217e4aa872099d6cc2cf7"
+          "sha256": "8936c5dcd619c41f5a27f7c08e8c50b22e428069c36217e4aa872099d6cc2cf7",
+          "mode": "100644"
         }
       ]
     },
@@ -8018,67 +8664,80 @@
         {
           "path": "skills/finance-investing/financial-analyst/SKILL.md",
           "owner": "financial-analyst",
-          "sha256": "141a5093749c079d5a79f4c380ff26dd1082a225cb64f9764f2f9f12d06f0ba0"
+          "sha256": "141a5093749c079d5a79f4c380ff26dd1082a225cb64f9764f2f9f12d06f0ba0",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/assets/dcf_analysis_template.md",
           "owner": "financial-analyst",
-          "sha256": "07593113bc953a5c3d6010daeb2a0cfa9e427d02ca5a0f1b453a5ce25bd47500"
+          "sha256": "07593113bc953a5c3d6010daeb2a0cfa9e427d02ca5a0f1b453a5ce25bd47500",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/assets/expected_output.json",
           "owner": "financial-analyst",
-          "sha256": "0ff42094c7cfc31cf1c979620e316c136a1030639ed1c0fdb4472fc8da3ac683"
+          "sha256": "0ff42094c7cfc31cf1c979620e316c136a1030639ed1c0fdb4472fc8da3ac683",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/assets/forecast_report_template.md",
           "owner": "financial-analyst",
-          "sha256": "8683aef2844e510075cd1c0fc08d85c8656480d7fd494b3b4dd9e396e3b4a227"
+          "sha256": "8683aef2844e510075cd1c0fc08d85c8656480d7fd494b3b4dd9e396e3b4a227",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/assets/sample_financial_data.json",
           "owner": "financial-analyst",
-          "sha256": "1e7f486e62e9de2b585a10a6b0ace771cfed26bd02575e305234c3e3a54a902c"
+          "sha256": "1e7f486e62e9de2b585a10a6b0ace771cfed26bd02575e305234c3e3a54a902c",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/assets/variance_report_template.md",
           "owner": "financial-analyst",
-          "sha256": "428aa3e407b8f15b08b460e0523d97d90a9bb82cb151600aea3f14b3d8847c33"
+          "sha256": "428aa3e407b8f15b08b460e0523d97d90a9bb82cb151600aea3f14b3d8847c33",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/references/financial-ratios-guide.md",
           "owner": "financial-analyst",
-          "sha256": "a1c7b935963a738981427a8e3a8807e7d912e3579fbacac86d8888c459223a40"
+          "sha256": "a1c7b935963a738981427a8e3a8807e7d912e3579fbacac86d8888c459223a40",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/references/forecasting-best-practices.md",
           "owner": "financial-analyst",
-          "sha256": "f12e8496eeb7a6626c65a82b72cce326c5e364d1856d715f5928a08aed078282"
+          "sha256": "f12e8496eeb7a6626c65a82b72cce326c5e364d1856d715f5928a08aed078282",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/references/valuation-methodology.md",
           "owner": "financial-analyst",
-          "sha256": "d7cedb0aa0325bdf2d956d8b3ff21e08bd2d2ab6c8c79b1fa758ff4e16fe1b5d"
+          "sha256": "d7cedb0aa0325bdf2d956d8b3ff21e08bd2d2ab6c8c79b1fa758ff4e16fe1b5d",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/scripts/budget_variance_analyzer.py",
           "owner": "financial-analyst",
-          "sha256": "4f8b9f566b36685bdbcb28889886397eb7d4c7a94324df49f0a5027d688c47ee"
+          "sha256": "4f8b9f566b36685bdbcb28889886397eb7d4c7a94324df49f0a5027d688c47ee",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/scripts/dcf_valuation.py",
           "owner": "financial-analyst",
-          "sha256": "54b471ccff7a38d750009905fc507b74592b2af97875a31da8a6f63c4db24958"
+          "sha256": "54b471ccff7a38d750009905fc507b74592b2af97875a31da8a6f63c4db24958",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/scripts/forecast_builder.py",
           "owner": "financial-analyst",
-          "sha256": "ed3cfecdf2f70cc288b0d6452626baee0bb3cada02f77720221ec3d0fcbc102d"
+          "sha256": "ed3cfecdf2f70cc288b0d6452626baee0bb3cada02f77720221ec3d0fcbc102d",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-analyst/scripts/ratio_calculator.py",
           "owner": "financial-analyst",
-          "sha256": "c217dbfae287e74aee376fb4efe785fb34df954e0899cbe8b927ddac854120da"
+          "sha256": "c217dbfae287e74aee376fb4efe785fb34df954e0899cbe8b927ddac854120da",
+          "mode": "100644"
         }
       ]
     },
@@ -8198,77 +8857,92 @@
         {
           "path": "skills/finance-investing/financial-data-collector/.gitignore",
           "owner": "financial-data-collector",
-          "sha256": "0fbe5e1ed3b2b6fd829e11477a7b348e43e2e1cd6fe15196c1f2d89a1f35fbb5"
+          "sha256": "0fbe5e1ed3b2b6fd829e11477a7b348e43e2e1cd6fe15196c1f2d89a1f35fbb5",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/SKILL.md",
           "owner": "financial-data-collector",
-          "sha256": "e44d7827bb3d9990e172d6a85b8a56e09e904d864992f837153f2d6545b06839"
+          "sha256": "e44d7827bb3d9990e172d6a85b8a56e09e904d864992f837153f2d6545b06839",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/assets/sample_sec_company_tickers.json",
           "owner": "financial-data-collector",
-          "sha256": "d73d74048bca97742c84d2be42613958f8c2c1e733af2a786818797fac7484d7"
+          "sha256": "d73d74048bca97742c84d2be42613958f8c2c1e733af2a786818797fac7484d7",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/assets/sample_sec_companyfacts.json",
           "owner": "financial-data-collector",
-          "sha256": "7db819bff9720741d4bcaea72fd51ce421cfd1e9bd0574983d29abc48757b370"
+          "sha256": "7db819bff9720741d4bcaea72fd51ce421cfd1e9bd0574983d29abc48757b370",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/assets/sample_sec_submissions.json",
           "owner": "financial-data-collector",
-          "sha256": "fe17955b00f890d60b7d38586a3a77e5abf388839c2aec14ae153ea48d83b55a"
+          "sha256": "fe17955b00f890d60b7d38586a3a77e5abf388839c2aec14ae153ea48d83b55a",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/assets/sample_yahoo_quote_summary.json",
           "owner": "financial-data-collector",
-          "sha256": "ed4fc9b369ce42a2c5f0950c6fd4c47b0580de00f48bf552644fdb7a5f49542d"
+          "sha256": "ed4fc9b369ce42a2c5f0950c6fd4c47b0580de00f48bf552644fdb7a5f49542d",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/assets/sample_yahoo_tnx_chart.json",
           "owner": "financial-data-collector",
-          "sha256": "4562d0e6305a12b35149657839be66825f98507900e7cc4df6d3a2614fc3f756"
+          "sha256": "4562d0e6305a12b35149657839be66825f98507900e7cc4df6d3a2614fc3f756",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/references/output-schema.md",
           "owner": "financial-data-collector",
-          "sha256": "9493a54232425bd9f1094f24ce50e12ae45cc11b5943f358ba65eb1c151853b2"
+          "sha256": "9493a54232425bd9f1094f24ce50e12ae45cc11b5943f358ba65eb1c151853b2",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/references/sec-official-sources.md",
           "owner": "financial-data-collector",
-          "sha256": "89122051fcb45ce2c30d374133874487e795eaabecf43da46f2a76ea795a042d"
+          "sha256": "89122051fcb45ce2c30d374133874487e795eaabecf43da46f2a76ea795a042d",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/references/yahoo-web-sources.md",
           "owner": "financial-data-collector",
-          "sha256": "4988a03b2f6dd796eda0a5a8fccb2134aa7af95670fa6507351eae64b24b07a4"
+          "sha256": "4988a03b2f6dd796eda0a5a8fccb2134aa7af95670fa6507351eae64b24b07a4",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/references/yfinance-pitfalls.md",
           "owner": "financial-data-collector",
-          "sha256": "dc6898f2e56f168d12e0cdd4767fa489851f8829226a402f0d9591e4d0b700f0"
+          "sha256": "dc6898f2e56f168d12e0cdd4767fa489851f8829226a402f0d9591e4d0b700f0",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/scripts/collect_data.py",
           "owner": "financial-data-collector",
-          "sha256": "c9d23ba85e5e242ae8ff68af23d5dd5b23523943c29ceeced4a9ae9ab5b00fe2"
+          "sha256": "c9d23ba85e5e242ae8ff68af23d5dd5b23523943c29ceeced4a9ae9ab5b00fe2",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/scripts/sec_api.py",
           "owner": "financial-data-collector",
-          "sha256": "9c55200c5cb380eb7785913823aa833da2c451db02b7cdafbdad779bad50d025"
+          "sha256": "9c55200c5cb380eb7785913823aa833da2c451db02b7cdafbdad779bad50d025",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/scripts/validate_data.py",
           "owner": "financial-data-collector",
-          "sha256": "2c21dd65d96e308d28dde1a0cd7e8c163418c19a2502f6ce48bc87998aaae3c1"
+          "sha256": "2c21dd65d96e308d28dde1a0cd7e8c163418c19a2502f6ce48bc87998aaae3c1",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/financial-data-collector/scripts/yahoo_web_api.py",
           "owner": "financial-data-collector",
-          "sha256": "c15376b802acefeeb576e25279b8d8a95c2ef8339e7cbdc9fbc9d83126460a58"
+          "sha256": "c15376b802acefeeb576e25279b8d8a95c2ef8339e7cbdc9fbc9d83126460a58",
+          "mode": "100644"
         }
       ]
     },
@@ -8323,12 +8997,14 @@
         {
           "path": "skills/developer-engineering/frontend-design/LICENSE.txt",
           "owner": "frontend-design",
-          "sha256": "0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594"
+          "sha256": "0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/frontend-design/SKILL.md",
           "owner": "frontend-design",
-          "sha256": "59fd29ba4d1eb007eeb1d2e73380498e301aa5949f9d2b3c94e06e5f1e66b736"
+          "sha256": "59fd29ba4d1eb007eeb1d2e73380498e301aa5949f9d2b3c94e06e5f1e66b736",
+          "mode": "100644"
         }
       ]
     },
@@ -8403,32 +9079,38 @@
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/LICENSE.txt",
           "owner": "gh-address-comments",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/SKILL.md",
           "owner": "gh-address-comments",
-          "sha256": "02d4b209a05ff328d9d3bc75fd3055d93624ed8383c167346b6146d2d90e65e9"
+          "sha256": "02d4b209a05ff328d9d3bc75fd3055d93624ed8383c167346b6146d2d90e65e9",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/agents/openai.yaml",
           "owner": "gh-address-comments",
-          "sha256": "12cf845a78254dde85e60eefb45a60e6ce2129d321f3e1d691d4ebca9a140861"
+          "sha256": "12cf845a78254dde85e60eefb45a60e6ce2129d321f3e1d691d4ebca9a140861",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/assets/github-small.svg",
           "owner": "gh-address-comments",
-          "sha256": "ee05e92d373d4d84f4612af3c1090ef67698d421bbe30896a4ed5a00cb86a069"
+          "sha256": "ee05e92d373d4d84f4612af3c1090ef67698d421bbe30896a4ed5a00cb86a069",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/assets/github.png",
           "owner": "gh-address-comments",
-          "sha256": "d55a9baa41798d8b5108e3058df3a5bda09914ea9fd73b49929cc38a8832424f"
+          "sha256": "d55a9baa41798d8b5108e3058df3a5bda09914ea9fd73b49929cc38a8832424f",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-address-comments/scripts/fetch_comments.py",
           "owner": "gh-address-comments",
-          "sha256": "d7bc64f6b26f7482f9ca9dd7c923a5b8b20e1ef13491ae2d9052cd208a7c1ad1"
+          "sha256": "d7bc64f6b26f7482f9ca9dd7c923a5b8b20e1ef13491ae2d9052cd208a7c1ad1",
+          "mode": "100644"
         }
       ]
     },
@@ -8503,32 +9185,38 @@
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/LICENSE.txt",
           "owner": "gh-fix-ci",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/SKILL.md",
           "owner": "gh-fix-ci",
-          "sha256": "abae42d4e993683829520278ef4b8f07fd84f684867cd21fab0feb6a3a8a12c4"
+          "sha256": "abae42d4e993683829520278ef4b8f07fd84f684867cd21fab0feb6a3a8a12c4",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/agents/openai.yaml",
           "owner": "gh-fix-ci",
-          "sha256": "36f73b9450504983d1647c960689596f59bf9147c14b1b43162912ed7ada9af6"
+          "sha256": "36f73b9450504983d1647c960689596f59bf9147c14b1b43162912ed7ada9af6",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/assets/github-small.svg",
           "owner": "gh-fix-ci",
-          "sha256": "ee05e92d373d4d84f4612af3c1090ef67698d421bbe30896a4ed5a00cb86a069"
+          "sha256": "ee05e92d373d4d84f4612af3c1090ef67698d421bbe30896a4ed5a00cb86a069",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/assets/github.png",
           "owner": "gh-fix-ci",
-          "sha256": "d55a9baa41798d8b5108e3058df3a5bda09914ea9fd73b49929cc38a8832424f"
+          "sha256": "d55a9baa41798d8b5108e3058df3a5bda09914ea9fd73b49929cc38a8832424f",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/gh-fix-ci/scripts/inspect_pr_checks.py",
           "owner": "gh-fix-ci",
-          "sha256": "9459e5b03f86785d184a83e5cd8d621b832e918ec04158a2962d867785812c6c"
+          "sha256": "9459e5b03f86785d184a83e5cd8d621b832e918ec04158a2962d867785812c6c",
+          "mode": "100644"
         }
       ]
     },
@@ -8578,7 +9266,8 @@
         {
           "path": "skills/developer-engineering/git-worktree-manager/SKILL.md",
           "owner": "git-worktree-manager",
-          "sha256": "4e9cf18ab41a3d03ac5fb0a38d455083673f62027b81d3e0c1cc1c4cf938c04d"
+          "sha256": "4e9cf18ab41a3d03ac5fb0a38d455083673f62027b81d3e0c1cc1c4cf938c04d",
+          "mode": "100644"
         }
       ]
     },
@@ -8628,7 +9317,8 @@
         {
           "path": "skills/engineering-workflow-automation/github/SKILL.md",
           "owner": "github",
-          "sha256": "f78d268b7277c99c035136e10ab3e36109af9c0b0bb18bd6910de3e16bf21b12"
+          "sha256": "f78d268b7277c99c035136e10ab3e36109af9c0b0bb18bd6910de3e16bf21b12",
+          "mode": "100644"
         }
       ]
     },
@@ -8698,27 +9388,32 @@
         {
           "path": "skills/developer-engineering/github-contributor/.security-scan-passed",
           "owner": "github-contributor",
-          "sha256": "c7a9433efa8163808d625e56610234008fa049fd9a9234f7ce2f683870abb34f"
+          "sha256": "c7a9433efa8163808d625e56610234008fa049fd9a9234f7ce2f683870abb34f",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/github-contributor/SKILL.md",
           "owner": "github-contributor",
-          "sha256": "d252816add85a436bcc95614be2ab0e6ebcf09c7fe5263399d412118f84abc74"
+          "sha256": "d252816add85a436bcc95614be2ab0e6ebcf09c7fe5263399d412118f84abc74",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/github-contributor/references/communication_templates.md",
           "owner": "github-contributor",
-          "sha256": "69d416e0e406f66d7429b18227c6852ffa354b14f330235881031f0bcf05a1c2"
+          "sha256": "69d416e0e406f66d7429b18227c6852ffa354b14f330235881031f0bcf05a1c2",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/github-contributor/references/pr_checklist.md",
           "owner": "github-contributor",
-          "sha256": "27c1b4992706190ffac781c41a3603a2f92b8963adbda6aba0f62ffa4b414553"
+          "sha256": "27c1b4992706190ffac781c41a3603a2f92b8963adbda6aba0f62ffa4b414553",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/github-contributor/references/project_evaluation.md",
           "owner": "github-contributor",
-          "sha256": "917b315e6896c497a8558a165cd1d3e4fb2537a005a338a072b4e2d3c01c8be3"
+          "sha256": "917b315e6896c497a8558a165cd1d3e4fb2537a005a338a072b4e2d3c01c8be3",
+          "mode": "100644"
         }
       ]
     },
@@ -8793,32 +9488,38 @@
         {
           "path": "skills/devops-sre/github-ops/SKILL.md",
           "owner": "github-ops",
-          "sha256": "d911b0fdbefe86b0246e12b87788c5fd84ec79cee71161cd671aaadcc460738f"
+          "sha256": "d911b0fdbefe86b0246e12b87788c5fd84ec79cee71161cd671aaadcc460738f",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/github-ops/references/api_reference.md",
           "owner": "github-ops",
-          "sha256": "913ac3bee15fcc1db5e22c390747dc683faface3f46149d62aa99e3d70b87071"
+          "sha256": "913ac3bee15fcc1db5e22c390747dc683faface3f46149d62aa99e3d70b87071",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/github-ops/references/best_practices.md",
           "owner": "github-ops",
-          "sha256": "e1d2d2c8465635875698a8a3d49c4b87f1f64545a26706e708723ec7e1ade141"
+          "sha256": "e1d2d2c8465635875698a8a3d49c4b87f1f64545a26706e708723ec7e1ade141",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/github-ops/references/issue_operations.md",
           "owner": "github-ops",
-          "sha256": "77bd65811372f62d2f4d8ed5272ec9baef69da885036eaf866e37d7fc3847cfb"
+          "sha256": "77bd65811372f62d2f4d8ed5272ec9baef69da885036eaf866e37d7fc3847cfb",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/github-ops/references/pr_operations.md",
           "owner": "github-ops",
-          "sha256": "4a16b60d261102ab4d474017d87a496f90b305aa947de0df67897ab1515072f8"
+          "sha256": "4a16b60d261102ab4d474017d87a496f90b305aa947de0df67897ab1515072f8",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/github-ops/references/workflow_operations.md",
           "owner": "github-ops",
-          "sha256": "58b4a1f8b58610bd52aba20aa4d55573c3d72bb34fb9aac10c2f62859e0b95d7"
+          "sha256": "58b4a1f8b58610bd52aba20aa4d55573c3d72bb34fb9aac10c2f62859e0b95d7",
+          "mode": "100644"
         }
       ]
     },
@@ -8883,22 +9584,26 @@
         {
           "path": "skills/multimodal-media/gpt-image2/.gitignore",
           "owner": "gpt-image2",
-          "sha256": "771819d9043947d3251946e4a7252d7e583474e34b92138f515b41e71dd29e15"
+          "sha256": "771819d9043947d3251946e4a7252d7e583474e34b92138f515b41e71dd29e15",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/gpt-image2/SKILL.md",
           "owner": "gpt-image2",
-          "sha256": "37417bcdcbf9a990504ed586b9afc756b4c1874b8224b7477f369b4bccc5c528"
+          "sha256": "37417bcdcbf9a990504ed586b9afc756b4c1874b8224b7477f369b4bccc5c528",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/gpt-image2/scripts/.env.example",
           "owner": "gpt-image2",
-          "sha256": "f4c46f22701f92309dceac858f3f75bdf64ea12502428fd8bf09470bd570a1ea"
+          "sha256": "f4c46f22701f92309dceac858f3f75bdf64ea12502428fd8bf09470bd570a1ea",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/gpt-image2/scripts/gpt-image2.mjs",
           "owner": "gpt-image2",
-          "sha256": "2cd6259349404336a0c521719d793f4a45261e7a40576f5948f6025a31eff1a6"
+          "sha256": "2cd6259349404336a0c521719d793f4a45261e7a40576f5948f6025a31eff1a6",
+          "mode": "100644"
         }
       ]
     },
@@ -8948,7 +9653,8 @@
         {
           "path": "skills/developer-engineering/graphql-expert/SKILL.md",
           "owner": "graphql-expert",
-          "sha256": "16016d2a6375c885eae6f069c53616c66463d6390637d91c10fbf4054041cf2f"
+          "sha256": "16016d2a6375c885eae6f069c53616c66463d6390637d91c10fbf4054041cf2f",
+          "mode": "100644"
         }
       ]
     },
@@ -8998,7 +9704,8 @@
         {
           "path": "skills/security-and-reliability/grype-syft-sbom-scanner/SKILL.md",
           "owner": "grype-syft-sbom-scanner",
-          "sha256": "3a1762c57fc9ea40a97141703e232c5aa4d72b627dc8f396f7dc0e654c906f17"
+          "sha256": "3a1762c57fc9ea40a97141703e232c5aa4d72b627dc8f396f7dc0e654c906f17",
+          "mode": "100644"
         }
       ]
     },
@@ -9048,7 +9755,8 @@
         {
           "path": "skills/engineering-workflow-automation/gsd-graphify-brownfield-bootstrap/SKILL.md",
           "owner": "gsd-graphify-brownfield-bootstrap",
-          "sha256": "3562c7b3f89c2b8cf8d91e2ca129e8d8a46a6b498c6c973433be2d0d6fe61704"
+          "sha256": "3562c7b3f89c2b8cf8d91e2ca129e8d8a46a6b498c6c973433be2d0d6fe61704",
+          "mode": "100644"
         }
       ],
       "composition": {
@@ -9264,152 +9972,182 @@
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/SKILL.md",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "f85a3954cc73bbfc759556e13aa84fe9676b5c8d98d5e0925c204340370d3a19"
+          "sha256": "f85a3954cc73bbfc759556e13aa84fe9676b5c8d98d5e0925c204340370d3a19",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/references/ai-workflow-auto-continue-snippet.md",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "fae899961d3dc08aec0847e99b14643f8d7a6f575883ff63d5f36ecce61a59ea"
+          "sha256": "fae899961d3dc08aec0847e99b14643f8d7a6f575883ff63d5f36ecce61a59ea",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/references/auto-continue-best-practices.md",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "7b7599991be1efd31975a52350800cf4a3d1803dc1a3b7c81b471490ae259339"
+          "sha256": "7b7599991be1efd31975a52350800cf4a3d1803dc1a3b7c81b471490ae259339",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/references/first-install.md",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "76fccad901a6084f6e3b3318bd854ed14ad8754d6ac852e80eb0feae586d0fbf"
+          "sha256": "76fccad901a6084f6e3b3318bd854ed14ad8754d6ac852e80eb0feae586d0fbf",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/references/upgrade-contract.md",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "770edc4b68511955ea5e2a379f1b0cd6e52b300b508d1167e023b75ad458698c"
+          "sha256": "770edc4b68511955ea5e2a379f1b0cd6e52b300b508d1167e023b75ad458698c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/ai-workflow.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "104d847dc397eb45d667101c70aa454cf7d4e578a2dfbfa809c1887e8f399062"
+          "sha256": "104d847dc397eb45d667101c70aa454cf7d4e578a2dfbfa809c1887e8f399062",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/bootstrap-toolchain.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "421f548f5c5041a195a6d573fc9b92f02e11d552e27f76ba60bee7ba9155d1ae"
+          "sha256": "421f548f5c5041a195a6d573fc9b92f02e11d552e27f76ba60bee7ba9155d1ae",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/graphify-wrapper.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "6285a37f0ffece8c6a76a356acb1a333f7b2901e2ea399f023c0f89af31eb29d"
+          "sha256": "6285a37f0ffece8c6a76a356acb1a333f7b2901e2ea399f023c0f89af31eb29d",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/gsd-sdk-wrapper.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "dfa8a8d69f16a11735cfe69973e9ff3ad4586dd3654c8dc11e86b1ac58757d3c"
+          "sha256": "dfa8a8d69f16a11735cfe69973e9ff3ad4586dd3654c8dc11e86b1ac58757d3c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-checkpoint.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "151fcec2daa1056fb0869460158d6accd3a1ba33a586cd10217608d684be2f13"
+          "sha256": "151fcec2daa1056fb0869460158d6accd3a1ba33a586cd10217608d684be2f13",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-config.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "4df4672571eb4506c8650dfa82b53eb8f02cdda8bbd96e1bea23d401dc4ef292"
+          "sha256": "4df4672571eb4506c8650dfa82b53eb8f02cdda8bbd96e1bea23d401dc4ef292",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-learnings.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "f24a381d97c0bd82ff41f85d38b53f53b4dccee12dcb31bea20a4bbc9eb8fe23"
+          "sha256": "f24a381d97c0bd82ff41f85d38b53f53b4dccee12dcb31bea20a4bbc9eb8fe23",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-mark-complete.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "bf5ecaf1722952460cc6b645f668faf608a2926af16462fa7c110d87deef8ad1"
+          "sha256": "bf5ecaf1722952460cc6b645f668faf608a2926af16462fa7c110d87deef8ad1",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-notify.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "090a4b6871dd5ff5a7a7f4b1d4c3c46bbc72079b0d1bc6106a0c9832abe9b8e7"
+          "sha256": "090a4b6871dd5ff5a7a7f4b1d4c3c46bbc72079b0d1bc6106a0c9832abe9b8e7",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-resume-if-ready.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "63c43ce2492f599a0bdcc804868cb5cdb12a0f2d7949eb57bf002844587218fe"
+          "sha256": "63c43ce2492f599a0bdcc804868cb5cdb12a0f2d7949eb57bf002844587218fe",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-status.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "c7fa427eb4cc4cbfee092a63b56bda32c4964492e91c8d8549632002b9f0bea2"
+          "sha256": "c7fa427eb4cc4cbfee092a63b56bda32c4964492e91c8d8549632002b9f0bea2",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-summary.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "c325877b746e847c64ba59fbfc31c0ebf5aa4a2594feb47f6d13929707b65a0e"
+          "sha256": "c325877b746e847c64ba59fbfc31c0ebf5aa4a2594feb47f6d13929707b65a0e",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-task-board-complete-if-ready.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "b1607272e4dd77625add0cdb4e9ce1012bb476c2472dfd282a4320997656bb6f"
+          "sha256": "b1607272e4dd77625add0cdb4e9ce1012bb476c2472dfd282a4320997656bb6f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-task-board-init.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "910be512c17e6c1aeda2b5114d7cb7aa17b929a1bf82be8833d32c6bee448a11"
+          "sha256": "910be512c17e6c1aeda2b5114d7cb7aa17b929a1bf82be8833d32c6bee448a11",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-task-board-status.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "ea380f67ea5cd7926ad8453e95c73bca413795a8c09a329b6cccb9b3ac62f1f2"
+          "sha256": "ea380f67ea5cd7926ad8453e95c73bca413795a8c09a329b6cccb9b3ac62f1f2",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-task-board-sync-docs.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "fcccee7462f59eccfe4e130ce6b94590ca427541ae2c3959c26b1eadf81e2fb4"
+          "sha256": "fcccee7462f59eccfe4e130ce6b94590ca427541ae2c3959c26b1eadf81e2fb4",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-task-board-update.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "7abbca4807d2e19e9e5af89811918c1caa3d60f228030d5674ec844114ff6424"
+          "sha256": "7abbca4807d2e19e9e5af89811918c1caa3d60f228030d5674ec844114ff6424",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-auto-continue-trigger.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "6e20d2e37d60038a4f08097d66fd45c720a0e5feceeaa4e32c0e0fc616e411de"
+          "sha256": "6e20d2e37d60038a4f08097d66fd45c720a0e5feceeaa4e32c0e0fc616e411de",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-graphify-strategy-hints.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "194bd62fb34378a3e1f4f13d9c9dacfdaa6ab0b651e2d29c33e135d336946fab"
+          "sha256": "194bd62fb34378a3e1f4f13d9c9dacfdaa6ab0b651e2d29c33e135d336946fab",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-gsd-next-state.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "e97d47497af184384f89df5325483a81aa83103ed928b59f29a0025faade15b4"
+          "sha256": "e97d47497af184384f89df5325483a81aa83103ed928b59f29a0025faade15b4",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-gsd-phase-engine-status.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "b49c5876cfb3ab42a1b04da6325b60a8c5a38e41c9a8b6e6e3a04ecb93ac9ba4"
+          "sha256": "b49c5876cfb3ab42a1b04da6325b60a8c5a38e41c9a8b6e6e3a04ecb93ac9ba4",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/hermes-gsd-sync-runtime-mirror.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "a33d266184167f23b55fc6cd0e10b1c8e96d90d72b04226c5b7039298d124d50"
+          "sha256": "a33d266184167f23b55fc6cd0e10b1c8e96d90d72b04226c5b7039298d124d50",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/husky-post-commit-auto-continue.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "e4ee447692f4f87b37aaa30a62c9890fc2164c321cbc38d3f02429c69e9d0ccb"
+          "sha256": "e4ee447692f4f87b37aaa30a62c9890fc2164c321cbc38d3f02429c69e9d0ccb",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/husky-post-merge-auto-continue.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "88acbe23a1fc6fbf3360f142ea34970840ffca304bfd78fe818b20224a8a442f"
+          "sha256": "88acbe23a1fc6fbf3360f142ea34970840ffca304bfd78fe818b20224a8a442f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-nonintrusive-workflow/templates/install-hermes-auto-continue-cron.sh",
           "owner": "hermes-graphify-gsd-nonintrusive-workflow",
-          "sha256": "a57c6a7f2c8596e8be367093954e9f21509be8468b2b0054784254fe9852ddfa"
+          "sha256": "a57c6a7f2c8596e8be367093954e9f21509be8468b2b0054784254fe9852ddfa",
+          "mode": "100644"
         }
       ],
       "composition": {
@@ -9515,42 +10253,50 @@
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/SKILL.md",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "cfae8f9afec337fb13abb97000d23c1b9b558c0ab09a3fb1540728bbc1f21f6a"
+          "sha256": "cfae8f9afec337fb13abb97000d23c1b9b558c0ab09a3fb1540728bbc1f21f6a",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/references/first-install.md",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "e2578f8eba3de569025c26691c693276235a36d0cd9f03a42f6bcb07d0d481fb"
+          "sha256": "e2578f8eba3de569025c26691c693276235a36d0cd9f03a42f6bcb07d0d481fb",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/references/integration-checklist.md",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "5f72a9b1bcb47401b7c8a35e52956b54dd18ac6609a89c12d9234567901cf063"
+          "sha256": "5f72a9b1bcb47401b7c8a35e52956b54dd18ac6609a89c12d9234567901cf063",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/templates/agents-section.md",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "cebbc7743ba2b7f030f2b32a52dd41b156acae6bf12d7344fdf2f4fac01567b0"
+          "sha256": "cebbc7743ba2b7f030f2b32a52dd41b156acae6bf12d7344fdf2f4fac01567b0",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/templates/ai-workflow.sh",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "3f04964ce25835943f6b81d2e4bc85d897efc2ba9460ce6b359f449ad1746e99"
+          "sha256": "3f04964ce25835943f6b81d2e4bc85d897efc2ba9460ce6b359f449ad1746e99",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/templates/bootstrap-toolchain.sh",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "f2b41452c96adc5f4e21170a561de6c5a33544f16f63440e437e53c5ed798e3a"
+          "sha256": "f2b41452c96adc5f4e21170a561de6c5a33544f16f63440e437e53c5ed798e3a",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/templates/graphify-sync.sh",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "d4d4ab91673534a67100350e53943d3da5a25f2a60200fea0f0ebbb0f94626ff"
+          "sha256": "d4d4ab91673534a67100350e53943d3da5a25f2a60200fea0f0ebbb0f94626ff",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/hermes-graphify-gsd-project-integration/templates/readme-section.md",
           "owner": "hermes-graphify-gsd-project-integration",
-          "sha256": "8b4c2c9cc48d85771971f3d8900f3729188395a37ef1711df8b20a2dc4e1cc9e"
+          "sha256": "8b4c2c9cc48d85771971f3d8900f3729188395a37ef1711df8b20a2dc4e1cc9e",
+          "mode": "100644"
         }
       ],
       "composition": {
@@ -9621,7 +10367,8 @@
         {
           "path": "skills/ai-agent-platform/hermes-graphify-gsd-runtime-operator/SKILL.md",
           "owner": "hermes-graphify-gsd-runtime-operator",
-          "sha256": "89de43d96332f8f7e47409d473c15486da3bb3efde4b7d5079b2c87aafa6fab1"
+          "sha256": "89de43d96332f8f7e47409d473c15486da3bb3efde4b7d5079b2c87aafa6fab1",
+          "mode": "100644"
         }
       ],
       "composition": {
@@ -9702,17 +10449,20 @@
         {
           "path": "skills/developer-engineering/i18n-expert/.security-scan-passed",
           "owner": "i18n-expert",
-          "sha256": "984ca6ad82c7b87b7d3207918bad8d6838ff4e5bcfbc347a0f599c065c88abe4"
+          "sha256": "984ca6ad82c7b87b7d3207918bad8d6838ff4e5bcfbc347a0f599c065c88abe4",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/i18n-expert/SKILL.md",
           "owner": "i18n-expert",
-          "sha256": "ce5ff37fb252c40b409d84cf67bc3151b7711da249f339ed4e6885eaf47fa0af"
+          "sha256": "ce5ff37fb252c40b409d84cf67bc3151b7711da249f339ed4e6885eaf47fa0af",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/i18n-expert/scripts/i18n_audit.py",
           "owner": "i18n-expert",
-          "sha256": "716c9597a7d86cff2b51d2354b314ec125de78ac459d01c3a6bcc7289af35f51"
+          "sha256": "716c9597a7d86cff2b51d2354b314ec125de78ac459d01c3a6bcc7289af35f51",
+          "mode": "100644"
         }
       ]
     },
@@ -9812,57 +10562,68 @@
         {
           "path": "skills/multimodal-media/imagegen/LICENSE.txt",
           "owner": "imagegen",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/SKILL.md",
           "owner": "imagegen",
-          "sha256": "72d1b419da85eab7e7145aa56d328a9d7c82dc232d7eb3b281eda4da989c6443"
+          "sha256": "72d1b419da85eab7e7145aa56d328a9d7c82dc232d7eb3b281eda4da989c6443",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/agents/openai.yaml",
           "owner": "imagegen",
-          "sha256": "051b82cce281829f36caaeacb676af013d45c5429fd824ec0eac5dcee07352fa"
+          "sha256": "051b82cce281829f36caaeacb676af013d45c5429fd824ec0eac5dcee07352fa",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/assets/imagegen-small.svg",
           "owner": "imagegen",
-          "sha256": "cff5f34f57ff60b3ee92eaedd17b15e96dd4b9e776df3e78936c9e00d42be294"
+          "sha256": "cff5f34f57ff60b3ee92eaedd17b15e96dd4b9e776df3e78936c9e00d42be294",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/assets/imagegen.png",
           "owner": "imagegen",
-          "sha256": "95952f644064eb9e890f98d8db07216347186526e4c41ad66d3420629eb86e20"
+          "sha256": "95952f644064eb9e890f98d8db07216347186526e4c41ad66d3420629eb86e20",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/references/cli.md",
           "owner": "imagegen",
-          "sha256": "c548d8897fb3df3c0a0d39b42cdd7a08247706696cbedda9f1b36cb7bbf60ab7"
+          "sha256": "c548d8897fb3df3c0a0d39b42cdd7a08247706696cbedda9f1b36cb7bbf60ab7",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/references/codex-network.md",
           "owner": "imagegen",
-          "sha256": "e0392ea43bdc6fa075ff8f842a999840e05ab025be3c217dc58791000efa5b18"
+          "sha256": "e0392ea43bdc6fa075ff8f842a999840e05ab025be3c217dc58791000efa5b18",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/references/image-api.md",
           "owner": "imagegen",
-          "sha256": "a31b576864fb7ab43e3191e039a24a19cdd85d2804e44c38a822f2ed1f4f78c3"
+          "sha256": "a31b576864fb7ab43e3191e039a24a19cdd85d2804e44c38a822f2ed1f4f78c3",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/references/prompting.md",
           "owner": "imagegen",
-          "sha256": "80383de47c15b2e0b014b95099cc95663497cb2ab8b0eac88d867fa2b5b208db"
+          "sha256": "80383de47c15b2e0b014b95099cc95663497cb2ab8b0eac88d867fa2b5b208db",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/references/sample-prompts.md",
           "owner": "imagegen",
-          "sha256": "be54f1ced28a7ac1d68670eb2d560d1491d7e0efe38972d9ba3309110f7d45e4"
+          "sha256": "be54f1ced28a7ac1d68670eb2d560d1491d7e0efe38972d9ba3309110f7d45e4",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/imagegen/scripts/image_gen.py",
           "owner": "imagegen",
-          "sha256": "f30607f1f5ee10d6d62f5fb2e28a128791e280ca7f369f9c98b1809bd2a4962a"
+          "sha256": "f30607f1f5ee10d6d62f5fb2e28a128791e280ca7f369f9c98b1809bd2a4962a",
+          "mode": "100644"
         }
       ]
     },
@@ -10032,127 +10793,152 @@
         {
           "path": "skills/devops-sre/incident-commander/README.md",
           "owner": "incident-commander",
-          "sha256": "063366eee36c7a7943aa951e1289d257434c382a35bc66e3cabd83b961740fdd"
+          "sha256": "063366eee36c7a7943aa951e1289d257434c382a35bc66e3cabd83b961740fdd",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/SKILL.md",
           "owner": "incident-commander",
-          "sha256": "a850d34869608db6550c8604b310d9052d286e49dff44a8a70cfcda39ef9c1b4"
+          "sha256": "a850d34869608db6550c8604b310d9052d286e49dff44a8a70cfcda39ef9c1b4",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/incident_report_template.md",
           "owner": "incident-commander",
-          "sha256": "04e51d53ba2241e8df8514565bfc357ce8607215c1ea2ff7ed827d42a308c436"
+          "sha256": "04e51d53ba2241e8df8514565bfc357ce8607215c1ea2ff7ed827d42a308c436",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/runbook_template.md",
           "owner": "incident-commander",
-          "sha256": "9a507ea76d9b4ad790a2693a2702cf718c7ad8f0ab424bd070cdca24c8997653"
+          "sha256": "9a507ea76d9b4ad790a2693a2702cf718c7ad8f0ab424bd070cdca24c8997653",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/sample_incident_classification.json",
           "owner": "incident-commander",
-          "sha256": "94cb59201f0916eadb09528fd5a7ef020e26b3068526f6710e0f9bac958790e8"
+          "sha256": "94cb59201f0916eadb09528fd5a7ef020e26b3068526f6710e0f9bac958790e8",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/sample_incident_data.json",
           "owner": "incident-commander",
-          "sha256": "85219460c0f7f0c92ba66b75e51ce3d78edc06d952a70df95dc8cc3ad510786e"
+          "sha256": "85219460c0f7f0c92ba66b75e51ce3d78edc06d952a70df95dc8cc3ad510786e",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/sample_incident_pir_data.json",
           "owner": "incident-commander",
-          "sha256": "a5c553fbeeb08d80de018b6a01b665778a810e9e8b2b072eda4c78244c3179ad"
+          "sha256": "a5c553fbeeb08d80de018b6a01b665778a810e9e8b2b072eda4c78244c3179ad",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/sample_timeline_events.json",
           "owner": "incident-commander",
-          "sha256": "1220c7dadccdb06869dd44e9ed96acc4e8e01221c15c5b7d55d49f2452a0e847"
+          "sha256": "1220c7dadccdb06869dd44e9ed96acc4e8e01221c15c5b7d55d49f2452a0e847",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/simple_incident.json",
           "owner": "incident-commander",
-          "sha256": "387cddacb46aa73846a6201dfa858acdc3e84c250d0f601a134defacdbf08005"
+          "sha256": "387cddacb46aa73846a6201dfa858acdc3e84c250d0f601a134defacdbf08005",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/assets/simple_timeline_events.json",
           "owner": "incident-commander",
-          "sha256": "c1245823b6de01900c25d4599c3c12e9d2d7d8d5b0eb853f415318735f67f7b0"
+          "sha256": "c1245823b6de01900c25d4599c3c12e9d2d7d8d5b0eb853f415318735f67f7b0",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/expected_outputs/incident_classification_text_output.txt",
           "owner": "incident-commander",
-          "sha256": "4c6699d2570dbf8e917466434410ad2e31347d28318803b701c7110f7f94bd17"
+          "sha256": "4c6699d2570dbf8e917466434410ad2e31347d28318803b701c7110f7f94bd17",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/expected_outputs/pir_markdown_output.md",
           "owner": "incident-commander",
-          "sha256": "152824fa3d0b7a5fc0e6b2d55a6229e7bc3734d6fa74ea65616c6289edf482df"
+          "sha256": "152824fa3d0b7a5fc0e6b2d55a6229e7bc3734d6fa74ea65616c6289edf482df",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/expected_outputs/simple_incident_classification.txt",
           "owner": "incident-commander",
-          "sha256": "52d1535ea77a2c1d5b817e1b64b6bc5856eced0f1682f48c152da2cd13394c9e"
+          "sha256": "52d1535ea77a2c1d5b817e1b64b6bc5856eced0f1682f48c152da2cd13394c9e",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/expected_outputs/timeline_reconstruction_text_output.txt",
           "owner": "incident-commander",
-          "sha256": "e57f7eaa732fa9e1351e6fd325b6cac70f786722d25e5de0caf5c58f8f582fc9"
+          "sha256": "e57f7eaa732fa9e1351e6fd325b6cac70f786722d25e5de0caf5c58f8f582fc9",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/references/communication_templates.md",
           "owner": "incident-commander",
-          "sha256": "330c38f4123f54ca9134b1e4256020642457158d7acecf852cbe34b323ecf815"
+          "sha256": "330c38f4123f54ca9134b1e4256020642457158d7acecf852cbe34b323ecf815",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/references/incident-response-framework.md",
           "owner": "incident-commander",
-          "sha256": "17331fc4e97da8fa4e42894505a10275f1f1e8b2f53d0b3e02d7ade696ac7c59"
+          "sha256": "17331fc4e97da8fa4e42894505a10275f1f1e8b2f53d0b3e02d7ade696ac7c59",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/references/incident_severity_matrix.md",
           "owner": "incident-commander",
-          "sha256": "6d2a809f678f7eaa2838e4b61873e1ef9f9c4edc5d40658a9fe5a6f1369561ae"
+          "sha256": "6d2a809f678f7eaa2838e4b61873e1ef9f9c4edc5d40658a9fe5a6f1369561ae",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/references/rca_frameworks_guide.md",
           "owner": "incident-commander",
-          "sha256": "3dc1ace4c047e996594853f8bfceb29416e883515ce15445690352a32ba2398e"
+          "sha256": "3dc1ace4c047e996594853f8bfceb29416e883515ce15445690352a32ba2398e",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/references/sla-management-guide.md",
           "owner": "incident-commander",
-          "sha256": "2ad4c714b39ce72af695f7d6fff55bbf60df2619469532d9d6ab0f7160041136"
+          "sha256": "2ad4c714b39ce72af695f7d6fff55bbf60df2619469532d9d6ab0f7160041136",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/incident_classifier.py",
           "owner": "incident-commander",
-          "sha256": "d94bf849a3c68f7f59b872e4436221743f4be31c9dac3c1a0ebe0d9447edbbbd"
+          "sha256": "d94bf849a3c68f7f59b872e4436221743f4be31c9dac3c1a0ebe0d9447edbbbd",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/incident_timeline_builder.py",
           "owner": "incident-commander",
-          "sha256": "936c4b702511b610b68204547c75fb840488de585b8b83f4dcdd2a53811f4a24"
+          "sha256": "936c4b702511b610b68204547c75fb840488de585b8b83f4dcdd2a53811f4a24",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/pir_generator.py",
           "owner": "incident-commander",
-          "sha256": "3b42b0051bf88f3b5e2a54cae37b796bec7db23c875ffdde2f6393aa4ffcb949"
+          "sha256": "3b42b0051bf88f3b5e2a54cae37b796bec7db23c875ffdde2f6393aa4ffcb949",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/postmortem_generator.py",
           "owner": "incident-commander",
-          "sha256": "46c5974fb2f4f880f474560f124d029e314cf0458c82b76a14c4a56b33af5648"
+          "sha256": "46c5974fb2f4f880f474560f124d029e314cf0458c82b76a14c4a56b33af5648",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/severity_classifier.py",
           "owner": "incident-commander",
-          "sha256": "912d7027eeb06b3b6c259ef87904555304c431098e0085864a2bf867e9237ed3"
+          "sha256": "912d7027eeb06b3b6c259ef87904555304c431098e0085864a2bf867e9237ed3",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/incident-commander/scripts/timeline_reconstructor.py",
           "owner": "incident-commander",
-          "sha256": "85537391a3fce47e5db96fb45fe4e50e2e97cf26cdcd8b1b12b6b7de7f9b4d24"
+          "sha256": "85537391a3fce47e5db96fb45fe4e50e2e97cf26cdcd8b1b12b6b7de7f9b4d24",
+          "mode": "100644"
         }
       ]
     },
@@ -10272,77 +11058,92 @@
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/CHANGELOG.md",
           "owner": "input-guard",
-          "sha256": "82a2642d67af717111bdc1090aecdc96ab92f8adfab4f18906d17306b218b66a"
+          "sha256": "82a2642d67af717111bdc1090aecdc96ab92f8adfab4f18906d17306b218b66a",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/INTEGRATION.md",
           "owner": "input-guard",
-          "sha256": "73fcd7e0ea9a96af5f9f66af4e0cc96a846177abb6b4cbe01b4ed86feac43140"
+          "sha256": "73fcd7e0ea9a96af5f9f66af4e0cc96a846177abb6b4cbe01b4ed86feac43140",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/README.md",
           "owner": "input-guard",
-          "sha256": "2445e1048da2afab015e52af12a186b75c1c1354990bda19af2142d59e294385"
+          "sha256": "2445e1048da2afab015e52af12a186b75c1c1354990bda19af2142d59e294385",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/SKILL.md",
           "owner": "input-guard",
-          "sha256": "6879d932715d85c03d14598936ea2680b88161aed294d88f054110e4cc5ed71f"
+          "sha256": "6879d932715d85c03d14598936ea2680b88161aed294d88f054110e4cc5ed71f",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/TESTING.md",
           "owner": "input-guard",
-          "sha256": "08833229c21c85d738ba350a83348ca9d03910fe178f390c80e31223113c1956"
+          "sha256": "08833229c21c85d738ba350a83348ca9d03910fe178f390c80e31223113c1956",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/_meta.json",
           "owner": "input-guard",
-          "sha256": "0811042927b895f236b65b55bf447af612a9aa70400c88eadfb8b672d2890264"
+          "sha256": "0811042927b895f236b65b55bf447af612a9aa70400c88eadfb8b672d2890264",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/evals/cases.json",
           "owner": "input-guard",
-          "sha256": "8197a4d8cbb1b734d061f9b2455b7a594e76af365356a66beda547907ea34c5a"
+          "sha256": "8197a4d8cbb1b734d061f9b2455b7a594e76af365356a66beda547907ea34c5a",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/evals/run.py",
           "owner": "input-guard",
-          "sha256": "0c8a4b08827e014240b6f9d7e3c07c96fb0657f970c81b8ab96069a21561ce85"
+          "sha256": "0c8a4b08827e014240b6f9d7e3c07c96fb0657f970c81b8ab96069a21561ce85",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/requirements.txt",
           "owner": "input-guard",
-          "sha256": "e55975ac7de9d8d307b95be3ec506866a013f530b2f5670fad03cdb8e75106ca"
+          "sha256": "e55975ac7de9d8d307b95be3ec506866a013f530b2f5670fad03cdb8e75106ca",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/scripts/get_taxonomy.py",
           "owner": "input-guard",
-          "sha256": "0aa42daf43da0179990d55e799a77d49e90de9e4bb22fe159542becbd8a04117"
+          "sha256": "0aa42daf43da0179990d55e799a77d49e90de9e4bb22fe159542becbd8a04117",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/scripts/llm_scanner.py",
           "owner": "input-guard",
-          "sha256": "49f09488b219dcce7acc82a05f97c771eedaffc6502a2ab50a2b6414b0fab8f4"
+          "sha256": "49f09488b219dcce7acc82a05f97c771eedaffc6502a2ab50a2b6414b0fab8f4",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/scripts/report-to-molthreats.sh",
           "owner": "input-guard",
-          "sha256": "5d85f57afa60434eb3b590aada868c2d165fab0e7e67a26d64d8f41b6f38d174"
+          "sha256": "5d85f57afa60434eb3b590aada868c2d165fab0e7e67a26d64d8f41b6f38d174",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/scripts/scan.py",
           "owner": "input-guard",
-          "sha256": "2f8e9cb41283c3df03a96206c4803d266954db7db1f3ab3afec902843ded908d"
+          "sha256": "2f8e9cb41283c3df03a96206c4803d266954db7db1f3ab3afec902843ded908d",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/scripts/scan.sh",
           "owner": "input-guard",
-          "sha256": "0ee2bd90deda9343afde547cbbfa7f0935be647b4364828dcfb526d32f602316"
+          "sha256": "0ee2bd90deda9343afde547cbbfa7f0935be647b4364828dcfb526d32f602316",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/input-guard/taxonomy.json",
           "owner": "input-guard",
-          "sha256": "a93e1f99307985395b854b0d908c6ab570701ef4c9db03db72c8d2f4e2b3f8b8"
+          "sha256": "a93e1f99307985395b854b0d908c6ab570701ef4c9db03db72c8d2f4e2b3f8b8",
+          "mode": "100644"
         }
       ]
     },
@@ -10457,72 +11258,86 @@
         {
           "path": "skills/operations-general/interview-system-designer/README.md",
           "owner": "interview-system-designer",
-          "sha256": "7e6953a196646f65ed31360abe3a183ce9de58eb77783644a455d88cd14a9647"
+          "sha256": "7e6953a196646f65ed31360abe3a183ce9de58eb77783644a455d88cd14a9647",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/SKILL.md",
           "owner": "interview-system-designer",
-          "sha256": "3e656d939aa9f47a8bc52cfd58c1c11ff20acd56c02da51a73b924b808070841"
+          "sha256": "3e656d939aa9f47a8bc52cfd58c1c11ff20acd56c02da51a73b924b808070841",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/assets/sample_interview_results.json",
           "owner": "interview-system-designer",
-          "sha256": "2eaeff0799b58aba1b19362c3ce856fe1569c5d07f0943bbe529086eacc654a7"
+          "sha256": "2eaeff0799b58aba1b19362c3ce856fe1569c5d07f0943bbe529086eacc654a7",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/assets/sample_role_definitions.json",
           "owner": "interview-system-designer",
-          "sha256": "7df776e1e67bfeaf25b1ebbc044856fa9e307e0481372e1d86de4dc3fb4aa41f"
+          "sha256": "7df776e1e67bfeaf25b1ebbc044856fa9e307e0481372e1d86de4dc3fb4aa41f",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/expected_outputs/product_manager_senior_questions.json",
           "owner": "interview-system-designer",
-          "sha256": "54ad0ead056028edb31393f10ad7564e861a43718943a75643f61abe3d1dfc25"
+          "sha256": "54ad0ead056028edb31393f10ad7564e861a43718943a75643f61abe3d1dfc25",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/expected_outputs/product_manager_senior_questions.txt",
           "owner": "interview-system-designer",
-          "sha256": "466e35f55087a13777b48f683023f2a62c11a6fc0916c70e2be27719c2a64905"
+          "sha256": "466e35f55087a13777b48f683023f2a62c11a6fc0916c70e2be27719c2a64905",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/expected_outputs/senior_software_engineer_senior_interview_loop.json",
           "owner": "interview-system-designer",
-          "sha256": "a9ac0a0307219ba30c62db945c4f03b93b7a772ea62e6683c1bdd90e258527bb"
+          "sha256": "a9ac0a0307219ba30c62db945c4f03b93b7a772ea62e6683c1bdd90e258527bb",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/expected_outputs/senior_software_engineer_senior_interview_loop.txt",
           "owner": "interview-system-designer",
-          "sha256": "84c166c63d1ed72f2010de30fe36a4645945e2bd7c883100f4cf651589db445c"
+          "sha256": "84c166c63d1ed72f2010de30fe36a4645945e2bd7c883100f4cf651589db445c",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/hiring_calibrator.py",
           "owner": "interview-system-designer",
-          "sha256": "c82d2494883c4c125e32b706068fa10612695c74a0b37d5fde435701419d4335"
+          "sha256": "c82d2494883c4c125e32b706068fa10612695c74a0b37d5fde435701419d4335",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/loop_designer.py",
           "owner": "interview-system-designer",
-          "sha256": "d3d478469a0e2d8f60bde73cffa1af01e7a1e7a16769a49e6ae89d313f4abb52"
+          "sha256": "d3d478469a0e2d8f60bde73cffa1af01e7a1e7a16769a49e6ae89d313f4abb52",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/question_bank_generator.py",
           "owner": "interview-system-designer",
-          "sha256": "6a3f881fcc52b6413b036543b516043e6052c9b4cb6941c83cda53e5ac71ac83"
+          "sha256": "6a3f881fcc52b6413b036543b516043e6052c9b4cb6941c83cda53e5ac71ac83",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/references/bias_mitigation_checklist.md",
           "owner": "interview-system-designer",
-          "sha256": "9f5f74260b9b3df5122b869a220b02ac90710332860b68bb587a4fe0bf29a76e"
+          "sha256": "9f5f74260b9b3df5122b869a220b02ac90710332860b68bb587a4fe0bf29a76e",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/references/competency_matrix_templates.md",
           "owner": "interview-system-designer",
-          "sha256": "6d37316769e31cef3caf66455cf618306f9c2fd408083bd882571554175b22da"
+          "sha256": "6d37316769e31cef3caf66455cf618306f9c2fd408083bd882571554175b22da",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/interview-system-designer/references/debrief_facilitation_guide.md",
           "owner": "interview-system-designer",
-          "sha256": "6861c96d574a2392cb28850436231de4ae82307a80a477b4df4143beecd65966"
+          "sha256": "6861c96d574a2392cb28850436231de4ae82307a80a477b4df4143beecd65966",
+          "mode": "100644"
         }
       ]
     },
@@ -10587,22 +11402,26 @@
         {
           "path": "skills/finance-investing/investment-memo-writer/SKILL.md",
           "owner": "investment-memo-writer",
-          "sha256": "3a3cfaeb5c48993253d9763bfa24b148c15e6b1cb5af57130e1474bb42d59f7a"
+          "sha256": "3a3cfaeb5c48993253d9763bfa24b148c15e6b1cb5af57130e1474bb42d59f7a",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/investment-memo-writer/assets/sample_thesis.json",
           "owner": "investment-memo-writer",
-          "sha256": "a6398e294da6d9b987da4e06fbec511befe44044c86b52e6c9ef056e3fa6b978"
+          "sha256": "a6398e294da6d9b987da4e06fbec511befe44044c86b52e6c9ef056e3fa6b978",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/investment-memo-writer/references/memo-outline.md",
           "owner": "investment-memo-writer",
-          "sha256": "6ebdc9937b604dfbdf029f797f802261bdec7eadf63d65b968a135fa3c27b4c6"
+          "sha256": "6ebdc9937b604dfbdf029f797f802261bdec7eadf63d65b968a135fa3c27b4c6",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/investment-memo-writer/scripts/build_memo.py",
           "owner": "investment-memo-writer",
-          "sha256": "1f59ce7b405bc66640628430785a5bb0d9dae78073ebeba42c0a741035b011e4"
+          "sha256": "1f59ce7b405bc66640628430785a5bb0d9dae78073ebeba42c0a741035b011e4",
+          "mode": "100644"
         }
       ]
     },
@@ -10707,62 +11526,74 @@
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/LICENSE.txt",
           "owner": "jupyter-notebook",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/SKILL.md",
           "owner": "jupyter-notebook",
-          "sha256": "269750a1367ea2871b5fd3e279fd3b64a92d394cbc7e555d98193ae2f66d34fd"
+          "sha256": "269750a1367ea2871b5fd3e279fd3b64a92d394cbc7e555d98193ae2f66d34fd",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/agents/openai.yaml",
           "owner": "jupyter-notebook",
-          "sha256": "3a2d6a8f9ed10e18f6caa66aeb26a02305bc61f36fc4b333c904e02f9988fb9c"
+          "sha256": "3a2d6a8f9ed10e18f6caa66aeb26a02305bc61f36fc4b333c904e02f9988fb9c",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/assets/experiment-template.ipynb",
           "owner": "jupyter-notebook",
-          "sha256": "25f85914103cd84244e20ef378f59097479c72481cd18d3a931354d107c3f300"
+          "sha256": "25f85914103cd84244e20ef378f59097479c72481cd18d3a931354d107c3f300",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/assets/jupyter-small.svg",
           "owner": "jupyter-notebook",
-          "sha256": "a36bd27bef3775f111309241754b386db81e7d356f07672190e2fcb24478a250"
+          "sha256": "a36bd27bef3775f111309241754b386db81e7d356f07672190e2fcb24478a250",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/assets/jupyter.png",
           "owner": "jupyter-notebook",
-          "sha256": "852fd5468885bb176d266d547e61684792332e44a88cfbc8cd07323937040ccb"
+          "sha256": "852fd5468885bb176d266d547e61684792332e44a88cfbc8cd07323937040ccb",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/assets/tutorial-template.ipynb",
           "owner": "jupyter-notebook",
-          "sha256": "704a809c09c7c9e6e5c437860df95524412b50c58571a14204610d73e0744765"
+          "sha256": "704a809c09c7c9e6e5c437860df95524412b50c58571a14204610d73e0744765",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/references/experiment-patterns.md",
           "owner": "jupyter-notebook",
-          "sha256": "1ff9c04281c01e8e2209bde9f1fd910b8e4b620dd1f1f040e2101f1d88513a91"
+          "sha256": "1ff9c04281c01e8e2209bde9f1fd910b8e4b620dd1f1f040e2101f1d88513a91",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/references/notebook-structure.md",
           "owner": "jupyter-notebook",
-          "sha256": "a85051a2e88fd3424bbed2636e952ec5f858e7efa4e076c28d62a8cc2cc9dc06"
+          "sha256": "a85051a2e88fd3424bbed2636e952ec5f858e7efa4e076c28d62a8cc2cc9dc06",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/references/quality-checklist.md",
           "owner": "jupyter-notebook",
-          "sha256": "ed01afe6ff47714d85935d11053b64c414772f02250fdc604e3fca65e5139136"
+          "sha256": "ed01afe6ff47714d85935d11053b64c414772f02250fdc604e3fca65e5139136",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/references/tutorial-patterns.md",
           "owner": "jupyter-notebook",
-          "sha256": "8c194bb640de2fb7747e3db87006ecec5219252d301f53670975dbb5310ff659"
+          "sha256": "8c194bb640de2fb7747e3db87006ecec5219252d301f53670975dbb5310ff659",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/jupyter-notebook/scripts/new_notebook.py",
           "owner": "jupyter-notebook",
-          "sha256": "a004e2ea3115edb24313928be0be6d1dc07e571d7ca6c1b24375f0569c616d2f"
+          "sha256": "a004e2ea3115edb24313928be0be6d1dc07e571d7ca6c1b24375f0569c616d2f",
+          "mode": "100644"
         }
       ]
     },
@@ -10812,7 +11643,8 @@
         {
           "path": "skills/security-and-reliability/link-checker/SKILL.md",
           "owner": "link-checker",
-          "sha256": "1ad3d11001bb0156a26babb26fabc45671cfb3d5bbd4124aa241583f44513c7f"
+          "sha256": "1ad3d11001bb0156a26babb26fabc45671cfb3d5bbd4124aa241583f44513c7f",
+          "mode": "100644"
         }
       ]
     },
@@ -10877,22 +11709,26 @@
         {
           "path": "skills/finance-investing/macro-regime-monitor/SKILL.md",
           "owner": "macro-regime-monitor",
-          "sha256": "973c016999521a94f5510cdd610ef39259bb4a9af30d768d40ae28c7a8b462cd"
+          "sha256": "973c016999521a94f5510cdd610ef39259bb4a9af30d768d40ae28c7a8b462cd",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/macro-regime-monitor/assets/sample_macro_data.json",
           "owner": "macro-regime-monitor",
-          "sha256": "838d47f94cee8a387482ac014f43f8a5ac118e95bf0cff70776b60ed733c671c"
+          "sha256": "838d47f94cee8a387482ac014f43f8a5ac118e95bf0cff70776b60ed733c671c",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/macro-regime-monitor/references/regime-framework.md",
           "owner": "macro-regime-monitor",
-          "sha256": "fa95ce2e83a2fb3b1d0c07f5a5359596575d7bf08c86214f6c108411e1064795"
+          "sha256": "fa95ce2e83a2fb3b1d0c07f5a5359596575d7bf08c86214f6c108411e1064795",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/macro-regime-monitor/scripts/classify_regime.py",
           "owner": "macro-regime-monitor",
-          "sha256": "a86aa0826be4d8a4c4afa6ae84c0cfe570e6e8b061db8313ed5e6a25a972846f"
+          "sha256": "a86aa0826be4d8a4c4afa6ae84c0cfe570e6e8b061db8313ed5e6a25a972846f",
+          "mode": "100644"
         }
       ]
     },
@@ -10982,47 +11818,56 @@
         {
           "path": "skills/office-white-collar/markdown-tools/SKILL.md",
           "owner": "markdown-tools",
-          "sha256": "ca6833b35b4f76f674da31e437c89496b71a4a57a34b915ff828f0596b04cc63"
+          "sha256": "ca6833b35b4f76f674da31e437c89496b71a4a57a34b915ff828f0596b04cc63",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/references/conversion-examples.md",
           "owner": "markdown-tools",
-          "sha256": "184b501c4e277f7df9db9fc09df8f0d1190c12071730ccd2d16d8fbcbffdaf71"
+          "sha256": "184b501c4e277f7df9db9fc09df8f0d1190c12071730ccd2d16d8fbcbffdaf71",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/references/heavy-mode-guide.md",
           "owner": "markdown-tools",
-          "sha256": "c9f3d56e3dc23f25ccf3babbc6b254363245e4c635cd840d2dfda0019c8c31e2"
+          "sha256": "c9f3d56e3dc23f25ccf3babbc6b254363245e4c635cd840d2dfda0019c8c31e2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/references/tool-comparison.md",
           "owner": "markdown-tools",
-          "sha256": "62c919cd00cb207b67438b0104e2596110bd48253ec9acd0fb840d1990ff0f6d"
+          "sha256": "62c919cd00cb207b67438b0104e2596110bd48253ec9acd0fb840d1990ff0f6d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/scripts/convert.py",
           "owner": "markdown-tools",
-          "sha256": "e7e9a8cd593e626273a5329c3b6c1f1b61cc0796d47d7eb7b9105c36224db513"
+          "sha256": "e7e9a8cd593e626273a5329c3b6c1f1b61cc0796d47d7eb7b9105c36224db513",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/scripts/convert_path.py",
           "owner": "markdown-tools",
-          "sha256": "09e22a4b8cce524c1f9b496e16378bde7db58b4825cf3a7599a4b2b4c5f9a853"
+          "sha256": "09e22a4b8cce524c1f9b496e16378bde7db58b4825cf3a7599a4b2b4c5f9a853",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/scripts/extract_pdf_images.py",
           "owner": "markdown-tools",
-          "sha256": "b5d02d782dfb8c799597fa1e67442927b0ad6bace71474fc8ebd7077af8c6d48"
+          "sha256": "b5d02d782dfb8c799597fa1e67442927b0ad6bace71474fc8ebd7077af8c6d48",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/scripts/merge_outputs.py",
           "owner": "markdown-tools",
-          "sha256": "b174d1d5871e9a393dc4e50da1f14d14f16762ad8d4e64e4a4618d361da4b6b4"
+          "sha256": "b174d1d5871e9a393dc4e50da1f14d14f16762ad8d4e64e4a4618d361da4b6b4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/markdown-tools/scripts/validate_output.py",
           "owner": "markdown-tools",
-          "sha256": "66033e5535c841120903819b76a9a7f92f64d5b1e97e4d3d1a1eeb8f33164e17"
+          "sha256": "66033e5535c841120903819b76a9a7f92f64d5b1e97e4d3d1a1eeb8f33164e17",
+          "mode": "100644"
         }
       ]
     },
@@ -11097,32 +11942,38 @@
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/SKILL.md",
           "owner": "marketing-demand-acquisition",
-          "sha256": "60e1bb7a7b6aa120799fd2b3ca9121815a6a72c4b5e5a4d4e1f5ba7c2a68b0d7"
+          "sha256": "60e1bb7a7b6aa120799fd2b3ca9121815a6a72c4b5e5a4d4e1f5ba7c2a68b0d7",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/references/attribution-guide.md",
           "owner": "marketing-demand-acquisition",
-          "sha256": "0d5f0555742e7dfe3d1e3b11c575a5dab377ff32a0701aff87427964339bfea3"
+          "sha256": "0d5f0555742e7dfe3d1e3b11c575a5dab377ff32a0701aff87427964339bfea3",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/references/campaign-templates.md",
           "owner": "marketing-demand-acquisition",
-          "sha256": "f02d04c4ee3d51774b3e581c543f8de81214eb92d059e389b9ad13e3d768bba2"
+          "sha256": "f02d04c4ee3d51774b3e581c543f8de81214eb92d059e389b9ad13e3d768bba2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/references/hubspot-workflows.md",
           "owner": "marketing-demand-acquisition",
-          "sha256": "9aeee64edf7eada107fdf4136bad4d87ee18151b574cb19bb50c88258e4aca9d"
+          "sha256": "9aeee64edf7eada107fdf4136bad4d87ee18151b574cb19bb50c88258e4aca9d",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/references/international-playbooks.md",
           "owner": "marketing-demand-acquisition",
-          "sha256": "dc929706768e816ad62e3f071c059580b79e3015c70c0a26eff9ae291df1d7c9"
+          "sha256": "dc929706768e816ad62e3f071c059580b79e3015c70c0a26eff9ae291df1d7c9",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition/scripts/calculate_cac.py",
           "owner": "marketing-demand-acquisition",
-          "sha256": "bd27692afc8a86764647d8c01b76777e015238d4b63b3aeb1fc7b0b5e6b1e8df"
+          "sha256": "bd27692afc8a86764647d8c01b76777e015238d4b63b3aeb1fc7b0b5e6b1e8df",
+          "mode": "100644"
         }
       ]
     },
@@ -11192,27 +12043,32 @@
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm/SKILL.md",
           "owner": "marketing-strategy-pmm",
-          "sha256": "049db4f8b0a5eec8782a973ded5dc6998e3eab940aa3ffebb7475731fff1b817"
+          "sha256": "049db4f8b0a5eec8782a973ded5dc6998e3eab940aa3ffebb7475731fff1b817",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm/references/international-gtm.md",
           "owner": "marketing-strategy-pmm",
-          "sha256": "1933d2f131048c446828ea6ea1bb9668d27572c108fed59c353cb831901d7d5c"
+          "sha256": "1933d2f131048c446828ea6ea1bb9668d27572c108fed59c353cb831901d7d5c",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm/references/launch-checklists.md",
           "owner": "marketing-strategy-pmm",
-          "sha256": "56eb263385be1769378a08150e9be1a003b2a825f3d19edfb84d963aa7bb2bfb"
+          "sha256": "56eb263385be1769378a08150e9be1a003b2a825f3d19edfb84d963aa7bb2bfb",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm/references/messaging-templates.md",
           "owner": "marketing-strategy-pmm",
-          "sha256": "019e1470bf02f706e17195148975cdf28dfadcfd38de46f26a2c038e39a33c87"
+          "sha256": "019e1470bf02f706e17195148975cdf28dfadcfd38de46f26a2c038e39a33c87",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm/references/positioning-frameworks.md",
           "owner": "marketing-strategy-pmm",
-          "sha256": "fe488a7a37d156e2ba1f68964406f608ddb1f182978cb8a10da68eb3a8dc20e6"
+          "sha256": "fe488a7a37d156e2ba1f68964406f608ddb1f182978cb8a10da68eb3a8dc20e6",
+          "mode": "100644"
         }
       ]
     },
@@ -11307,52 +12163,62 @@
         {
           "path": "skills/developer-engineering/mcp-builder/LICENSE.txt",
           "owner": "mcp-builder",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/SKILL.md",
           "owner": "mcp-builder",
-          "sha256": "e7a73af0a9d66da3049aa419941db0d1ff225f6e57a100d3533796ba28df5cb6"
+          "sha256": "e7a73af0a9d66da3049aa419941db0d1ff225f6e57a100d3533796ba28df5cb6",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/reference/evaluation.md",
           "owner": "mcp-builder",
-          "sha256": "8c99479f8a2d22a636c38e274537aac3610879e26f34e0709825077c4576f427"
+          "sha256": "8c99479f8a2d22a636c38e274537aac3610879e26f34e0709825077c4576f427",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/reference/mcp_best_practices.md",
           "owner": "mcp-builder",
-          "sha256": "80fb4369a349447cf18ecdd7494fe7938b6065377e9f08c077cec411093a3007"
+          "sha256": "80fb4369a349447cf18ecdd7494fe7938b6065377e9f08c077cec411093a3007",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/reference/node_mcp_server.md",
           "owner": "mcp-builder",
-          "sha256": "c3ba35a4f599dd53be9c6555ae72c19a7bf412cd5426576c2c08d42755482c66"
+          "sha256": "c3ba35a4f599dd53be9c6555ae72c19a7bf412cd5426576c2c08d42755482c66",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/reference/python_mcp_server.md",
           "owner": "mcp-builder",
-          "sha256": "2da52f77e675191014ca2e146a4b95aa04d0ca7dd7e2b100322df15ade685e80"
+          "sha256": "2da52f77e675191014ca2e146a4b95aa04d0ca7dd7e2b100322df15ade685e80",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/scripts/connections.py",
           "owner": "mcp-builder",
-          "sha256": "9403668a2041568772082a8b334122c1f88daf0541fb393af4522d0094a47a6e"
+          "sha256": "9403668a2041568772082a8b334122c1f88daf0541fb393af4522d0094a47a6e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/scripts/evaluation.py",
           "owner": "mcp-builder",
-          "sha256": "98cf19df73c1112699fc495cfd08d5a5ac8a48db1d7e38d023dfed4bc053fa6e"
+          "sha256": "98cf19df73c1112699fc495cfd08d5a5ac8a48db1d7e38d023dfed4bc053fa6e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/scripts/example_evaluation.xml",
           "owner": "mcp-builder",
-          "sha256": "9272b348ddcc4b06ba562367ccd0770e018158c0068ac5116d5e34aaeff8777a"
+          "sha256": "9272b348ddcc4b06ba562367ccd0770e018158c0068ac5116d5e34aaeff8777a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/mcp-builder/scripts/requirements.txt",
           "owner": "mcp-builder",
-          "sha256": "d5d7558b2368ecea9dfeed7d1fbc71ee9e0750bebd1282faa527d528a344c3c7"
+          "sha256": "d5d7558b2368ecea9dfeed7d1fbc71ee9e0750bebd1282faa527d528a344c3c7",
+          "mode": "100644"
         }
       ]
     },
@@ -11417,22 +12283,26 @@
         {
           "path": "skills/office-white-collar/meeting-minutes-taker/SKILL.md",
           "owner": "meeting-minutes-taker",
-          "sha256": "c47b46af4eed011fc01ba554530201608208a184021204cda6171c0b10835f9d"
+          "sha256": "c47b46af4eed011fc01ba554530201608208a184021204cda6171c0b10835f9d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/meeting-minutes-taker/references/completeness_review_checklist.md",
           "owner": "meeting-minutes-taker",
-          "sha256": "2c4ee3828d442815a2496481697e0f1d0bbcdee8485d916e154722a7a486a0c4"
+          "sha256": "2c4ee3828d442815a2496481697e0f1d0bbcdee8485d916e154722a7a486a0c4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/meeting-minutes-taker/references/context_file_template.md",
           "owner": "meeting-minutes-taker",
-          "sha256": "0dea06761bf73319e093c37727b8585fea43ce7bcdaa730396a0f8ee699452ae"
+          "sha256": "0dea06761bf73319e093c37727b8585fea43ce7bcdaa730396a0f8ee699452ae",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/meeting-minutes-taker/references/meeting_minutes_template.md",
           "owner": "meeting-minutes-taker",
-          "sha256": "1a9c0952e48716c6973110ee1a0ee32dfb7aa3fa2ad42e176c2076fa50bcbc5f"
+          "sha256": "1a9c0952e48716c6973110ee1a0ee32dfb7aa3fa2ad42e176c2076fa50bcbc5f",
+          "mode": "100644"
         }
       ]
     },
@@ -11502,27 +12372,32 @@
         {
           "path": "skills/office-white-collar/mermaid-tools/SKILL.md",
           "owner": "mermaid-tools",
-          "sha256": "68fafe0adeb1d9eceaaa4f6faa6418c5a98372af154bbc4f92ba6c3a3f048e1c"
+          "sha256": "68fafe0adeb1d9eceaaa4f6faa6418c5a98372af154bbc4f92ba6c3a3f048e1c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/mermaid-tools/references/setup_and_troubleshooting.md",
           "owner": "mermaid-tools",
-          "sha256": "da489c40856fbf8748230204ad0a586ba581d7855569a1f8ae68924379370170"
+          "sha256": "da489c40856fbf8748230204ad0a586ba581d7855569a1f8ae68924379370170",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/mermaid-tools/scripts/extract-and-generate.sh",
           "owner": "mermaid-tools",
-          "sha256": "02d1fbeea936fb6ab8890c9a7b3468baa2f1d7172dd803b1d39cfd4ed25f5f0b"
+          "sha256": "02d1fbeea936fb6ab8890c9a7b3468baa2f1d7172dd803b1d39cfd4ed25f5f0b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/mermaid-tools/scripts/extract_diagrams.py",
           "owner": "mermaid-tools",
-          "sha256": "e0eef21a581214b5ae5d72a36a14b044eacfc67545e8fa8153dcbde54a97f2ff"
+          "sha256": "e0eef21a581214b5ae5d72a36a14b044eacfc67545e8fa8153dcbde54a97f2ff",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/mermaid-tools/scripts/puppeteer-config.json",
           "owner": "mermaid-tools",
-          "sha256": "62868aec744a24c6f548047cb718692d35d14c768c0edfe23964e7796e4ed0bf"
+          "sha256": "62868aec744a24c6f548047cb718692d35d14c768c0edfe23964e7796e4ed0bf",
+          "mode": "100644"
         }
       ]
     },
@@ -11667,102 +12542,122 @@
         {
           "path": "skills/developer-engineering/migration-architect/README.md",
           "owner": "migration-architect",
-          "sha256": "828020e15870be2982f07049eeb96f4c6530394a5f8376aeddbcbc116c5fba0c"
+          "sha256": "828020e15870be2982f07049eeb96f4c6530394a5f8376aeddbcbc116c5fba0c",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/SKILL.md",
           "owner": "migration-architect",
-          "sha256": "48280c2fd46081416ff671eafc13d69ba5d55edea3667f6438a1090de33514fd"
+          "sha256": "48280c2fd46081416ff671eafc13d69ba5d55edea3667f6438a1090de33514fd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/assets/database_schema_after.json",
           "owner": "migration-architect",
-          "sha256": "4084b584c3fe328c4f0d70a1c1bcfdee08d392bc3b264b3cfbb06769ca1d3362"
+          "sha256": "4084b584c3fe328c4f0d70a1c1bcfdee08d392bc3b264b3cfbb06769ca1d3362",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/assets/database_schema_before.json",
           "owner": "migration-architect",
-          "sha256": "77c0979da2c460aedd9c5b9e094ecdfa9d4a9826503af9113e82b8b8e23ed59c"
+          "sha256": "77c0979da2c460aedd9c5b9e094ecdfa9d4a9826503af9113e82b8b8e23ed59c",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/assets/sample_database_migration.json",
           "owner": "migration-architect",
-          "sha256": "4061dfddb70dc6713e53c38603199d2c02c5c21204a4b9fa27dab2e060bd5892"
+          "sha256": "4061dfddb70dc6713e53c38603199d2c02c5c21204a4b9fa27dab2e060bd5892",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/assets/sample_service_migration.json",
           "owner": "migration-architect",
-          "sha256": "09a7084eb3d15cfa00a158c26c5778a5f4798c40cd1ba6fe340455512022f9bd"
+          "sha256": "09a7084eb3d15cfa00a158c26c5778a5f4798c40cd1ba6fe340455512022f9bd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/rollback_runbook.json",
           "owner": "migration-architect",
-          "sha256": "e61cc1fb18e4ca284a42d745179112ac31659fa590d3175b2cd2d5b679fc77d0"
+          "sha256": "e61cc1fb18e4ca284a42d745179112ac31659fa590d3175b2cd2d5b679fc77d0",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/rollback_runbook.txt",
           "owner": "migration-architect",
-          "sha256": "d0488ad1fe59db672edd5488548d36fc0719c05eb872d0ef8f7f91f106ec70b6"
+          "sha256": "d0488ad1fe59db672edd5488548d36fc0719c05eb872d0ef8f7f91f106ec70b6",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/sample_database_migration_plan.json",
           "owner": "migration-architect",
-          "sha256": "d1b5fb0dc4e0140ca14e29fcc4416058349573b742b6016868e70382c6a4cffd"
+          "sha256": "d1b5fb0dc4e0140ca14e29fcc4416058349573b742b6016868e70382c6a4cffd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/sample_database_migration_plan.txt",
           "owner": "migration-architect",
-          "sha256": "9cb6b5a5f34bcb6849d81b41c372295196101ec50664e7921ed20fac6df63a22"
+          "sha256": "9cb6b5a5f34bcb6849d81b41c372295196101ec50664e7921ed20fac6df63a22",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/sample_service_migration_plan.json",
           "owner": "migration-architect",
-          "sha256": "e114f0f9f935070b6f067db42c9948e4a503f00cd67befaa33fe356365d84a4f"
+          "sha256": "e114f0f9f935070b6f067db42c9948e4a503f00cd67befaa33fe356365d84a4f",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/sample_service_migration_plan.txt",
           "owner": "migration-architect",
-          "sha256": "89602c26d84f6e46131e13b81d61f8b6f8304f051bb4ce93967855bc14587658"
+          "sha256": "89602c26d84f6e46131e13b81d61f8b6f8304f051bb4ce93967855bc14587658",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/schema_compatibility_report.json",
           "owner": "migration-architect",
-          "sha256": "5659901ea0d085cf54dd6c8072983fc3a749a8f80cbea2d3bf2aeac3b516f708"
+          "sha256": "5659901ea0d085cf54dd6c8072983fc3a749a8f80cbea2d3bf2aeac3b516f708",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/expected_outputs/schema_compatibility_report.txt",
           "owner": "migration-architect",
-          "sha256": "576e3edb5f9ef7c97d3de16ef8e1da0065f6446013987dd7f136dcbcaa267e62"
+          "sha256": "576e3edb5f9ef7c97d3de16ef8e1da0065f6446013987dd7f136dcbcaa267e62",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/references/data_reconciliation_strategies.md",
           "owner": "migration-architect",
-          "sha256": "aede8a22789a7f21e881f56a996b7bdbd6588d67e73e09b5dc04c40b1b6c25d1"
+          "sha256": "aede8a22789a7f21e881f56a996b7bdbd6588d67e73e09b5dc04c40b1b6c25d1",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/references/migration_patterns_catalog.md",
           "owner": "migration-architect",
-          "sha256": "b7844ddde251f778e718de966047d3b769fe635b9c6e1f2fe99f77956946c338"
+          "sha256": "b7844ddde251f778e718de966047d3b769fe635b9c6e1f2fe99f77956946c338",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/references/zero_downtime_techniques.md",
           "owner": "migration-architect",
-          "sha256": "182d357f6756d1b3053af63627f0e0717b89bfb77e2f8e0d08b657fa55bf6c56"
+          "sha256": "182d357f6756d1b3053af63627f0e0717b89bfb77e2f8e0d08b657fa55bf6c56",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/scripts/compatibility_checker.py",
           "owner": "migration-architect",
-          "sha256": "b78ed4ba2d954f38f5fb5f52ebb1cd9819ca7824f60021ef8d2dfeb89687d565"
+          "sha256": "b78ed4ba2d954f38f5fb5f52ebb1cd9819ca7824f60021ef8d2dfeb89687d565",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/scripts/migration_planner.py",
           "owner": "migration-architect",
-          "sha256": "cc8a1b1042b9e87fb0ad1ab42fb5fead90175b69d34bfa5d14ad025e539d7aaf"
+          "sha256": "cc8a1b1042b9e87fb0ad1ab42fb5fead90175b69d34bfa5d14ad025e539d7aaf",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/migration-architect/scripts/rollback_generator.py",
           "owner": "migration-architect",
-          "sha256": "5ee0ce71dbd4cd8a134ece4e5c282f7ceb860164431ca5138bfa4996eba372eb"
+          "sha256": "5ee0ce71dbd4cd8a134ece4e5c282f7ceb860164431ca5138bfa4996eba372eb",
+          "mode": "100644"
         }
       ]
     },
@@ -11812,7 +12707,8 @@
         {
           "path": "skills/developer-engineering/monorepo-navigator/SKILL.md",
           "owner": "monorepo-navigator",
-          "sha256": "183eed86871c63e7c9ecc7cb31fae53503f17b28e9539ebb0e99a028edf27e8f"
+          "sha256": "183eed86871c63e7c9ecc7cb31fae53503f17b28e9539ebb0e99a028edf27e8f",
+          "mode": "100644"
         }
       ]
     },
@@ -11897,42 +12793,50 @@
         {
           "path": "skills/deployment-platforms/netlify-deploy/LICENSE.txt",
           "owner": "netlify-deploy",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/SKILL.md",
           "owner": "netlify-deploy",
-          "sha256": "61b3aa40783a4cf69c5774a1cdcca444feba5b50d2e8efa6b59fe8626fe9b1db"
+          "sha256": "61b3aa40783a4cf69c5774a1cdcca444feba5b50d2e8efa6b59fe8626fe9b1db",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/agents/openai.yaml",
           "owner": "netlify-deploy",
-          "sha256": "7d3acb1ee5376c98f3366401cd413200a4aab82af48bbe97382565dcdd04870f"
+          "sha256": "7d3acb1ee5376c98f3366401cd413200a4aab82af48bbe97382565dcdd04870f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/assets/netlify-small.svg",
           "owner": "netlify-deploy",
-          "sha256": "a2d9b9b5087c840247eb8e8360120ce9a20780c5470519b7703f49e920f780cd"
+          "sha256": "a2d9b9b5087c840247eb8e8360120ce9a20780c5470519b7703f49e920f780cd",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/assets/netlify.png",
           "owner": "netlify-deploy",
-          "sha256": "ffbeef6d0af29a9c52f84297630f57c2c8ae86c1771458b24ad19795c4811160"
+          "sha256": "ffbeef6d0af29a9c52f84297630f57c2c8ae86c1771458b24ad19795c4811160",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/references/cli-commands.md",
           "owner": "netlify-deploy",
-          "sha256": "a24b08401b8c796e4a58933a71441b3341b61afc840d690d9127b27ab00cfe05"
+          "sha256": "a24b08401b8c796e4a58933a71441b3341b61afc840d690d9127b27ab00cfe05",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/references/deployment-patterns.md",
           "owner": "netlify-deploy",
-          "sha256": "fdb8c3b96fe03099826e4207b4933df3ff97571415f5e283567979bdc86cdc85"
+          "sha256": "fdb8c3b96fe03099826e4207b4933df3ff97571415f5e283567979bdc86cdc85",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/netlify-deploy/references/netlify-toml.md",
           "owner": "netlify-deploy",
-          "sha256": "436ea3c2e0ce04abb34895db993d91b8660423977d9c52a89f2dfa014cad0b9c"
+          "sha256": "436ea3c2e0ce04abb34895db993d91b8660423977d9c52a89f2dfa014cad0b9c",
+          "mode": "100644"
         }
       ]
     },
@@ -12067,92 +12971,110 @@
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/LICENSE.txt",
           "owner": "notion-knowledge-capture",
-          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8"
+          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/SKILL.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "437fbfdc6d1c2dbcaed1407400cedc1ec2859dcccc229f84bcc3a19465684694"
+          "sha256": "437fbfdc6d1c2dbcaed1407400cedc1ec2859dcccc229f84bcc3a19465684694",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/agents/openai.yaml",
           "owner": "notion-knowledge-capture",
-          "sha256": "549a8c26475f190cb1518c960312bab5c5cf43cc3b0693cd67268e82c5f42b3a"
+          "sha256": "549a8c26475f190cb1518c960312bab5c5cf43cc3b0693cd67268e82c5f42b3a",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/assets/notion-small.svg",
           "owner": "notion-knowledge-capture",
-          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81"
+          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/assets/notion.png",
           "owner": "notion-knowledge-capture",
-          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4"
+          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/evaluations/README.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "2d965e000d73b013a0a0ab50802fa53e81efb8a657dba49a3d79ec6562ab3d23"
+          "sha256": "2d965e000d73b013a0a0ab50802fa53e81efb8a657dba49a3d79ec6562ab3d23",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/evaluations/conversation-to-wiki.json",
           "owner": "notion-knowledge-capture",
-          "sha256": "ff08f8d2b7c0634314b70e96cc2f7fa8aa757683dd0652d99d665c678c6c53ba"
+          "sha256": "ff08f8d2b7c0634314b70e96cc2f7fa8aa757683dd0652d99d665c678c6c53ba",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/evaluations/decision-record.json",
           "owner": "notion-knowledge-capture",
-          "sha256": "9f7c3de9390cb57dde8278fa0537bd3f779b4e7066b9a17ec72ec7a108e7ba32"
+          "sha256": "9f7c3de9390cb57dde8278fa0537bd3f779b4e7066b9a17ec72ec7a108e7ba32",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/examples/conversation-to-faq.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "2c78414d86d3d854ba51ff6c88ea5f1315268742816e2d3b13ee6848f1158a73"
+          "sha256": "2c78414d86d3d854ba51ff6c88ea5f1315268742816e2d3b13ee6848f1158a73",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/examples/decision-capture.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "c6fc42d095d842ac55ab1a95322bab7d0146669089e0b0d470f791ad8477b586"
+          "sha256": "c6fc42d095d842ac55ab1a95322bab7d0146669089e0b0d470f791ad8477b586",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/examples/how-to-guide.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "5c13ac240bf07a0575b1295a6c5d7f95d0112702652d92870a9858e3c74033e7"
+          "sha256": "5c13ac240bf07a0575b1295a6c5d7f95d0112702652d92870a9858e3c74033e7",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/database-best-practices.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "72190afe54894b8ef2566d6f6d60fdcfe39822f5a1db02e75c2186c6952ad83c"
+          "sha256": "72190afe54894b8ef2566d6f6d60fdcfe39822f5a1db02e75c2186c6952ad83c",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/decision-log-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "77d23a69b94cecaad520cb84f18b214994fa2c7873b88928f8d13da8b301c773"
+          "sha256": "77d23a69b94cecaad520cb84f18b214994fa2c7873b88928f8d13da8b301c773",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/documentation-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "727f6bb7a341e871ba8afe155f9b261fe6f5ecf7f5ca7a43db3ad646fee7244d"
+          "sha256": "727f6bb7a341e871ba8afe155f9b261fe6f5ecf7f5ca7a43db3ad646fee7244d",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/faq-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "2fedbd91f02df20541fa14372661d82d19e04cb96d261a184a74aff5b90089be"
+          "sha256": "2fedbd91f02df20541fa14372661d82d19e04cb96d261a184a74aff5b90089be",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/how-to-guide-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "a6002d032b0563e0234a4c225226ea6a207b120e69b0c839315c8402813b30e5"
+          "sha256": "a6002d032b0563e0234a4c225226ea6a207b120e69b0c839315c8402813b30e5",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/learning-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "8ceaa72bc7ab944ce1084df6233001c05b65d06ee5913a23caf760f248236e83"
+          "sha256": "8ceaa72bc7ab944ce1084df6233001c05b65d06ee5913a23caf760f248236e83",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture/reference/team-wiki-database.md",
           "owner": "notion-knowledge-capture",
-          "sha256": "b08cfd417d2d61cda223c1d44c199b0a588e35c177f75328681c1b820b6450f8"
+          "sha256": "b08cfd417d2d61cda223c1d44c199b0a588e35c177f75328681c1b820b6450f8",
+          "mode": "100644"
         }
       ]
     },
@@ -12292,97 +13214,116 @@
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/LICENSE.txt",
           "owner": "notion-meeting-intelligence",
-          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8"
+          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/SKILL.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "4d53b6c34f428c680620e23749cac2424996855e8185ba23422fbdde2b913afa"
+          "sha256": "4d53b6c34f428c680620e23749cac2424996855e8185ba23422fbdde2b913afa",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/agents/openai.yaml",
           "owner": "notion-meeting-intelligence",
-          "sha256": "5c7b40b8e174653303dadaa3152dd44d3c0e426c4857f937dc0d11e4ae982453"
+          "sha256": "5c7b40b8e174653303dadaa3152dd44d3c0e426c4857f937dc0d11e4ae982453",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/assets/notion-small.svg",
           "owner": "notion-meeting-intelligence",
-          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81"
+          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/assets/notion.png",
           "owner": "notion-meeting-intelligence",
-          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4"
+          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/evaluations/README.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "0991780b6c2a29a2ef84b8a37f5e3ea0dc898d31118b8968bbfe26680ac73f24"
+          "sha256": "0991780b6c2a29a2ef84b8a37f5e3ea0dc898d31118b8968bbfe26680ac73f24",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/evaluations/decision-meeting-prep.json",
           "owner": "notion-meeting-intelligence",
-          "sha256": "3ba23fc1fc3edfa26e51afff0d92f88f41e93e0f8a20852a19d90cd9354f299a"
+          "sha256": "3ba23fc1fc3edfa26e51afff0d92f88f41e93e0f8a20852a19d90cd9354f299a",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/evaluations/status-meeting-prep.json",
           "owner": "notion-meeting-intelligence",
-          "sha256": "3f7b065f14e68dc1f0d1ffc3720fb0cd32fcf9cdf23365d935338425b2ce4021"
+          "sha256": "3f7b065f14e68dc1f0d1ffc3720fb0cd32fcf9cdf23365d935338425b2ce4021",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/examples/customer-meeting.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "5371f1d9df68454df163ffc28e69ad8f2434ad47c19ebe19099d1aeaea0cc3f5"
+          "sha256": "5371f1d9df68454df163ffc28e69ad8f2434ad47c19ebe19099d1aeaea0cc3f5",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/examples/executive-review.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "e39b93e00564cc7631fcc95ba948f9d6fb94e5a7f23eb6100de6b421bddaa4fc"
+          "sha256": "e39b93e00564cc7631fcc95ba948f9d6fb94e5a7f23eb6100de6b421bddaa4fc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/examples/project-decision.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "511decfaed53dcf8462874a4f6cafe1656dca635fa4bcaf9196a354a3f1a86b5"
+          "sha256": "511decfaed53dcf8462874a4f6cafe1656dca635fa4bcaf9196a354a3f1a86b5",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/examples/sprint-planning.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "e6ad6b8b3ec26b8181ad61c2cb9f91897d023749dd6e57a2c86559c0130f2776"
+          "sha256": "e6ad6b8b3ec26b8181ad61c2cb9f91897d023749dd6e57a2c86559c0130f2776",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/brainstorming-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "4f118f04c8e5eef18f55faf12ecbdb7f8243cd189a4773c98c0d61b822706b14"
+          "sha256": "4f118f04c8e5eef18f55faf12ecbdb7f8243cd189a4773c98c0d61b822706b14",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/decision-meeting-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "f0b46b0f71a2886bd72af7f9b219ece1d68742b5fba6e2a7fe78f9c65f140d98"
+          "sha256": "f0b46b0f71a2886bd72af7f9b219ece1d68742b5fba6e2a7fe78f9c65f140d98",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/one-on-one-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "1c7f328738b5d6139b22e977608b5ef47f3fa45d95211991168efc632a73c7ae"
+          "sha256": "1c7f328738b5d6139b22e977608b5ef47f3fa45d95211991168efc632a73c7ae",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/retrospective-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "b1e18f96323ce83405f25fa24833b3d3e97fbab86e20c99e6ccfb9a826bd354c"
+          "sha256": "b1e18f96323ce83405f25fa24833b3d3e97fbab86e20c99e6ccfb9a826bd354c",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/sprint-planning-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "1eed8455dc48c330eaecd0f79cbd18150973d47b93329826c7ae611a10dece66"
+          "sha256": "1eed8455dc48c330eaecd0f79cbd18150973d47b93329826c7ae611a10dece66",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/status-update-template.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "c5f53adde43d8a9333555ce0e4634b85f4f6a44faa560f3a250c6104eebe4f17"
+          "sha256": "c5f53adde43d8a9333555ce0e4634b85f4f6a44faa560f3a250c6104eebe4f17",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence/reference/template-selection-guide.md",
           "owner": "notion-meeting-intelligence",
-          "sha256": "a29b16db340c153a3a32579b7031809b398ed319210fbea2d29ec424c68d147e"
+          "sha256": "a29b16db340c153a3a32579b7031809b398ed319210fbea2d29ec424c68d147e",
+          "mode": "100644"
         }
       ]
     },
@@ -12542,117 +13483,140 @@
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/LICENSE.txt",
           "owner": "notion-research-documentation",
-          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8"
+          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/SKILL.md",
           "owner": "notion-research-documentation",
-          "sha256": "a134865e4f0a6081d62f3d3aa54274815f8d3989efa3f03da5afbaa1e7a7f619"
+          "sha256": "a134865e4f0a6081d62f3d3aa54274815f8d3989efa3f03da5afbaa1e7a7f619",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/agents/openai.yaml",
           "owner": "notion-research-documentation",
-          "sha256": "4b30833ad6a110f63a7809ee1f11f2154f2301f4ae845d0432208f386d97f3d3"
+          "sha256": "4b30833ad6a110f63a7809ee1f11f2154f2301f4ae845d0432208f386d97f3d3",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/assets/notion-small.svg",
           "owner": "notion-research-documentation",
-          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81"
+          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/assets/notion.png",
           "owner": "notion-research-documentation",
-          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4"
+          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/evaluations/README.md",
           "owner": "notion-research-documentation",
-          "sha256": "3b4e26d61cf17f9357e5a80f90da662f3d858294f69cad5e94c620bf1ce29455"
+          "sha256": "3b4e26d61cf17f9357e5a80f90da662f3d858294f69cad5e94c620bf1ce29455",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/evaluations/basic-research.json",
           "owner": "notion-research-documentation",
-          "sha256": "41077f0746f28d4e6a12d88c6c2a23ceb5590dc448df4ed8c1335165d0ac6bb9"
+          "sha256": "41077f0746f28d4e6a12d88c6c2a23ceb5590dc448df4ed8c1335165d0ac6bb9",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/evaluations/research-to-database.json",
           "owner": "notion-research-documentation",
-          "sha256": "a442c3a60b864f98c2de80bc2e55176773fe31f87feab59b9d1bfd029966496d"
+          "sha256": "a442c3a60b864f98c2de80bc2e55176773fe31f87feab59b9d1bfd029966496d",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/examples/competitor-analysis.md",
           "owner": "notion-research-documentation",
-          "sha256": "e51bf2f471d928c4c908f85c86fba81a1b42ceba468bb46024e33adf5c29e4ca"
+          "sha256": "e51bf2f471d928c4c908f85c86fba81a1b42ceba468bb46024e33adf5c29e4ca",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/examples/market-research.md",
           "owner": "notion-research-documentation",
-          "sha256": "cb4ed96c9763fe2309354a40a7822c4770a7952909c01b890b3962e0e01adc4d"
+          "sha256": "cb4ed96c9763fe2309354a40a7822c4770a7952909c01b890b3962e0e01adc4d",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/examples/technical-investigation.md",
           "owner": "notion-research-documentation",
-          "sha256": "2db3f3a1664e6bff4b196b0e96d76e8048fc641722f570cb156f36aed8e74d85"
+          "sha256": "2db3f3a1664e6bff4b196b0e96d76e8048fc641722f570cb156f36aed8e74d85",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/examples/trip-planning.md",
           "owner": "notion-research-documentation",
-          "sha256": "3e2f7f8fc31fb2244af76a09649b8ecf2691ef737398ddef66d5da6e515c350b"
+          "sha256": "3e2f7f8fc31fb2244af76a09649b8ecf2691ef737398ddef66d5da6e515c350b",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/advanced-search.md",
           "owner": "notion-research-documentation",
-          "sha256": "f9c70a3b731ce76f35aee7caa53888cc8b22dadc17dd0f54cce95933a0cbbe91"
+          "sha256": "f9c70a3b731ce76f35aee7caa53888cc8b22dadc17dd0f54cce95933a0cbbe91",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/citations.md",
           "owner": "notion-research-documentation",
-          "sha256": "fc81043a5220a350ec17d818c43814f0a5fd466c6cbaaf732fc487d21833a5a6"
+          "sha256": "fc81043a5220a350ec17d818c43814f0a5fd466c6cbaaf732fc487d21833a5a6",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/comparison-format.md",
           "owner": "notion-research-documentation",
-          "sha256": "e80f6ca6573d5d776e24454df04b4a038498dcd2aa93d97edb4113cfdbd88851"
+          "sha256": "e80f6ca6573d5d776e24454df04b4a038498dcd2aa93d97edb4113cfdbd88851",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/comparison-template.md",
           "owner": "notion-research-documentation",
-          "sha256": "4c3af7b72a704beb22ab8741e97d26830421dbb5f489fdc53509fdcbe4000f2f"
+          "sha256": "4c3af7b72a704beb22ab8741e97d26830421dbb5f489fdc53509fdcbe4000f2f",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/comprehensive-report-format.md",
           "owner": "notion-research-documentation",
-          "sha256": "956da824ce2e9c5a167dcca8322b18e29c0438ca91109f7e2cbede6785541979"
+          "sha256": "956da824ce2e9c5a167dcca8322b18e29c0438ca91109f7e2cbede6785541979",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/comprehensive-report-template.md",
           "owner": "notion-research-documentation",
-          "sha256": "043096d757ab5cb681c8e0abc3783663dbc5afe544012f8a9a230b0c31d62882"
+          "sha256": "043096d757ab5cb681c8e0abc3783663dbc5afe544012f8a9a230b0c31d62882",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/format-selection-guide.md",
           "owner": "notion-research-documentation",
-          "sha256": "6280f5219e141b3e284fbe47e550a1bed1831de044eb0b1b145b43ac86f38133"
+          "sha256": "6280f5219e141b3e284fbe47e550a1bed1831de044eb0b1b145b43ac86f38133",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/quick-brief-format.md",
           "owner": "notion-research-documentation",
-          "sha256": "de02fca650fb676db4e2dd5772c9393b91fc9467edc2d4e33ca57df7ccd58d13"
+          "sha256": "de02fca650fb676db4e2dd5772c9393b91fc9467edc2d4e33ca57df7ccd58d13",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/quick-brief-template.md",
           "owner": "notion-research-documentation",
-          "sha256": "280912ecdb1c1543038a883d6341587aa8afc8f699952b7449e314dbe68c9243"
+          "sha256": "280912ecdb1c1543038a883d6341587aa8afc8f699952b7449e314dbe68c9243",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/research-summary-format.md",
           "owner": "notion-research-documentation",
-          "sha256": "29308d84318a717c8f8550bbfaded1826d4f7372f658c68638380d6a2b58f89b"
+          "sha256": "29308d84318a717c8f8550bbfaded1826d4f7372f658c68638380d6a2b58f89b",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-research-documentation/reference/research-summary-template.md",
           "owner": "notion-research-documentation",
-          "sha256": "c1e704d6b28b4414fd8d37b07095859704e34ce92041fa872b15e53da15dfa2a"
+          "sha256": "c1e704d6b28b4414fd8d37b07095859704e34ce92041fa872b15e53da15dfa2a",
+          "mode": "100644"
         }
       ]
     },
@@ -12792,97 +13756,116 @@
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/LICENSE.txt",
           "owner": "notion-spec-to-implementation",
-          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8"
+          "sha256": "0f377d9b2a1db642e4b0531ffa126e96d9bc6c085f8d9441f220fb25f723c6f8",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/SKILL.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "9a98edca0bfa49486bf71dcf57e1c9bd4303e324a0893a74c67f89c89708efd6"
+          "sha256": "9a98edca0bfa49486bf71dcf57e1c9bd4303e324a0893a74c67f89c89708efd6",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/agents/openai.yaml",
           "owner": "notion-spec-to-implementation",
-          "sha256": "1e4ba970e5e4b0e1fbbea6f1c3795a70e38d9c670c5a652c932b2d04982ca377"
+          "sha256": "1e4ba970e5e4b0e1fbbea6f1c3795a70e38d9c670c5a652c932b2d04982ca377",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/assets/notion-small.svg",
           "owner": "notion-spec-to-implementation",
-          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81"
+          "sha256": "00f5e4b758cc5c3e36e783dca2fabfafd05169c2f2175063e56d2e1fb6a55f81",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/assets/notion.png",
           "owner": "notion-spec-to-implementation",
-          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4"
+          "sha256": "5eef1e62d96a3d09bc9d18e4140486c22799145b017033bd0924c2c49d741cd4",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/evaluations/README.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "5fdf4830a9b4889b55f1636675d2d26161945530298b6a34a19f4c7f7fc9cc0f"
+          "sha256": "5fdf4830a9b4889b55f1636675d2d26161945530298b6a34a19f4c7f7fc9cc0f",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/evaluations/basic-spec-implementation.json",
           "owner": "notion-spec-to-implementation",
-          "sha256": "0b1aa05f74e3e3503b4faaa0263cbbb1142d679140322682bc2dba6148648b50"
+          "sha256": "0b1aa05f74e3e3503b4faaa0263cbbb1142d679140322682bc2dba6148648b50",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/evaluations/spec-to-tasks.json",
           "owner": "notion-spec-to-implementation",
-          "sha256": "fea35f66e20c8f1f918815ef13d77f8ee85a3a86d8902c0d0b7d1cfbdb19cf45"
+          "sha256": "fea35f66e20c8f1f918815ef13d77f8ee85a3a86d8902c0d0b7d1cfbdb19cf45",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/examples/api-feature.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "5ac3e41507ad34c1a18d3c964a431c464fdaa1593bda96e5cf00b169a4ee46c6"
+          "sha256": "5ac3e41507ad34c1a18d3c964a431c464fdaa1593bda96e5cf00b169a4ee46c6",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/examples/database-migration.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "575ef697c6c9c55add54b43714460adb3bfa8aa2bec3ecbebd7e16757be511d3"
+          "sha256": "575ef697c6c9c55add54b43714460adb3bfa8aa2bec3ecbebd7e16757be511d3",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/examples/ui-component.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "5fa8788e1f3fd53e00729065cb574cf46db3bd866d254f108b91b41a08318307"
+          "sha256": "5fa8788e1f3fd53e00729065cb574cf46db3bd866d254f108b91b41a08318307",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/milestone-summary-template.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "52bebb1e531a69a85b5f9764e27b0129dbed1258e34669ae7b26d8bb6d536efe"
+          "sha256": "52bebb1e531a69a85b5f9764e27b0129dbed1258e34669ae7b26d8bb6d536efe",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/progress-tracking.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "1aefc791440c61e26169cc955d7e4e08699e3cc8c3f506d4a8a9be684be90447"
+          "sha256": "1aefc791440c61e26169cc955d7e4e08699e3cc8c3f506d4a8a9be684be90447",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/progress-update-template.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "649ff810bc8b14b91df74b2506a11f2837a64a9880010466b6ce6d532967bb9a"
+          "sha256": "649ff810bc8b14b91df74b2506a11f2837a64a9880010466b6ce6d532967bb9a",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/quick-implementation-plan.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "7e19f4aafe8b5312825624247f7cced405482718f67ece9d8f88a4bdbf323055"
+          "sha256": "7e19f4aafe8b5312825624247f7cced405482718f67ece9d8f88a4bdbf323055",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/spec-parsing.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "e978a605c45b13001bb68850b635d87be694e79b415d766aa6975a0c3068f5ee"
+          "sha256": "e978a605c45b13001bb68850b635d87be694e79b415d766aa6975a0c3068f5ee",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/standard-implementation-plan.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "98405060e286d0d60140648996d757cc102abb588ae2eaaaabf0a99e93530a15"
+          "sha256": "98405060e286d0d60140648996d757cc102abb588ae2eaaaabf0a99e93530a15",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/task-creation-template.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "010a9a3b1d95633220bb93ffcab5f2f49e897c5d4e4231940d691719bec1be34"
+          "sha256": "010a9a3b1d95633220bb93ffcab5f2f49e897c5d4e4231940d691719bec1be34",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation/reference/task-creation.md",
           "owner": "notion-spec-to-implementation",
-          "sha256": "60a2eb24530097b7c4011582bb3954576655a30c0c95e9a8a12ff6a19aee3a26"
+          "sha256": "60a2eb24530097b7c4011582bb3954576655a30c0c95e9a8a12ff6a19aee3a26",
+          "mode": "100644"
         }
       ]
     },
@@ -12992,67 +13975,80 @@
         {
           "path": "skills/devops-sre/observability-designer/README.md",
           "owner": "observability-designer",
-          "sha256": "3f8de7f4215e895d48af660bc964f301315e38f9463014b2bd72f3a63283d422"
+          "sha256": "3f8de7f4215e895d48af660bc964f301315e38f9463014b2bd72f3a63283d422",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/SKILL.md",
           "owner": "observability-designer",
-          "sha256": "3c369da945cd62a06dc1eb58f7b0d07ae9d7fa4bcfb4963f0c96374dbf21f17f"
+          "sha256": "3c369da945cd62a06dc1eb58f7b0d07ae9d7fa4bcfb4963f0c96374dbf21f17f",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/assets/sample_alerts.json",
           "owner": "observability-designer",
-          "sha256": "0426a8d9e2624d6f991b336473129c80994fc3f08396f9379b418c78b6698314"
+          "sha256": "0426a8d9e2624d6f991b336473129c80994fc3f08396f9379b418c78b6698314",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/assets/sample_service_api.json",
           "owner": "observability-designer",
-          "sha256": "3385253b70d962f096651d43081449b0789ad6091c78c12902db3f3326b3cf96"
+          "sha256": "3385253b70d962f096651d43081449b0789ad6091c78c12902db3f3326b3cf96",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/assets/sample_service_web.json",
           "owner": "observability-designer",
-          "sha256": "75a72079afcde60b93dc79bfb9a38803002289d17112dec26ffb4e516f31ecc8"
+          "sha256": "75a72079afcde60b93dc79bfb9a38803002289d17112dec26ffb4e516f31ecc8",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/expected_outputs/sample_dashboard.json",
           "owner": "observability-designer",
-          "sha256": "6ab204632adc8e20fa940d15d7e1220077aa2aa9d168ceae26fb80c43176071b"
+          "sha256": "6ab204632adc8e20fa940d15d7e1220077aa2aa9d168ceae26fb80c43176071b",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/expected_outputs/sample_slo_framework.json",
           "owner": "observability-designer",
-          "sha256": "b090ae487fadb65f5040675e88ca2dfbaab7772cc8e43eafac7b8a80be961405"
+          "sha256": "b090ae487fadb65f5040675e88ca2dfbaab7772cc8e43eafac7b8a80be961405",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/references/alert_design_patterns.md",
           "owner": "observability-designer",
-          "sha256": "257b29ca6bf9acc7535d1222e7ffd1455710a34862e1a75e19943473672d6382"
+          "sha256": "257b29ca6bf9acc7535d1222e7ffd1455710a34862e1a75e19943473672d6382",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/references/dashboard_best_practices.md",
           "owner": "observability-designer",
-          "sha256": "b9215f45b7fe10912532e4302ed960e4554d85678ca0a7603ef7c8a06b6726d6"
+          "sha256": "b9215f45b7fe10912532e4302ed960e4554d85678ca0a7603ef7c8a06b6726d6",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/references/slo_cookbook.md",
           "owner": "observability-designer",
-          "sha256": "6fca3afda3ba7f0dcf1e3184ccf6f1f01e938d59deca7ba873a7540a099efa77"
+          "sha256": "6fca3afda3ba7f0dcf1e3184ccf6f1f01e938d59deca7ba873a7540a099efa77",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/scripts/alert_optimizer.py",
           "owner": "observability-designer",
-          "sha256": "d2d5b3ae98906c0df1a7868f4c058dc0341a3341437e1c5f0d69f942e5b75f70"
+          "sha256": "d2d5b3ae98906c0df1a7868f4c058dc0341a3341437e1c5f0d69f942e5b75f70",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/scripts/dashboard_generator.py",
           "owner": "observability-designer",
-          "sha256": "7886f4f797e00a7e008d252ac802edc558b3adaaec3a7834e2d1b8f3a5045cd5"
+          "sha256": "7886f4f797e00a7e008d252ac802edc558b3adaaec3a7834e2d1b8f3a5045cd5",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/observability-designer/scripts/slo_designer.py",
           "owner": "observability-designer",
-          "sha256": "724e7c97db3b0f466219a92401a65189b1a4d43fe9aaf49cc51260e3f7929a12"
+          "sha256": "724e7c97db3b0f466219a92401a65189b1a4d43fe9aaf49cc51260e3f7929a12",
+          "mode": "100644"
         }
       ]
     },
@@ -13122,27 +14118,32 @@
         {
           "path": "skills/ai-agent-platform/openai-docs/LICENSE.txt",
           "owner": "openai-docs",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/openai-docs/SKILL.md",
           "owner": "openai-docs",
-          "sha256": "31d4ef364682fe9d0b959d1d9dc0b5d5bafc2a613743f5b82ffefdbaef5a211c"
+          "sha256": "31d4ef364682fe9d0b959d1d9dc0b5d5bafc2a613743f5b82ffefdbaef5a211c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/openai-docs/agents/openai.yaml",
           "owner": "openai-docs",
-          "sha256": "a2049be7cc970cc0148509e5a262793dab45e2eca56b31cac1723d6bb6e6a805"
+          "sha256": "a2049be7cc970cc0148509e5a262793dab45e2eca56b31cac1723d6bb6e6a805",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/openai-docs/assets/openai-small.svg",
           "owner": "openai-docs",
-          "sha256": "45be1f0757eb18889eefb1e7db79668ef46a275dc4e0e78e8df5ebd7f6cdeadc"
+          "sha256": "45be1f0757eb18889eefb1e7db79668ef46a275dc4e0e78e8df5ebd7f6cdeadc",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/openai-docs/assets/openai.png",
           "owner": "openai-docs",
-          "sha256": "156cc84d7332bfe95b310350bd470b690d22aa33d65340cc6c2e06022946194c"
+          "sha256": "156cc84d7332bfe95b310350bd470b690d22aa33d65340cc6c2e06022946194c",
+          "mode": "100644"
         }
       ]
     },
@@ -13207,22 +14208,26 @@
         {
           "path": "skills/finance-investing/options-strategy-evaluator/SKILL.md",
           "owner": "options-strategy-evaluator",
-          "sha256": "f659c789d3dfabf16998f9e8047e89abaf8d6fe209e657c660997a594c9d38d6"
+          "sha256": "f659c789d3dfabf16998f9e8047e89abaf8d6fe209e657c660997a594c9d38d6",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/options-strategy-evaluator/assets/sample_options_strategy.json",
           "owner": "options-strategy-evaluator",
-          "sha256": "555b0ca359b6dcda1cd3fedf48c7a9f6b691a8809e4ab254fc7dc5c9e9859a99"
+          "sha256": "555b0ca359b6dcda1cd3fedf48c7a9f6b691a8809e4ab254fc7dc5c9e9859a99",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/options-strategy-evaluator/references/options-review-checklist.md",
           "owner": "options-strategy-evaluator",
-          "sha256": "a3fd235fc008e1f2ed7b6745f0ee0735069c21debfdc89ef50ea243e15fd02a5"
+          "sha256": "a3fd235fc008e1f2ed7b6745f0ee0735069c21debfdc89ef50ea243e15fd02a5",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/options-strategy-evaluator/scripts/evaluate_strategy.py",
           "owner": "options-strategy-evaluator",
-          "sha256": "032a008d105fc62013eee2045e9adaeb8d91250cbcb6c8a142d3d17cd3d0dff9"
+          "sha256": "032a008d105fc62013eee2045e9adaeb8d91250cbcb6c8a142d3d17cd3d0dff9",
+          "mode": "100644"
         }
       ]
     },
@@ -13272,7 +14277,8 @@
         {
           "path": "skills/security-and-reliability/osv-scanner/SKILL.md",
           "owner": "osv-scanner",
-          "sha256": "27144186eed821b292fe0f5d898634fa4e32960a2d03f1ba4e190932b56e77b3"
+          "sha256": "27144186eed821b292fe0f5d898634fa4e32960a2d03f1ba4e190932b56e77b3",
+          "mode": "100644"
         }
       ]
     },
@@ -13387,72 +14393,86 @@
         {
           "path": "skills/office-white-collar/pdf/LICENSE.txt",
           "owner": "pdf",
-          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa"
+          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/SKILL.md",
           "owner": "pdf",
-          "sha256": "134ee6643f4ffd76249aa30cb50e7aa0409daaee40370050d0498df2c897da9c"
+          "sha256": "134ee6643f4ffd76249aa30cb50e7aa0409daaee40370050d0498df2c897da9c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/forms.md",
           "owner": "pdf",
-          "sha256": "9530b3f57034792e0242a3abfe8b3c296466329551916f2ff6c5a70db78f7e44"
+          "sha256": "9530b3f57034792e0242a3abfe8b3c296466329551916f2ff6c5a70db78f7e44",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/reference.md",
           "owner": "pdf",
-          "sha256": "03a5f964f8abecbbe156f363356e927e864d7ee964f1012c84ee1bfc8acbeb95"
+          "sha256": "03a5f964f8abecbbe156f363356e927e864d7ee964f1012c84ee1bfc8acbeb95",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/batch_convert.py",
           "owner": "pdf",
-          "sha256": "2e3cd0323a503b3807385a66eb658fcc09b918e72206cc354b91a0c8d35631ae"
+          "sha256": "2e3cd0323a503b3807385a66eb658fcc09b918e72206cc354b91a0c8d35631ae",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/check_bounding_boxes.py",
           "owner": "pdf",
-          "sha256": "0ced522402dd7b3c82a0be9518cf4e485fa9cc0467d7beab6ddb04cb36fcc3e1"
+          "sha256": "0ced522402dd7b3c82a0be9518cf4e485fa9cc0467d7beab6ddb04cb36fcc3e1",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/check_fillable_fields.py",
           "owner": "pdf",
-          "sha256": "1fe10b9980a5493c9bbec8c20630c603eaa475b45403751c08f26738736647b8"
+          "sha256": "1fe10b9980a5493c9bbec8c20630c603eaa475b45403751c08f26738736647b8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/convert_pdf_to_images.py",
           "owner": "pdf",
-          "sha256": "7f58e292a67e18a8ff000d30bad2469389546731f7e8a698cc1d0aed001ea15d"
+          "sha256": "7f58e292a67e18a8ff000d30bad2469389546731f7e8a698cc1d0aed001ea15d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/create_validation_image.py",
           "owner": "pdf",
-          "sha256": "8fa9fd7962c9f940045b81cf6b991e7c1057c1838e3f9cc6d305007a222ffebf"
+          "sha256": "8fa9fd7962c9f940045b81cf6b991e7c1057c1838e3f9cc6d305007a222ffebf",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/extract_form_field_info.py",
           "owner": "pdf",
-          "sha256": "bb235b36f497bbb1c7c6821cecf527bbba7213520de11219da99f7b13a38c109"
+          "sha256": "bb235b36f497bbb1c7c6821cecf527bbba7213520de11219da99f7b13a38c109",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/extract_form_structure.py",
           "owner": "pdf",
-          "sha256": "6814e3fe8f78c2b16d766c132b5a727ff7a31b71d76a7d46bd6e40fe50bc97c5"
+          "sha256": "6814e3fe8f78c2b16d766c132b5a727ff7a31b71d76a7d46bd6e40fe50bc97c5",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/fill_fillable_fields.py",
           "owner": "pdf",
-          "sha256": "d140872c2e92e41b1e05370ae8d270c5b7f5ebdf55d9905f03bc974a9c708ff5"
+          "sha256": "d140872c2e92e41b1e05370ae8d270c5b7f5ebdf55d9905f03bc974a9c708ff5",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/fill_pdf_form_with_annotations.py",
           "owner": "pdf",
-          "sha256": "8a56e063a49ed53c0b0e1d312ecf8023af76816ed139486ec3b539873de202fd"
+          "sha256": "8a56e063a49ed53c0b0e1d312ecf8023af76816ed139486ec3b539873de202fd",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pdf/scripts/md_to_pdf.py",
           "owner": "pdf",
-          "sha256": "c033742d4e120a947e93cde5fd9ac7d4b7a2abb39111cf6a5d1b6bbe9e275751"
+          "sha256": "c033742d4e120a947e93cde5fd9ac7d4b7a2abb39111cf6a5d1b6bbe9e275751",
+          "mode": "100644"
         }
       ]
     },
@@ -13502,7 +14522,8 @@
         {
           "path": "skills/developer-engineering/performance-profiler/SKILL.md",
           "owner": "performance-profiler",
-          "sha256": "efbfd0c28a68479ffd7567e7a3779f5c20831055de7a0243073d5398712ef029"
+          "sha256": "efbfd0c28a68479ffd7567e7a3779f5c20831055de7a0243073d5398712ef029",
+          "mode": "100644"
         }
       ]
     },
@@ -13592,47 +14613,56 @@
         {
           "path": "skills/engineering-workflow-automation/playwright/LICENSE.txt",
           "owner": "playwright",
-          "sha256": "c16f8dcf1a368b83be78d826ea23de4079fe1b4469a0ab9ee20563f37ff3d44b"
+          "sha256": "c16f8dcf1a368b83be78d826ea23de4079fe1b4469a0ab9ee20563f37ff3d44b",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/NOTICE.txt",
           "owner": "playwright",
-          "sha256": "417d5d3372914ecfd9fe102ac1d7dc2119253209f9718d6c222f616876c1904b"
+          "sha256": "417d5d3372914ecfd9fe102ac1d7dc2119253209f9718d6c222f616876c1904b",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/SKILL.md",
           "owner": "playwright",
-          "sha256": "6215b59eff5b77ba1b61174a3b37df64d16da6276d0bd8c76e1e43345fb1ca72"
+          "sha256": "6215b59eff5b77ba1b61174a3b37df64d16da6276d0bd8c76e1e43345fb1ca72",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/agents/openai.yaml",
           "owner": "playwright",
-          "sha256": "ddda43720fc566fffa45264be8f17f7745a3cee28d5245d41d3b963bc9967230"
+          "sha256": "ddda43720fc566fffa45264be8f17f7745a3cee28d5245d41d3b963bc9967230",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/assets/playwright-small.svg",
           "owner": "playwright",
-          "sha256": "f1d213c0f76735d8272c3d3e9fbf71fe7b894e2d1588907044c780f2c33a9732"
+          "sha256": "f1d213c0f76735d8272c3d3e9fbf71fe7b894e2d1588907044c780f2c33a9732",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/assets/playwright.png",
           "owner": "playwright",
-          "sha256": "521669f088c838196c6c852ccc9abdd7234d8f37fc9a8a7a9af7db2d50193381"
+          "sha256": "521669f088c838196c6c852ccc9abdd7234d8f37fc9a8a7a9af7db2d50193381",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/references/cli.md",
           "owner": "playwright",
-          "sha256": "7c069a8206ba20b9ddbdc42436b04de30bb3aa4a825ba98680757ee62e954900"
+          "sha256": "7c069a8206ba20b9ddbdc42436b04de30bb3aa4a825ba98680757ee62e954900",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/references/workflows.md",
           "owner": "playwright",
-          "sha256": "a2b5835a00ebee3906c146adf7f764f7718ea3f89a8702d86eaa135dfe0fc8c2"
+          "sha256": "a2b5835a00ebee3906c146adf7f764f7718ea3f89a8702d86eaa135dfe0fc8c2",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/playwright/scripts/playwright_cli.sh",
           "owner": "playwright",
-          "sha256": "aa3fdff5d0e4556177f4dfd5f04117e772aa54f94b6a2e34b6c0edf629c6b9b5"
+          "sha256": "aa3fdff5d0e4556177f4dfd5f04117e772aa54f94b6a2e34b6c0edf629c6b9b5",
+          "mode": "100644"
         }
       ]
     },
@@ -13682,7 +14712,8 @@
         {
           "path": "skills/engineering-workflow-automation/playwright-pro/SKILL.md",
           "owner": "playwright-pro",
-          "sha256": "9612c0614e151c581982b6c141300f11703848fc6fe481cc8838d6b40ea60b27"
+          "sha256": "9612c0614e151c581982b6c141300f11703848fc6fe481cc8838d6b40ea60b27",
+          "mode": "100644"
         }
       ]
     },
@@ -13762,37 +14793,44 @@
         {
           "path": "skills/finance-investing/portfolio-risk-manager/SKILL.md",
           "owner": "portfolio-risk-manager",
-          "sha256": "907d765cddf3cbb762180b3bbc4dea030050526620dfa6422da9a83762a6a452"
+          "sha256": "907d765cddf3cbb762180b3bbc4dea030050526620dfa6422da9a83762a6a452",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/assets/sample_portfolio.json",
           "owner": "portfolio-risk-manager",
-          "sha256": "47125fe50013a44601e03a66015a9396cb1f1875181a93bf567bbb737146ed7c"
+          "sha256": "47125fe50013a44601e03a66015a9396cb1f1875181a93bf567bbb737146ed7c",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/assets/sample_returns.json",
           "owner": "portfolio-risk-manager",
-          "sha256": "22c9739d4efbcdd5bd583e31659c846cfbb64d562129cfa6af68297ad020dd28"
+          "sha256": "22c9739d4efbcdd5bd583e31659c846cfbb64d562129cfa6af68297ad020dd28",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/references/low-dependency-portfolio-workflow.md",
           "owner": "portfolio-risk-manager",
-          "sha256": "0020cefef421b206ac212de60dfac77734c34957f904f840c8c2fee6879ab766"
+          "sha256": "0020cefef421b206ac212de60dfac77734c34957f904f840c8c2fee6879ab766",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/references/risk-metrics.md",
           "owner": "portfolio-risk-manager",
-          "sha256": "7efaa12ad60ffeaf05eeeb29d19961a0f5676bf97801a2cd4b817807b80f298b"
+          "sha256": "7efaa12ad60ffeaf05eeeb29d19961a0f5676bf97801a2cd4b817807b80f298b",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/scripts/build_optimizer_inputs.py",
           "owner": "portfolio-risk-manager",
-          "sha256": "75c7da3a078fc7bbed7c4cd2660e87ff600788bf4675fc5c0d6d3f8604db32e4"
+          "sha256": "75c7da3a078fc7bbed7c4cd2660e87ff600788bf4675fc5c0d6d3f8604db32e4",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/portfolio-risk-manager/scripts/portfolio_risk.py",
           "owner": "portfolio-risk-manager",
-          "sha256": "7468c87a097e8a1d29a6193c00bb58aa19298e37bca57d063bef40c07c1cc655"
+          "sha256": "7468c87a097e8a1d29a6193c00bb58aa19298e37bca57d063bef40c07c1cc655",
+          "mode": "100644"
         }
       ]
     },
@@ -14192,357 +15230,428 @@
         {
           "path": "skills/office-white-collar/pptx/LICENSE.txt",
           "owner": "pptx",
-          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa"
+          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/SKILL.md",
           "owner": "pptx",
-          "sha256": "5827504de73d23ca69917ec72b3fc8e7bf2f81cbecd69400449884c385703e77"
+          "sha256": "5827504de73d23ca69917ec72b3fc8e7bf2f81cbecd69400449884c385703e77",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/editing.md",
           "owner": "pptx",
-          "sha256": "6cb47c3ab17e60b7de37e83131c409ef5a90a01bfb54e999905a9c9f7dd88e68"
+          "sha256": "6cb47c3ab17e60b7de37e83131c409ef5a90a01bfb54e999905a9c9f7dd88e68",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/pptxgenjs.md",
           "owner": "pptx",
-          "sha256": "9539534d92b7170813b735a448750df3580390da2da6c52a02b687ed53ecba86"
+          "sha256": "9539534d92b7170813b735a448750df3580390da2da6c52a02b687ed53ecba86",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/CHECKLIST.md",
           "owner": "pptx",
-          "sha256": "161040739ede3e7ffafc55ef47d534c4e6fad8dcb4c0be4ffce51d65cd3bfcf0"
+          "sha256": "161040739ede3e7ffafc55ef47d534c4e6fad8dcb4c0be4ffce51d65cd3bfcf0",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/EXAMPLES.md",
           "owner": "pptx",
-          "sha256": "cdc8c2907fd40758c58dbb062020b2ec5390f3064fa36265414aa8fd665cd7e4"
+          "sha256": "cdc8c2907fd40758c58dbb062020b2ec5390f3064fa36265414aa8fd665cd7e4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/INTAKE.md",
           "owner": "pptx",
-          "sha256": "eefe736993205ce29c5d111726101d0639760d00f4ac388af89a3b06b528f608"
+          "sha256": "eefe736993205ce29c5d111726101d0639760d00f4ac388af89a3b06b528f608",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/ORCHESTRATION_DATA_CHARTS.md",
           "owner": "pptx",
-          "sha256": "935a8d29a8e4380d66a450d9dd9ef57bee2694f01e3b4bb7d46e27c0c02c1f25"
+          "sha256": "935a8d29a8e4380d66a450d9dd9ef57bee2694f01e3b4bb7d46e27c0c02c1f25",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/ORCHESTRATION_OVERVIEW.md",
           "owner": "pptx",
-          "sha256": "57d6100ef313c061c3e94f55591585565309c6e66a306e26309a8c979b1b242c"
+          "sha256": "57d6100ef313c061c3e94f55591585565309c6e66a306e26309a8c979b1b242c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/ORCHESTRATION_PPTX.md",
           "owner": "pptx",
-          "sha256": "862476456ad35039eda92b0d2c6483ded5fa4062cd58a1e65fdca44ad28c336e"
+          "sha256": "862476456ad35039eda92b0d2c6483ded5fa4062cd58a1e65fdca44ad28c336e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/RUBRIC.md",
           "owner": "pptx",
-          "sha256": "f627a24e4fe986d77a602ec14c31c63ad09fded41274e9d120ee999ff3d6f7bf"
+          "sha256": "f627a24e4fe986d77a602ec14c31c63ad09fded41274e9d120ee999ff3d6f7bf",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/STYLE-GUIDE.md",
           "owner": "pptx",
-          "sha256": "2128ec5d4e0cd5d5d094186d72ccb4c6dcbf1baa188b3e938720446577b3728c"
+          "sha256": "2128ec5d4e0cd5d5d094186d72ccb4c6dcbf1baa188b3e938720446577b3728c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/TEMPLATES.md",
           "owner": "pptx",
-          "sha256": "f997afda13f49003e6424e7caa97fe40c4ddef0de27dc716f9b6885f48d3a42c"
+          "sha256": "f997afda13f49003e6424e7caa97fe40c4ddef0de27dc716f9b6885f48d3a42c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/VIS-GUIDE.md",
           "owner": "pptx",
-          "sha256": "73fbcda7b4f61960e318c69e9449a7b1c90a82b09a78e28a3bc40f8a318fe3bb"
+          "sha256": "73fbcda7b4f61960e318c69e9449a7b1c90a82b09a78e28a3bc40f8a318fe3bb",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/references/creator-workflow/WORKFLOW.md",
           "owner": "pptx",
-          "sha256": "93304c3c0c6796ca3799b172d171e2bb3c6ff512e22f4b7dce60d1a1703f157c"
+          "sha256": "93304c3c0c6796ca3799b172d171e2bb3c6ff512e22f4b7dce60d1a1703f157c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/__init__.py",
           "owner": "pptx",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/add_slide.py",
           "owner": "pptx",
-          "sha256": "04233ba3932c6b8611677347891616456e243cc09b7f9769408b8c83d9acfe64"
+          "sha256": "04233ba3932c6b8611677347891616456e243cc09b7f9769408b8c83d9acfe64",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/chartkit.py",
           "owner": "pptx",
-          "sha256": "b4c19cc55d1976b0b05279c44e90e98444d1f468e416177bcf9bb560d50b9709"
+          "sha256": "b4c19cc55d1976b0b05279c44e90e98444d1f468e416177bcf9bb560d50b9709",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/clean.py",
           "owner": "pptx",
-          "sha256": "3e3966a17f488a1ddc7145f0b7ec9f25595afa1f3a427ab05e610f1a328feea9"
+          "sha256": "3e3966a17f488a1ddc7145f0b7ec9f25595afa1f3a427ab05e610f1a328feea9",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/helpers/__init__.py",
           "owner": "pptx",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/helpers/merge_runs.py",
           "owner": "pptx",
-          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7"
+          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/helpers/simplify_redlines.py",
           "owner": "pptx",
-          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896"
+          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/pack.py",
           "owner": "pptx",
-          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683"
+          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd",
           "owner": "pptx",
-          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354"
+          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd",
           "owner": "pptx",
-          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412"
+          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd",
           "owner": "pptx",
-          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40"
+          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd",
           "owner": "pptx",
-          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026"
+          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd",
           "owner": "pptx",
-          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9"
+          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd",
           "owner": "pptx",
-          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c"
+          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd",
           "owner": "pptx",
-          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88"
+          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd",
           "owner": "pptx",
-          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614"
+          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd",
           "owner": "pptx",
-          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff"
+          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd",
           "owner": "pptx",
-          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8"
+          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd",
           "owner": "pptx",
-          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2"
+          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd",
           "owner": "pptx",
-          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece"
+          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd",
           "owner": "pptx",
-          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281"
+          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd",
           "owner": "pptx",
-          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4"
+          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd",
           "owner": "pptx",
-          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285"
+          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd",
           "owner": "pptx",
-          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368"
+          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd",
           "owner": "pptx",
-          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b"
+          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd",
           "owner": "pptx",
-          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a"
+          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd",
           "owner": "pptx",
-          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637"
+          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd",
           "owner": "pptx",
-          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578"
+          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd",
           "owner": "pptx",
-          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763"
+          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd",
           "owner": "pptx",
-          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155"
+          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd",
           "owner": "pptx",
-          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e"
+          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd",
           "owner": "pptx",
-          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519"
+          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd",
           "owner": "pptx",
-          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831"
+          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd",
           "owner": "pptx",
-          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd"
+          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd",
           "owner": "pptx",
-          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2"
+          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd",
           "owner": "pptx",
-          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a"
+          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd",
           "owner": "pptx",
-          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8"
+          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd",
           "owner": "pptx",
-          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24"
+          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd",
           "owner": "pptx",
-          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26"
+          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/mce/mc.xsd",
           "owner": "pptx",
-          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413"
+          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-2010.xsd",
           "owner": "pptx",
-          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2"
+          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-2012.xsd",
           "owner": "pptx",
-          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74"
+          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-2018.xsd",
           "owner": "pptx",
-          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad"
+          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-cex-2018.xsd",
           "owner": "pptx",
-          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081"
+          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-cid-2016.xsd",
           "owner": "pptx",
-          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d"
+          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd",
           "owner": "pptx",
-          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604"
+          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/schemas/microsoft/wml-symex-2015.xsd",
           "owner": "pptx",
-          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b"
+          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/soffice.py",
           "owner": "pptx",
-          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0"
+          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/unpack.py",
           "owner": "pptx",
-          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62"
+          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validate.py",
           "owner": "pptx",
-          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514"
+          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validators/__init__.py",
           "owner": "pptx",
-          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987"
+          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validators/base.py",
           "owner": "pptx",
-          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25"
+          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validators/docx.py",
           "owner": "pptx",
-          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345"
+          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validators/pptx.py",
           "owner": "pptx",
-          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc"
+          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/office/validators/redlining.py",
           "owner": "pptx",
-          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40"
+          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/pptx/scripts/thumbnail.py",
           "owner": "pptx",
-          "sha256": "e959ecd4f19735161218bc44d0648a46da17874323fb3e19c2e9cb50cefe6ce7"
+          "sha256": "e959ecd4f19735161218bc44d0648a46da17874323fb3e19c2e9cb50cefe6ce7",
+          "mode": "100644"
         }
       ]
     },
@@ -14592,7 +15701,8 @@
         {
           "path": "skills/developer-engineering/pr-review-expert/SKILL.md",
           "owner": "pr-review-expert",
-          "sha256": "0ddc10937e9465e16ce36e44ac02e3850a07f5e5b61870589891ed96025c1698"
+          "sha256": "0ddc10937e9465e16ce36e44ac02e3850a07f5e5b61870589891ed96025c1698",
+          "mode": "100644"
         }
       ]
     },
@@ -14662,27 +15772,32 @@
         {
           "path": "skills/product-design/product-manager-toolkit/SKILL.md",
           "owner": "product-manager-toolkit",
-          "sha256": "da9a3c5f8919e22b5d5a33722fd605918a5f5475c79f1f63e049a6b404624c5e"
+          "sha256": "da9a3c5f8919e22b5d5a33722fd605918a5f5475c79f1f63e049a6b404624c5e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-manager-toolkit/references/frameworks.md",
           "owner": "product-manager-toolkit",
-          "sha256": "6ce2eb6a15bc67040d16fdd4bcc0f2ef3c37f384d19b7dcdfa2065c7f4ee324d"
+          "sha256": "6ce2eb6a15bc67040d16fdd4bcc0f2ef3c37f384d19b7dcdfa2065c7f4ee324d",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-manager-toolkit/references/prd_templates.md",
           "owner": "product-manager-toolkit",
-          "sha256": "cd0d50ea82142ad801e2cd5a9c1a7ce88ce024259df7da15923b9d6bf2d3c85d"
+          "sha256": "cd0d50ea82142ad801e2cd5a9c1a7ce88ce024259df7da15923b9d6bf2d3c85d",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-manager-toolkit/scripts/customer_interview_analyzer.py",
           "owner": "product-manager-toolkit",
-          "sha256": "eedd2a80d9f444c375cb3b7cebca5b25b2ffa83927661a6a3b981dac13c9e67e"
+          "sha256": "eedd2a80d9f444c375cb3b7cebca5b25b2ffa83927661a6a3b981dac13c9e67e",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-manager-toolkit/scripts/rice_prioritizer.py",
           "owner": "product-manager-toolkit",
-          "sha256": "9ceb1964ebb949f6aaa7afda9651cd8d4ea1502df2fe58ed9e8cceb080a3f043"
+          "sha256": "9ceb1964ebb949f6aaa7afda9651cd8d4ea1502df2fe58ed9e8cceb080a3f043",
+          "mode": "100644"
         }
       ]
     },
@@ -14752,27 +15867,32 @@
         {
           "path": "skills/product-design/product-strategist/SKILL.md",
           "owner": "product-strategist",
-          "sha256": "e532b956ce126ad3509e993ec52cad1dbf7154ec38aa22b220aa73b2890b7a79"
+          "sha256": "e532b956ce126ad3509e993ec52cad1dbf7154ec38aa22b220aa73b2890b7a79",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-strategist/references/examples/sample_growth_okrs.json",
           "owner": "product-strategist",
-          "sha256": "2cd15f94c44de6df32731746e5082e26fc5626cbdf75fe6bc27b60c7cc6168df"
+          "sha256": "2cd15f94c44de6df32731746e5082e26fc5626cbdf75fe6bc27b60c7cc6168df",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-strategist/references/okr_framework.md",
           "owner": "product-strategist",
-          "sha256": "f2893540bf149085df11fb7578c389ee5fb1b00ef0b57be0b2f9621cc8f58d57"
+          "sha256": "f2893540bf149085df11fb7578c389ee5fb1b00ef0b57be0b2f9621cc8f58d57",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-strategist/references/strategy_types.md",
           "owner": "product-strategist",
-          "sha256": "03c0c85181412c43bc8089d835b19e8a89c9128c478e9f4f4796cd871d4acef6"
+          "sha256": "03c0c85181412c43bc8089d835b19e8a89c9128c478e9f4f4796cd871d4acef6",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/product-strategist/scripts/okr_cascade_generator.py",
           "owner": "product-strategist",
-          "sha256": "c6e9f1426267c726067e18d29dcc9273854fb57e9ec431e57202662ce4132e45"
+          "sha256": "c6e9f1426267c726067e18d29dcc9273854fb57e9ec431e57202662ce4132e45",
+          "mode": "100644"
         }
       ]
     },
@@ -14847,32 +15967,38 @@
         {
           "path": "skills/ai-workflow/prompt-optimizer/.security-scan-passed",
           "owner": "prompt-optimizer",
-          "sha256": "33aeeb0fb45330fba2057880d0d19c23ed203e2b9adc592405479d5b9fc521ad"
+          "sha256": "33aeeb0fb45330fba2057880d0d19c23ed203e2b9adc592405479d5b9fc521ad",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/prompt-optimizer/SKILL.md",
           "owner": "prompt-optimizer",
-          "sha256": "f6a082b7f507fa145e41660dc317e747395ab54d39f027914ae4b2b2c508de0c"
+          "sha256": "f6a082b7f507fa145e41660dc317e747395ab54d39f027914ae4b2b2c508de0c",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/prompt-optimizer/references/advanced_techniques.md",
           "owner": "prompt-optimizer",
-          "sha256": "a888cc3a6e3ce2c423a6788e304b3512166049a4c3994cf7f3b3761255e7a786"
+          "sha256": "a888cc3a6e3ce2c423a6788e304b3512166049a4c3994cf7f3b3761255e7a786",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/prompt-optimizer/references/domain_theories.md",
           "owner": "prompt-optimizer",
-          "sha256": "981dd36fa9e76c50285b24b92a5a416161bc7d244d7bd3e63f6454ad6c233a12"
+          "sha256": "981dd36fa9e76c50285b24b92a5a416161bc7d244d7bd3e63f6454ad6c233a12",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/prompt-optimizer/references/ears_syntax.md",
           "owner": "prompt-optimizer",
-          "sha256": "3263bc31b5bca9b34ccfa235c2f1844769e96322f87ed632887f696999b5e3ef"
+          "sha256": "3263bc31b5bca9b34ccfa235c2f1844769e96322f87ed632887f696999b5e3ef",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/prompt-optimizer/references/examples.md",
           "owner": "prompt-optimizer",
-          "sha256": "194bfbc0203edc723e2a7696ad891000d9d8d6508dea2817a9de40c02883a30f"
+          "sha256": "194bfbc0203edc723e2a7696ad891000d9d8d6508dea2817a9de40c02883a30f",
+          "mode": "100644"
         }
       ]
     },
@@ -14937,22 +16063,26 @@
         {
           "path": "skills/developer-engineering/promptfoo-evaluation/.security-scan-passed",
           "owner": "promptfoo-evaluation",
-          "sha256": "802a3c3149ab0a00211bfaa849f7f7a4b5209d7dcbc9030dc6ff98662cc044c3"
+          "sha256": "802a3c3149ab0a00211bfaa849f7f7a4b5209d7dcbc9030dc6ff98662cc044c3",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/promptfoo-evaluation/SKILL.md",
           "owner": "promptfoo-evaluation",
-          "sha256": "91bf891961613bdba39d06eddfe49fb611fe0a3da8f330e34cc43a80b8867046"
+          "sha256": "91bf891961613bdba39d06eddfe49fb611fe0a3da8f330e34cc43a80b8867046",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/promptfoo-evaluation/references/promptfoo_api.md",
           "owner": "promptfoo-evaluation",
-          "sha256": "2b1bbe14822147e3dd76ffad2a53809a07012b595b4cf5866aebaaeb1e694f5f"
+          "sha256": "2b1bbe14822147e3dd76ffad2a53809a07012b595b4cf5866aebaaeb1e694f5f",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/promptfoo-evaluation/scripts/metrics.py",
           "owner": "promptfoo-evaluation",
-          "sha256": "862e032d5855d17b85f41ac0870607ba6b2e607608226c7b52433caf9c482bd6"
+          "sha256": "862e032d5855d17b85f41ac0870607ba6b2e607608226c7b52433caf9c482bd6",
+          "mode": "100644"
         }
       ]
     },
@@ -15047,52 +16177,62 @@
         {
           "path": "skills/developer-engineering/qa-expert/.security-scan-passed",
           "owner": "qa-expert",
-          "sha256": "2f4f692ac7678af40a5fac20992ac4603db2d864c4879db0ae509c10c7a517f2"
+          "sha256": "2f4f692ac7678af40a5fac20992ac4603db2d864c4879db0ae509c10c7a517f2",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/SKILL.md",
           "owner": "qa-expert",
-          "sha256": "8560a3a93a16a7ce2a5c86e686ee80c63282ee1d840c8deb0f73760e580288e2"
+          "sha256": "8560a3a93a16a7ce2a5c86e686ee80c63282ee1d840c8deb0f73760e580288e2",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/assets/templates/TEST-CASE-TEMPLATE.md",
           "owner": "qa-expert",
-          "sha256": "bdbc08fbf879a770885c5dee2363539c3220894f09a57ad5c407d0bbdf2a3766"
+          "sha256": "bdbc08fbf879a770885c5dee2363539c3220894f09a57ad5c407d0bbdf2a3766",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/references/day1_onboarding.md",
           "owner": "qa-expert",
-          "sha256": "0b3c0d92b4cd867877aa0e1068b23d01e35cad99a395d1d15d85e5d02c505394"
+          "sha256": "0b3c0d92b4cd867877aa0e1068b23d01e35cad99a395d1d15d85e5d02c505394",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/references/google_testing_standards.md",
           "owner": "qa-expert",
-          "sha256": "013b15a355a573f44c470024b6d87dcd3d13fb8851eb8e4a44110c86a0c78e28"
+          "sha256": "013b15a355a573f44c470024b6d87dcd3d13fb8851eb8e4a44110c86a0c78e28",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/references/ground_truth_principle.md",
           "owner": "qa-expert",
-          "sha256": "635f88f4e83506d5e8c6854abbcefcd4b57f02cd1d470d5154c3f3d0844ea7ed"
+          "sha256": "635f88f4e83506d5e8c6854abbcefcd4b57f02cd1d470d5154c3f3d0844ea7ed",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/references/llm_prompts_library.md",
           "owner": "qa-expert",
-          "sha256": "bc7a0e80c436a880cdd530a7ad2cfefbec5ef55bf59f40de68233a784df1fc93"
+          "sha256": "bc7a0e80c436a880cdd530a7ad2cfefbec5ef55bf59f40de68233a784df1fc93",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/references/master_qa_prompt.md",
           "owner": "qa-expert",
-          "sha256": "2cdf046bc12ca97da63871310aaa636a92de4daeb692a20c436d5e9776c0a5db"
+          "sha256": "2cdf046bc12ca97da63871310aaa636a92de4daeb692a20c436d5e9776c0a5db",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/scripts/calculate_metrics.py",
           "owner": "qa-expert",
-          "sha256": "ae7265dd5310dd20c9838e52a746b0e9e7404a839b09db732cadeebc0a19252a"
+          "sha256": "ae7265dd5310dd20c9838e52a746b0e9e7404a839b09db732cadeebc0a19252a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/qa-expert/scripts/init_qa_project.py",
           "owner": "qa-expert",
-          "sha256": "e35d9d4a939a63ae1f678ff4bd4acbd42a68d03a6879be0b1ddb7a30e2b1a271"
+          "sha256": "e35d9d4a939a63ae1f678ff4bd4acbd42a68d03a6879be0b1ddb7a30e2b1a271",
+          "mode": "100644"
         }
       ]
     },
@@ -15172,37 +16312,44 @@
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/SKILL.md",
           "owner": "rag-architect",
-          "sha256": "f482235beca4b7de75c00211091ef87ee56da6010b2c0115bd5367868335bfcc"
+          "sha256": "f482235beca4b7de75c00211091ef87ee56da6010b2c0115bd5367868335bfcc",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/chunking_optimizer.py",
           "owner": "rag-architect",
-          "sha256": "390cf0b370e6cabbcdc367f809e455c36da4651d7fa2808938b2a958e416d0cc"
+          "sha256": "390cf0b370e6cabbcdc367f809e455c36da4651d7fa2808938b2a958e416d0cc",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/rag_pipeline_designer.py",
           "owner": "rag-architect",
-          "sha256": "c285db2e2642e4001d480b26809208f92f54e4c0a6dcf021f06d53b535a536f1"
+          "sha256": "c285db2e2642e4001d480b26809208f92f54e4c0a6dcf021f06d53b535a536f1",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/references/chunking_strategies_comparison.md",
           "owner": "rag-architect",
-          "sha256": "9660ca53d86521338e5e168a4fae83bf553c51e33d8f556cabb6f1ed12701b13"
+          "sha256": "9660ca53d86521338e5e168a4fae83bf553c51e33d8f556cabb6f1ed12701b13",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/references/embedding_model_benchmark.md",
           "owner": "rag-architect",
-          "sha256": "033e3c0b94b2751b1289933e01791dc11415eabf2465a0f3286e122f51a93e34"
+          "sha256": "033e3c0b94b2751b1289933e01791dc11415eabf2465a0f3286e122f51a93e34",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/references/rag_evaluation_framework.md",
           "owner": "rag-architect",
-          "sha256": "6c625f57489db2bf9f0836dba33eb8e253c59b01bf4516f69b536bdefbb5a2f6"
+          "sha256": "6c625f57489db2bf9f0836dba33eb8e253c59b01bf4516f69b536bdefbb5a2f6",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/rag-architect/retrieval_evaluator.py",
           "owner": "rag-architect",
-          "sha256": "43b05ec3861a929c0317bac8e9605108d820c16683a10c90acc44f4243cf873d"
+          "sha256": "43b05ec3861a929c0317bac8e9605108d820c16683a10c90acc44f4243cf873d",
+          "mode": "100644"
         }
       ]
     },
@@ -15257,12 +16404,14 @@
         {
           "path": "skills/developer-engineering/react-native-engineering/SKILL.md",
           "owner": "react-native-engineering",
-          "sha256": "dcf508e3af7793b73d803b943e6012e124714308fdb52c29de084931ef59f803"
+          "sha256": "dcf508e3af7793b73d803b943e6012e124714308fdb52c29de084931ef59f803",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/react-native-engineering/evals/evals.json",
           "owner": "react-native-engineering",
-          "sha256": "27a28b41fb7b700fce2bd668a79db02408f9f948e83e1a46c0c47590905e49b5"
+          "sha256": "27a28b41fb7b700fce2bd668a79db02408f9f948e83e1a46c0c47590905e49b5",
+          "mode": "100644"
         }
       ]
     },
@@ -15427,122 +16576,146 @@
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/CLAWDHUB-PUBLISHING-GUIDE.md",
           "owner": "reflect-learn",
-          "sha256": "aff3dc4753122943c86e5658c857f8f9c61638de4f2ea6c2003175b7e2527039"
+          "sha256": "aff3dc4753122943c86e5658c857f8f9c61638de4f2ea6c2003175b7e2527039",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/README.md",
           "owner": "reflect-learn",
-          "sha256": "c6c29fd0fb6ffa7d8d44f1fe7f7e90b56be429761704720c1dcab2186100dc0f"
+          "sha256": "c6c29fd0fb6ffa7d8d44f1fe7f7e90b56be429761704720c1dcab2186100dc0f",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/SKILL.md",
           "owner": "reflect-learn",
-          "sha256": "aa91e1a2863ed6bcfbc71f2141fef32a0fd20198e70ea48eea263fca8a8f8e5f"
+          "sha256": "aa91e1a2863ed6bcfbc71f2141fef32a0fd20198e70ea48eea263fca8a8f8e5f",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/_meta.json",
           "owner": "reflect-learn",
-          "sha256": "452bffce00dd789209b040d0cfb782ac0973d317a655e17105be5ea9ed0c13df"
+          "sha256": "452bffce00dd789209b040d0cfb782ac0973d317a655e17105be5ea9ed0c13df",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/assets/learnings_schema.yaml",
           "owner": "reflect-learn",
-          "sha256": "c9965eb1ced98d45f8f06e22de878a717c714a2005367fd41d6bece8971a43c7"
+          "sha256": "c9965eb1ced98d45f8f06e22de878a717c714a2005367fd41d6bece8971a43c7",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/assets/reflection_template.md",
           "owner": "reflect-learn",
-          "sha256": "0305f198da22db2928cedd04a6475c6ce4a7265cb07090c71c26166476fa1954"
+          "sha256": "0305f198da22db2928cedd04a6475c6ce4a7265cb07090c71c26166476fa1954",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/data/agent_mappings.md",
           "owner": "reflect-learn",
-          "sha256": "609196e141bfd2e630de6ea59a95b3bc51c62525b931437c4b23e7eaf9daf248"
+          "sha256": "609196e141bfd2e630de6ea59a95b3bc51c62525b931437c4b23e7eaf9daf248",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/data/signal_patterns.md",
           "owner": "reflect-learn",
-          "sha256": "ec85f35116788c3ee387ed90017b188f60acf1503212d75330308cee17850fff"
+          "sha256": "ec85f35116788c3ee387ed90017b188f60acf1503212d75330308cee17850fff",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/hooks/README.md",
           "owner": "reflect-learn",
-          "sha256": "bb0a924d9111a35aceb946d49b9b172e009fb3ab13e33ba5ed5dc09a8ebb7390"
+          "sha256": "bb0a924d9111a35aceb946d49b9b172e009fb3ab13e33ba5ed5dc09a8ebb7390",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/hooks/precompact_reflect.py",
           "owner": "reflect-learn",
-          "sha256": "31f8d6297d35ecd47879f8783d52e16a896edea5b2bc4443898775b01b90b55a"
+          "sha256": "31f8d6297d35ecd47879f8783d52e16a896edea5b2bc4443898775b01b90b55a",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/hooks/settings-snippet.json",
           "owner": "reflect-learn",
-          "sha256": "7bf3a65cc05c2d0ced469d556849d387b4702b060cd2f05733308ee437c3543f"
+          "sha256": "7bf3a65cc05c2d0ced469d556849d387b4702b060cd2f05733308ee437c3543f",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/references/agent_mappings.md",
           "owner": "reflect-learn",
-          "sha256": "9be1a886e032e4169639ffb00b91e797bd93bf7c85a075bea45a0fc260963a0a"
+          "sha256": "9be1a886e032e4169639ffb00b91e797bd93bf7c85a075bea45a0fc260963a0a",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/references/signal_patterns.md",
           "owner": "reflect-learn",
-          "sha256": "34266d871b4266d3054660d5d3001f4b9ec385d519e87a46d6cf19360e1b71ee"
+          "sha256": "34266d871b4266d3054660d5d3001f4b9ec385d519e87a46d6cf19360e1b71ee",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/references/skill_template.md",
           "owner": "reflect-learn",
-          "sha256": "cd5ce679e71b79e673c36b27432a928b98ccddc4f55ccc264ae5c73dc8b69724"
+          "sha256": "cd5ce679e71b79e673c36b27432a928b98ccddc4f55ccc264ae5c73dc8b69724",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/logs/chat.json",
           "owner": "reflect-learn",
-          "sha256": "88fc974c402d9d8b9f962dff3fbff4005b46be5660f4fadaaf1a8a04b9f3b2df"
+          "sha256": "88fc974c402d9d8b9f962dff3fbff4005b46be5660f4fadaaf1a8a04b9f3b2df",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/logs/notification.json",
           "owner": "reflect-learn",
-          "sha256": "6fd137f0b9d6cfc6827ad06ee54dc07c41b01ccb5fc5184ec1d45837f25c59c3"
+          "sha256": "6fd137f0b9d6cfc6827ad06ee54dc07c41b01ccb5fc5184ec1d45837f25c59c3",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/logs/stop.json",
           "owner": "reflect-learn",
-          "sha256": "09f7c295cc5b0b23f9f5301bac9eb215bf35efe1492d460db1073b373c373fbf"
+          "sha256": "09f7c295cc5b0b23f9f5301bac9eb215bf35efe1492d460db1073b373c373fbf",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/logs/subagent_stop.json",
           "owner": "reflect-learn",
-          "sha256": "096cd76e2c2adf3918eb5fd6c14874ebf1478ec9848a54b3a36f74964a3ad49d"
+          "sha256": "096cd76e2c2adf3918eb5fd6c14874ebf1478ec9848a54b3a36f74964a3ad49d",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/logs/user_prompt_submit.json",
           "owner": "reflect-learn",
-          "sha256": "0674593631fd7d8b01c41742fdd09d15cac67289f2f49dfdc1cedb97ce8a5851"
+          "sha256": "0674593631fd7d8b01c41742fdd09d15cac67289f2f49dfdc1cedb97ce8a5851",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/metrics_updater.py",
           "owner": "reflect-learn",
-          "sha256": "2bfe85729d0af3243635e8163a4bc7ae8f8569d18b16e7b3a035dcf3f69670b0"
+          "sha256": "2bfe85729d0af3243635e8163a4bc7ae8f8569d18b16e7b3a035dcf3f69670b0",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/output_generator.py",
           "owner": "reflect-learn",
-          "sha256": "856080683994685e80068f4a3e726625d772400cf013349938498a3c582f888b"
+          "sha256": "856080683994685e80068f4a3e726625d772400cf013349938498a3c582f888b",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/signal_detector.py",
           "owner": "reflect-learn",
-          "sha256": "e829c0a831c628e23795fc293c06af7dc044444ac01bdd74c5b7b86de94da82d"
+          "sha256": "e829c0a831c628e23795fc293c06af7dc044444ac01bdd74c5b7b86de94da82d",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/scripts/state_manager.py",
           "owner": "reflect-learn",
-          "sha256": "e69e248f7569d670b890f9b025797b25ec7fdf5763ced4f8ef21603a765556be"
+          "sha256": "e69e248f7569d670b890f9b025797b25ec7fdf5763ced4f8ef21603a765556be",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/reflect-learn/skill.json",
           "owner": "reflect-learn",
-          "sha256": "2a17ddaab7d60a0664391dca80b3fdb5792c862cbc0d41805473ca64ef29a344"
+          "sha256": "2a17ddaab7d60a0664391dca80b3fdb5792c862cbc0d41805473ca64ef29a344",
+          "mode": "100644"
         }
       ]
     },
@@ -15662,77 +16835,92 @@
         {
           "path": "skills/devops-sre/release-manager/README.md",
           "owner": "release-manager",
-          "sha256": "a9743dd563d62fa68c726aded2ab783e6f756627ed787b7291c7e0a76b94417d"
+          "sha256": "a9743dd563d62fa68c726aded2ab783e6f756627ed787b7291c7e0a76b94417d",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/SKILL.md",
           "owner": "release-manager",
-          "sha256": "9f1b11153d3f223a5f23d07617b34fc6ca69f39dab886dfc05a21ab0673dff2c"
+          "sha256": "9f1b11153d3f223a5f23d07617b34fc6ca69f39dab886dfc05a21ab0673dff2c",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/assets/sample_commits.json",
           "owner": "release-manager",
-          "sha256": "83a0b9c9bcb198e18bc6943a98610c8b1f4cd827d7b82806b8e1b4b531dc6f9b"
+          "sha256": "83a0b9c9bcb198e18bc6943a98610c8b1f4cd827d7b82806b8e1b4b531dc6f9b",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/assets/sample_git_log.txt",
           "owner": "release-manager",
-          "sha256": "8de6b9810ff92d673ea497612026efa32f1805c285bd92b7c8818f59c15d2107"
+          "sha256": "8de6b9810ff92d673ea497612026efa32f1805c285bd92b7c8818f59c15d2107",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/assets/sample_git_log_full.txt",
           "owner": "release-manager",
-          "sha256": "e003097525fb381aa6717d090d2a24f51e6b3ed26493d62f95e80d0631256197"
+          "sha256": "e003097525fb381aa6717d090d2a24f51e6b3ed26493d62f95e80d0631256197",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/assets/sample_release_plan.json",
           "owner": "release-manager",
-          "sha256": "96e287d13b56d87241aa18b5a8ebc40ebad7da81a4f9c402f2641e39ddd0289c"
+          "sha256": "96e287d13b56d87241aa18b5a8ebc40ebad7da81a4f9c402f2641e39ddd0289c",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/changelog_generator.py",
           "owner": "release-manager",
-          "sha256": "db52fe962f0a65132ae8d8dc086e6851ea1a31fbe4eaf472bd8d47e835610916"
+          "sha256": "db52fe962f0a65132ae8d8dc086e6851ea1a31fbe4eaf472bd8d47e835610916",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/expected_outputs/changelog_example.md",
           "owner": "release-manager",
-          "sha256": "db0473ccfc403e36f026eea48bdf4bbcb7cf1d22778a114207019ff74a33b405"
+          "sha256": "db0473ccfc403e36f026eea48bdf4bbcb7cf1d22778a114207019ff74a33b405",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/expected_outputs/release_readiness_example.txt",
           "owner": "release-manager",
-          "sha256": "2639f7b408d6f99b9a95c09b8f5718fb8e75674b737d9727146507ba873c942d"
+          "sha256": "2639f7b408d6f99b9a95c09b8f5718fb8e75674b737d9727146507ba873c942d",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/expected_outputs/version_bump_example.txt",
           "owner": "release-manager",
-          "sha256": "ae1d73bcec7667d4f528604205f79a792c5198e8cdb27ff2c025eae8c5b18526"
+          "sha256": "ae1d73bcec7667d4f528604205f79a792c5198e8cdb27ff2c025eae8c5b18526",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/references/conventional-commits-guide.md",
           "owner": "release-manager",
-          "sha256": "502f3bd42b4796bc75abb52b4eefb62156267176a4017681eab2d63d2197302d"
+          "sha256": "502f3bd42b4796bc75abb52b4eefb62156267176a4017681eab2d63d2197302d",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/references/hotfix-procedures.md",
           "owner": "release-manager",
-          "sha256": "7b5b85c6a40fc48af84bc612229ba774f29c3329486117b6600a52fc0370f640"
+          "sha256": "7b5b85c6a40fc48af84bc612229ba774f29c3329486117b6600a52fc0370f640",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/references/release-workflow-comparison.md",
           "owner": "release-manager",
-          "sha256": "b971e0aa1ceab4627a7e52060cb1829520e0aaf51b6881661d694134436ebc1a"
+          "sha256": "b971e0aa1ceab4627a7e52060cb1829520e0aaf51b6881661d694134436ebc1a",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/release_planner.py",
           "owner": "release-manager",
-          "sha256": "508c8747a97fe08346750172be3d44f83559c8fe719f4024988de09ff71db05a"
+          "sha256": "508c8747a97fe08346750172be3d44f83559c8fe719f4024988de09ff71db05a",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/release-manager/version_bumper.py",
           "owner": "release-manager",
-          "sha256": "1423be76d7376cee055ef47bcf6fd5f0f7d0b444e2f807cfb8dcc9dd11dddf11"
+          "sha256": "1423be76d7376cee055ef47bcf6fd5f0f7d0b444e2f807cfb8dcc9dd11dddf11",
+          "mode": "100644"
         }
       ]
     },
@@ -15882,107 +17070,128 @@
         {
           "path": "skills/deployment-platforms/render-deploy/LICENSE.txt",
           "owner": "render-deploy",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/SKILL.md",
           "owner": "render-deploy",
-          "sha256": "74b6e71dbe48fb7dbe8d125eb0733d68043c0cd1693ab75e9849f251279866c3"
+          "sha256": "74b6e71dbe48fb7dbe8d125eb0733d68043c0cd1693ab75e9849f251279866c3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/agents/openai.yaml",
           "owner": "render-deploy",
-          "sha256": "9d14eae8aad5f2e02112f1003e823df2da2b5b5df626fae4439f44349f59d291"
+          "sha256": "9d14eae8aad5f2e02112f1003e823df2da2b5b5df626fae4439f44349f59d291",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/docker.yaml",
           "owner": "render-deploy",
-          "sha256": "3fd98d72fc490df5c2a57ee5ddb3997347d31ea72ac68035f6442e787a19e091"
+          "sha256": "3fd98d72fc490df5c2a57ee5ddb3997347d31ea72ac68035f6442e787a19e091",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/go-api.yaml",
           "owner": "render-deploy",
-          "sha256": "fed7f5f2f59dc98cfc505533177d7b35dd3a993e6a93d0a6be1fae59a676af0b"
+          "sha256": "fed7f5f2f59dc98cfc505533177d7b35dd3a993e6a93d0a6be1fae59a676af0b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/nextjs-postgres.yaml",
           "owner": "render-deploy",
-          "sha256": "0c3d482632b88c0e5f3dc620d32b06216b356205b1fd988f69b6fc69ee41d2d3"
+          "sha256": "0c3d482632b88c0e5f3dc620d32b06216b356205b1fd988f69b6fc69ee41d2d3",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/node-express.yaml",
           "owner": "render-deploy",
-          "sha256": "1785a380074f7439e983f0cd50381559fd804a76c56f8d2da7d988a30ac8b519"
+          "sha256": "1785a380074f7439e983f0cd50381559fd804a76c56f8d2da7d988a30ac8b519",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/python-django.yaml",
           "owner": "render-deploy",
-          "sha256": "ce9e540e8cff7171557223044f61a83a058f0012831d07f99750cac70a4e236c"
+          "sha256": "ce9e540e8cff7171557223044f61a83a058f0012831d07f99750cac70a4e236c",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/render-small.svg",
           "owner": "render-deploy",
-          "sha256": "27cc74f766850724ac4a01bda8fb4a765a997522cdf5b93748e2e0c546193623"
+          "sha256": "27cc74f766850724ac4a01bda8fb4a765a997522cdf5b93748e2e0c546193623",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/render.png",
           "owner": "render-deploy",
-          "sha256": "becffed2fbc78e10cf25fb7837299b30bed33764bdd1ba521d7b6bd4e9167693"
+          "sha256": "becffed2fbc78e10cf25fb7837299b30bed33764bdd1ba521d7b6bd4e9167693",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/assets/static-site.yaml",
           "owner": "render-deploy",
-          "sha256": "d0a7df7c7a987049ec3609c28f1fdeef8e2e01f534c64372c6079746df286ac1"
+          "sha256": "d0a7df7c7a987049ec3609c28f1fdeef8e2e01f534c64372c6079746df286ac1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/blueprint-spec.md",
           "owner": "render-deploy",
-          "sha256": "52cdb41c930c22ec5578c2e56cef33ffbba910ef6c72de57965908be7ec54139"
+          "sha256": "52cdb41c930c22ec5578c2e56cef33ffbba910ef6c72de57965908be7ec54139",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/codebase-analysis.md",
           "owner": "render-deploy",
-          "sha256": "54c4fe84ae50a4b358f7c9048dfcd68f9eddd88ddfbe24c50b4be7949dc9f6a7"
+          "sha256": "54c4fe84ae50a4b358f7c9048dfcd68f9eddd88ddfbe24c50b4be7949dc9f6a7",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/configuration-guide.md",
           "owner": "render-deploy",
-          "sha256": "f0bdee2c78db76066e797139b1ee1230cf277192e8fbe9c42d277e82bef2ec40"
+          "sha256": "f0bdee2c78db76066e797139b1ee1230cf277192e8fbe9c42d277e82bef2ec40",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/deployment-details.md",
           "owner": "render-deploy",
-          "sha256": "fa6aa90a707494fcc9438b65829ef4891b9ed03c1cf69d6323fbd997b1f6782a"
+          "sha256": "fa6aa90a707494fcc9438b65829ef4891b9ed03c1cf69d6323fbd997b1f6782a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/direct-creation.md",
           "owner": "render-deploy",
-          "sha256": "3b148def3c12061582229599616b680f57972c86a8782e22a765cf261ec80adc"
+          "sha256": "3b148def3c12061582229599616b680f57972c86a8782e22a765cf261ec80adc",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/error-patterns.md",
           "owner": "render-deploy",
-          "sha256": "b5556cdd3ba832e8f33602cf207cd80872df9c89ed17fe92129a56903176675b"
+          "sha256": "b5556cdd3ba832e8f33602cf207cd80872df9c89ed17fe92129a56903176675b",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/post-deploy-checks.md",
           "owner": "render-deploy",
-          "sha256": "bd1e3e24abe6c9eb63164ac8ada9b285ceaffbd1722f58bbc1d3d94af4c59911"
+          "sha256": "bd1e3e24abe6c9eb63164ac8ada9b285ceaffbd1722f58bbc1d3d94af4c59911",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/runtimes.md",
           "owner": "render-deploy",
-          "sha256": "285b66f9fbb7b20195be80d3bc91bdfc82944c779debbffad85f08ba338b414f"
+          "sha256": "285b66f9fbb7b20195be80d3bc91bdfc82944c779debbffad85f08ba338b414f",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/service-types.md",
           "owner": "render-deploy",
-          "sha256": "459590bed5b5600f155f8a9d39c7ca3a32e307270e58d636b30e7b25e6ca4e64"
+          "sha256": "459590bed5b5600f155f8a9d39c7ca3a32e307270e58d636b30e7b25e6ca4e64",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/render-deploy/references/troubleshooting-basics.md",
           "owner": "render-deploy",
-          "sha256": "f999b13fc56ff62ccf6eec593d0e4cee94e52dec27a815e40d68532bf558a4ca"
+          "sha256": "f999b13fc56ff62ccf6eec593d0e4cee94e52dec27a815e40d68532bf558a4ca",
+          "mode": "100644"
         }
       ]
     },
@@ -16047,22 +17256,26 @@
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/SKILL.md",
           "owner": "repomix-safe-mixer",
-          "sha256": "ad2013350af8c0a8fd300077e5df9cd341d03ec32a3b838030483b2db5468978"
+          "sha256": "ad2013350af8c0a8fd300077e5df9cd341d03ec32a3b838030483b2db5468978",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/references/common_secrets.md",
           "owner": "repomix-safe-mixer",
-          "sha256": "4646d9df8fed8e4124eaf4c0150955832bf389bda59a1462140d5feba2ff7549"
+          "sha256": "4646d9df8fed8e4124eaf4c0150955832bf389bda59a1462140d5feba2ff7549",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/scripts/safe_pack.py",
           "owner": "repomix-safe-mixer",
-          "sha256": "c4c4a3793c7cd13cfbf39252e1ae32d6026dbc76ef20037166dcd861e03fff04"
+          "sha256": "c4c4a3793c7cd13cfbf39252e1ae32d6026dbc76ef20037166dcd861e03fff04",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py",
           "owner": "repomix-safe-mixer",
-          "sha256": "6c6bc353f303c0de57a043356bd076e36edbac0505b869e8d957edc8b4ef15cd"
+          "sha256": "6c6bc353f303c0de57a043356bd076e36edbac0505b869e8d957edc8b4ef15cd",
+          "mode": "100644"
         }
       ]
     },
@@ -16112,7 +17325,8 @@
         {
           "path": "skills/openclaw-memory-and-safety/runbook-generator/SKILL.md",
           "owner": "runbook-generator",
-          "sha256": "53dd00f4b90725b2d464ac285102993ca28c72cc6580dcf4656b5f48bee3572c"
+          "sha256": "53dd00f4b90725b2d464ac285102993ca28c72cc6580dcf4656b5f48bee3572c",
+          "mode": "100644"
         }
       ]
     },
@@ -16162,7 +17376,8 @@
         {
           "path": "skills/product-design/saas-scaffolder/SKILL.md",
           "owner": "saas-scaffolder",
-          "sha256": "3c57415289a20410a7ef685ae153a999a473d0bb7dc4eb1a264b19244f2cefa9"
+          "sha256": "3c57415289a20410a7ef685ae153a999a473d0bb7dc4eb1a264b19244f2cefa9",
+          "mode": "100644"
         }
       ]
     },
@@ -16262,57 +17477,68 @@
         {
           "path": "skills/multimodal-media/screenshot/LICENSE.txt",
           "owner": "screenshot",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/SKILL.md",
           "owner": "screenshot",
-          "sha256": "3fd7db89e5960cfe4a2e2b297482eaca8e883093ab96cd5d417ee50907347e20"
+          "sha256": "3fd7db89e5960cfe4a2e2b297482eaca8e883093ab96cd5d417ee50907347e20",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/agents/openai.yaml",
           "owner": "screenshot",
-          "sha256": "f29638eb930e27d44846474620b0d817b4b77fb5d09caf27db269463ae45cfa8"
+          "sha256": "f29638eb930e27d44846474620b0d817b4b77fb5d09caf27db269463ae45cfa8",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/assets/screenshot-small.svg",
           "owner": "screenshot",
-          "sha256": "b0ff24097dfcd889504fab312a0e20d1d79dde0745268647a8cc2471b4baf794"
+          "sha256": "b0ff24097dfcd889504fab312a0e20d1d79dde0745268647a8cc2471b4baf794",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/assets/screenshot.png",
           "owner": "screenshot",
-          "sha256": "4ff96a476f2a2ac4ca7b626f9d4b78a7aa8cce0219e0688c5f15355513b61b5b"
+          "sha256": "4ff96a476f2a2ac4ca7b626f9d4b78a7aa8cce0219e0688c5f15355513b61b5b",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/ensure_macos_permissions.sh",
           "owner": "screenshot",
-          "sha256": "9aa750f1e9592519d6c18b966fd65c1d4108c25bd3471ce625dfafd784856d7f"
+          "sha256": "9aa750f1e9592519d6c18b966fd65c1d4108c25bd3471ce625dfafd784856d7f",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/macos_display_info.swift",
           "owner": "screenshot",
-          "sha256": "0969cfef9c9890c82cae5ad75a6cd40fd56d33b28f27347642ef5e837f18b042"
+          "sha256": "0969cfef9c9890c82cae5ad75a6cd40fd56d33b28f27347642ef5e837f18b042",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/macos_permissions.swift",
           "owner": "screenshot",
-          "sha256": "cf110651350e50d600268f0a1a892ac8d662505474b4455cdfde2ac5b5f4aca6"
+          "sha256": "cf110651350e50d600268f0a1a892ac8d662505474b4455cdfde2ac5b5f4aca6",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/macos_window_info.swift",
           "owner": "screenshot",
-          "sha256": "c7faff7913d6072284b7ef1e5d26c524ab861ad32afc0c066f24ba95ae3f3597"
+          "sha256": "c7faff7913d6072284b7ef1e5d26c524ab861ad32afc0c066f24ba95ae3f3597",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/take_screenshot.ps1",
           "owner": "screenshot",
-          "sha256": "a31a2242e41fd1c5471651afbcced660f98fbc884f11e531218348f700a3f826"
+          "sha256": "a31a2242e41fd1c5471651afbcced660f98fbc884f11e531218348f700a3f826",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/screenshot/scripts/take_screenshot.py",
           "owner": "screenshot",
-          "sha256": "56eeabe2dac5d23915b9a0fb57a07431fad2d310c5444f60f71f09299899232b"
+          "sha256": "56eeabe2dac5d23915b9a0fb57a07431fad2d310c5444f60f71f09299899232b",
+          "mode": "100644"
         }
       ]
     },
@@ -16377,22 +17603,26 @@
         {
           "path": "skills/finance-investing/sec-filing-reviewer/SKILL.md",
           "owner": "sec-filing-reviewer",
-          "sha256": "69819df6303d132359f280535e503f22cad2f03009a65cba91fb52ced9d34a0a"
+          "sha256": "69819df6303d132359f280535e503f22cad2f03009a65cba91fb52ced9d34a0a",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/sec-filing-reviewer/assets/sample_filing_sections.json",
           "owner": "sec-filing-reviewer",
-          "sha256": "31783cccd6fbd8dea9b7395e7e36b197f86e8debe375524d90ba54237db27832"
+          "sha256": "31783cccd6fbd8dea9b7395e7e36b197f86e8debe375524d90ba54237db27832",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/sec-filing-reviewer/references/sec-sources.md",
           "owner": "sec-filing-reviewer",
-          "sha256": "dd932b23e15df5b78020f2b42c2e065ba2a03b76053363b50119ee38a8c8ffa7"
+          "sha256": "dd932b23e15df5b78020f2b42c2e065ba2a03b76053363b50119ee38a8c8ffa7",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/sec-filing-reviewer/scripts/review_filing.py",
           "owner": "sec-filing-reviewer",
-          "sha256": "1a4a1d6c8a26b0619e8529ba3ea40e45344691424fae7fbe29c9a07e205b311e"
+          "sha256": "1a4a1d6c8a26b0619e8529ba3ea40e45344691424fae7fbe29c9a07e205b311e",
+          "mode": "100644"
         }
       ]
     },
@@ -16442,7 +17672,8 @@
         {
           "path": "skills/security-and-reliability/security-auditor/SKILL.md",
           "owner": "security-auditor",
-          "sha256": "0fc15d1e144ab6181b54036eb613fa17e4ab39d76aff6b8d9d5975b9563578ab"
+          "sha256": "0fc15d1e144ab6181b54036eb613fa17e4ab39d76aff6b8d9d5975b9563578ab",
+          "mode": "100644"
         }
       ]
     },
@@ -16552,67 +17783,80 @@
         {
           "path": "skills/security-and-reliability/security-best-practices/LICENSE.txt",
           "owner": "security-best-practices",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/SKILL.md",
           "owner": "security-best-practices",
-          "sha256": "4db2acd0105711f9393ad1fb6ea2d8c7f679ad7c4cdd4ce05fbf68383fc02c79"
+          "sha256": "4db2acd0105711f9393ad1fb6ea2d8c7f679ad7c4cdd4ce05fbf68383fc02c79",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/agents/openai.yaml",
           "owner": "security-best-practices",
-          "sha256": "6e9c6f2edce448eb2b589f81ad6e3f722665021785513bcbfd0bf7b86b529171"
+          "sha256": "6e9c6f2edce448eb2b589f81ad6e3f722665021785513bcbfd0bf7b86b529171",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/golang-general-backend-security.md",
           "owner": "security-best-practices",
-          "sha256": "a73c47c34497b120672d48411fe51dc90d426a571801a0b3f649e2ce4ec658b4"
+          "sha256": "a73c47c34497b120672d48411fe51dc90d426a571801a0b3f649e2ce4ec658b4",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-express-web-server-security.md",
           "owner": "security-best-practices",
-          "sha256": "427835cbb5be7ba96172ea6ca9af80ddd4419c833e9ebf870996740c80d8406c"
+          "sha256": "427835cbb5be7ba96172ea6ca9af80ddd4419c833e9ebf870996740c80d8406c",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-general-web-frontend-security.md",
           "owner": "security-best-practices",
-          "sha256": "3a7bc7b3f6e7ff043db9dbaa8933894d7a19d987d0607e4ddae5d70184a63d63"
+          "sha256": "3a7bc7b3f6e7ff043db9dbaa8933894d7a19d987d0607e4ddae5d70184a63d63",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-jquery-web-frontend-security.md",
           "owner": "security-best-practices",
-          "sha256": "bcbad2fa6c2a02709e47e889e70102c76886bf36bc798624d27db570eccf40da"
+          "sha256": "bcbad2fa6c2a02709e47e889e70102c76886bf36bc798624d27db570eccf40da",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-typescript-nextjs-web-server-security.md",
           "owner": "security-best-practices",
-          "sha256": "71c773f7a97ce60c853adfa100b3d88b3b7bc4c6b8acaef1432ffabd923ee182"
+          "sha256": "71c773f7a97ce60c853adfa100b3d88b3b7bc4c6b8acaef1432ffabd923ee182",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-typescript-react-web-frontend-security.md",
           "owner": "security-best-practices",
-          "sha256": "d3030c0f24bddb56b9bbb91bbec1ee49eb7778bce4d3e0297b2641b2fc6b0d9c"
+          "sha256": "d3030c0f24bddb56b9bbb91bbec1ee49eb7778bce4d3e0297b2641b2fc6b0d9c",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/javascript-typescript-vue-web-frontend-security.md",
           "owner": "security-best-practices",
-          "sha256": "77c6a747f9f17e3df03aad0fcb20d99ac7898001b81aef8b80908e45ac14a688"
+          "sha256": "77c6a747f9f17e3df03aad0fcb20d99ac7898001b81aef8b80908e45ac14a688",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/python-django-web-server-security.md",
           "owner": "security-best-practices",
-          "sha256": "4fb69b5d45f10e588d1a8c35cdc5f59e18910f6b46a93e2d342d90f286f8dfd2"
+          "sha256": "4fb69b5d45f10e588d1a8c35cdc5f59e18910f6b46a93e2d342d90f286f8dfd2",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/python-fastapi-web-server-security.md",
           "owner": "security-best-practices",
-          "sha256": "7383c7f4fc271190b05e562ada7e825982a2c76b6c79a9f95a1da7687b65a616"
+          "sha256": "7383c7f4fc271190b05e562ada7e825982a2c76b6c79a9f95a1da7687b65a616",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-best-practices/references/python-flask-web-server-security.md",
           "owner": "security-best-practices",
-          "sha256": "9606d69190c04c167fdeac57e61297547a57b0542fd89dede36f355970446929"
+          "sha256": "9606d69190c04c167fdeac57e61297547a57b0542fd89dede36f355970446929",
+          "mode": "100644"
         }
       ]
     },
@@ -16697,42 +17941,50 @@
         {
           "path": "skills/security-and-reliability/security-ownership-map/LICENSE.txt",
           "owner": "security-ownership-map",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/SKILL.md",
           "owner": "security-ownership-map",
-          "sha256": "b753fa83ade0d5ad2de81c6db02a549550ed90e662a79ccdb5fe6dea5a7cc8df"
+          "sha256": "b753fa83ade0d5ad2de81c6db02a549550ed90e662a79ccdb5fe6dea5a7cc8df",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/agents/openai.yaml",
           "owner": "security-ownership-map",
-          "sha256": "40877a3cdb1753aa187fc85a83bc138a866a1edb74165e009c885cfb6a16e433"
+          "sha256": "40877a3cdb1753aa187fc85a83bc138a866a1edb74165e009c885cfb6a16e433",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/references/neo4j-import.md",
           "owner": "security-ownership-map",
-          "sha256": "176d0ef2ed3588530ed65ccda7cb30ae322e4cbec5c374dba5d1685e2bb9dd02"
+          "sha256": "176d0ef2ed3588530ed65ccda7cb30ae322e4cbec5c374dba5d1685e2bb9dd02",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/scripts/build_ownership_map.py",
           "owner": "security-ownership-map",
-          "sha256": "c0454c47c7eb001b6e247cd7e473df1b28a3a148a2dca6b2fe88a74a7602cc9b"
+          "sha256": "c0454c47c7eb001b6e247cd7e473df1b28a3a148a2dca6b2fe88a74a7602cc9b",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/scripts/community_maintainers.py",
           "owner": "security-ownership-map",
-          "sha256": "95adec5458cc85b41d0ae7965b0a17e4e8eaa6aaab274459324580d9a91cc3cc"
+          "sha256": "95adec5458cc85b41d0ae7965b0a17e4e8eaa6aaab274459324580d9a91cc3cc",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/scripts/query_ownership.py",
           "owner": "security-ownership-map",
-          "sha256": "0f8d1a1ac3ef807a9b66939a8cdfd02564f4cda018489a3664d37f8c3a7b1b93"
+          "sha256": "0f8d1a1ac3ef807a9b66939a8cdfd02564f4cda018489a3664d37f8c3a7b1b93",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-ownership-map/scripts/run_ownership_map.py",
           "owner": "security-ownership-map",
-          "sha256": "362b547d6133659eb5c4fe889b8b930bea790f31e412f3198671baae09eec692"
+          "sha256": "362b547d6133659eb5c4fe889b8b930bea790f31e412f3198671baae09eec692",
+          "mode": "100644"
         }
       ]
     },
@@ -16802,27 +18054,32 @@
         {
           "path": "skills/security-and-reliability/security-threat-model/LICENSE.txt",
           "owner": "security-threat-model",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-threat-model/SKILL.md",
           "owner": "security-threat-model",
-          "sha256": "c160a69178eebfb9a81adedff1bfb1c40fea04efe19b38db163a6811c447889d"
+          "sha256": "c160a69178eebfb9a81adedff1bfb1c40fea04efe19b38db163a6811c447889d",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-threat-model/agents/openai.yaml",
           "owner": "security-threat-model",
-          "sha256": "3319b59736312abceca614e341c0e59cae47263e3b58a22b2b5ddf1e5fc8c227"
+          "sha256": "3319b59736312abceca614e341c0e59cae47263e3b58a22b2b5ddf1e5fc8c227",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-threat-model/references/prompt-template.md",
           "owner": "security-threat-model",
-          "sha256": "81a59aa3fb3ac3a739d6a26ab38e4015965f215581ee54becef21a2b121ec29b"
+          "sha256": "81a59aa3fb3ac3a739d6a26ab38e4015965f215581ee54becef21a2b121ec29b",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/security-threat-model/references/security-controls-and-assets.md",
           "owner": "security-threat-model",
-          "sha256": "d536cfa9acad2523dc39134bcf33b9566c29dd9a57b407cbc9901637230c6b98"
+          "sha256": "d536cfa9acad2523dc39134bcf33b9566c29dd9a57b407cbc9901637230c6b98",
+          "mode": "100644"
         }
       ]
     },
@@ -16872,7 +18129,8 @@
         {
           "path": "skills/security-and-reliability/semgrep-appsec-scanner/SKILL.md",
           "owner": "semgrep-appsec-scanner",
-          "sha256": "f3b65b67690e67daffcb4f16284b9f04669ed6296caa99ac6bbb452d9147c433"
+          "sha256": "f3b65b67690e67daffcb4f16284b9f04669ed6296caa99ac6bbb452d9147c433",
+          "mode": "100644"
         }
       ]
     },
@@ -16952,37 +18210,44 @@
         {
           "path": "skills/devops-sre/senior-devops/SKILL.md",
           "owner": "senior-devops",
-          "sha256": "878e4b27696575dff3a5d68358834570a460829ff725b84d88b0a5ef9d2c528c"
+          "sha256": "878e4b27696575dff3a5d68358834570a460829ff725b84d88b0a5ef9d2c528c",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/references/cicd_pipeline_guide.md",
           "owner": "senior-devops",
-          "sha256": "1a9081fd856eaad7643ddbb1b704b1e7dcf66f0e531e42e8740b21dd09439ddc"
+          "sha256": "1a9081fd856eaad7643ddbb1b704b1e7dcf66f0e531e42e8740b21dd09439ddc",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/references/deployment_strategies.md",
           "owner": "senior-devops",
-          "sha256": "63d164425e4d097a60d947f2fe515e4e8e60966cba97b418858a6ee5b144660f"
+          "sha256": "63d164425e4d097a60d947f2fe515e4e8e60966cba97b418858a6ee5b144660f",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/references/infrastructure_as_code.md",
           "owner": "senior-devops",
-          "sha256": "82f85a94d900384b7f57b13d4519af5c6f4b47a0d2a53129f0b4452f11945374"
+          "sha256": "82f85a94d900384b7f57b13d4519af5c6f4b47a0d2a53129f0b4452f11945374",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/scripts/deployment_manager.py",
           "owner": "senior-devops",
-          "sha256": "11644f32cacc37d6340c805f698e96f8b3692a79352c16f500f96ccc7dde30f9"
+          "sha256": "11644f32cacc37d6340c805f698e96f8b3692a79352c16f500f96ccc7dde30f9",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/scripts/pipeline_generator.py",
           "owner": "senior-devops",
-          "sha256": "716dccacc6edd012e3295880138e28a573eba5185ed843f883f56866b50e387b"
+          "sha256": "716dccacc6edd012e3295880138e28a573eba5185ed843f883f56866b50e387b",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/senior-devops/scripts/terraform_scaffolder.py",
           "owner": "senior-devops",
-          "sha256": "f5c3a34fa93cc91635a957163525cbb0324489451cb869225dccb38f927c6794"
+          "sha256": "f5c3a34fa93cc91635a957163525cbb0324489451cb869225dccb38f927c6794",
+          "mode": "100644"
         }
       ]
     },
@@ -17057,32 +18322,38 @@
         {
           "path": "skills/security-and-reliability/sentry/LICENSE.txt",
           "owner": "sentry",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/sentry/SKILL.md",
           "owner": "sentry",
-          "sha256": "8609b7f9b771c38657357a13860f8c73a7bc15a49065ad43b8510e8e74fd9b7f"
+          "sha256": "8609b7f9b771c38657357a13860f8c73a7bc15a49065ad43b8510e8e74fd9b7f",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/sentry/agents/openai.yaml",
           "owner": "sentry",
-          "sha256": "c7ed57441b9a1e3f4caa19da4d90d432a65cd398c4f361b47dbf9408be0e065f"
+          "sha256": "c7ed57441b9a1e3f4caa19da4d90d432a65cd398c4f361b47dbf9408be0e065f",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/sentry/assets/sentry-small.svg",
           "owner": "sentry",
-          "sha256": "f1de8efc906c03b583b4d74560b003175c8a3d9ea5950d891ce3142fec11ca99"
+          "sha256": "f1de8efc906c03b583b4d74560b003175c8a3d9ea5950d891ce3142fec11ca99",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/sentry/assets/sentry.png",
           "owner": "sentry",
-          "sha256": "b61e0534635a275cf56f7dad26ac7cc36504b7bd9a60c95791d6e72634129fb1"
+          "sha256": "b61e0534635a275cf56f7dad26ac7cc36504b7bd9a60c95791d6e72634129fb1",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/sentry/scripts/sentry_api.py",
           "owner": "sentry",
-          "sha256": "688e4ba95c4a9780d1c15b4afbefaca9c1255a10d032dd66cfca160c89ad4608"
+          "sha256": "688e4ba95c4a9780d1c15b4afbefaca9c1255a10d032dd66cfca160c89ad4608",
+          "mode": "100644"
         }
       ]
     },
@@ -17152,27 +18423,32 @@
         {
           "path": "skills/ai-workflow/skill-reviewer/.security-scan-passed",
           "owner": "skill-reviewer",
-          "sha256": "cd9cc9ed5084a3983db321ee1928ca4099fb60460d975e2ebbd839feda00fd5d"
+          "sha256": "cd9cc9ed5084a3983db321ee1928ca4099fb60460d975e2ebbd839feda00fd5d",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-reviewer/SKILL.md",
           "owner": "skill-reviewer",
-          "sha256": "8cbb71e831494026fea552ba4a02d3c79121de64496a7987b7156684e72fc2f0"
+          "sha256": "8cbb71e831494026fea552ba4a02d3c79121de64496a7987b7156684e72fc2f0",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-reviewer/references/evaluation_checklist.md",
           "owner": "skill-reviewer",
-          "sha256": "b9ecbe4e61fb00c4e04a8324bcf38b04c4161ae422665f2f37a7c8cd76fca4fe"
+          "sha256": "b9ecbe4e61fb00c4e04a8324bcf38b04c4161ae422665f2f37a7c8cd76fca4fe",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-reviewer/references/marketplace_template.json",
           "owner": "skill-reviewer",
-          "sha256": "b2fcd07f73b6f1d84faa5bfda4246dfd09a5f5ae5745ad457cb8c922b2d2a5d2"
+          "sha256": "b2fcd07f73b6f1d84faa5bfda4246dfd09a5f5ae5745ad457cb8c922b2d2a5d2",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-reviewer/references/pr_template.md",
           "owner": "skill-reviewer",
-          "sha256": "e6bddddec4ab0fa6b4064bb134ec4770dda1905423f883dc6f9f0da20344c94e"
+          "sha256": "e6bddddec4ab0fa6b4064bb134ec4770dda1905423f883dc6f9f0da20344c94e",
+          "mode": "100644"
         }
       ]
     },
@@ -17297,82 +18573,98 @@
         {
           "path": "skills/developer-engineering/skill-tester/README.md",
           "owner": "skill-tester",
-          "sha256": "b02483e58b14a85d48fa11f7b171a9f71c6ba5c82020bbef3a073ca96d9e6765"
+          "sha256": "b02483e58b14a85d48fa11f7b171a9f71c6ba5c82020bbef3a073ca96d9e6765",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/SKILL.md",
           "owner": "skill-tester",
-          "sha256": "e766ec66586130d935cc0596cdc34cbdd0c68e7a4c6208d0ff20275c38d3b732"
+          "sha256": "e766ec66586130d935cc0596cdc34cbdd0c68e7a4c6208d0ff20275c38d3b732",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/README.md",
           "owner": "skill-tester",
-          "sha256": "c187758ccfd99b9748dcb8974f9469dee79b128c0b93a7c9df8c3b8d0b824dcf"
+          "sha256": "c187758ccfd99b9748dcb8974f9469dee79b128c0b93a7c9df8c3b8d0b824dcf",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/SKILL.md",
           "owner": "skill-tester",
-          "sha256": "d480a026684bec64cdd1f87063a7d66fa9beaf7ed28f0e3e3d8e525f7034c45e"
+          "sha256": "d480a026684bec64cdd1f87063a7d66fa9beaf7ed28f0e3e3d8e525f7034c45e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/assets/sample_text.txt",
           "owner": "skill-tester",
-          "sha256": "ae5fdf5d0cf9b29d1809336caef86cb0ef5cf258d64667c8759a96930ab3f9d6"
+          "sha256": "ae5fdf5d0cf9b29d1809336caef86cb0ef5cf258d64667c8759a96930ab3f9d6",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/assets/test_data.csv",
           "owner": "skill-tester",
-          "sha256": "a7a80cb6cdf5a28f1026e7d34488bdab8d8d5c5d11771f25df757d73d5294d2e"
+          "sha256": "a7a80cb6cdf5a28f1026e7d34488bdab8d8d5c5d11771f25df757d73d5294d2e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/expected_outputs/sample_text_analysis.json",
           "owner": "skill-tester",
-          "sha256": "a3cce0cc03dfd0c44068aedbb581c0f6a401cd14e5c3081b0fce41b78bd246bb"
+          "sha256": "a3cce0cc03dfd0c44068aedbb581c0f6a401cd14e5c3081b0fce41b78bd246bb",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/references/api-reference.md",
           "owner": "skill-tester",
-          "sha256": "f1fb53af7f7fd35396aa1d5c346559a63294518e2bf4bf3a2f20fed595eafa31"
+          "sha256": "f1fb53af7f7fd35396aa1d5c346559a63294518e2bf4bf3a2f20fed595eafa31",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/assets/sample-skill/scripts/text_processor.py",
           "owner": "skill-tester",
-          "sha256": "d87c4cb65223eba9921f124d7389e4689746a77314fc002965edcaf2c3c95754"
+          "sha256": "d87c4cb65223eba9921f124d7389e4689746a77314fc002965edcaf2c3c95754",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/expected_outputs/sample_validation_report.json",
           "owner": "skill-tester",
-          "sha256": "7a22e78cc243e51aa2a0e419afb734292d0b616bc71126f1266ab6997540d269"
+          "sha256": "7a22e78cc243e51aa2a0e419afb734292d0b616bc71126f1266ab6997540d269",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/references/quality-scoring-rubric.md",
           "owner": "skill-tester",
-          "sha256": "daf988aa91cb4ba85469b0af8b71d33059aa21bd31eaf3f762a8370ee716a2c6"
+          "sha256": "daf988aa91cb4ba85469b0af8b71d33059aa21bd31eaf3f762a8370ee716a2c6",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/references/skill-structure-specification.md",
           "owner": "skill-tester",
-          "sha256": "f3b0d79fe0de94cd96fa50d4545d73d825b0891744de20c47605c01a853def58"
+          "sha256": "f3b0d79fe0de94cd96fa50d4545d73d825b0891744de20c47605c01a853def58",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/references/tier-requirements-matrix.md",
           "owner": "skill-tester",
-          "sha256": "e3403a2f7484eee83f0a8ba789f8f27fa526c5d0e6f33166bf44924f0db35569"
+          "sha256": "e3403a2f7484eee83f0a8ba789f8f27fa526c5d0e6f33166bf44924f0db35569",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/scripts/quality_scorer.py",
           "owner": "skill-tester",
-          "sha256": "a0e5b2c7778f9098811fc7e4ec2d09a7c7b6a407291ba0132a40258111eebca1"
+          "sha256": "a0e5b2c7778f9098811fc7e4ec2d09a7c7b6a407291ba0132a40258111eebca1",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/scripts/script_tester.py",
           "owner": "skill-tester",
-          "sha256": "e2c73561f35e4afd5064a3581e8da2a4082821947af292ba7b804799eeb8ad9a"
+          "sha256": "e2c73561f35e4afd5064a3581e8da2a4082821947af292ba7b804799eeb8ad9a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/skill-tester/scripts/skill_validator.py",
           "owner": "skill-tester",
-          "sha256": "7c375c6b157416fe7fb0dd020f4cbd9b4e46a5e7227c47d0e3df862edb7fe6a0"
+          "sha256": "7c375c6b157416fe7fb0dd020f4cbd9b4e46a5e7227c47d0e3df862edb7fe6a0",
+          "mode": "100644"
         }
       ]
     },
@@ -17422,7 +18714,8 @@
         {
           "path": "skills/security-and-reliability/skill-vetter/SKILL.md",
           "owner": "skill-vetter",
-          "sha256": "b6f372ea6a7ea5fefac23a647713adf53209596c0070b5b73f66c503a25cd441"
+          "sha256": "b6f372ea6a7ea5fefac23a647713adf53209596c0070b5b73f66c503a25cd441",
+          "mode": "100644"
         }
       ]
     },
@@ -17502,37 +18795,44 @@
         {
           "path": "skills/operations-general/slack-gif-creator/LICENSE.txt",
           "owner": "slack-gif-creator",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/SKILL.md",
           "owner": "slack-gif-creator",
-          "sha256": "7b08bc27411549390bad80363bda9d1a329e26cfbe74b33241272ff354038fb6"
+          "sha256": "7b08bc27411549390bad80363bda9d1a329e26cfbe74b33241272ff354038fb6",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/core/easing.py",
           "owner": "slack-gif-creator",
-          "sha256": "60bc943449802541f0f0881a874faa7ef408aaaf0b758fde756664ada7740452"
+          "sha256": "60bc943449802541f0f0881a874faa7ef408aaaf0b758fde756664ada7740452",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/core/frame_composer.py",
           "owner": "slack-gif-creator",
-          "sha256": "a127ea8f2a58893ea10a5c7b5cab4e2010af6515adc538676eb0cc14f5a03985"
+          "sha256": "a127ea8f2a58893ea10a5c7b5cab4e2010af6515adc538676eb0cc14f5a03985",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/core/gif_builder.py",
           "owner": "slack-gif-creator",
-          "sha256": "b6f50d738c491ee0438a2e86e897f71cdab9792494ba4605f140befb0bddbf89"
+          "sha256": "b6f50d738c491ee0438a2e86e897f71cdab9792494ba4605f140befb0bddbf89",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/core/validators.py",
           "owner": "slack-gif-creator",
-          "sha256": "56bd19e3aae05f8387d78ec8185d6098b3dc909d1fa041211753da37212528a3"
+          "sha256": "56bd19e3aae05f8387d78ec8185d6098b3dc909d1fa041211753da37212528a3",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/slack-gif-creator/requirements.txt",
           "owner": "slack-gif-creator",
-          "sha256": "edc7108a0c6b56183566c71ee96830f6dc791e3b41952112d9cb56b33a6bd757"
+          "sha256": "edc7108a0c6b56183566c71ee96830f6dc791e3b41952112d9cb56b33a6bd757",
+          "mode": "100644"
         }
       ]
     },
@@ -17612,37 +18912,44 @@
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/HOW_TO_USE.md",
           "owner": "social-media-analyzer",
-          "sha256": "183fb0224c6d4332b6e8aa41dfc3687eaa416461c937ea3e2ed9258fcfe0faa4"
+          "sha256": "183fb0224c6d4332b6e8aa41dfc3687eaa416461c937ea3e2ed9258fcfe0faa4",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/SKILL.md",
           "owner": "social-media-analyzer",
-          "sha256": "8bfa40474c11ae3f8705230afcf8eae94e8ccde9d9cefeea24a0aebd9d99af94"
+          "sha256": "8bfa40474c11ae3f8705230afcf8eae94e8ccde9d9cefeea24a0aebd9d99af94",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/assets/expected_output.json",
           "owner": "social-media-analyzer",
-          "sha256": "ce13ad2784d7a60f1172e1059f9b598f78b43246601c0f0f4d7c560e2b2726ee"
+          "sha256": "ce13ad2784d7a60f1172e1059f9b598f78b43246601c0f0f4d7c560e2b2726ee",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/assets/sample_input.json",
           "owner": "social-media-analyzer",
-          "sha256": "e4210a55977c498092fdb93046ab4667cc479001dffac8b6e94a0ef701a8be5f"
+          "sha256": "e4210a55977c498092fdb93046ab4667cc479001dffac8b6e94a0ef701a8be5f",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/references/platform-benchmarks.md",
           "owner": "social-media-analyzer",
-          "sha256": "59643afbc1a0b21b09bfc9acdf84a193ce5e120bf914001b8683a425d3dd6e34"
+          "sha256": "59643afbc1a0b21b09bfc9acdf84a193ce5e120bf914001b8683a425d3dd6e34",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/scripts/analyze_performance.py",
           "owner": "social-media-analyzer",
-          "sha256": "cf1addc5fc1e6f02cc2637b8a958b18de88767d68aa51fdccc17ad85788ca0ac"
+          "sha256": "cf1addc5fc1e6f02cc2637b8a958b18de88767d68aa51fdccc17ad85788ca0ac",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/social-media-analyzer/scripts/calculate_metrics.py",
           "owner": "social-media-analyzer",
-          "sha256": "1f57c3fe56ca0c881321036a7bbf315cb5ba83143b52dfd5d9225eb41960dd6c"
+          "sha256": "1f57c3fe56ca0c881321036a7bbf315cb5ba83143b52dfd5d9225eb41960dd6c",
+          "mode": "100644"
         }
       ]
     },
@@ -17757,72 +19064,86 @@
         {
           "path": "skills/multimodal-media/sora/LICENSE.txt",
           "owner": "sora",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/SKILL.md",
           "owner": "sora",
-          "sha256": "e70de46c19c33c9254826729e445895a97ad143366fb41c06b91836415cf0008"
+          "sha256": "e70de46c19c33c9254826729e445895a97ad143366fb41c06b91836415cf0008",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/agents/openai.yaml",
           "owner": "sora",
-          "sha256": "5ee2165f93414e984273e48f3108934837783da5a7229f71c5da02a45fe5bf3e"
+          "sha256": "5ee2165f93414e984273e48f3108934837783da5a7229f71c5da02a45fe5bf3e",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/assets/sora-small.svg",
           "owner": "sora",
-          "sha256": "fecb5ef27b4b01028892a28a621c60d948595e9b38b542d47b5b97a3147d341d"
+          "sha256": "fecb5ef27b4b01028892a28a621c60d948595e9b38b542d47b5b97a3147d341d",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/assets/sora.png",
           "owner": "sora",
-          "sha256": "c0d8a1e9c9dce967f4aea9b6195b95aa1a8cd06bfd57b8da27542654a7b4ba43"
+          "sha256": "c0d8a1e9c9dce967f4aea9b6195b95aa1a8cd06bfd57b8da27542654a7b4ba43",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/cinematic-shots.md",
           "owner": "sora",
-          "sha256": "c7e827b1c03e01da7cc24c89f843a820b6151e250c67a51b06be75c42d186446"
+          "sha256": "c7e827b1c03e01da7cc24c89f843a820b6151e250c67a51b06be75c42d186446",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/cli.md",
           "owner": "sora",
-          "sha256": "7be7b6dc2a2a1502b905cc9a036a65fcb1c7d97d8040faa0019bf4af7859aa15"
+          "sha256": "7be7b6dc2a2a1502b905cc9a036a65fcb1c7d97d8040faa0019bf4af7859aa15",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/codex-network.md",
           "owner": "sora",
-          "sha256": "923fce6a135ea02b7119292418490ee4bf5764104fcb69aaabd89baa8fde57c4"
+          "sha256": "923fce6a135ea02b7119292418490ee4bf5764104fcb69aaabd89baa8fde57c4",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/prompting.md",
           "owner": "sora",
-          "sha256": "ed4d3d9d160f3fe36a26e3921bfafcae4a3f608e695f6801697644994394d3c7"
+          "sha256": "ed4d3d9d160f3fe36a26e3921bfafcae4a3f608e695f6801697644994394d3c7",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/sample-prompts.md",
           "owner": "sora",
-          "sha256": "9a463fff010791a51f30a30969c7a9ee58c9942e377d2acbd100998e7f4792cb"
+          "sha256": "9a463fff010791a51f30a30969c7a9ee58c9942e377d2acbd100998e7f4792cb",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/social-ads.md",
           "owner": "sora",
-          "sha256": "bc79e56ee044ccf676add6b5e879ec984a9c138a796b28d7df71f217beb1d7f7"
+          "sha256": "bc79e56ee044ccf676add6b5e879ec984a9c138a796b28d7df71f217beb1d7f7",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/troubleshooting.md",
           "owner": "sora",
-          "sha256": "4d012cf7ebd564c7889655ae216f2dec24abef98669c1cad8c1c6ef6c530a29f"
+          "sha256": "4d012cf7ebd564c7889655ae216f2dec24abef98669c1cad8c1c6ef6c530a29f",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/references/video-api.md",
           "owner": "sora",
-          "sha256": "01a2e01f4d595e9e5b7de24dfe4943e227a3c59b1513215acfaee68912870587"
+          "sha256": "01a2e01f4d595e9e5b7de24dfe4943e227a3c59b1513215acfaee68912870587",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sora/scripts/sora.py",
           "owner": "sora",
-          "sha256": "1596ba5bc155cbdedc82882a7abb452aeac424918d038914680bdd7460af219b"
+          "sha256": "1596ba5bc155cbdedc82882a7abb452aeac424918d038914680bdd7460af219b",
+          "mode": "100644"
         }
       ]
     },
@@ -17947,82 +19268,98 @@
         {
           "path": "skills/multimodal-media/speech/LICENSE.txt",
           "owner": "speech",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/SKILL.md",
           "owner": "speech",
-          "sha256": "2c45c7fdd6b6c980d9d2dadb9ce278eb32980184a162d13a62627a255a03074f"
+          "sha256": "2c45c7fdd6b6c980d9d2dadb9ce278eb32980184a162d13a62627a255a03074f",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/agents/openai.yaml",
           "owner": "speech",
-          "sha256": "1a152d9e7e66b86100db33b8e6ff3327955bf107bb9e77044a1ad6dfb10d6e18"
+          "sha256": "1a152d9e7e66b86100db33b8e6ff3327955bf107bb9e77044a1ad6dfb10d6e18",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/assets/speech-small.svg",
           "owner": "speech",
-          "sha256": "b879fe9fc476f183e1c9bfd0e2883b8b2c28c708ca3d90f409bed051fe6a173e"
+          "sha256": "b879fe9fc476f183e1c9bfd0e2883b8b2c28c708ca3d90f409bed051fe6a173e",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/assets/speech.png",
           "owner": "speech",
-          "sha256": "b5abb383bba63a309f73a4da1060b50b6c92b1b5f974f44b8f609b3da10112f9"
+          "sha256": "b5abb383bba63a309f73a4da1060b50b6c92b1b5f974f44b8f609b3da10112f9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/accessibility.md",
           "owner": "speech",
-          "sha256": "34cd91bc6a3ef65c8da8997e312d163babcdfc3241f9e359418b3f5a76f15b76"
+          "sha256": "34cd91bc6a3ef65c8da8997e312d163babcdfc3241f9e359418b3f5a76f15b76",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/audio-api.md",
           "owner": "speech",
-          "sha256": "dba58cfc0d5e125cf1ac13875193950233aa948639b268ed7799ca17bca66bfe"
+          "sha256": "dba58cfc0d5e125cf1ac13875193950233aa948639b268ed7799ca17bca66bfe",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/cli.md",
           "owner": "speech",
-          "sha256": "77e6a0c01036ac0092cf37c3d5c88dc6800b223524c5b9c8920d10fc4f68e0cc"
+          "sha256": "77e6a0c01036ac0092cf37c3d5c88dc6800b223524c5b9c8920d10fc4f68e0cc",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/codex-network.md",
           "owner": "speech",
-          "sha256": "c956a51d3e67246cfb43982aa8c82065350fcce4ef7b94bd89e599c575c94d9c"
+          "sha256": "c956a51d3e67246cfb43982aa8c82065350fcce4ef7b94bd89e599c575c94d9c",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/ivr.md",
           "owner": "speech",
-          "sha256": "2aaf225b7cea9277fe5413eb0360a845de035c00ea0d6f30348b5ce7138803fc"
+          "sha256": "2aaf225b7cea9277fe5413eb0360a845de035c00ea0d6f30348b5ce7138803fc",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/narration.md",
           "owner": "speech",
-          "sha256": "3e68829fe4a5a47c3d37cbe9a1ed95ff3cedf1b303ff02a10501e56ad5e7c74a"
+          "sha256": "3e68829fe4a5a47c3d37cbe9a1ed95ff3cedf1b303ff02a10501e56ad5e7c74a",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/prompting.md",
           "owner": "speech",
-          "sha256": "2adcb001813be04e56918eb0d34d9a45f9326aa0fb240526ae74a926522b6554"
+          "sha256": "2adcb001813be04e56918eb0d34d9a45f9326aa0fb240526ae74a926522b6554",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/sample-prompts.md",
           "owner": "speech",
-          "sha256": "c14e1b1c526f2fe555ab2dc86c0e8aead33d38238d2bfcfbf9de0c18d28bde03"
+          "sha256": "c14e1b1c526f2fe555ab2dc86c0e8aead33d38238d2bfcfbf9de0c18d28bde03",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/voice-directions.md",
           "owner": "speech",
-          "sha256": "5da0a4c59bdadb47d1795f51a9708b515fbf2901f0ca808cc5c66d83a336986d"
+          "sha256": "5da0a4c59bdadb47d1795f51a9708b515fbf2901f0ca808cc5c66d83a336986d",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/references/voiceover.md",
           "owner": "speech",
-          "sha256": "a4bb96c31c8be6a62d35a103f9d7fc700b8004df2efd10595d00b63f0c096486"
+          "sha256": "a4bb96c31c8be6a62d35a103f9d7fc700b8004df2efd10595d00b63f0c096486",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/speech/scripts/text_to_speech.py",
           "owner": "speech",
-          "sha256": "0000014efdf1194512c017ffa0d0574ae65881f6a1340b7ed822053b6e3d3c44"
+          "sha256": "0000014efdf1194512c017ffa0d0574ae65881f6a1340b7ed822053b6e3d3c44",
+          "mode": "100644"
         }
       ]
     },
@@ -18087,22 +19424,26 @@
         {
           "path": "skills/finance-investing/stock-screener-builder/SKILL.md",
           "owner": "stock-screener-builder",
-          "sha256": "bd7e77dd934ff483b3728069bec4201c6d5f71ae52155a0793cf92f99723cc5f"
+          "sha256": "bd7e77dd934ff483b3728069bec4201c6d5f71ae52155a0793cf92f99723cc5f",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/stock-screener-builder/assets/sample_universe.json",
           "owner": "stock-screener-builder",
-          "sha256": "d2733eeb89ba5442b07360a03f8ec9118873da72bbc3c5a6149d5337569ee13b"
+          "sha256": "d2733eeb89ba5442b07360a03f8ec9118873da72bbc3c5a6149d5337569ee13b",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/stock-screener-builder/references/screener-design.md",
           "owner": "stock-screener-builder",
-          "sha256": "2caea74b08ce37a5981648f085b45cafc54e9c363166c95f97b32fddf6fb9fcd"
+          "sha256": "2caea74b08ce37a5981648f085b45cafc54e9c363166c95f97b32fddf6fb9fcd",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/stock-screener-builder/scripts/screen_stocks.py",
           "owner": "stock-screener-builder",
-          "sha256": "b1f2e5075cc50dead0cc39dc69736b2b29de2686b5427f7967b1dc94c16bda69"
+          "sha256": "b1f2e5075cc50dead0cc39dc69736b2b29de2686b5427f7967b1dc94c16bda69",
+          "mode": "100644"
         }
       ]
     },
@@ -18232,87 +19573,104 @@
         {
           "path": "skills/developer-engineering/tech-debt-tracker/README.md",
           "owner": "tech-debt-tracker",
-          "sha256": "1a847da1e467f753b06493160a66d59ed808025007ecbc4f50832fd62f314c38"
+          "sha256": "1a847da1e467f753b06493160a66d59ed808025007ecbc4f50832fd62f314c38",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/SKILL.md",
           "owner": "tech-debt-tracker",
-          "sha256": "433b8e9cf20b8f3e1d9712611d6bcff22d5f4b3516b3a398f70315e290a33af3"
+          "sha256": "433b8e9cf20b8f3e1d9712611d6bcff22d5f4b3516b3a398f70315e290a33af3",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/historical_debt_2024-01-15.json",
           "owner": "tech-debt-tracker",
-          "sha256": "4ae4f44c2f24068165a96b5f9fd058416c852c0d4eef62bf2db835c762e3ca70"
+          "sha256": "4ae4f44c2f24068165a96b5f9fd058416c852c0d4eef62bf2db835c762e3ca70",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/historical_debt_2024-02-01.json",
           "owner": "tech-debt-tracker",
-          "sha256": "b6c65b533b005bc3c4b7cbe5efaf8de07f346424e3a5c055d8b5e6eea142277c"
+          "sha256": "b6c65b533b005bc3c4b7cbe5efaf8de07f346424e3a5c055d8b5e6eea142277c",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/sample_codebase/src/frontend.js",
           "owner": "tech-debt-tracker",
-          "sha256": "a9eedae239571e0aa8d1d0263ee9ded5b212fe5b2c5e92431b22257654be142b"
+          "sha256": "a9eedae239571e0aa8d1d0263ee9ded5b212fe5b2c5e92431b22257654be142b",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/sample_codebase/src/payment_processor.py",
           "owner": "tech-debt-tracker",
-          "sha256": "1719406de43edf6f109a85bc9f094d4fb3dd97411540534219fea2c3ebd9aa1e"
+          "sha256": "1719406de43edf6f109a85bc9f094d4fb3dd97411540534219fea2c3ebd9aa1e",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/sample_codebase/src/user_service.py",
           "owner": "tech-debt-tracker",
-          "sha256": "f948b98c2b9ed10227fe7b4770e90c396a09b25cda71e66ac48e4a42f2fe5213"
+          "sha256": "f948b98c2b9ed10227fe7b4770e90c396a09b25cda71e66ac48e4a42f2fe5213",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/assets/sample_debt_inventory.json",
           "owner": "tech-debt-tracker",
-          "sha256": "3c72c6947de5bde8f8517e693633d8aba64e59cdc3060ce8ff7245942509acc9"
+          "sha256": "3c72c6947de5bde8f8517e693633d8aba64e59cdc3060ce8ff7245942509acc9",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/expected_outputs/sample_dashboard_output.json",
           "owner": "tech-debt-tracker",
-          "sha256": "4b14c1ebbb20ed884cb6dc8337bff5da0f9f7b0b7569aca4d912dbf48d34e5e7"
+          "sha256": "4b14c1ebbb20ed884cb6dc8337bff5da0f9f7b0b7569aca4d912dbf48d34e5e7",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/expected_outputs/sample_prioritization_output.json",
           "owner": "tech-debt-tracker",
-          "sha256": "4c4c024c64b5169bc5d8cc10d834d5934ad3b1fa7f9f2fc9ad1f14d85a8fbc11"
+          "sha256": "4c4c024c64b5169bc5d8cc10d834d5934ad3b1fa7f9f2fc9ad1f14d85a8fbc11",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/expected_outputs/sample_scan_output.json",
           "owner": "tech-debt-tracker",
-          "sha256": "f44089c4bc4d4dea5e13d89ffd6f4c55489f819edc5b9d7a64c5866905ee8e0d"
+          "sha256": "f44089c4bc4d4dea5e13d89ffd6f4c55489f819edc5b9d7a64c5866905ee8e0d",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/references/debt-classification-taxonomy.md",
           "owner": "tech-debt-tracker",
-          "sha256": "00e1313c2d253043dd49d667df07c6c65062b4c68ec0478f6cf1dda311a70713"
+          "sha256": "00e1313c2d253043dd49d667df07c6c65062b4c68ec0478f6cf1dda311a70713",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/references/prioritization-framework.md",
           "owner": "tech-debt-tracker",
-          "sha256": "03e47d8e96c6d70a18b1583c4d7e919154c8180be7f03edf70dc9a06dc56f2ea"
+          "sha256": "03e47d8e96c6d70a18b1583c4d7e919154c8180be7f03edf70dc9a06dc56f2ea",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/references/stakeholder-communication-templates.md",
           "owner": "tech-debt-tracker",
-          "sha256": "13f9b1812ef6baecce883b82fbabc1f032e0e5f14d06cadc33c13f719b9243bb"
+          "sha256": "13f9b1812ef6baecce883b82fbabc1f032e0e5f14d06cadc33c13f719b9243bb",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/scripts/debt_dashboard.py",
           "owner": "tech-debt-tracker",
-          "sha256": "3d5d7b519fc6038453aa0d9461539ff44e5e44a489b0de5e435006833541d345"
+          "sha256": "3d5d7b519fc6038453aa0d9461539ff44e5e44a489b0de5e435006833541d345",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/scripts/debt_prioritizer.py",
           "owner": "tech-debt-tracker",
-          "sha256": "ddc579908d5205654ec4f0c2b90e0ecc71a8aad92dbc289396a5e2d414290871"
+          "sha256": "ddc579908d5205654ec4f0c2b90e0ecc71a8aad92dbc289396a5e2d414290871",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tech-debt-tracker/scripts/debt_scanner.py",
           "owner": "tech-debt-tracker",
-          "sha256": "a68ff9ad23961d0878c477e1ee4efb025ca547ce8f278ddefd334e8fbc9e1f92"
+          "sha256": "a68ff9ad23961d0878c477e1ee4efb025ca547ce8f278ddefd334e8fbc9e1f92",
+          "mode": "100644"
         }
       ]
     },
@@ -18422,67 +19780,80 @@
         {
           "path": "skills/operations-general/theme-factory/LICENSE.txt",
           "owner": "theme-factory",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/SKILL.md",
           "owner": "theme-factory",
-          "sha256": "1f5696d4a3f8ad841484c1e8fc8826537fe68bb5f92c51c656778e8de21d8925"
+          "sha256": "1f5696d4a3f8ad841484c1e8fc8826537fe68bb5f92c51c656778e8de21d8925",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/theme-showcase.pdf",
           "owner": "theme-factory",
-          "sha256": "3e126eca9fe99088051f7cb984c97cedb31c7d9e09ce0ba5d61bd01e70a0d253"
+          "sha256": "3e126eca9fe99088051f7cb984c97cedb31c7d9e09ce0ba5d61bd01e70a0d253",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/arctic-frost.md",
           "owner": "theme-factory",
-          "sha256": "868a75a8fb5b2a61d0f0ab87c437fe632d3cbab6371c418f06aa2816ac109ae0"
+          "sha256": "868a75a8fb5b2a61d0f0ab87c437fe632d3cbab6371c418f06aa2816ac109ae0",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/botanical-garden.md",
           "owner": "theme-factory",
-          "sha256": "222cb8e7496abc9b75b29453c809fb9839e7e4b01fa45deecdd896b38d087765"
+          "sha256": "222cb8e7496abc9b75b29453c809fb9839e7e4b01fa45deecdd896b38d087765",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/desert-rose.md",
           "owner": "theme-factory",
-          "sha256": "bd065b8629be3b64655183927e248e3d892a27b8d184b009cfba89c96102744f"
+          "sha256": "bd065b8629be3b64655183927e248e3d892a27b8d184b009cfba89c96102744f",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/forest-canopy.md",
           "owner": "theme-factory",
-          "sha256": "ecb722efa24688e808b5bf323c334ca2349e989cfddd72ce8400ce5d4c4bd3e7"
+          "sha256": "ecb722efa24688e808b5bf323c334ca2349e989cfddd72ce8400ce5d4c4bd3e7",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/golden-hour.md",
           "owner": "theme-factory",
-          "sha256": "3444a00df971d3c2f06b665e21a2e9eb5d7d7d6f6281f2758773b8345776a139"
+          "sha256": "3444a00df971d3c2f06b665e21a2e9eb5d7d7d6f6281f2758773b8345776a139",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/midnight-galaxy.md",
           "owner": "theme-factory",
-          "sha256": "0e134c4c0324df41e34ac314269aa6829cd378cf3c304b31858d0cd158d2f944"
+          "sha256": "0e134c4c0324df41e34ac314269aa6829cd378cf3c304b31858d0cd158d2f944",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/modern-minimalist.md",
           "owner": "theme-factory",
-          "sha256": "b8bc572b75948d4df69c401af703b9262ed6820a3ceb270da30a529e92763614"
+          "sha256": "b8bc572b75948d4df69c401af703b9262ed6820a3ceb270da30a529e92763614",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/ocean-depths.md",
           "owner": "theme-factory",
-          "sha256": "a7ad8eec85341dbfcb2665da827a4b6a4baee08ab3335ac02421f18e6b46b2e2"
+          "sha256": "a7ad8eec85341dbfcb2665da827a4b6a4baee08ab3335ac02421f18e6b46b2e2",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/sunset-boulevard.md",
           "owner": "theme-factory",
-          "sha256": "658af11ab04be4923692571081ffb42a428141ae537703117b9236d9f8ee22a3"
+          "sha256": "658af11ab04be4923692571081ffb42a428141ae537703117b9236d9f8ee22a3",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/theme-factory/themes/tech-innovation.md",
           "owner": "theme-factory",
-          "sha256": "183648163026dd5eeba3df5effa335b55ba333c3ee1fe215278605e55f40a52a"
+          "sha256": "183648163026dd5eeba3df5effa335b55ba333c3ee1fe215278605e55f40a52a",
+          "mode": "100644"
         }
       ]
     },
@@ -18562,37 +19933,44 @@
         {
           "path": "skills/multimodal-media/transcribe/LICENSE.txt",
           "owner": "transcribe",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/SKILL.md",
           "owner": "transcribe",
-          "sha256": "f1d6d43ec7c6cf25110e5b7989bfda4c94965208b8d291ea23daf8a89c89b4bc"
+          "sha256": "f1d6d43ec7c6cf25110e5b7989bfda4c94965208b8d291ea23daf8a89c89b4bc",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/agents/openai.yaml",
           "owner": "transcribe",
-          "sha256": "fe7a20b9c03ce027e2f3023a4fd363c2d958ceeae1b7daaef77d1f6d055d97a4"
+          "sha256": "fe7a20b9c03ce027e2f3023a4fd363c2d958ceeae1b7daaef77d1f6d055d97a4",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/assets/transcribe-small.svg",
           "owner": "transcribe",
-          "sha256": "7d67890abf0f145a77f5fb87752bb6337b394fd4e26f5969c57d82d40e369a14"
+          "sha256": "7d67890abf0f145a77f5fb87752bb6337b394fd4e26f5969c57d82d40e369a14",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/assets/transcribe.png",
           "owner": "transcribe",
-          "sha256": "0860df58af6b9e58f4445a81baca7bfd94029a447742ae9b9e896e7c5b748688"
+          "sha256": "0860df58af6b9e58f4445a81baca7bfd94029a447742ae9b9e896e7c5b748688",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/references/api.md",
           "owner": "transcribe",
-          "sha256": "a2bf7e59d69aa127b176255c5c01afbafda4e3029b12b4413e75074233ffb36d"
+          "sha256": "a2bf7e59d69aa127b176255c5c01afbafda4e3029b12b4413e75074233ffb36d",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/transcribe/scripts/transcribe_diarize.py",
           "owner": "transcribe",
-          "sha256": "d623b1fed1491b7ca4b7b5b393089165e3581a83d90d5a57868241f1b2a5d951"
+          "sha256": "d623b1fed1491b7ca4b7b5b393089165e3581a83d90d5a57868241f1b2a5d951",
+          "mode": "100644"
         }
       ]
     },
@@ -18982,347 +20360,416 @@
         {
           "path": "skills/office-white-collar/transcript-fixer/.gitignore",
           "owner": "transcript-fixer",
-          "sha256": "671c5836a80fcc048d927b67f47a9a0036ea98ae60190de43c4ee9c7f51f17f1"
+          "sha256": "671c5836a80fcc048d927b67f47a9a0036ea98ae60190de43c4ee9c7f51f17f1",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/SKILL.md",
           "owner": "transcript-fixer",
-          "sha256": "b557b1ed4cb5207d692deb7370ee14d3c9c714a09aec1a7c06becb32a266a078"
+          "sha256": "b557b1ed4cb5207d692deb7370ee14d3c9c714a09aec1a7c06becb32a266a078",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/architecture.md",
           "owner": "transcript-fixer",
-          "sha256": "aa9e8513afbb5b5b551c007d205928590640777950daa8ea09472c352647183d"
+          "sha256": "aa9e8513afbb5b5b551c007d205928590640777950daa8ea09472c352647183d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/best_practices.md",
           "owner": "transcript-fixer",
-          "sha256": "a5ae4efa0773d8e6c7fc1067497f22c60fc5cca7ee3bd660ea2a33b30f96aa19"
+          "sha256": "a5ae4efa0773d8e6c7fc1067497f22c60fc5cca7ee3bd660ea2a33b30f96aa19",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/database_schema.md",
           "owner": "transcript-fixer",
-          "sha256": "9877df6f24d8be24aca2ccc8ed38c8c43c20c3033e9b76ca58a4bfd65d007a52"
+          "sha256": "9877df6f24d8be24aca2ccc8ed38c8c43c20c3033e9b76ca58a4bfd65d007a52",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/dictionary_guide.md",
           "owner": "transcript-fixer",
-          "sha256": "94c743a377174b8b67f7f61c7653a476513191f81536f7408b6f7dd16efc4dbc"
+          "sha256": "94c743a377174b8b67f7f61c7653a476513191f81536f7408b6f7dd16efc4dbc",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/file_formats.md",
           "owner": "transcript-fixer",
-          "sha256": "4d2153d867b51bb88389b74f0a97b414a17e14e6fae4249eec3d82e3b1aa0681"
+          "sha256": "4d2153d867b51bb88389b74f0a97b414a17e14e6fae4249eec3d82e3b1aa0681",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/glm_api_setup.md",
           "owner": "transcript-fixer",
-          "sha256": "0d66db55e478f1d351aee11c2a2f0baaf9c4d0c93d6e5c95fde8f1ffad33e4dd"
+          "sha256": "0d66db55e478f1d351aee11c2a2f0baaf9c4d0c93d6e5c95fde8f1ffad33e4dd",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/installation_setup.md",
           "owner": "transcript-fixer",
-          "sha256": "ae0d3653ce56704e9e7e14dde449cd0bad3b485cf82395f8e8de75f171bc02df"
+          "sha256": "ae0d3653ce56704e9e7e14dde449cd0bad3b485cf82395f8e8de75f171bc02df",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/iteration_workflow.md",
           "owner": "transcript-fixer",
-          "sha256": "2cd62b1631ca0ddc84326ca5d9d7bba115d3758a12c99c80bbe671a664dec85b"
+          "sha256": "2cd62b1631ca0ddc84326ca5d9d7bba115d3758a12c99c80bbe671a664dec85b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/quick_reference.md",
           "owner": "transcript-fixer",
-          "sha256": "55be70bfd398901c9ad6cf7437357ab9a43e718e1fea197afaafde8b84a3c095"
+          "sha256": "55be70bfd398901c9ad6cf7437357ab9a43e718e1fea197afaafde8b84a3c095",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/script_parameters.md",
           "owner": "transcript-fixer",
-          "sha256": "2c5d9fc47dd8ca074f5d829d820a6e6566eb2d4f5097dace12304a811dc00b80"
+          "sha256": "2c5d9fc47dd8ca074f5d829d820a6e6566eb2d4f5097dace12304a811dc00b80",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/sql_queries.md",
           "owner": "transcript-fixer",
-          "sha256": "ffd0c3b9c3bcf7fc380e3754ec4284fea99befbcca99514abf9e8ac172fbf64e"
+          "sha256": "ffd0c3b9c3bcf7fc380e3754ec4284fea99befbcca99514abf9e8ac172fbf64e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/team_collaboration.md",
           "owner": "transcript-fixer",
-          "sha256": "a88bc9d1c3afbd86b308c8dca376edd8291484d3f81e9411fa2b832f618a052b"
+          "sha256": "a88bc9d1c3afbd86b308c8dca376edd8291484d3f81e9411fa2b832f618a052b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/troubleshooting.md",
           "owner": "transcript-fixer",
-          "sha256": "4f47dc6b88868b0873c4a18556ce76c03c7cdbdd5f9d50610f724147a2d5a16e"
+          "sha256": "4f47dc6b88868b0873c4a18556ce76c03c7cdbdd5f9d50610f724147a2d5a16e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/references/workflow_guide.md",
           "owner": "transcript-fixer",
-          "sha256": "095c1f13fad47e865730f6e994bdaf1c985c11ccd3c3ae046e79e975a37e2038"
+          "sha256": "095c1f13fad47e865730f6e994bdaf1c985c11ccd3c3ae046e79e975a37e2038",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/requirements.txt",
           "owner": "transcript-fixer",
-          "sha256": "5a281d5e3433e58ae03a33591c05121e3d7e3ca5fd1ba6f113412834f5904d6c"
+          "sha256": "5a281d5e3433e58ae03a33591c05121e3d7e3ca5fd1ba6f113412834f5904d6c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "45f253d0bf424603ea3296d5f427fe0b02b15304076da0c3f76d3d5d4d9c3b53"
+          "sha256": "45f253d0bf424603ea3296d5f427fe0b02b15304076da0c3f76d3d5d4d9c3b53",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/check_type_hints.py",
           "owner": "transcript-fixer",
-          "sha256": "cd09a3f5327e861a29f4e20ff43144d7810324d92968ec023d65760f38b881ff"
+          "sha256": "cd09a3f5327e861a29f4e20ff43144d7810324d92968ec023d65760f38b881ff",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/cli/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "57fe03347101fb30aff5b83f77dbbb8f12e8851536f43186c255b86f21c94f3a"
+          "sha256": "57fe03347101fb30aff5b83f77dbbb8f12e8851536f43186c255b86f21c94f3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/cli/argument_parser.py",
           "owner": "transcript-fixer",
-          "sha256": "d56e0bc4bd75da486812fad779a1787ebf4a7f30a4d0e8e199bea5e2c8e35c33"
+          "sha256": "d56e0bc4bd75da486812fad779a1787ebf4a7f30a4d0e8e199bea5e2c8e35c33",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/cli/commands.py",
           "owner": "transcript-fixer",
-          "sha256": "4121fdeadc61de801ade34ef82fb872027d3d6e024b0fdf10160ba34df0fcbb9"
+          "sha256": "4121fdeadc61de801ade34ef82fb872027d3d6e024b0fdf10160ba34df0fcbb9",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "8d5d698ec00d5e09e4cdc139e9b011ec75a3ad281d99ca49753065aea228a379"
+          "sha256": "8d5d698ec00d5e09e4cdc139e9b011ec75a3ad281d99ca49753065aea228a379",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/ai_processor.py",
           "owner": "transcript-fixer",
-          "sha256": "2c5dfaa17daf282081b52d8d9d91abb1a382fe3aa08ed928e3ee83738cf0db85"
+          "sha256": "2c5dfaa17daf282081b52d8d9d91abb1a382fe3aa08ed928e3ee83738cf0db85",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/ai_processor_async.py",
           "owner": "transcript-fixer",
-          "sha256": "bdb89ff1cfa5bb3d5a611e8f49772beeac03dafb3bb11df08de0b915462a9658"
+          "sha256": "bdb89ff1cfa5bb3d5a611e8f49772beeac03dafb3bb11df08de0b915462a9658",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/change_extractor.py",
           "owner": "transcript-fixer",
-          "sha256": "0a35cddcab8c303cf5aabe4483cdf9999a1eeb0a04327420aae0410b3faa6936"
+          "sha256": "0a35cddcab8c303cf5aabe4483cdf9999a1eeb0a04327420aae0410b3faa6936",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/connection_pool.py",
           "owner": "transcript-fixer",
-          "sha256": "70df9c3a3679d6ea89e14b988b379caaf33a032ff7774797bfe9bb50875d0360"
+          "sha256": "70df9c3a3679d6ea89e14b988b379caaf33a032ff7774797bfe9bb50875d0360",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/correction_repository.py",
           "owner": "transcript-fixer",
-          "sha256": "bf9027ea827d6a7595f6a60ca89e94a5c02f0684325ad1a4b1907f3c8bc438a2"
+          "sha256": "bf9027ea827d6a7595f6a60ca89e94a5c02f0684325ad1a4b1907f3c8bc438a2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/correction_service.py",
           "owner": "transcript-fixer",
-          "sha256": "de9d9d9a2d9da41f43f94f86ceb09fb7a3663f20d35bcba605afe15964e77d31"
+          "sha256": "de9d9d9a2d9da41f43f94f86ceb09fb7a3663f20d35bcba605afe15964e77d31",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/dictionary_processor.py",
           "owner": "transcript-fixer",
-          "sha256": "530219ec144f956e64a06d121d7242e81688702552f4130171d08c2f8c71eb97"
+          "sha256": "530219ec144f956e64a06d121d7242e81688702552f4130171d08c2f8c71eb97",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/learning_engine.py",
           "owner": "transcript-fixer",
-          "sha256": "0c19597c8e0371ec893a0058ca2d0a9d085d4547b868ce337520f14f6d6392f3"
+          "sha256": "0c19597c8e0371ec893a0058ca2d0a9d085d4547b868ce337520f14f6d6392f3",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/core/schema.sql",
           "owner": "transcript-fixer",
-          "sha256": "c8fe9cdf254790664d4bb60e2a178bc2883083843938216b33ebf24612683eda"
+          "sha256": "c8fe9cdf254790664d4bb60e2a178bc2883083843938216b33ebf24612683eda",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/ensure_deps.py",
           "owner": "transcript-fixer",
-          "sha256": "07cf832d093f25488c81070c3b8f38b20a00e1bdbac468ada58ddf21efb1443f"
+          "sha256": "07cf832d093f25488c81070c3b8f38b20a00e1bdbac468ada58ddf21efb1443f",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/examples/bulk_import.py",
           "owner": "transcript-fixer",
-          "sha256": "6138f5d9e57d2165b8a488b8f4742827052705458c6c57f1a05ddbacaf5c702f"
+          "sha256": "6138f5d9e57d2165b8a488b8f4742827052705458c6c57f1a05ddbacaf5c702f",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/fix_transcript_enhanced.py",
           "owner": "transcript-fixer",
-          "sha256": "d4b50704f84eed7629270515c9bb98243b25754d0500c3e6984d08a996119c0e"
+          "sha256": "d4b50704f84eed7629270515c9bb98243b25754d0500c3e6984d08a996119c0e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/fix_transcription.py",
           "owner": "transcript-fixer",
-          "sha256": "b476b8395fee1a6d9d2ce2a38c31d1e0f14476789d65c73bc9616514d1e31498"
+          "sha256": "b476b8395fee1a6d9d2ce2a38c31d1e0f14476789d65c73bc9616514d1e31498",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/generate_word_diff.py",
           "owner": "transcript-fixer",
-          "sha256": "e8a8e7c713177f89121082bb686971f2c669fade6544b1b3b983726686e8b049"
+          "sha256": "e8a8e7c713177f89121082bb686971f2c669fade6544b1b3b983726686e8b049",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "186fbcbac438899550a9ff26859b3a7eadc9bb655ba210993757f9540ce3afac"
+          "sha256": "186fbcbac438899550a9ff26859b3a7eadc9bb655ba210993757f9540ce3afac",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_audit_log_retention.py",
           "owner": "transcript-fixer",
-          "sha256": "d76f2d0d2762f472bef729e6097988f6cb3bd70c5f1e119ae2f84cb666e9ca48"
+          "sha256": "d76f2d0d2762f472bef729e6097988f6cb3bd70c5f1e119ae2f84cb666e9ca48",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_connection_pool.py",
           "owner": "transcript-fixer",
-          "sha256": "de91b3727f71c4047a749c39a935915079cb7e2c6e4e488d89752d76bf958ab4"
+          "sha256": "de91b3727f71c4047a749c39a935915079cb7e2c6e4e488d89752d76bf958ab4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_correction_service.py",
           "owner": "transcript-fixer",
-          "sha256": "d6c571b6c7272a208173cc91087f181b9c3dbd9e683f7c76a52a1579df4478f2"
+          "sha256": "d6c571b6c7272a208173cc91087f181b9c3dbd9e683f7c76a52a1579df4478f2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_domain_validator.py",
           "owner": "transcript-fixer",
-          "sha256": "59df81d0c8583bdd5e6e53b506523aee44404827c591c0217a2082b02e1b3d37"
+          "sha256": "59df81d0c8583bdd5e6e53b506523aee44404827c591c0217a2082b02e1b3d37",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_error_recovery.py",
           "owner": "transcript-fixer",
-          "sha256": "d7f77c3a30f4041005e8e5842a57e113e122c6879c228858b5bcd9baefd1f57b"
+          "sha256": "d7f77c3a30f4041005e8e5842a57e113e122c6879c228858b5bcd9baefd1f57b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_learning_engine.py",
           "owner": "transcript-fixer",
-          "sha256": "32d5ed0a302d5c264aaba9ab0e257e6c5543f4d2102048a0f94e62c46ae340b2"
+          "sha256": "32d5ed0a302d5c264aaba9ab0e257e6c5543f4d2102048a0f94e62c46ae340b2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/tests/test_path_validator.py",
           "owner": "transcript-fixer",
-          "sha256": "ad54c741405c30db23f436e79e5c4551dd894ffa29d42afbcafec7ca717dd05c"
+          "sha256": "ad54c741405c30db23f436e79e5c4551dd894ffa29d42afbcafec7ca717dd05c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "cde2b285df9c79237b46070514686f2cf7a27309c267ee95da142d37e5eda893"
+          "sha256": "cde2b285df9c79237b46070514686f2cf7a27309c267ee95da142d37e5eda893",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/audit_log_retention.py",
           "owner": "transcript-fixer",
-          "sha256": "bf46b84208bc7e6cb1c00a36aef3839e905f6b2300b202a166ab227f3d5faff8"
+          "sha256": "bf46b84208bc7e6cb1c00a36aef3839e905f6b2300b202a166ab227f3d5faff8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/concurrency_manager.py",
           "owner": "transcript-fixer",
-          "sha256": "142f72d11aa707e1c21e6da04e68a8a76977393d76e97fe518e90b1565718b66"
+          "sha256": "142f72d11aa707e1c21e6da04e68a8a76977393d76e97fe518e90b1565718b66",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/config.py",
           "owner": "transcript-fixer",
-          "sha256": "8b6f62b244e194c5ed92ab9cb98461bde0409d798476ad450968da9b0e4ea70f"
+          "sha256": "8b6f62b244e194c5ed92ab9cb98461bde0409d798476ad450968da9b0e4ea70f",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/database_migration.py",
           "owner": "transcript-fixer",
-          "sha256": "c2b5a67608cbea5e13d196788e37eea7b69fc1ec437e3671ce656ed1fa5f1977"
+          "sha256": "c2b5a67608cbea5e13d196788e37eea7b69fc1ec437e3671ce656ed1fa5f1977",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/db_migrations_cli.py",
           "owner": "transcript-fixer",
-          "sha256": "48b8b9fce6fd4f494b6c14e585f6a85d83a2cb5cf773526671772fd5cd9eb7f6"
+          "sha256": "48b8b9fce6fd4f494b6c14e585f6a85d83a2cb5cf773526671772fd5cd9eb7f6",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/__init__.py",
           "owner": "transcript-fixer",
-          "sha256": "4085e42c8f76869fa71812d6ef1cf16f16e29c669f2184953cccc36116adac26"
+          "sha256": "4085e42c8f76869fa71812d6ef1cf16f16e29c669f2184953cccc36116adac26",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/change_extractor.py",
           "owner": "transcript-fixer",
-          "sha256": "4a3fc38e677158fe37025a2412533d6ad7f3e7336ca07e6046e24f0152f0de12"
+          "sha256": "4a3fc38e677158fe37025a2412533d6ad7f3e7336ca07e6046e24f0152f0de12",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/html_format.py",
           "owner": "transcript-fixer",
-          "sha256": "9c2d904ee4f13513cf535e92fbd8e514d056ef9ad41cb2ab9fa2082b8fa53682"
+          "sha256": "9c2d904ee4f13513cf535e92fbd8e514d056ef9ad41cb2ab9fa2082b8fa53682",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/inline_format.py",
           "owner": "transcript-fixer",
-          "sha256": "914204e870187e29fb6085ee222d42535a8fef698606588581224281c5810f97"
+          "sha256": "914204e870187e29fb6085ee222d42535a8fef698606588581224281c5810f97",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/markdown_format.py",
           "owner": "transcript-fixer",
-          "sha256": "1a2d5d6ab841d2064fccc7d4e06c9742929bc83a7b8d2a2eec671dd8ab67e4db"
+          "sha256": "1a2d5d6ab841d2064fccc7d4e06c9742929bc83a7b8d2a2eec671dd8ab67e4db",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/text_splitter.py",
           "owner": "transcript-fixer",
-          "sha256": "d0fb53bad691be0a99fe46eab277395c3e54674176f7ce3d41f011fd7d5b1e19"
+          "sha256": "d0fb53bad691be0a99fe46eab277395c3e54674176f7ce3d41f011fd7d5b1e19",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_formats/unified_format.py",
           "owner": "transcript-fixer",
-          "sha256": "170c4531b993c7561d6986b3cbbefba0f96cc6e2551ad07b3bfbed7c2c0410ef"
+          "sha256": "170c4531b993c7561d6986b3cbbefba0f96cc6e2551ad07b3bfbed7c2c0410ef",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/diff_generator.py",
           "owner": "transcript-fixer",
-          "sha256": "154a4be50b4712904907746fd29d91ec95a6eb88295a9e00d7d881444e9c7dad"
+          "sha256": "154a4be50b4712904907746fd29d91ec95a6eb88295a9e00d7d881444e9c7dad",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/domain_validator.py",
           "owner": "transcript-fixer",
-          "sha256": "b09f60de6f8f932d0679eb4d57c4c5317f5bf44cdc34ec72309431953cf1f015"
+          "sha256": "b09f60de6f8f932d0679eb4d57c4c5317f5bf44cdc34ec72309431953cf1f015",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/health_check.py",
           "owner": "transcript-fixer",
-          "sha256": "da156a115f3b16d79dfba0b9109b91fcf6a1fcdaa757de362fd9afbe7c5f0074"
+          "sha256": "da156a115f3b16d79dfba0b9109b91fcf6a1fcdaa757de362fd9afbe7c5f0074",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/logging_config.py",
           "owner": "transcript-fixer",
-          "sha256": "7e4719819784f43be262a457f138f3ed3693f136ae5b25750249fea994bb12b2"
+          "sha256": "7e4719819784f43be262a457f138f3ed3693f136ae5b25750249fea994bb12b2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/metrics.py",
           "owner": "transcript-fixer",
-          "sha256": "e8707f27e36c978862e3a3c14678778153e9e73c506d84c7decefbebe669c54a"
+          "sha256": "e8707f27e36c978862e3a3c14678778153e9e73c506d84c7decefbebe669c54a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/migrations.py",
           "owner": "transcript-fixer",
-          "sha256": "a9eba381480304751de51742afc2eec4cafe03187bd082e298c290e4e3e7fbc6"
+          "sha256": "a9eba381480304751de51742afc2eec4cafe03187bd082e298c290e4e3e7fbc6",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/path_validator.py",
           "owner": "transcript-fixer",
-          "sha256": "a33913472aec01bcbf6c47957b8bb7f6a8ee1cef4dcaacdae5d558bd106b29b1"
+          "sha256": "a33913472aec01bcbf6c47957b8bb7f6a8ee1cef4dcaacdae5d558bd106b29b1",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/rate_limiter.py",
           "owner": "transcript-fixer",
-          "sha256": "dbe220bc6dfa96d8bcd773729000266dd4b08a0e19c9a48794f635921de02ec6"
+          "sha256": "dbe220bc6dfa96d8bcd773729000266dd4b08a0e19c9a48794f635921de02ec6",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/retry_logic.py",
           "owner": "transcript-fixer",
-          "sha256": "3638c1f1feb36d6483f7fbd15d6950deb1bf8c6ccd503ad95034757d991f4e1b"
+          "sha256": "3638c1f1feb36d6483f7fbd15d6950deb1bf8c6ccd503ad95034757d991f4e1b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/security.py",
           "owner": "transcript-fixer",
-          "sha256": "8c2be80d63acfe143ff00e62a9d8475d2079e8987d8fe8cf4ad10ab4fe01b66e"
+          "sha256": "8c2be80d63acfe143ff00e62a9d8475d2079e8987d8fe8cf4ad10ab4fe01b66e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/utils/validation.py",
           "owner": "transcript-fixer",
-          "sha256": "c330821a636685174c0a0c9cd499771dfe8d58abc12b4d26bd98d825e64bc3df"
+          "sha256": "c330821a636685174c0a0c9cd499771dfe8d58abc12b4d26bd98d825e64bc3df",
+          "mode": "100644"
         }
       ]
     },
@@ -19372,7 +20819,8 @@
         {
           "path": "skills/security-and-reliability/trivy-vulnerability-scanner/SKILL.md",
           "owner": "trivy-vulnerability-scanner",
-          "sha256": "eee5fe50f8a2109f45f3876c911e724d2bb37601173162f56294a86ece2743d4"
+          "sha256": "eee5fe50f8a2109f45f3876c911e724d2bb37601173162f56294a86ece2743d4",
+          "mode": "100644"
         }
       ]
     },
@@ -19422,7 +20870,8 @@
         {
           "path": "skills/growth-operations-xiaohongshu/tweetclaw-source-research/SKILL.md",
           "owner": "tweetclaw-source-research",
-          "sha256": "28bd15cce7d15e50dda969ca9301d5f872e852445a9fc1d387ce32aef3cd5d83"
+          "sha256": "28bd15cce7d15e50dda969ca9301d5f872e852445a9fc1d387ce32aef3cd5d83",
+          "mode": "100644"
         }
       ]
     },
@@ -19487,22 +20936,26 @@
         {
           "path": "skills/growth-operations-xiaohongshu/twitter-reader/.security-scan-passed",
           "owner": "twitter-reader",
-          "sha256": "59903709d9644c13fe202b54047655b4596718d2b6eaa7458200091c6f1af41c"
+          "sha256": "59903709d9644c13fe202b54047655b4596718d2b6eaa7458200091c6f1af41c",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/twitter-reader/SKILL.md",
           "owner": "twitter-reader",
-          "sha256": "49ef6cfb596543e08158c965ba4971188fce316bcb4428bb91ba3314b6efdde2"
+          "sha256": "49ef6cfb596543e08158c965ba4971188fce316bcb4428bb91ba3314b6efdde2",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/twitter-reader/scripts/fetch_tweet.py",
           "owner": "twitter-reader",
-          "sha256": "955d842a332244e736b986fbbb4eaf02bcc5664595257630e96faa49f449132f"
+          "sha256": "955d842a332244e736b986fbbb4eaf02bcc5664595257630e96faa49f449132f",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/twitter-reader/scripts/fetch_tweets.sh",
           "owner": "twitter-reader",
-          "sha256": "a7f54b40f87ded264ecde457a3f002cc0e10817b2d823dbeeb57328a18a2a9da"
+          "sha256": "a7f54b40f87ded264ecde457a3f002cc0e10817b2d823dbeeb57328a18a2a9da",
+          "mode": "100644"
         }
       ]
     },
@@ -19552,7 +21005,8 @@
         {
           "path": "skills/developer-engineering/typescript-best-practices/SKILL.md",
           "owner": "typescript-best-practices",
-          "sha256": "fb632ff254d4f16b5948cc6b97c997d7ec311dc9d662ae56e1da5de895fa66dc"
+          "sha256": "fb632ff254d4f16b5948cc6b97c997d7ec311dc9d662ae56e1da5de895fa66dc",
+          "mode": "100644"
         }
       ]
     },
@@ -19627,32 +21081,38 @@
         {
           "path": "skills/product-design/ui-design-system/SKILL.md",
           "owner": "ui-design-system",
-          "sha256": "82337617b8a1c74ab42b1f8b707942a55fe64e0cbfaea0a87824c59b58cf62c8"
+          "sha256": "82337617b8a1c74ab42b1f8b707942a55fe64e0cbfaea0a87824c59b58cf62c8",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ui-design-system/references/component-architecture.md",
           "owner": "ui-design-system",
-          "sha256": "4cf363aa2e206dc05c3e07c0f0b4ba1b11fda1fad10ba471b6e84ab9e7a85b84"
+          "sha256": "4cf363aa2e206dc05c3e07c0f0b4ba1b11fda1fad10ba471b6e84ab9e7a85b84",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ui-design-system/references/developer-handoff.md",
           "owner": "ui-design-system",
-          "sha256": "14087541aa4b8f897391c88737629dff403a6565463bdf3f5e27f5860f29a875"
+          "sha256": "14087541aa4b8f897391c88737629dff403a6565463bdf3f5e27f5860f29a875",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ui-design-system/references/responsive-calculations.md",
           "owner": "ui-design-system",
-          "sha256": "f15fcf793ef2147c9470f0b8b8b712321cd4a5bcd2f64bed3d942f30fbc20eb7"
+          "sha256": "f15fcf793ef2147c9470f0b8b8b712321cd4a5bcd2f64bed3d942f30fbc20eb7",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ui-design-system/references/token-generation.md",
           "owner": "ui-design-system",
-          "sha256": "4a96787e57c40d7bf1a05b1f3348e3b7221cff4d4e11e0f9650f0a1681b29aa1"
+          "sha256": "4a96787e57c40d7bf1a05b1f3348e3b7221cff4d4e11e0f9650f0a1681b29aa1",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ui-design-system/scripts/design_token_generator.py",
           "owner": "ui-design-system",
-          "sha256": "95752d620c74dc24a39fd6f612f336dc90086280b034ed0be5a24efcd79b8522"
+          "sha256": "95752d620c74dc24a39fd6f612f336dc90086280b034ed0be5a24efcd79b8522",
+          "mode": "100644"
         }
       ]
     },
@@ -19702,7 +21162,8 @@
         {
           "path": "skills/product-design/ui-ux-pro-max/SKILL.md",
           "owner": "ui-ux-pro-max",
-          "sha256": "6c5e1e88e8fd691872f2d1731eb1db1d924f657bed05a7039d3b1d1e06dee548"
+          "sha256": "6c5e1e88e8fd691872f2d1731eb1db1d924f657bed05a7039d3b1d1e06dee548",
+          "mode": "100644"
         }
       ]
     },
@@ -19777,32 +21238,38 @@
         {
           "path": "skills/product-design/ux-researcher-designer/SKILL.md",
           "owner": "ux-researcher-designer",
-          "sha256": "87e0bc031209f3b0680a6c6a5a16ce635b893a15572a816ed36e49812d1a6fa6"
+          "sha256": "87e0bc031209f3b0680a6c6a5a16ce635b893a15572a816ed36e49812d1a6fa6",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ux-researcher-designer/references/example-personas.md",
           "owner": "ux-researcher-designer",
-          "sha256": "e2f8d8a65f3c1c4d4be0edc03db3e382592b03c51946bdcba610984da99e9750"
+          "sha256": "e2f8d8a65f3c1c4d4be0edc03db3e382592b03c51946bdcba610984da99e9750",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ux-researcher-designer/references/journey-mapping-guide.md",
           "owner": "ux-researcher-designer",
-          "sha256": "27059750646dfbbc036dd5d647df70d63591afa1a5454de3326fb9ad672b81ac"
+          "sha256": "27059750646dfbbc036dd5d647df70d63591afa1a5454de3326fb9ad672b81ac",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ux-researcher-designer/references/persona-methodology.md",
           "owner": "ux-researcher-designer",
-          "sha256": "a31e7a35880af5d7768f337f165dab9168a88016fed91e39f187cfa9c2fc1e5f"
+          "sha256": "a31e7a35880af5d7768f337f165dab9168a88016fed91e39f187cfa9c2fc1e5f",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ux-researcher-designer/references/usability-testing-frameworks.md",
           "owner": "ux-researcher-designer",
-          "sha256": "0a71d1fc59676df7d005f6bdc42e09ed94e924b6ef98837f5877f0bf3fc31676"
+          "sha256": "0a71d1fc59676df7d005f6bdc42e09ed94e924b6ef98837f5877f0bf3fc31676",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/ux-researcher-designer/scripts/persona_generator.py",
           "owner": "ux-researcher-designer",
-          "sha256": "8b4d3bf4d4a946ece102d75ce29156134d44af81da754117d73d79bb8c765268"
+          "sha256": "8b4d3bf4d4a946ece102d75ce29156134d44af81da754117d73d79bb8c765268",
+          "mode": "100644"
         }
       ]
     },
@@ -19877,32 +21344,38 @@
         {
           "path": "skills/deployment-platforms/vercel-deploy/LICENSE.txt",
           "owner": "vercel-deploy",
-          "sha256": "e0fad1e120e56b02bb8e65745ff5be6d3234368f2df9d0dd183183879e595fc1"
+          "sha256": "e0fad1e120e56b02bb8e65745ff5be6d3234368f2df9d0dd183183879e595fc1",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/vercel-deploy/SKILL.md",
           "owner": "vercel-deploy",
-          "sha256": "cd0abede816c5923986340edd5bd59ca17a9c2a027296248c35757d4e778661a"
+          "sha256": "cd0abede816c5923986340edd5bd59ca17a9c2a027296248c35757d4e778661a",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/vercel-deploy/agents/openai.yaml",
           "owner": "vercel-deploy",
-          "sha256": "5fdfff98a8cd084737f47231d65e7b8315e9036e12c8f2c90df7593f75abcf74"
+          "sha256": "5fdfff98a8cd084737f47231d65e7b8315e9036e12c8f2c90df7593f75abcf74",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/vercel-deploy/assets/vercel-small.svg",
           "owner": "vercel-deploy",
-          "sha256": "169e5fedb5898d756254c29e02873508eef714a8dd11638f283ca8e7c46096a5"
+          "sha256": "169e5fedb5898d756254c29e02873508eef714a8dd11638f283ca8e7c46096a5",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/vercel-deploy/assets/vercel.png",
           "owner": "vercel-deploy",
-          "sha256": "ab37ffb06bdb1ab6d076c26329e8677d057ba95d66f7e2c710221345ff6e2043"
+          "sha256": "ab37ffb06bdb1ab6d076c26329e8677d057ba95d66f7e2c710221345ff6e2043",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/vercel-deploy/scripts/deploy.sh",
           "owner": "vercel-deploy",
-          "sha256": "91f16c6a298c8b70eff7b7722f860e54101be2f23cea75d2e26ec0778006f9b4"
+          "sha256": "91f16c6a298c8b70eff7b7722f860e54101be2f23cea75d2e26ec0778006f9b4",
+          "mode": "100644"
         }
       ]
     },
@@ -19952,7 +21425,8 @@
         {
           "path": "skills/security-and-reliability/vuls-linux-cve-scanner/SKILL.md",
           "owner": "vuls-linux-cve-scanner",
-          "sha256": "ee9788e397a3c01d8f6f901b87a53c97e444cac0c36aaf4bb745e5dade5815c9"
+          "sha256": "ee9788e397a3c01d8f6f901b87a53c97e444cac0c36aaf4bb745e5dade5815c9",
+          "mode": "100644"
         }
       ]
     },
@@ -20022,27 +21496,32 @@
         {
           "path": "skills/developer-engineering/web-artifacts-builder/LICENSE.txt",
           "owner": "web-artifacts-builder",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/web-artifacts-builder/SKILL.md",
           "owner": "web-artifacts-builder",
-          "sha256": "9611359f88da893d4fde293899ce13b192c7024a4edeb93022103c73c332bffd"
+          "sha256": "9611359f88da893d4fde293899ce13b192c7024a4edeb93022103c73c332bffd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/web-artifacts-builder/scripts/bundle-artifact.sh",
           "owner": "web-artifacts-builder",
-          "sha256": "abf0e480bf6585b56fab8526a407dfb7dc740812bddd70c636e1e8f3df5f9618"
+          "sha256": "abf0e480bf6585b56fab8526a407dfb7dc740812bddd70c636e1e8f3df5f9618",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/web-artifacts-builder/scripts/init-artifact.sh",
           "owner": "web-artifacts-builder",
-          "sha256": "355e5dd4382aaaee91f01f1627eaeab30b2676ffa8d9b3ec328a1ae450ebccaa"
+          "sha256": "355e5dd4382aaaee91f01f1627eaeab30b2676ffa8d9b3ec328a1ae450ebccaa",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/web-artifacts-builder/scripts/shadcn-components.tar.gz",
           "owner": "web-artifacts-builder",
-          "sha256": "1296f069e825de7933de7e8ac63672495cacce3f88f2dc45554dbcddbcbca60f"
+          "sha256": "1296f069e825de7933de7e8ac63672495cacce3f88f2dc45554dbcddbcbca60f",
+          "mode": "100644"
         }
       ]
     },
@@ -20092,7 +21571,8 @@
         {
           "path": "skills/engineering-workflow-automation/web-scraper/SKILL.md",
           "owner": "web-scraper",
-          "sha256": "cd046dba98e766a09700ec4237ad7428f26654acb2b8923e17330b249bdef5f3"
+          "sha256": "cd046dba98e766a09700ec4237ad7428f26654acb2b8923e17330b249bdef5f3",
+          "mode": "100644"
         }
       ]
     },
@@ -20167,32 +21647,38 @@
         {
           "path": "skills/developer-engineering/webapp-testing/LICENSE.txt",
           "owner": "webapp-testing",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/webapp-testing/SKILL.md",
           "owner": "webapp-testing",
-          "sha256": "2d3577154f057a693b0e5c8e92010b19c4ecbda6c47ba9a82d42dc2caef9b85a"
+          "sha256": "2d3577154f057a693b0e5c8e92010b19c4ecbda6c47ba9a82d42dc2caef9b85a",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/webapp-testing/examples/console_logging.py",
           "owner": "webapp-testing",
-          "sha256": "ea46877289acb82da7e7ce59d0bc37c8977cd57e2a006d0c88d7a1c625bf95da"
+          "sha256": "ea46877289acb82da7e7ce59d0bc37c8977cd57e2a006d0c88d7a1c625bf95da",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/webapp-testing/examples/element_discovery.py",
           "owner": "webapp-testing",
-          "sha256": "d63c89604a22f8845d724e95dda45db49b1bf57c25ce0a83afbb7b8da3d402f0"
+          "sha256": "d63c89604a22f8845d724e95dda45db49b1bf57c25ce0a83afbb7b8da3d402f0",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/webapp-testing/examples/static_html_automation.py",
           "owner": "webapp-testing",
-          "sha256": "9d533aafb875ee3ab8b8ebf8f5b9003ac8d999da3d09b285cce252e623140064"
+          "sha256": "9d533aafb875ee3ab8b8ebf8f5b9003ac8d999da3d09b285cce252e623140064",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/webapp-testing/scripts/with_server.py",
           "owner": "webapp-testing",
-          "sha256": "b0dcf4918935b795f4eda9821579b9902119235ff4447f687a30286e7d0925fd"
+          "sha256": "b0dcf4918935b795f4eda9821579b9902119235ff4447f687a30286e7d0925fd",
+          "mode": "100644"
         }
       ]
     },
@@ -20242,7 +21728,8 @@
         {
           "path": "skills/ai-workflow/writing-plans/SKILL.md",
           "owner": "writing-plans",
-          "sha256": "69fb7790bde4d4b75afedb26bd910995f906d950cb6e61e412fcff9e895644a1"
+          "sha256": "69fb7790bde4d4b75afedb26bd910995f906d950cb6e61e412fcff9e895644a1",
+          "mode": "100644"
         }
       ]
     },
@@ -20592,307 +22079,368 @@
         {
           "path": "skills/office-white-collar/xlsx/LICENSE.txt",
           "owner": "xlsx",
-          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa"
+          "sha256": "79f6d8f5b427252fa3b1c11ecdbdb6bf610b944f7530b4de78f770f38741cfaa",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/SKILL.md",
           "owner": "xlsx",
-          "sha256": "64436391a6a2171ffcebb4b462f2754507d27b537353d420a2eed2de387f9122"
+          "sha256": "64436391a6a2171ffcebb4b462f2754507d27b537353d420a2eed2de387f9122",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/references/excel-automation/formatting-reference.md",
           "owner": "xlsx",
-          "sha256": "7747e3997e7f8deb6d6c10561b32e3d190a7a4df4f250e1c765d47afb88d7854"
+          "sha256": "7747e3997e7f8deb6d6c10561b32e3d190a7a4df4f250e1c765d47afb88d7854",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/references/openpyxl-examples/create_basic_spreadsheet.py",
           "owner": "xlsx",
-          "sha256": "7c291b6230c9809145c8f7f216fd2b7d099b16b89d3fae0ab4d5a3d990c05418"
+          "sha256": "7c291b6230c9809145c8f7f216fd2b7d099b16b89d3fae0ab4d5a3d990c05418",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/references/openpyxl-examples/create_spreadsheet_with_styling.py",
           "owner": "xlsx",
-          "sha256": "fbfd41b9eca17f0f274f4ce7bd8ead6bc9292d764fe3bc325a1fca57dbe954ea"
+          "sha256": "fbfd41b9eca17f0f274f4ce7bd8ead6bc9292d764fe3bc325a1fca57dbe954ea",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/references/openpyxl-examples/read_existing_spreadsheet.py",
           "owner": "xlsx",
-          "sha256": "cf2f24d90174d92bd9044e95035ab4cf2e34a5faa355a2fa1898e49088e9ad02"
+          "sha256": "cf2f24d90174d92bd9044e95035ab4cf2e34a5faa355a2fa1898e49088e9ad02",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/references/openpyxl-examples/styling_spreadsheet.py",
           "owner": "xlsx",
-          "sha256": "5427ca11beb2b408a5dede6af1fa868fa131ad2a435d40bb88e52c4a8de7bc67"
+          "sha256": "5427ca11beb2b408a5dede6af1fa868fa131ad2a435d40bb88e52c4a8de7bc67",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/create_formatted_excel.py",
           "owner": "xlsx",
-          "sha256": "cdc90bf1bad8e8160a786196d3f525939df284b60fa38e4d91102c5d103aa8c2"
+          "sha256": "cdc90bf1bad8e8160a786196d3f525939df284b60fa38e4d91102c5d103aa8c2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/helpers/__init__.py",
           "owner": "xlsx",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/helpers/merge_runs.py",
           "owner": "xlsx",
-          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7"
+          "sha256": "7c40ed838b88639c51f9ffdcfd564b568f26832b78fe44008c0e01b742669ca7",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/helpers/simplify_redlines.py",
           "owner": "xlsx",
-          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896"
+          "sha256": "560cb55978a834c505406eb18e2c61f62f998fc7a2d8e9721b9c563b42597896",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/pack.py",
           "owner": "xlsx",
-          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683"
+          "sha256": "b1800987e568261a31f462df8e1303d386e9e6ccc11a75ef46e60cc528c20683",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chart.xsd",
           "owner": "xlsx",
-          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354"
+          "sha256": "41b93bd8857cc68b1e43be2806a872d736a9bdd6566900062d8fdb57d7bbb354",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-chartDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412"
+          "sha256": "3fd0586f2637b98bb9886f0e0b67d89e1cc987c2d158cc7deb5f5b9890ced412",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-diagram.xsd",
           "owner": "xlsx",
-          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40"
+          "sha256": "29b254ee0d10414a8504b5a08149c7baec35a60d5ff607d6b3f492aa36815f40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-lockedCanvas.xsd",
           "owner": "xlsx",
-          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026"
+          "sha256": "5cb76dabd8b97d1e9308a1700b90c20139be4d50792d21a7f09789f5cccd6026",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-main.xsd",
           "owner": "xlsx",
-          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9"
+          "sha256": "5375417f0f5394b8dd1a7035b9679151f19a6b65df309dec10cfb4a420cb00e9",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-picture.xsd",
           "owner": "xlsx",
-          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c"
+          "sha256": "5d389d42befbebd91945d620242347caecd3367f9a3a7cf8d97949507ae1f53c",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-spreadsheetDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88"
+          "sha256": "b4532b6d258832953fbb3ee4c711f4fe25d3faf46a10644b2505f17010d01e88",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/dml-wordprocessingDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614"
+          "sha256": "bdad416b096b61d37b71603b2c949484f9070c830bdaeba93bf35e15c8900614",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/pml.xsd",
           "owner": "xlsx",
-          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff"
+          "sha256": "d173c3e5d61e42e2e3a97226c632fd2ab7cc481fc4e492365b87024ab546daff",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-additionalCharacteristics.xsd",
           "owner": "xlsx",
-          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8"
+          "sha256": "3c6709101c6aaa82888df5d8795c33f9e857196790eb320d9194e64be2b6bdd8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-bibliography.xsd",
           "owner": "xlsx",
-          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2"
+          "sha256": "0b364451dc36a48dd6dae0f3b6ada05fd9b71e5208211f8ee5537d7e51a587e2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-commonSimpleTypes.xsd",
           "owner": "xlsx",
-          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece"
+          "sha256": "e2abacbb9a55ce1365f8961bc1b1395bbc811e512b111000d8c333f98458dece",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlDataProperties.xsd",
           "owner": "xlsx",
-          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281"
+          "sha256": "0ef4bb354ff44b923564c4ddbdda5987919d220225129ec94614a618ceafc281",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-customXmlSchemaProperties.xsd",
           "owner": "xlsx",
-          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4"
+          "sha256": "0d103b99a4a8652f8871552a69d42d2a3760ac6a5e3ef02d979c4273257ff6a4",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesCustom.xsd",
           "owner": "xlsx",
-          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285"
+          "sha256": "9c085407751b9061c1f996f6c39ce58451be22a8d334f09175f0e89e42736285",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesExtended.xsd",
           "owner": "xlsx",
-          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368"
+          "sha256": "bc92e36ccd233722d4c5869bec71ddc7b12e2df56059942cce5a39065cc9c368",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-documentPropertiesVariantTypes.xsd",
           "owner": "xlsx",
-          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b"
+          "sha256": "7b5b7413e2c895b1e148e82e292a117d53c7ec65b0696c992edca57b61b4a74b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-math.xsd",
           "owner": "xlsx",
-          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a"
+          "sha256": "3213ef1631606250f5010b42cad7ef716f7c59426367798e33c374c0ec391d3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/shared-relationshipReference.xsd",
           "owner": "xlsx",
-          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637"
+          "sha256": "12264f3c03d738311cd9237d212f1c07479e70f0cbe1ae725d29b36539aef637",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/sml.xsd",
           "owner": "xlsx",
-          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578"
+          "sha256": "beffeed56945c22a77440122c8bdc426f3fcbe7f3b12ea0976c770d1f8d54578",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-main.xsd",
           "owner": "xlsx",
-          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763"
+          "sha256": "f5ee623b08b6a66935e5aced2f5d8ad0fc71bf9e8e833cd490150c0fa94b8763",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-officeDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155"
+          "sha256": "585bedc1313b40888dcc544cb74cd939a105ee674f3b1d3aa1cc6d34f70ff155",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-presentationDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e"
+          "sha256": "133c9f64a5c5d573b78d0a474122b22506d8eadb5e063f67cdbbb8fa2f161d0e",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-spreadsheetDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519"
+          "sha256": "6bdeb169c3717eb01108853bd9fc5a3750fb1fa5b82abbdd854d49855a40f519",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/vml-wordprocessingDrawing.xsd",
           "owner": "xlsx",
-          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831"
+          "sha256": "475dcae1e7d1ea46232db6f8481040c15e53a52a3c256831d3df204212b0e831",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/wml.xsd",
           "owner": "xlsx",
-          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd"
+          "sha256": "c2dd9f61f892deae6acd8d20771ea79b12018af25f3bf8d06639c8542d218cfd",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ISO-IEC29500-4_2016/xml.xsd",
           "owner": "xlsx",
-          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2"
+          "sha256": "a539aa2fb154fa50e0f5cc97e6ad7cbc66f8ec3e3746f61ec6a8b0d5d15ecdf2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-contentTypes.xsd",
           "owner": "xlsx",
-          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a"
+          "sha256": "9e0b7209fc69ab11987900404540969976000c5ebe4d4f58c43dc3842886bf3a",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-coreProperties.xsd",
           "owner": "xlsx",
-          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8"
+          "sha256": "451958454e8588dfc7cd945981ada142ca06ff3307937f5700df059c2b307fa8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-digSig.xsd",
           "owner": "xlsx",
-          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24"
+          "sha256": "6de111e11403f7cd49027400755bae0ea1cabef2815f09bd40a24f0017613b24",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/ecma/fouth-edition/opc-relationships.xsd",
           "owner": "xlsx",
-          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26"
+          "sha256": "f565adfef5a502044abc3a9153e157edc25af78304d335994afb958874b15e26",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/mce/mc.xsd",
           "owner": "xlsx",
-          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413"
+          "sha256": "3a37e461ecf5a8670fdec34029703401f8728ab9c96ec1739a6ae58d55212413",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-2010.xsd",
           "owner": "xlsx",
-          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2"
+          "sha256": "568b26ee156cb9549aa439ca2158965f77b7c1602b7e0316f40ac6cf586e35f2",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-2012.xsd",
           "owner": "xlsx",
-          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74"
+          "sha256": "0fa75578a000439a7988ba0c59fdc69f774bbd416cbacc14d07125b3f686cb74",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-2018.xsd",
           "owner": "xlsx",
-          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad"
+          "sha256": "be0ff793a22dd31384650c3a4da14c2fa8062751c2e97b0e5ee852bda13c60ad",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-cex-2018.xsd",
           "owner": "xlsx",
-          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081"
+          "sha256": "fddc2b880cabb9005aebbc7e783e53c19fec1c03df7d0e2f2076a33a0fdfd081",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-cid-2016.xsd",
           "owner": "xlsx",
-          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d"
+          "sha256": "127ca209fa73d7cb708449cb355c871867948a96e4a74f7bf5811ef62d17991d",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-sdtdatahash-2020.xsd",
           "owner": "xlsx",
-          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604"
+          "sha256": "842e7163409c8d74f4d7088a8bc99500d80bc75332681a0980055b08f374a604",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/schemas/microsoft/wml-symex-2015.xsd",
           "owner": "xlsx",
-          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b"
+          "sha256": "16f6f8072249f431370723c2cd8974672e0d9c897e00e97dd918079df934871b",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/soffice.py",
           "owner": "xlsx",
-          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0"
+          "sha256": "a3e21840e29e32f947d5286028931b96eaf2dee63f75d883b8eb19c943c80aa0",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/unpack.py",
           "owner": "xlsx",
-          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62"
+          "sha256": "83f69cecc87910183654c06345837244402e8a99edbf3bdddc1cf72f11304b62",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validate.py",
           "owner": "xlsx",
-          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514"
+          "sha256": "1aef24f8e316965a0584c30859776bd2c82a9fb69f72d79cfed041119cf95514",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validators/__init__.py",
           "owner": "xlsx",
-          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987"
+          "sha256": "83e0f035c5abea238d3f2c3968afbd511ed022b527b7c9cb60a9434cc34ff987",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validators/base.py",
           "owner": "xlsx",
-          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25"
+          "sha256": "d6358b67252df4dbfe4fa6647423a765960c949346ef6a8c4eb8722bb1108d25",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validators/docx.py",
           "owner": "xlsx",
-          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345"
+          "sha256": "0ef04ce86b2e6b6a1cb088c0276fd0bd5b770d96fdfe7a6cc73d005feb3f0345",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validators/pptx.py",
           "owner": "xlsx",
-          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc"
+          "sha256": "f937961e62a5fa0d002b8dc51a4c4e2cd8fcd59fe65853fa54edaca3fe99eccc",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/office/validators/redlining.py",
           "owner": "xlsx",
-          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40"
+          "sha256": "f4c33fdb9da0651d1d9aa76f0d5294cc9955869339ae131b2f75f3b2e366cb40",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/parse_complex_excel.py",
           "owner": "xlsx",
-          "sha256": "581d8d5319ef49da20ba9aa35f7031f9671163345598614874b4cc5ec54a23b8"
+          "sha256": "581d8d5319ef49da20ba9aa35f7031f9671163345598614874b4cc5ec54a23b8",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/xlsx/scripts/recalc.py",
           "owner": "xlsx",
-          "sha256": "cf419d15e02965aeaec17773c05b61303f7f520f67fa2696547e7da07502eac7"
+          "sha256": "cf419d15e02965aeaec17773c05b61303f7f520f67fa2696547e7da07502eac7",
+          "mode": "100644"
         }
       ]
     },
@@ -20962,27 +22510,32 @@
         {
           "path": "skills/engineering-workflow-automation/yeet/LICENSE.txt",
           "owner": "yeet",
-          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9"
+          "sha256": "4dd13869245e356246a5b770723247bbb80a8f07a181d1d3d873a1734297cdb9",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/yeet/SKILL.md",
           "owner": "yeet",
-          "sha256": "8df0954336439db825d53b03691b510b2bad8a9cde5d75d108db811bc2973f65"
+          "sha256": "8df0954336439db825d53b03691b510b2bad8a9cde5d75d108db811bc2973f65",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/yeet/agents/openai.yaml",
           "owner": "yeet",
-          "sha256": "6f0a463b53232932ad70aec529e25fad9d54312de0bd29d64a38bb14a4e748de"
+          "sha256": "6f0a463b53232932ad70aec529e25fad9d54312de0bd29d64a38bb14a4e748de",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/yeet/assets/yeet-small.svg",
           "owner": "yeet",
-          "sha256": "e4b365d5389b8772e9bad36ad7a37d8333436fa961bb98c8d77b8fbf4e9dbc3b"
+          "sha256": "e4b365d5389b8772e9bad36ad7a37d8333436fa961bb98c8d77b8fbf4e9dbc3b",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/yeet/assets/yeet.png",
           "owner": "yeet",
-          "sha256": "6b5448b6c5b3480ca7511f983fa81ced59e6b9c664332bc559ea0d323fc06ab8"
+          "sha256": "6b5448b6c5b3480ca7511f983fa81ced59e6b9c664332bc559ea0d323fc06ab8",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/larksuite-cli-2026-05.skills.json
+++ b/docs/sources/larksuite-cli-2026-05.skills.json
@@ -63,7 +63,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-approval/SKILL.md",
           "owner": "lark-approval",
-          "sha256": "f75f728e1add4f62a254f2f893d91519634d88f62fe5d756ab368dc2e17f5eb5"
+          "sha256": "f75f728e1add4f62a254f2f893d91519634d88f62fe5d756ab368dc2e17f5eb5",
+          "mode": "100644"
         }
       ]
     },
@@ -112,7 +113,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-attendance/SKILL.md",
           "owner": "lark-attendance",
-          "sha256": "6e7d7ca4cf69b6baad0eb39ac27a0279918939aba896a735a8fac00e4b0f1ac0"
+          "sha256": "6e7d7ca4cf69b6baad0eb39ac27a0279918939aba896a735a8fac00e4b0f1ac0",
+          "mode": "100644"
         }
       ]
     },
@@ -621,467 +623,560 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/SKILL.md",
           "sha256": "c8aeddfb368c543a6ed8465d93db6834ad7d2e583a860024e8a5fcf9076f67ad",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/dashboard-block-data-config.md",
           "sha256": "cc318a9df3b274ca10aa82391c03e32afcaf0deb4548bdb83811cb64062915fd",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/examples.md",
           "sha256": "0f7be64b7722b33130201187c20713a0404fb917596b6d44291d2b2df0c1e4a8",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/formula-field-guide.md",
           "sha256": "cde1028cacd338b9fcc964d9df24136fe39f0c58deeb65aceefaac773554b731",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-disable.md",
           "sha256": "05d36503ead10e0b49c420214bbbef4be7245a7d708a78a05aaf22865876ca4a",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-enable.md",
           "sha256": "91fd193577751dc9865b266e691cdf3a186f808977346538648d0542a52df2da",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-copy.md",
           "sha256": "73c814419bcc5a8e9ef941faadba18d663fe47eaf83a32303740e0b059378f84",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-create.md",
           "sha256": "ee2f67665161e351986f3836c0ce8c6a5ac5e7dc807b9374a19a974055eac45e",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-get.md",
           "sha256": "92603e480db34b350fcd4e5fecbe63860f949d4c5fe1ea65743e2ebcd4f75ff3",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-cell-value.md",
           "sha256": "d859c1b8295ab2b0cd6f5799aaf36a65a53587c60deb0fe30cf76ac58925f724",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-arrange.md",
           "sha256": "d903af66287796c4389c563fb084791102874b5a92cf8045593805a26fdf281d",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-create.md",
           "sha256": "5ebd279891d2efa1f2571d38f6db9c75029b3ca20188308c4d80222295224e44",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-delete.md",
           "sha256": "0391101bc3e2a5d6e169e69ece48a36f83ac2e2d01c1eb3484405fb00100cfdb",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-get.md",
           "sha256": "42ad4e82b3b9293d3880f62d4f7ced2ed1128b679aba9fc02963a07c6c6a7d87",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-list.md",
           "sha256": "823017601a9c36d8dfe11b073d57ce4ed12853d39db4f9ee3664219ebe8354a3",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-update.md",
           "sha256": "3f17ec4e0826a53424d83dc55b6a77e89a6b629ae64a6df647a116372aa8cdf2",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-create.md",
           "sha256": "6e275de197377e861fd5935245ea9424b02da622b74086a6cfc0a4bbfe48cd5f",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-delete.md",
           "sha256": "2d1e753de77b0b667e5afd8cada503b10f57bec616a003616fafaefa5a96f435",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-get.md",
           "sha256": "7abd66f68700643c440f591898239a50e19c6b56b20a251d93a66d27c09a2bbb",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-list.md",
           "sha256": "b723924c7e45936377bfbaaf3352841a3872a252a6fcf51426b2676ab55fd77a",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-update.md",
           "sha256": "787f7e9c4d69606434166a87f1add10a01c0b9cefd481029a108bfabae41f042",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard.md",
           "sha256": "79cea2a2953fa462144e58d14b06bd8c2653943a775d8f89c342e6ed59cd1880",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-analysis-sop.md",
           "sha256": "5d0cde83fa156214f6138d3aedcebc0be912e5f5d52fdce61e6a956f76dff1c8",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-query.md",
           "sha256": "b61d6e0cac1d441e7621f8056b443d0fec3aeff6cbd29173931d764ac0f63399",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-create.md",
           "sha256": "1d5383eb6863b632e46789b553c2f03627c426732e1111bcbb5e7ed0c51c4e25",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-delete.md",
           "sha256": "a8c2ac0c07d9324d82b4f0ce222ee753c7da6635e6b1ec6c5161c2507f72a25d",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-get.md",
           "sha256": "445cd8c2695151429e494a5e3646e42abce810f0624f9822daac18397fccd3fb",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-list.md",
           "sha256": "e255466b5d80b097a64f20fcb7bc3174e96a29368360125b23c848e6ab30a857",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-search-options.md",
           "sha256": "051d81c714e055d127ffe3e8fd419e38fecb4e740b44b338feee3e50d4db2b28",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-update.md",
           "sha256": "4b26b33d5dd86cb8d74664d2fb7fd76182afbeef5df108e3f62871a583053895",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field.md",
           "sha256": "7a19eef7e94fb994b59edd07b0ac59a5f7f8a75ab8aac4de77b332f80dcc3aae",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-create.md",
           "sha256": "af8920dd2d99c913678955c78eee8d3b358760d2ee1fd8b1000415626c22ac22",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-delete.md",
           "sha256": "a70548d638e8a264d6b03f6fe0a0c6c57e70602658161f46f0e45bf215736f4d",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-get.md",
           "sha256": "de2555f8893e7789b561395f93c80b089953c5052213f831cd10e608c7159a57",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-list.md",
           "sha256": "2f4abbd42efab52a59f77c318e0dabd866fdbb4665cd8ab7e2e5f55b9e84c42a",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-create.md",
           "sha256": "351239be729d5fb386cf6378ba9c38307bdc3385a73360adc047bf9153301cff",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-delete.md",
           "sha256": "e2cc8406a7427ff872839a02a8691bc90de0ab6fdee3e5f4a707e5e2fd938d03",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-list.md",
           "sha256": "e7c4dc232520c0bc8da88f6977899bac51195a06f0e0880d35f019ac60f8e114",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-update.md",
           "sha256": "cc9a3621bbb52b55fec0462d38cdb9c404a1507924da8c886e51dba1c2c86bf6",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions.md",
           "sha256": "078b016000a0fd2c8cd4de118bdcbfc4bd2fc1aa21308d2769678a2a1875fa7b",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-update.md",
           "sha256": "20fda299dc71451cc077efacef92504ce5ef3b9aa23fcc768c46eb59178e99cf",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form.md",
           "sha256": "d85662a4ebc57c2b97060530396db906cd102917c1fc3aae67825e712c2f4022",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-history.md",
           "sha256": "5eb5dee08ef909dc87611c1e6f7cddf15adcbb6e94e401a952ddd36c738bd546",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-create.md",
           "sha256": "093868dd85788e41509ead7a3ceaa34807c1dea81cf37723f837328d10ef3229",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-update.md",
           "sha256": "96789f7a5ecebc73c616b9ffccd3045947ea0a2b3ede3927cc517add65773017",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-delete.md",
           "sha256": "51b2de73559873955e21181df575f3df19dcd0551ba4fbb44237c9f1d7ac25e1",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-history-list.md",
           "sha256": "65e4b3ffc8d268394398aede90124ad4d80f186dc603769e949bcde6ae460ba7",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-share-link-create.md",
           "sha256": "b38bfb8068a5855b1ac16c2dc96217d9dffa5f3b7bd074c938582f2cef885b16",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upload-attachment.md",
           "sha256": "a71471147725ba5afd4de15c9ac716bb719f96966ff7db5e5d6ca5f68d361532",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upsert.md",
           "sha256": "3f830f29e16361b52bfb013e1b7cae9dc194b8ccc09feb3a402afd8c370a4ca5",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record.md",
           "sha256": "55cdbf35ccea42b8056ca6d00c01a76fee65f4750aa0103febae796db9237356",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-create.md",
           "sha256": "fb10e0924a7ba1a8e2a0387bf694d0018eb013490a3bc73bb0c7253f578bbdb8",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-delete.md",
           "sha256": "549c51bd252ed017d8a27c3ead85ff46628bc16894cd0fc0b08eb053841860b2",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-get.md",
           "sha256": "12f811421870ad85f584010ffaa4fba01ab386f051f1a1dc4483bd16ffd015b3",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-list.md",
           "sha256": "11a5dcfe51256e0efce3834ca51e7842bb0532379e9c79858f6f98dad2e6ea47",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-update.md",
           "sha256": "f0f0108ae9e00195600e7ccdf21b75ddbf883b9a7ab4e3ea7162680f4ac91986",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-shortcut-field-properties.md",
           "sha256": "5db5335ee798a733ca094b9b7646cf2986033ba9caf5ba6c70fbd4e2d7cf889c",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-create.md",
           "sha256": "23c4de0912e68be116a841ef7a381df8f55eb150dc0e1940b701371ebb660cca",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-delete.md",
           "sha256": "e837c0911381afdcc9394c4144a9e0fbb8e7f9f905487b4953065faa58282000",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-get.md",
           "sha256": "eac9ef07b5c157f284563190885ff9ab23318f82218696fa407a43d5912aee4f",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-list.md",
           "sha256": "00eeb746d6620b12b2fca673ec0e912882246f8e1a5db02f63c2bc4bda95b893",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-update.md",
           "sha256": "08bac24758306d002316ffdba2678db2eac7d03b406d6ca4a68f827afb1bd380",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table.md",
           "sha256": "a6f82974e4e4af616ab24f19f13a974b28b174ad01aea6a4d806fb2ee798029e",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-create.md",
           "sha256": "f40fb05f0fb1dbabeb833bb2c242c2150093dc2de8468ef298abc902c3a0c84b",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-delete.md",
           "sha256": "ff793bd36c8234684f72b25564744259e690da30d44e2f2ba244fe65186ec2b9",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-card.md",
           "sha256": "d841409fdf659af685a310766dbd24c80d16a2ec90210715aecfe9aa69dc8c61",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-filter.md",
           "sha256": "d0181e83b534b76f007ae9ab72dfe7b043efce8b305b16c962665f9859723e57",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-group.md",
           "sha256": "06ae779640a53c12da9b4ecd6d1d411ed67e0d19b684daf52182597c5443633c",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-sort.md",
           "sha256": "78cba8dfa78f809a74df8b8544e1b4cf859e10ba0e12cb472e11f447ed240ee0",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-timebar.md",
           "sha256": "6fc13d1cea144713e95aa07f15671129d2b8f547ef9b8b8c776351faec4e450a",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-visible-fields.md",
           "sha256": "c3222d34c3b396ba7e6148413562accce1dd71b7895845af9b4a82bd730670d9",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get.md",
           "sha256": "85269658f2930066a80f41672b4466a55ee24270f1984ec0a4176b951fd4cbd8",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-list.md",
           "sha256": "ed409d8e578e7bee2814d7d2b4293c7500537a6755c400fbcc738a769d853b93",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-rename.md",
           "sha256": "106ddce503f5d9088a407c59ee3b5025b1f3289a6bc15514a32ddc26fe29e8b5",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-card.md",
           "sha256": "39630f6bab34aa5fe68e16b5fbfd2a12dbd56b1c118dbff3dbd660737181b3cc",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-filter.md",
           "sha256": "d12a8f91590951fb00e0ebfb8fec9666ed7b8a17919fba5fbb7a5c7015bc18e1",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-group.md",
           "sha256": "103d66bd207bae75b91980ad48857e7dbeb4e3501b3658b53027d44578f0903e",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-sort.md",
           "sha256": "a7f24bb2267eb7b768a7129d4183385e7ba1268e869351016099eb98b7cc5cda",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-timebar.md",
           "sha256": "701fef8bbfcaba87bfded19fabe18f656f8679ee7eb72ee41053dbe817519d68",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-visible-fields.md",
           "sha256": "4731e0f53556da468ae5221d1cc3ce2e38403ee508c09d299867795988bbb139",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view.md",
           "sha256": "c5afc15cf5941d4d7196732ab7cb8ccab15ef50419cd12ebeabb049069f12604",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-create.md",
           "sha256": "22ca47b7938073a7372cb20690d7f53db3f83bb6ff08e468e166b1173e71c4f3",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-disable.md",
           "sha256": "19b39a6e3a881614330d4bca6171a1c5dc4d623d7141d819b7d306bb7f7b4194",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-enable.md",
           "sha256": "0ebc8e39f32f5b664bb8cd5128ab6199050d09f47225857569c24de439aa2d20",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-get.md",
           "sha256": "52cd887a812c0ef1966f45f76cacf0f76914dfcc5b978276ef74be855e737122",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-guide.md",
           "sha256": "3198cea58cc735a9b838372329bff29f5505243843647f17785f94bb7421ce97",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-list.md",
           "sha256": "f67dcbde6618547937521ba4b27f9e91d05d1d024c9a856e286f4390b8b126e7",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-schema.md",
           "sha256": "0e9f722a8b3ce3c8eec2dd70c25dcb60f359d32c4e9af7cc68ccf73c54aade49",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-update.md",
           "sha256": "8fe49981ce5bcdc3114e2ae298fb310992cb7d1fe8e0f0146795f57d631720c3",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow.md",
           "sha256": "573360ed0dfcd8da0df819ec6e6e0ded12aa35d5e864f4aef1067807346b487f",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workspace.md",
           "sha256": "d8178f5db0f006feb774e0bf2e5147558cbcbfa5cdbae9a094275c444dd83cdc",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/lookup-field-guide.md",
           "sha256": "7c22d5dcabfcb6bd70f16d912394e3e3a546d381001261e43878f5704c875b1c",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/references/role-config.md",
           "sha256": "b1f89be9b38ae89fb7bef4bd22fce15216bfab146a15ddd383afb7e86a400e23",
-          "owner": "lark-base"
+          "owner": "lark-base",
+          "mode": "100644"
         }
       ]
     },
@@ -1170,47 +1265,56 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/SKILL.md",
           "sha256": "5323ed83b9d513561064a6f8a79bc10739af900dee73d6310096d79993dc6a64",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-agenda.md",
           "sha256": "810713427524da397939ff95e3f5bcfd870fba1fcc8b2c7546f2253969d57d65",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-create.md",
           "sha256": "23433c243fc3bb1dcd6fc1cd6d31633f3740b126fb32ecb53587408368421b59",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-freebusy.md",
           "sha256": "ff3b79ae776e4fb7b37f58f41c1826056b717f0d57087c6fcd30833fc20bcbea",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-room-find.md",
           "sha256": "edfa65a74174dba9f8a4b474e94ae16e5bc5afd6b5d3d8c57f7234d5cee984b8",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-rsvp.md",
           "sha256": "1ec25ef0827c5a0f5823b42c86e3e2dc9dde55fadcfad73b8daf2e845a729369",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-schedule-meeting.md",
           "sha256": "3a5ab5622d29b71985ec195416ac0ec7817b8e9c5ad694a5df517b3deb448332",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-suggestion.md",
           "sha256": "6398e2172951919e94e299f0d95ae41d9b0e70d91d106978e47646cdb35257c6",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-update.md",
           "sha256": "5d0f262cedbad499ad58dd86f8dac8e4a6a4a3b4fb5dda3ca704b58840460441",
-          "owner": "lark-calendar"
+          "owner": "lark-calendar",
+          "mode": "100644"
         }
       ]
     },
@@ -1269,17 +1373,20 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-contact/SKILL.md",
           "sha256": "efe3010dfb69360c5349d9683b61e9b443d3bf5d06304810f8fe24773e8847bf",
-          "owner": "lark-contact"
+          "owner": "lark-contact",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-get-user.md",
           "sha256": "24ba2fbd92ec33ebf04de44a6bb10ee9af91e5808aa8d1898486d332da2c5b6e",
-          "owner": "lark-contact"
+          "owner": "lark-contact",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-search-user.md",
           "sha256": "70282ead84762fe71e07363ab0f0c265f011b0c021caf0452b2fb6d8b4e1d35f",
-          "owner": "lark-contact"
+          "owner": "lark-contact",
+          "mode": "100644"
         }
       ]
     },
@@ -1393,72 +1500,86 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/SKILL.md",
           "sha256": "4ea2cc9b96ae253dd89608ed76948d21f5a2821f7238c330f36a2475f1a07ada",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-create.md",
           "sha256": "2829456a92d4fcee9525b292bd490d82da995b51e7600ab868f7c0283a682f1e",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-fetch.md",
           "sha256": "f80af9f538c747e434e51920caef53fd665bd8861620a61d46594908e79c762f",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-md.md",
           "sha256": "7b0e0e132d93f2974264c359d066f3a21f957cafe9a13b0637bca69e8e7486b9",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-download.md",
           "sha256": "d4c7f67d07b907106a037500e5809405ce74ee4b642767af3e417c5edd527277",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-insert.md",
           "sha256": "1c1e4f799ba056e51a7cb84188da3d3c4b22d687403b43d4bb8971551b455dfd",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-preview.md",
           "sha256": "ebecf432d6ad0dbfa249cbf3dab91e7e20e25ee29e1c4874a039aa2bb8194200",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-search.md",
           "sha256": "2640ee97762ab91c5e9556c818c5e467fc04cc91c4ecb7c4cfe2c3b8f6875074",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-update.md",
           "sha256": "9cfba006b8cc7f17de604775cbbd120eed29a79c279fdd04e9544363f8459344",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-whiteboard.md",
           "sha256": "900e26f29d85f775a9bd33bf13b07b3e67eebf57d01eea8b6407a959e92f2ae8",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-xml.md",
           "sha256": "0b89e88f26f15d0477dc57cd5971405f4c3a2ee45dca309101805c93bed098c3",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-create-workflow.md",
           "sha256": "b51e7412716e26f36b44275fb148990925ffdd5eaf7591267efe5a5e36829090",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-style.md",
           "sha256": "af50103f52d14c88d6ad906875d5b6a2ac55039e33cf8df90c563eb5f3aa57c4",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-update-workflow.md",
           "sha256": "07499da6c82b515257c1e134eccc77bdd94c3fbf636adbd02ce8c38f4da639ba",
-          "owner": "lark-doc"
+          "owner": "lark-doc",
+          "mode": "100644"
         }
       ]
     },
@@ -1612,112 +1733,134 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/SKILL.md",
           "sha256": "69ebc8e2a94b44a7d4c82e454c750a1416a2b8bc8c72a18f5fa26b4ecf12efed",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-add-comment.md",
           "sha256": "ff6752bb54beea2d14d242161251c84b381d6c57fad06838cc0acc3849d02f71",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-apply-permission.md",
           "sha256": "d267016d3cac5f73d5be1fdfab8e28c495c6eea3389eff641398acd666d814e7",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-folder.md",
           "sha256": "2dcc2d29b4c9119395b9ca1b13aa6d04c4cbe2478985db15455430c511eb4c8f",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-shortcut.md",
           "sha256": "aca426b7dfbfb44c2fe17d1801bb2525ef770e7bc763fb2e0e6dbe3f13bb829d",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-delete.md",
           "sha256": "efd530e3d60eeca98fa1314a01be4d7f6905ff9693f26b9c79bce7ae53b05106",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-download.md",
           "sha256": "0ee64549dff3dc86eacd0f940784e2fa8b04cd91ad77be32a44f45920a572ded",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export-download.md",
           "sha256": "e02cb3e43a485371bc491f9ce214e4b620d45560bacff0999d223c2f911166e1",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export.md",
           "sha256": "28cbb4fc64db7f3af380bee2f91e6a4c29082b3552a0e86a6ca28c4e4f98dbc4",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-import.md",
           "sha256": "71449f17ccd57a2a9cea556aee6ecfa80eb092c934f6794acaa189120f49c934",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-move.md",
           "sha256": "c4da1157d8994dc1ec4d94173f6f1e613fd04ec39eee0b5e9fd0af48f6db4c81",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-pull.md",
           "sha256": "722d735ca1676da24ca871b67f43f118aff8087814ccbb0e7331d026dbdfc908",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-push.md",
           "sha256": "48075fcf824cb1d031a295de0ce23ca65854316e2827f0327575c16d6ef907f1",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-reactions.md",
           "sha256": "7c6761ac97e2e65f1ddb9a368a916a2a2b17b2d7c8b3146f1cad531b394c720d",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-search.md",
           "sha256": "0152b5157f15515843bbb2757e5f167fd1e8b6de02ce213baf73e0e0595fde8c",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-status.md",
           "sha256": "10769fc4e3ca8f4f9dedee6f23c225996e401bd23b7bea2f33971afefc116139",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-task-result.md",
           "sha256": "0feba3abac5e5ec64ed1336792159b00befee57af69a4c40fdb2b62c779535e4",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-upload.md",
           "sha256": "20cbd4ce992d67b1fe83526165461abeed73c41f490dcb9a94fa4fe5941140ee",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-delete.md",
           "sha256": "0e47f7d95496c97c8143f74bcdd829b41a5d5a6ad10c3998c995cdf774497704",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-get.md",
           "sha256": "7bfe1629ff5f6838dbc251619d9bd7226f3c89e11a97a2c2204357c7354a057f",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-history.md",
           "sha256": "aa1110d97a19ccd6dfdc78e1a5ac9cb74bbc6d74379a8a22d78bb5de99575294",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-revert.md",
           "sha256": "c909d6a84cb0e6c783b0685e8c1c4bfe9f79db8a59bac056e60c46b033aacf3e",
-          "owner": "lark-drive"
+          "owner": "lark-drive",
+          "mode": "100644"
         }
       ]
     },
@@ -1771,12 +1914,14 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-event/SKILL.md",
           "sha256": "4129f49bb9091217aa50cc427199f4d5653fc6274313c47f88fdedb34ee9063a",
-          "owner": "lark-event"
+          "owner": "lark-event",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-event/references/lark-event-im.md",
           "sha256": "b67c3cad7c1748477f66fd99ebf19dfc8f9b5a773f3a36bb5305ce2c5b66486f",
-          "owner": "lark-event"
+          "owner": "lark-event",
+          "mode": "100644"
         }
       ]
     },
@@ -1905,87 +2050,104 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/SKILL.md",
           "sha256": "67f7cd8ecf045589d578dfc51aeea9c136ef4c8ea1cdd03b392b5650555ad912",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-create.md",
           "sha256": "2757a5849b8f5426379200209c8141adedd16243ff4a0dcf84e201d6cc9f9f6b",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-identity.md",
           "sha256": "449708ed9be8b3b4657c685509e9b587c4f728f51b00bdeb08db20941a4135b1",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-list.md",
           "sha256": "867269726e570ab749938b22f0c5eb4ee177e7a1cfa90de842eef84e58a7a656",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-messages-list.md",
           "sha256": "a9e250b55143bfa46b92373d1ce0400f68f950500533a5080f21b906b6809474",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-search.md",
           "sha256": "f84173d20cfcd5d6755cb9f0b4fa13f844a29f0ce64be0077ff13fbd8e09a4fd",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-update.md",
           "sha256": "5e27243b3e230711107f1bf05b99fe282e8b23b0aaeb411e27a7fdc66f689f4a",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-cancel.md",
           "sha256": "bc1a242cf265cc8744d3c5e4e326248d797c59b2d37117a353ae523a2166483b",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-create.md",
           "sha256": "61f13376f14986f61b1e61146ee5d89fbd5c978d574cb13e78e52c71f982761a",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-list.md",
           "sha256": "1baab8956d29eef137afe9f98c8715ee5bcb4c9987851f2393e798d876d4ba48",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-mget.md",
           "sha256": "6ee4a509ebe37849fd7b70d0981a9ce5ecb32ee7ca2100561d27dd630402d85f",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-reply.md",
           "sha256": "24a521c92f249dafba04a73da25a78a3c5483e1e39d0d92a3211e4d171e4d424",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-resources-download.md",
           "sha256": "54d59b009672bb0533d5eae3bd5496eb6fa559496bfd4a7be96544627f7c36d7",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-search.md",
           "sha256": "765eaba0e67d23b7bd65cf80a4ca147cf1e7cbf6414efdddb575849221320e28",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-send.md",
           "sha256": "f41bd266c0f79d1ff033096bf3f84ca1d527cd74ab735e536e35869a0b9adb73",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-reactions.md",
           "sha256": "97f0cd3b0d3e672f150314fc7e41534b78244af78eeecd34b00949bb765e1945",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-threads-messages-list.md",
           "sha256": "820573d2a8e7ce447bdc4189eda6acc635019f50b79a06b61294055f3804a5cc",
-          "owner": "lark-im"
+          "owner": "lark-im",
+          "mode": "100644"
         }
       ]
     },
@@ -2119,92 +2281,110 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/SKILL.md",
           "sha256": "72d8afb05a8d6bf89796b3b2231ed63da8354e95caa2be59ddf791e97305d477",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-decline-receipt.md",
           "sha256": "dc888a26f4eda3aa1483f6be81f02eac32d053b41bb6089b3b1badd327053665",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-create.md",
           "sha256": "0c57bf5ae4f09185aa621f2a708c18ce182d94fad41da40adb5aaa3e37537d74",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-edit.md",
           "sha256": "7b430dbb16498d4aa260ce730303f01aaf61e6295bb88181cb1a57df31e060b4",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-forward.md",
           "sha256": "808612b1f493c873558f5f9be03e4b489cfff7b353df5d7fdd6fbb25af7acdab",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-message.md",
           "sha256": "cc27e13876dad4f47d83d7838267bef75a96ab2870b2e58a0b97bc72a1a72b6a",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-messages.md",
           "sha256": "908aea214f246a719bcca039bee11ad198796c59a8ee2e239effa09d4050227e",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply-all.md",
           "sha256": "58d003783bb32886d0524df922268c5f55083f0462a9b9929045acf4f53ab9ce",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply.md",
           "sha256": "674c6be7e699f5c77447aab45213fc66b2192254cc472944ea56cb9f17f799c2",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send-receipt.md",
           "sha256": "19af1149866916a9d7403f92405cffa70d1cc4e3c364dd54c2d82c45f7736c56",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send.md",
           "sha256": "b20381dcf99317fc7fd283feb9d80c50a1261b36a6d815ae8d63f1c47edbc0d0",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-share-to-chat.md",
           "sha256": "983a642f8305312ee81a98f45760ffe8ad720347bd8c4fbaa55beb38baa05a9e",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-signature.md",
           "sha256": "fa759bf8b2ee70dcf3ab5403e6f31833d86eb1cf86812dd7c30dd909897416b2",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-create.md",
           "sha256": "368c9bc14dd4e2cf81f9e0efbc112b695a2c6055fb601cd48b85fd16ef39c02d",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-update.md",
           "sha256": "f819cc2504e4e8898a7fb1fbd4f63b6e0ea07dd3e1ddc14c1649049ba78abc40",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-thread.md",
           "sha256": "ef0f803f3dc95c4012e55c3da546a9835953e56cbfdbb5fc759a3d277cee4503",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-triage.md",
           "sha256": "0b5ee4c76aa1fe7a1f6ed7fe246b6c7d83fefd05267fcddbb1e6077355da5833",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-watch.md",
           "sha256": "3e9bd88f9b73477165128c84433931734255c1a3d6c540a2e773d644a247be12",
-          "owner": "lark-mail"
+          "owner": "lark-mail",
+          "mode": "100644"
         }
       ]
     },
@@ -2273,27 +2453,32 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/SKILL.md",
           "sha256": "ec74e6609dd0d409075abfeca8484426af1b58cc217cfd345c8e4672854b3b85",
-          "owner": "lark-markdown"
+          "owner": "lark-markdown",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-create.md",
           "sha256": "3f4788c0a9e6eb8c19f6e3b9c2173ecb4104867aa8e13836d78a8765b1e3200e",
-          "owner": "lark-markdown"
+          "owner": "lark-markdown",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-fetch.md",
           "sha256": "0c68f0d56ddd7272485f32f7cf9321171dbdd1be4c4f98e0304beb78038bf2d0",
-          "owner": "lark-markdown"
+          "owner": "lark-markdown",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-overwrite.md",
           "sha256": "67265b9bc7ca2e97ed966f7bf693e349f10795e567e5e80870ba4b39b1d81bd0",
-          "owner": "lark-markdown"
+          "owner": "lark-markdown",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-patch.md",
           "sha256": "4e4a5cc39c87722500dc8f121045f8f7e159cf913ca521bfd129cb5c96c62192",
-          "owner": "lark-markdown"
+          "owner": "lark-markdown",
+          "mode": "100644"
         }
       ]
     },
@@ -2357,22 +2542,26 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-minutes/SKILL.md",
           "sha256": "73f533d1d72b6e9e43a8565028d605e173d23f64015352a3dbaa1bd51b4d3348",
-          "owner": "lark-minutes"
+          "owner": "lark-minutes",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-download.md",
           "sha256": "c3dae9d73080f32f330d5978d7757c02abba38b24680452731aa6923b42ee2fe",
-          "owner": "lark-minutes"
+          "owner": "lark-minutes",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-search.md",
           "sha256": "afe1df6f47cad9d254ce2b6a111fe7e7758900b89dacbd410e414311aba510ef",
-          "owner": "lark-minutes"
+          "owner": "lark-minutes",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-upload.md",
           "sha256": "3f7914a791f12e2cf4ae2ae512888d8cf92a08f5b87c4b2806b42f34dc642812",
-          "owner": "lark-minutes"
+          "owner": "lark-minutes",
+          "mode": "100644"
         }
       ]
     },
@@ -2471,57 +2660,68 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/SKILL.md",
           "sha256": "5a7328d1d9501839f0a72e2ac523ffd33d4f8eb1fd056c35d373fee913f680ce",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-contentblock.md",
           "sha256": "11a75f520d658a9a4c29191e8ccc67f3292dfa07ad2fd998fb31daa70bb8d424",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-detail.md",
           "sha256": "7bc2c7b1cb9f3b04e3b96dae201f48cbc31406a4e44c9b6c28d13c636b76f8b0",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-list.md",
           "sha256": "edd01257f2b02c169ffec485d226ec6515d7448b9d3defb6bc55d221838084cd",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-entities.md",
           "sha256": "615fa21c04155413700bec22ad11751e6d06a6c45ca74941a8637b4a67032766",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-image-upload.md",
           "sha256": "4a5324ab2cc5b4ca42d51ef8066ed9e3375c921cf243eb40bbb41d73bb7e7bdd",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-create.md",
           "sha256": "6180a09a96f86b069af2f6f8822eafa655336f912a5aef32ced5227e6dba8197",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-delete.md",
           "sha256": "c96a580dc99bdd5e675718cf799870d6d84b7aa9b7f6f5f51c88182f9965d7c6",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-get.md",
           "sha256": "47b8ead617177fc99b41f66b6e8a0f00397040d3a7fa861c0602385233dbfe68",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-list.md",
           "sha256": "a9ece8f369ccd1680be1d936dd7fea1421583d9f42202760852bffd23f36585a",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-update.md",
           "sha256": "5ab9512f440f12c66de9c1355cf053a9db0f5550c61e65a3a7d18283be5d0bdb",
-          "owner": "lark-okr"
+          "owner": "lark-okr",
+          "mode": "100644"
         }
       ]
     },
@@ -2570,7 +2770,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-openapi-explorer/SKILL.md",
           "owner": "lark-openapi-explorer",
-          "sha256": "bc8ad66b8a108c1792235bb203a22c4cdbbce6f382be155b7233832bc15eda3b"
+          "sha256": "bc8ad66b8a108c1792235bb203a22c4cdbbce6f382be155b7233832bc15eda3b",
+          "mode": "100644"
         }
       ]
     },
@@ -2666,37 +2867,44 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/SKILL.md",
           "sha256": "59884e9976548bbb0a2f64986c04b8cd21db0e3713ac9ec84a6bb2f373a4c13a",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-config-init.md",
           "sha256": "d995546300e59284e223e9be856ff5674056900b86c9ad022c4e9b2bf0f24563",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-high-risk-approval.md",
           "sha256": "b8bbff0c71d376564f8d6ea640686b08645d6ff4c905aa03c79882b98bd6bf05",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-identity-and-permissions.md",
           "sha256": "68c8f409ceeb062b4460a63ea4a8822e4150db475b7ca2f4baaf1e67162907f1",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-output-contract.md",
           "sha256": "8f47ada21810a83de272d1bef088ece187947c2cb0743ded7590d82d8c175699",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-update-notice.md",
           "sha256": "6e1d08f7338721053087f8292c98302a947ee97358be71a60a7110a3b91e8d3a",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-wiki-token-routing.md",
           "sha256": "42ba982e9ebc85aefca3db64a434d08dadba49c5d42d617388964866543f7c79",
-          "owner": "lark-shared"
+          "owner": "lark-shared",
+          "mode": "100644"
         }
       ]
     },
@@ -2795,57 +3003,68 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/SKILL.md",
           "sha256": "c6f35ea0701e5a9ec89561d288d96b7e4265dbd0cedca8684638ce497c0ef555",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-data.md",
           "sha256": "b5ccf7ed434aa732ef543515dbf627c2885cc6ec952d8af20e9d995638e98276",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-images.md",
           "sha256": "571411163d6411fb9658face1f7a6d9cf42ebbc93783fdeb9af5ea7d99d34ee7",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-style-and-merge.md",
           "sha256": "b7039a8aace961ca1f4f1f98ff6e87e64492f3c666e3ac7f0ea737423722bf81",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-dropdown.md",
           "sha256": "31279b5cc5682be405bae16095e5788ab177dada80fc295e3fbfd46c8184adbc",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-filter-views.md",
           "sha256": "6ef382e8286474c78832f68a815a56b9a1171a59ba0c7a1ae2cb0cedb7ebeec5",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-float-images.md",
           "sha256": "431faaac5ea35d7615a4cbef119c89578f9155e7fefb3a11baa5093b4a556638",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-formula.md",
           "sha256": "82953029dcaf3cea6bb934a0c214da99d7a55b96ac0f3a3204f470e659b22228",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-row-column-management.md",
           "sha256": "d98c8af2be5bd535f0caedc6f68c9590d3c52220d1d23f86b50d8a5f95dc2126",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-sheet-management.md",
           "sha256": "cf31c86753be34955dadd47cf631322299795c797ffe691c644c7de47f4fd90c",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-spreadsheet-management.md",
           "sha256": "b89b5dfde342294299722a1c45696151981862d8b9c1e1103f000e620c206d98",
-          "owner": "lark-sheets"
+          "owner": "lark-sheets",
+          "mode": "100644"
         }
       ]
     },
@@ -2894,7 +3113,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-skill-maker/SKILL.md",
           "owner": "lark-skill-maker",
-          "sha256": "19e65217a02c544c0db9e0a728d8ef154d5dfd08b542b3db0690c293df92a120"
+          "sha256": "19e65217a02c544c0db9e0a728d8ef154d5dfd08b542b3db0690c293df92a120",
+          "mode": "100644"
         }
       ]
     },
@@ -3283,347 +3503,416 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/SKILL.md",
           "sha256": "c7c6ba762535ef5013a4168d7ce241947deed5e43e9982d5c0bfdcf480b3b3f3",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--all_hands_meeting.xml",
           "sha256": "da2097b75003b64b58b43915a76ae830a71d97adeac29addb74c5e62c2a8cc06",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--annual_gala.xml",
           "sha256": "f8e379f5d0f51e7f07ad7238c8600d661bcf080019c387fc860ab4bb8ff9f243",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--company_intro.xml",
           "sha256": "6dbeffcf5eec4c126fdec266d1272bdd58ccf4629cc4e3092d200dfc324237ce",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--corporate_culture.xml",
           "sha256": "bfd97f8fa63d59db63bf745452e62e54bda5dd655847c43303c393910970a428",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training.xml",
           "sha256": "704eb2bcc35e307ebe9d2b99f41a0c2db49cc166bb21e25b0bbeba89e60ba536",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training_workshop.xml",
           "sha256": "18880d746884b8b2dd82398a747876f9f4d0d1429b9a5d9a5cd6dab3b8168b88",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--onboarding.xml",
           "sha256": "a23a12505ed3f803b160757427a95939900d3eefdd1afb08f695d074337d331c",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_communication.xml",
           "sha256": "1b4956197dabc8e3d9ed6df4daeaffd05b88c7768dde663efeb0f778bdcc41b2",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_logo_design.xml",
           "sha256": "8510b2c63f821f73b70057d71c5be1978efe66723fd39e65500684b6614e56fe",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_operations_plan.xml",
           "sha256": "1b2a512c8c7eb4483461a224db2e0db0ee76bd3a7336830cc36af32e33fe3bda",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--business_plan.xml",
           "sha256": "951bee6fcfa23eca451444192f47a9decc53faefe6c4b01d286752718aad2ee7",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_plan.xml",
           "sha256": "600bbc157ecfc493a6d0c05ee27a82bc6eca5ec9be87d03aef054e2425530301",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_strategy.xml",
           "sha256": "fa2d0d80d5076610c0b99d20acaeefb627c17a2ad202efa0ad0eb2f9db69c234",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--product_whitepaper.xml",
           "sha256": "b09f9fbb73d8434e4206bf237a1447c597db786e851c214bffdb982eb4f09366",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--roadshow_business_plan.xml",
           "sha256": "f8299013a1ff1a0420333f8f0d7d4a9bd653a5a2e313aad628617dce2043f41b",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--book_sharing.xml",
           "sha256": "cc6a910379fafaeee07464fe97f795fc442afbf84b2524c2102fd54aaba74e14",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--club_event_plan.xml",
           "sha256": "91251a12beeaefcb290e19adc41e0cb6435e95237ac886cad6d38071b2f1b8b2",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--student_career_plan.xml",
           "sha256": "15a8d986bc5ca0ad621c6157f6744b3b708a1e56cb3e2a298157b2f936eaf112",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dark_general.xml",
           "sha256": "f6f70cc77e0101811b521b32f38c4331cdc9a56bb91ec987614591a1350bf5bb",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dept_annual_report.xml",
           "sha256": "805a48f14e44d867ef8e21b4299275b9019c184fb46ab2772930bed369d21b48",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--light_general.xml",
           "sha256": "ca3eb82001238023d3d9ccc30f1c776a00ae3908849dc01d02eae28d4535ac19",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--project_kickoff.xml",
           "sha256": "618219c4c1d1423db8f1b29bfbfca65d57fbeac935f778e7ac5dc7f96d15ce8c",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--quarterly_review.xml",
           "sha256": "101b445ceda65fa088c62a8e8edf74526c463f32628b6992f76fccfef111f766",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_report.xml",
           "sha256": "08eb23c24478315b838f907dbbf3ea3edbcb5dce1c5b91a64f46f28ab079829e",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary.xml",
           "sha256": "e2aff31c704f810f5e3fc0e4caa4cf5047a936f7ff2bde41532d99a07053796c",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary_report.xml",
           "sha256": "232e54b627d896cbc888a51766ba75884be3f4a473d89c2a31a8e1493e7bc523",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_logo_design.xml",
           "sha256": "8510b2c63f821f73b70057d71c5be1978efe66723fd39e65500684b6614e56fe",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_operations_plan.xml",
           "sha256": "1b2a512c8c7eb4483461a224db2e0db0ee76bd3a7336830cc36af32e33fe3bda",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--marketing_plan.xml",
           "sha256": "600bbc157ecfc493a6d0c05ee27a82bc6eca5ec9be87d03aef054e2425530301",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--product_promotion.xml",
           "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--experience_sharing.xml",
           "sha256": "bc2dd06c505d3b03c4a157c6af6e7f6318cc1278440f5b65950b4c7b7621779a",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--personal_resume.xml",
           "sha256": "eb407262940be201cc63882ec241501c84533ebe2e96dcf2b2fbf79e455de84d",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_defense.xml",
           "sha256": "77bc6ce1b863085297d5223f1a86a7bc5e88ce72f428740c2c8cd08dfc49166e",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_report.xml",
           "sha256": "35e81547a8568280d548567bcf38c965defef256748a2b14bbb652524be73236",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--self_intro.xml",
           "sha256": "f8c1b89ceaabd29b45d45ad8d20454724e6ae295e1a880cdea412d630bcbaea8",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--teaching_sharing.xml",
           "sha256": "1b98c2bd93d364a47c0d4445f5418b5954d899968be5032b77110b1f73b7e741",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--business_case_analysis.xml",
           "sha256": "6a1ee314548e84efb4ff8b36a1ded03e8203ae35b3b6c752e2625f06c5091830",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--market_analysis.xml",
           "sha256": "287867189b8a1606cfd72eb9b0cc3035be895edfe7cc68968397b50d2451f12f",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_analysis.xml",
           "sha256": "05a62b00f456e9498bd1a5c8e01ee61c02f38b1b2a6f66b89ce4af3c79d811c3",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_intro.xml",
           "sha256": "319cf60656a68eaa2b0d64fb8ddc7afe26611fea2bae80275d66e0d1c5f2ad4c",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion.xml",
           "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion_2.xml",
           "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/asset-planning.md",
           "sha256": "0b7149b3e91f9f86e4488593db547f15ff322cdda5611d4de50316b2f3f33bcb",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/examples.md",
           "sha256": "3e465212249d8f7ec45460e009d3008aa3995824a82cc0840d81f37c9b333ff3",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-create.md",
           "sha256": "6c28e8afb6e58e1ace2ebe63afb1943865953a04e9749a51c521a3ab36438045",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-edit-workflows.md",
           "sha256": "45e597b23a5925a40ffd37212bdf898f5b61630e5a3b3104083bfcc2cae9f439",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-media-upload.md",
           "sha256": "f99aa38dcf61c99e06161b462c2ab76df71ee7629667404a4f175901a06606b8",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-replace-slide.md",
           "sha256": "4ee3ddd488512d77279c60b13157ac7a23c885a02d9a0e42d4e710fb896ce8a3",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-create.md",
           "sha256": "51ab2d0d925242fa43c6f3ac0c8a8c920fceab126bd449c96fabbe20936f0513",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-delete.md",
           "sha256": "c403f1727e0c5ae0b290d73af604a658e29680396e17a5fe83d4d74991639e7f",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-get.md",
           "sha256": "dd6c557f4043aadf678a49e93af19adf0669e50eba9aa78fe63c30995c235525",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-replace.md",
           "sha256": "7235ac05f4acc8f8aa5a0230df6ca2edc88169d31dea1025de18f8ec35b69ef5",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentations-get.md",
           "sha256": "a2cbf1fe3d88b21ef56e7b98b35c4c6300f7a9bdaed1d5865b5c792cc907d622",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/planning-layer.md",
           "sha256": "4b5998424d4b59b77b9028e455cec2ca8159b07fdef4dff5121b36bbd98147d0",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slide-templates.md",
           "sha256": "8d6e820db415985296c14d87c6ec08cfe154cf4e4e431bb433b1f460b1e374e2",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_demo.xml",
           "sha256": "331ab7a90fb19a4d27b57a6bf1335dfb73081299d23346ba2888f7b6efd74859",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_xml_schema_definition.xml",
           "sha256": "e457748005c83d1f636fc421982e8a142e3348c5d851b6472a8d6b4493073b83",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/template-catalog.md",
           "sha256": "1aa8c0db6788d97ab537f77e415f5befa9d895967e9b8df74a50a9409f3b291f",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/template-index.json",
           "sha256": "f473026e75283f6f9d61ba715ea0d5c76871393a8390d34cf47c25dba16a3274",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/troubleshooting.md",
           "sha256": "ece5b2a10c52bcc383a1b8d047bb07d76437e894be2512d92ac39d62b18524ec",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/validation-checklist.md",
           "sha256": "1e87eb73a6bc70c2fc5ce2d1eb6a92cda2c1a0ba55011bdc36b186453a11ca6b",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/visual-planning.md",
           "sha256": "7942ba4f297b25868554f39791f2d87382d2c02e505d2c6bf6d977fa8d546e53",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-format-guide.md",
           "sha256": "ad31703280fa4c51c341dd2970eacefc971fe5301f2012dd984473d40614e59d",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-schema-quick-ref.md",
           "sha256": "24ed1e837fafe121c90260dd55a0ecea96f3517cf42d974ac736afd7af90599e",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool.py",
           "sha256": "02132b415153ed259811727a5a077b84c2d5960e280b1add3c00c8a0db952956",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool_test.py",
           "sha256": "a43a5454b4cd9219fa9723f33edb5a0f7055ec36f585965fee315bf0d5255a7c",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint.py",
           "sha256": "431567c190b9f3cfb4bcbcc8dd69dcc6d09ce26240dcdaba0f70f878f267884e",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint_test.py",
           "sha256": "1f65bf904b1ea432323d8daae3559fe8c4c303d181bcbcda15c95c3511a7607f",
-          "owner": "lark-slides"
+          "owner": "lark-slides",
+          "mode": "100644"
         }
       ]
     },
@@ -3762,97 +4051,116 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/SKILL.md",
           "sha256": "100c05bd9afc6c5a8bca09edbedeee4216544a4d1fbec416edf1c5e7d4455ec6",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-assign.md",
           "sha256": "21e7f23794a9b6250e936d747d6e48cfeda1ecd576496a0ccc80b272270719a6",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-comment.md",
           "sha256": "a214797e0cda20b84e1c7b4fb74e16f09435372a0839a8e0fd4030951c6d975c",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-complete.md",
           "sha256": "8d80f65403dbfb425bd53de2087d12a39d05dca029987b23cb13fc3197ac64da",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-create.md",
           "sha256": "657ec7f0426e9d7e7eaeb084451c2561e876a0649aeff701693c7525d8b03363",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-followers.md",
           "sha256": "3c68ce7dcd2402bd534222bfff79e4de8be5bb1496292c0d7f546cc46b6c8648",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-my-tasks.md",
           "sha256": "7a2004a93530adb6a5a0cfe8dba996924a15fc43bb4aea19e5c0c048799c1446",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-related-tasks.md",
           "sha256": "f5e8ba3221d29d452c017b38086cb68e52340b281e973077b95ac8a40c6f2d62",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reminder.md",
           "sha256": "299565d936ffccec2ef3e34dee1fae424d9ea469799d7fc8232a6290a5c1b7bd",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reopen.md",
           "sha256": "393c52d0f801a992a59748baf28d8671f8ae63a2a674dbe8e55f99b603b038ac",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-search.md",
           "sha256": "a666ba6a9c70dee6a06290ed74054a3d751dc0ae098d9d898b74e42e0467b0b6",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-set-ancestor.md",
           "sha256": "f07dd5a0706f6a95dd83417a4a215903f9dbad3f16c3a2a915d3bd0b850d4fcd",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-subscribe-event.md",
           "sha256": "a519dea5a52616cb3f1b5f45a83b162d232aa2fa78272fd1707c08feb88946e0",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-create.md",
           "sha256": "011f4bf1902063f39ebbe18c94790e77dc621dd5d8a0a0318f361a2411d5c9ab",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-members.md",
           "sha256": "68c21892a5f4fb104fa0f455f4781f427b6766c999e7a8c242b642f1553d2e96",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-search.md",
           "sha256": "c9a70b4d017bef95f8f779343e3f01e49d2ec01e1af2263f13476d3b918124af",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-task-add.md",
           "sha256": "11dfb8d31bb7c5946e9cd7b881f593b82fc9592c319c0f3139b7b13433edb51b",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-update.md",
           "sha256": "5ff63ebbf0b5413bf3d4e1c9dab0dac8f1015258b58a315080dc31798eee6bc2",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-upload-attachment.md",
           "sha256": "6275490511a6e7cd13c617f3a9332011d309b63d4130342e66ca92ab8a826871",
-          "owner": "lark-task"
+          "owner": "lark-task",
+          "mode": "100644"
         }
       ]
     },
@@ -3916,22 +4224,26 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc/SKILL.md",
           "sha256": "fb014718287e5d41381d1697f44b88d8067fcf32c791fff9b1a388bda60cbf1f",
-          "owner": "lark-vc"
+          "owner": "lark-vc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-notes.md",
           "sha256": "5668fac9867c52cee0ebc4b3c24c7d711ad770b3b3ed2fac1c1727a526ae166f",
-          "owner": "lark-vc"
+          "owner": "lark-vc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-recording.md",
           "sha256": "676951fe9dcd63fb6c81750eac7a599f3fcdf27a227c288812f4f9b77172faa6",
-          "owner": "lark-vc"
+          "owner": "lark-vc",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-search.md",
           "sha256": "779357c97ba1be87811d2920890f7ec39e81bcf8fc68448bd02e20add0ca1456",
-          "owner": "lark-vc"
+          "owner": "lark-vc",
+          "mode": "100644"
         }
       ]
     },
@@ -3995,22 +4307,26 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/SKILL.md",
           "sha256": "f68571eb87f2b39a73be134d29f8cd51c68ef21fa3df3421546e81ed2a300328",
-          "owner": "lark-vc-agent"
+          "owner": "lark-vc-agent",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-events.md",
           "sha256": "0f6f743baea0ed555b40ae886a3690a905dea5d022f36091d852215d3e1b41e9",
-          "owner": "lark-vc-agent"
+          "owner": "lark-vc-agent",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-join.md",
           "sha256": "6c08f172b7035e5a0813eb14e8605d4a97b569e2f392dfa552c968f53d57de2a",
-          "owner": "lark-vc-agent"
+          "owner": "lark-vc-agent",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-leave.md",
           "sha256": "e36c4c515621d84d82db77269c30cd4db00ab8c7bbfa7e21adbf3b46267b423f",
-          "owner": "lark-vc-agent"
+          "owner": "lark-vc-agent",
+          "mode": "100644"
         }
       ]
     },
@@ -4194,142 +4510,170 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/SKILL.md",
           "sha256": "48f80c0e89a78ff96ab7437c2e793ed101e81b5a3a233a5733574656088d81c0",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/connectors.md",
           "sha256": "c4211b04f7decc0f63422d0f0bb6e47bdaa1fa85ce04ec508fe99d6e880b7db6",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/content.md",
           "sha256": "8ed9a8b5552f63f7072e14957219eea369a06b4bb7d6ebe8f401df802a0eecf2",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/image.md",
           "sha256": "5d5b60de1edc20781f4d731e1b523eb5637166ab25e3c4467fe97866eb59820e",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-query.md",
           "sha256": "818eb2944baea1a1aad6237bbf75a1f638087afa4fed2e6f2d627b9b2a3b900b",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-update.md",
           "sha256": "9ff34252232198cff159b4e67449975e319d534237ea7e73eec2209156270c3c",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/layout.md",
           "sha256": "de9b72e8a09675d573f7000ca67187f50316e7b17e896e54b0680aa8409273e0",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/schema.md",
           "sha256": "6249857554511fdc2bcc1f2cc3375ed640ba583281705530eaf17323e103ccc6",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/style.md",
           "sha256": "b596a86895b7d6858b14cb8d18e37a842cb0078d774654f50fcd6b37be146752",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/typography.md",
           "sha256": "9df28a4ec089b7bfe894e2ac798d28f992c697b1a1012ce2a4561ca35fcee761",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/dsl.md",
           "sha256": "7bd2b4601e5788bf1ae45448bfe918cc1927ed832fab654b0ef1447ae1bb3c8c",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/mermaid.md",
           "sha256": "d1e75a0b63087b09d08778995518bbf7df52b07444aeca81d39ef973f756c157",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/svg.md",
           "sha256": "c44e986bd730565937eccf79f8e31aebc86e6d3cd851718330fa536669011f29",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/architecture.md",
           "sha256": "12eed6cca334d58eb31d45c2eba9b8f9a5204597dc56d0dc52bd384f64cf2191",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/bar-chart.md",
           "sha256": "441f0b732bb519a7315472f59240c5188b14c17f43c564062b913a19b75b7c33",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/comparison.md",
           "sha256": "8f93eb09b817f4c13f50acacae83b44b10d01996f6e586e610a7ef80d90665ca",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/fishbone.md",
           "sha256": "92d4a425702c5d10a041af2b81064fa919cabf8da35bd31638a9313add6b553e",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flowchart.md",
           "sha256": "00c586db0e4c22f10266d8a64866fb15ddbe5a90490ab2444967b9fc7fc74b2c",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flywheel.md",
           "sha256": "033a8936a13cee5cc4b7279db3b7babd3ff80d66882e6de5a0615d328403c001",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/funnel.md",
           "sha256": "5198fc1d84ea27dd4501a8e8a451f390ca3be1373c587bcaf6d2238c28eae2a3",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/line-chart.md",
           "sha256": "a1d3716eb8ab0cc88df4bf24c62cb7b2f9965eb11c63dd45c5a5e2519e96d3d2",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/mermaid.md",
           "sha256": "4e8e4d2cd7e94d40369f123034e7fed96f0a367ec0e0924ab2702b692162e8d5",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/milestone.md",
           "sha256": "a047231f45e8a514a2b198606d1484fe845613d1700dafe0b8e8c02199559c43",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/organization.md",
           "sha256": "508110eb0b15a400b3d91ec744db31dce5a492c3310f1202b03d02479b1a3ca8",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/photo-showcase.md",
           "sha256": "30ef8e0373f89cfdca073e5936dbb992461c85027b2ba5a45875b3f9fa54af38",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/pyramid.md",
           "sha256": "9cd7c1e3c509a8183919ac7b6a10a1a184a2d2e9eca88dcf6800d0b5e3d7a64b",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/swimlane.md",
           "sha256": "1513ff28e8dd321d3b2ec62403b88e955c736725af815c6263ec34027e628b7b",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/treemap.md",
           "sha256": "6320fecd2a4cb8f700e2307cf80f7eae9d540e469900c786e238386ca6f58e06",
-          "owner": "lark-whiteboard"
+          "owner": "lark-whiteboard",
+          "mode": "100644"
         }
       ]
     },
@@ -4408,37 +4752,44 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/SKILL.md",
           "sha256": "607e543c15286064aee6399f491876a3000699dce45f78408813133338091a0f",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-delete-space.md",
           "sha256": "c52818ed3106e41d866211db61933707788d694962b5c16f8e354b12bf6f6919",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-move.md",
           "sha256": "0e7ffcbc7992a2a168a0c1c0ba46dbc0a741db4cfbfa5638ed02132e1d88051d",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-copy.md",
           "sha256": "dbaa3f65c78e517b580d0f02d4115f8960c65fdeddaa588f60b3d186472a1ded",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-create.md",
           "sha256": "e0fbb63b55798b200291b65f2295cb67eac89ed069e26fd881ea2e680b32a1d9",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-list.md",
           "sha256": "b855aa44feacc2ba22afef68a9226d215d918911322006bf7aee2edfedcd1a01",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-space-list.md",
           "sha256": "d4921cfbfaba564217f214b6f87daf7e3ccbfda5b9759f73ab6a999c682913ae",
-          "owner": "lark-wiki"
+          "owner": "lark-wiki",
+          "mode": "100644"
         }
       ]
     },
@@ -4487,7 +4838,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-workflow-meeting-summary/SKILL.md",
           "owner": "lark-workflow-meeting-summary",
-          "sha256": "8151085041f3c1fb58195dcc8e0a019cc47b496b1cbce4b2d92bd51d2091360e"
+          "sha256": "8151085041f3c1fb58195dcc8e0a019cc47b496b1cbce4b2d92bd51d2091360e",
+          "mode": "100644"
         }
       ]
     },
@@ -4536,7 +4888,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lark-workflow-standup-report/SKILL.md",
           "owner": "lark-workflow-standup-report",
-          "sha256": "bf92b4d15d9ac89791233c015216ab92ea37852150e13721be9ed164a16ee2ad"
+          "sha256": "bf92b4d15d9ac89791233c015216ab92ea37852150e13721be9ed164a16ee2ad",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/larksuite-cli-2026-05.skills.json
+++ b/docs/sources/larksuite-cli-2026-05.skills.json
@@ -144,6 +144,466 @@
             {
               "source": "skills/lark-base/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-base/SKILL.md"
+            },
+            {
+              "source": "skills/lark-base/references/dashboard-block-data-config.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/dashboard-block-data-config.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/examples.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/formula-field-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/formula-field-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-advperm-disable.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-disable.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-advperm-enable.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-enable.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-base-copy.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-copy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-base-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-base-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-cell-value.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-cell-value.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-arrange.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-arrange.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-block-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-block-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-block-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-block-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-block-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-dashboard.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-data-analysis-sop.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-analysis-sop.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-data-query.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-query.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-search-options.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-search-options.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-field.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-questions-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-questions-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-questions-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-questions-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-questions.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-form.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-history.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-history.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-batch-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-batch-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-history-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-history-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-share-link-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-share-link-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-upload-attachment.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upload-attachment.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record-upsert.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upsert.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-record.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-role-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-role-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-role-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-role-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-role-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-shortcut-field-properties.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-shortcut-field-properties.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-table.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-card.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-card.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-filter.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-filter.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-group.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-group.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-sort.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-sort.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-timebar.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-timebar.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get-visible-fields.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-visible-fields.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-rename.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-rename.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-card.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-card.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-filter.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-filter.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-group.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-group.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-sort.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-sort.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-timebar.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-timebar.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view-set-visible-fields.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-visible-fields.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-view.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-disable.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-disable.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-enable.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-enable.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-schema.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workflow.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lark-base-workspace.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workspace.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/lookup-field-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/lookup-field-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-base/references/role-config.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-base/references/role-config.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -160,8 +620,468 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-base/SKILL.md",
-          "owner": "lark-base",
-          "sha256": "c8aeddfb368c543a6ed8465d93db6834ad7d2e583a860024e8a5fcf9076f67ad"
+          "sha256": "c8aeddfb368c543a6ed8465d93db6834ad7d2e583a860024e8a5fcf9076f67ad",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/dashboard-block-data-config.md",
+          "sha256": "cc318a9df3b274ca10aa82391c03e32afcaf0deb4548bdb83811cb64062915fd",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/examples.md",
+          "sha256": "0f7be64b7722b33130201187c20713a0404fb917596b6d44291d2b2df0c1e4a8",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/formula-field-guide.md",
+          "sha256": "cde1028cacd338b9fcc964d9df24136fe39f0c58deeb65aceefaac773554b731",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-disable.md",
+          "sha256": "05d36503ead10e0b49c420214bbbef4be7245a7d708a78a05aaf22865876ca4a",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-advperm-enable.md",
+          "sha256": "91fd193577751dc9865b266e691cdf3a186f808977346538648d0542a52df2da",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-copy.md",
+          "sha256": "73c814419bcc5a8e9ef941faadba18d663fe47eaf83a32303740e0b059378f84",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-create.md",
+          "sha256": "ee2f67665161e351986f3836c0ce8c6a5ac5e7dc807b9374a19a974055eac45e",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-base-get.md",
+          "sha256": "92603e480db34b350fcd4e5fecbe63860f949d4c5fe1ea65743e2ebcd4f75ff3",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-cell-value.md",
+          "sha256": "d859c1b8295ab2b0cd6f5799aaf36a65a53587c60deb0fe30cf76ac58925f724",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-arrange.md",
+          "sha256": "d903af66287796c4389c563fb084791102874b5a92cf8045593805a26fdf281d",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-create.md",
+          "sha256": "5ebd279891d2efa1f2571d38f6db9c75029b3ca20188308c4d80222295224e44",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-delete.md",
+          "sha256": "0391101bc3e2a5d6e169e69ece48a36f83ac2e2d01c1eb3484405fb00100cfdb",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-get.md",
+          "sha256": "42ad4e82b3b9293d3880f62d4f7ced2ed1128b679aba9fc02963a07c6c6a7d87",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-list.md",
+          "sha256": "823017601a9c36d8dfe11b073d57ce4ed12853d39db4f9ee3664219ebe8354a3",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-block-update.md",
+          "sha256": "3f17ec4e0826a53424d83dc55b6a77e89a6b629ae64a6df647a116372aa8cdf2",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-create.md",
+          "sha256": "6e275de197377e861fd5935245ea9424b02da622b74086a6cfc0a4bbfe48cd5f",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-delete.md",
+          "sha256": "2d1e753de77b0b667e5afd8cada503b10f57bec616a003616fafaefa5a96f435",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-get.md",
+          "sha256": "7abd66f68700643c440f591898239a50e19c6b56b20a251d93a66d27c09a2bbb",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-list.md",
+          "sha256": "b723924c7e45936377bfbaaf3352841a3872a252a6fcf51426b2676ab55fd77a",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard-update.md",
+          "sha256": "787f7e9c4d69606434166a87f1add10a01c0b9cefd481029a108bfabae41f042",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-dashboard.md",
+          "sha256": "79cea2a2953fa462144e58d14b06bd8c2653943a775d8f89c342e6ed59cd1880",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-analysis-sop.md",
+          "sha256": "5d0cde83fa156214f6138d3aedcebc0be912e5f5d52fdce61e6a956f76dff1c8",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-data-query.md",
+          "sha256": "b61d6e0cac1d441e7621f8056b443d0fec3aeff6cbd29173931d764ac0f63399",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-create.md",
+          "sha256": "1d5383eb6863b632e46789b553c2f03627c426732e1111bcbb5e7ed0c51c4e25",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-delete.md",
+          "sha256": "a8c2ac0c07d9324d82b4f0ce222ee753c7da6635e6b1ec6c5161c2507f72a25d",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-get.md",
+          "sha256": "445cd8c2695151429e494a5e3646e42abce810f0624f9822daac18397fccd3fb",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-list.md",
+          "sha256": "e255466b5d80b097a64f20fcb7bc3174e96a29368360125b23c848e6ab30a857",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-search-options.md",
+          "sha256": "051d81c714e055d127ffe3e8fd419e38fecb4e740b44b338feee3e50d4db2b28",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field-update.md",
+          "sha256": "4b26b33d5dd86cb8d74664d2fb7fd76182afbeef5df108e3f62871a583053895",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-field.md",
+          "sha256": "7a19eef7e94fb994b59edd07b0ac59a5f7f8a75ab8aac4de77b332f80dcc3aae",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-create.md",
+          "sha256": "af8920dd2d99c913678955c78eee8d3b358760d2ee1fd8b1000415626c22ac22",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-delete.md",
+          "sha256": "a70548d638e8a264d6b03f6fe0a0c6c57e70602658161f46f0e45bf215736f4d",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-get.md",
+          "sha256": "de2555f8893e7789b561395f93c80b089953c5052213f831cd10e608c7159a57",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-list.md",
+          "sha256": "2f4abbd42efab52a59f77c318e0dabd866fdbb4665cd8ab7e2e5f55b9e84c42a",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-create.md",
+          "sha256": "351239be729d5fb386cf6378ba9c38307bdc3385a73360adc047bf9153301cff",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-delete.md",
+          "sha256": "e2cc8406a7427ff872839a02a8691bc90de0ab6fdee3e5f4a707e5e2fd938d03",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-list.md",
+          "sha256": "e7c4dc232520c0bc8da88f6977899bac51195a06f0e0880d35f019ac60f8e114",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions-update.md",
+          "sha256": "cc9a3621bbb52b55fec0462d38cdb9c404a1507924da8c886e51dba1c2c86bf6",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-questions.md",
+          "sha256": "078b016000a0fd2c8cd4de118bdcbfc4bd2fc1aa21308d2769678a2a1875fa7b",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form-update.md",
+          "sha256": "20fda299dc71451cc077efacef92504ce5ef3b9aa23fcc768c46eb59178e99cf",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-form.md",
+          "sha256": "d85662a4ebc57c2b97060530396db906cd102917c1fc3aae67825e712c2f4022",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-history.md",
+          "sha256": "5eb5dee08ef909dc87611c1e6f7cddf15adcbb6e94e401a952ddd36c738bd546",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-create.md",
+          "sha256": "093868dd85788e41509ead7a3ceaa34807c1dea81cf37723f837328d10ef3229",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-batch-update.md",
+          "sha256": "96789f7a5ecebc73c616b9ffccd3045947ea0a2b3ede3927cc517add65773017",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-delete.md",
+          "sha256": "51b2de73559873955e21181df575f3df19dcd0551ba4fbb44237c9f1d7ac25e1",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-history-list.md",
+          "sha256": "65e4b3ffc8d268394398aede90124ad4d80f186dc603769e949bcde6ae460ba7",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-share-link-create.md",
+          "sha256": "b38bfb8068a5855b1ac16c2dc96217d9dffa5f3b7bd074c938582f2cef885b16",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upload-attachment.md",
+          "sha256": "a71471147725ba5afd4de15c9ac716bb719f96966ff7db5e5d6ca5f68d361532",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record-upsert.md",
+          "sha256": "3f830f29e16361b52bfb013e1b7cae9dc194b8ccc09feb3a402afd8c370a4ca5",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-record.md",
+          "sha256": "55cdbf35ccea42b8056ca6d00c01a76fee65f4750aa0103febae796db9237356",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-create.md",
+          "sha256": "fb10e0924a7ba1a8e2a0387bf694d0018eb013490a3bc73bb0c7253f578bbdb8",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-delete.md",
+          "sha256": "549c51bd252ed017d8a27c3ead85ff46628bc16894cd0fc0b08eb053841860b2",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-get.md",
+          "sha256": "12f811421870ad85f584010ffaa4fba01ab386f051f1a1dc4483bd16ffd015b3",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-list.md",
+          "sha256": "11a5dcfe51256e0efce3834ca51e7842bb0532379e9c79858f6f98dad2e6ea47",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-role-update.md",
+          "sha256": "f0f0108ae9e00195600e7ccdf21b75ddbf883b9a7ab4e3ea7162680f4ac91986",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-shortcut-field-properties.md",
+          "sha256": "5db5335ee798a733ca094b9b7646cf2986033ba9caf5ba6c70fbd4e2d7cf889c",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-create.md",
+          "sha256": "23c4de0912e68be116a841ef7a381df8f55eb150dc0e1940b701371ebb660cca",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-delete.md",
+          "sha256": "e837c0911381afdcc9394c4144a9e0fbb8e7f9f905487b4953065faa58282000",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-get.md",
+          "sha256": "eac9ef07b5c157f284563190885ff9ab23318f82218696fa407a43d5912aee4f",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-list.md",
+          "sha256": "00eeb746d6620b12b2fca673ec0e912882246f8e1a5db02f63c2bc4bda95b893",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table-update.md",
+          "sha256": "08bac24758306d002316ffdba2678db2eac7d03b406d6ca4a68f827afb1bd380",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-table.md",
+          "sha256": "a6f82974e4e4af616ab24f19f13a974b28b174ad01aea6a4d806fb2ee798029e",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-create.md",
+          "sha256": "f40fb05f0fb1dbabeb833bb2c242c2150093dc2de8468ef298abc902c3a0c84b",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-delete.md",
+          "sha256": "ff793bd36c8234684f72b25564744259e690da30d44e2f2ba244fe65186ec2b9",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-card.md",
+          "sha256": "d841409fdf659af685a310766dbd24c80d16a2ec90210715aecfe9aa69dc8c61",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-filter.md",
+          "sha256": "d0181e83b534b76f007ae9ab72dfe7b043efce8b305b16c962665f9859723e57",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-group.md",
+          "sha256": "06ae779640a53c12da9b4ecd6d1d411ed67e0d19b684daf52182597c5443633c",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-sort.md",
+          "sha256": "78cba8dfa78f809a74df8b8544e1b4cf859e10ba0e12cb472e11f447ed240ee0",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-timebar.md",
+          "sha256": "6fc13d1cea144713e95aa07f15671129d2b8f547ef9b8b8c776351faec4e450a",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get-visible-fields.md",
+          "sha256": "c3222d34c3b396ba7e6148413562accce1dd71b7895845af9b4a82bd730670d9",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-get.md",
+          "sha256": "85269658f2930066a80f41672b4466a55ee24270f1984ec0a4176b951fd4cbd8",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-list.md",
+          "sha256": "ed409d8e578e7bee2814d7d2b4293c7500537a6755c400fbcc738a769d853b93",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-rename.md",
+          "sha256": "106ddce503f5d9088a407c59ee3b5025b1f3289a6bc15514a32ddc26fe29e8b5",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-card.md",
+          "sha256": "39630f6bab34aa5fe68e16b5fbfd2a12dbd56b1c118dbff3dbd660737181b3cc",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-filter.md",
+          "sha256": "d12a8f91590951fb00e0ebfb8fec9666ed7b8a17919fba5fbb7a5c7015bc18e1",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-group.md",
+          "sha256": "103d66bd207bae75b91980ad48857e7dbeb4e3501b3658b53027d44578f0903e",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-sort.md",
+          "sha256": "a7f24bb2267eb7b768a7129d4183385e7ba1268e869351016099eb98b7cc5cda",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-timebar.md",
+          "sha256": "701fef8bbfcaba87bfded19fabe18f656f8679ee7eb72ee41053dbe817519d68",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view-set-visible-fields.md",
+          "sha256": "4731e0f53556da468ae5221d1cc3ce2e38403ee508c09d299867795988bbb139",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-view.md",
+          "sha256": "c5afc15cf5941d4d7196732ab7cb8ccab15ef50419cd12ebeabb049069f12604",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-create.md",
+          "sha256": "22ca47b7938073a7372cb20690d7f53db3f83bb6ff08e468e166b1173e71c4f3",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-disable.md",
+          "sha256": "19b39a6e3a881614330d4bca6171a1c5dc4d623d7141d819b7d306bb7f7b4194",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-enable.md",
+          "sha256": "0ebc8e39f32f5b664bb8cd5128ab6199050d09f47225857569c24de439aa2d20",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-get.md",
+          "sha256": "52cd887a812c0ef1966f45f76cacf0f76914dfcc5b978276ef74be855e737122",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-guide.md",
+          "sha256": "3198cea58cc735a9b838372329bff29f5505243843647f17785f94bb7421ce97",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-list.md",
+          "sha256": "f67dcbde6618547937521ba4b27f9e91d05d1d024c9a856e286f4390b8b126e7",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-schema.md",
+          "sha256": "0e9f722a8b3ce3c8eec2dd70c25dcb60f359d32c4e9af7cc68ccf73c54aade49",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow-update.md",
+          "sha256": "8fe49981ce5bcdc3114e2ae298fb310992cb7d1fe8e0f0146795f57d631720c3",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workflow.md",
+          "sha256": "573360ed0dfcd8da0df819ec6e6e0ded12aa35d5e864f4aef1067807346b487f",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lark-base-workspace.md",
+          "sha256": "d8178f5db0f006feb774e0bf2e5147558cbcbfa5cdbae9a094275c444dd83cdc",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/lookup-field-guide.md",
+          "sha256": "7c22d5dcabfcb6bd70f16d912394e3e3a546d381001261e43878f5704c875b1c",
+          "owner": "lark-base"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-base/references/role-config.md",
+          "sha256": "b1f89be9b38ae89fb7bef4bd22fce15216bfab146a15ddd383afb7e86a400e23",
+          "owner": "lark-base"
         }
       ]
     },
@@ -193,6 +1113,46 @@
             {
               "source": "skills/lark-calendar/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-calendar/SKILL.md"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-agenda.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-agenda.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-freebusy.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-freebusy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-room-find.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-room-find.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-rsvp.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-rsvp.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-schedule-meeting.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-schedule-meeting.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-suggestion.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-suggestion.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-calendar/references/lark-calendar-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-update.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -209,8 +1169,48 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-calendar/SKILL.md",
-          "owner": "lark-calendar",
-          "sha256": "5323ed83b9d513561064a6f8a79bc10739af900dee73d6310096d79993dc6a64"
+          "sha256": "5323ed83b9d513561064a6f8a79bc10739af900dee73d6310096d79993dc6a64",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-agenda.md",
+          "sha256": "810713427524da397939ff95e3f5bcfd870fba1fcc8b2c7546f2253969d57d65",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-create.md",
+          "sha256": "23433c243fc3bb1dcd6fc1cd6d31633f3740b126fb32ecb53587408368421b59",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-freebusy.md",
+          "sha256": "ff3b79ae776e4fb7b37f58f41c1826056b717f0d57087c6fcd30833fc20bcbea",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-room-find.md",
+          "sha256": "edfa65a74174dba9f8a4b474e94ae16e5bc5afd6b5d3d8c57f7234d5cee984b8",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-rsvp.md",
+          "sha256": "1ec25ef0827c5a0f5823b42c86e3e2dc9dde55fadcfad73b8daf2e845a729369",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-schedule-meeting.md",
+          "sha256": "3a5ab5622d29b71985ec195416ac0ec7817b8e9c5ad694a5df517b3deb448332",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-suggestion.md",
+          "sha256": "6398e2172951919e94e299f0d95ae41d9b0e70d91d106978e47646cdb35257c6",
+          "owner": "lark-calendar"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-calendar/references/lark-calendar-update.md",
+          "sha256": "5d0f262cedbad499ad58dd86f8dac8e4a6a4a3b4fb5dda3ca704b58840460441",
+          "owner": "lark-calendar"
         }
       ]
     },
@@ -242,6 +1242,16 @@
             {
               "source": "skills/lark-contact/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-contact/SKILL.md"
+            },
+            {
+              "source": "skills/lark-contact/references/lark-contact-get-user.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-get-user.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-contact/references/lark-contact-search-user.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-search-user.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -258,8 +1268,18 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-contact/SKILL.md",
-          "owner": "lark-contact",
-          "sha256": "efe3010dfb69360c5349d9683b61e9b443d3bf5d06304810f8fe24773e8847bf"
+          "sha256": "efe3010dfb69360c5349d9683b61e9b443d3bf5d06304810f8fe24773e8847bf",
+          "owner": "lark-contact"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-get-user.md",
+          "sha256": "24ba2fbd92ec33ebf04de44a6bb10ee9af91e5808aa8d1898486d332da2c5b6e",
+          "owner": "lark-contact"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-contact/references/lark-contact-search-user.md",
+          "sha256": "70282ead84762fe71e07363ab0f0c265f011b0c021caf0452b2fb6d8b4e1d35f",
+          "owner": "lark-contact"
         }
       ]
     },
@@ -291,6 +1311,71 @@
             {
               "source": "skills/lark-doc/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-doc/SKILL.md"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-fetch.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-fetch.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-md.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-md.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-media-download.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-download.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-media-insert.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-insert.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-media-preview.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-preview.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-whiteboard.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-whiteboard.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/lark-doc-xml.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-xml.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/style/lark-doc-create-workflow.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-create-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/style/lark-doc-style.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-style.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-doc/references/style/lark-doc-update-workflow.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-update-workflow.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -307,8 +1392,73 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-doc/SKILL.md",
-          "owner": "lark-doc",
-          "sha256": "4ea2cc9b96ae253dd89608ed76948d21f5a2821f7238c330f36a2475f1a07ada"
+          "sha256": "4ea2cc9b96ae253dd89608ed76948d21f5a2821f7238c330f36a2475f1a07ada",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-create.md",
+          "sha256": "2829456a92d4fcee9525b292bd490d82da995b51e7600ab868f7c0283a682f1e",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-fetch.md",
+          "sha256": "f80af9f538c747e434e51920caef53fd665bd8861620a61d46594908e79c762f",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-md.md",
+          "sha256": "7b0e0e132d93f2974264c359d066f3a21f957cafe9a13b0637bca69e8e7486b9",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-download.md",
+          "sha256": "d4c7f67d07b907106a037500e5809405ce74ee4b642767af3e417c5edd527277",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-insert.md",
+          "sha256": "1c1e4f799ba056e51a7cb84188da3d3c4b22d687403b43d4bb8971551b455dfd",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-media-preview.md",
+          "sha256": "ebecf432d6ad0dbfa249cbf3dab91e7e20e25ee29e1c4874a039aa2bb8194200",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-search.md",
+          "sha256": "2640ee97762ab91c5e9556c818c5e467fc04cc91c4ecb7c4cfe2c3b8f6875074",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-update.md",
+          "sha256": "9cfba006b8cc7f17de604775cbbd120eed29a79c279fdd04e9544363f8459344",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-whiteboard.md",
+          "sha256": "900e26f29d85f775a9bd33bf13b07b3e67eebf57d01eea8b6407a959e92f2ae8",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/lark-doc-xml.md",
+          "sha256": "0b89e88f26f15d0477dc57cd5971405f4c3a2ee45dca309101805c93bed098c3",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-create-workflow.md",
+          "sha256": "b51e7412716e26f36b44275fb148990925ffdd5eaf7591267efe5a5e36829090",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-style.md",
+          "sha256": "af50103f52d14c88d6ad906875d5b6a2ac55039e33cf8df90c563eb5f3aa57c4",
+          "owner": "lark-doc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-doc/references/style/lark-doc-update-workflow.md",
+          "sha256": "07499da6c82b515257c1e134eccc77bdd94c3fbf636adbd02ce8c38f4da639ba",
+          "owner": "lark-doc"
         }
       ]
     },
@@ -340,6 +1490,111 @@
             {
               "source": "skills/lark-drive/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-drive/SKILL.md"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-add-comment.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-add-comment.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-apply-permission.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-apply-permission.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-create-folder.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-folder.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-create-shortcut.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-shortcut.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-download.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-download.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-export-download.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export-download.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-export.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-import.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-import.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-move.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-move.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-pull.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-pull.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-push.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-push.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-reactions.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-reactions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-status.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-status.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-task-result.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-task-result.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-upload.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-upload.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-version-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-version-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-version-history.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-history.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-drive/references/lark-drive-version-revert.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-revert.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -356,8 +1611,113 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-drive/SKILL.md",
-          "owner": "lark-drive",
-          "sha256": "69ebc8e2a94b44a7d4c82e454c750a1416a2b8bc8c72a18f5fa26b4ecf12efed"
+          "sha256": "69ebc8e2a94b44a7d4c82e454c750a1416a2b8bc8c72a18f5fa26b4ecf12efed",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-add-comment.md",
+          "sha256": "ff6752bb54beea2d14d242161251c84b381d6c57fad06838cc0acc3849d02f71",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-apply-permission.md",
+          "sha256": "d267016d3cac5f73d5be1fdfab8e28c495c6eea3389eff641398acd666d814e7",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-folder.md",
+          "sha256": "2dcc2d29b4c9119395b9ca1b13aa6d04c4cbe2478985db15455430c511eb4c8f",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-create-shortcut.md",
+          "sha256": "aca426b7dfbfb44c2fe17d1801bb2525ef770e7bc763fb2e0e6dbe3f13bb829d",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-delete.md",
+          "sha256": "efd530e3d60eeca98fa1314a01be4d7f6905ff9693f26b9c79bce7ae53b05106",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-download.md",
+          "sha256": "0ee64549dff3dc86eacd0f940784e2fa8b04cd91ad77be32a44f45920a572ded",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export-download.md",
+          "sha256": "e02cb3e43a485371bc491f9ce214e4b620d45560bacff0999d223c2f911166e1",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-export.md",
+          "sha256": "28cbb4fc64db7f3af380bee2f91e6a4c29082b3552a0e86a6ca28c4e4f98dbc4",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-import.md",
+          "sha256": "71449f17ccd57a2a9cea556aee6ecfa80eb092c934f6794acaa189120f49c934",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-move.md",
+          "sha256": "c4da1157d8994dc1ec4d94173f6f1e613fd04ec39eee0b5e9fd0af48f6db4c81",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-pull.md",
+          "sha256": "722d735ca1676da24ca871b67f43f118aff8087814ccbb0e7331d026dbdfc908",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-push.md",
+          "sha256": "48075fcf824cb1d031a295de0ce23ca65854316e2827f0327575c16d6ef907f1",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-reactions.md",
+          "sha256": "7c6761ac97e2e65f1ddb9a368a916a2a2b17b2d7c8b3146f1cad531b394c720d",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-search.md",
+          "sha256": "0152b5157f15515843bbb2757e5f167fd1e8b6de02ce213baf73e0e0595fde8c",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-status.md",
+          "sha256": "10769fc4e3ca8f4f9dedee6f23c225996e401bd23b7bea2f33971afefc116139",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-task-result.md",
+          "sha256": "0feba3abac5e5ec64ed1336792159b00befee57af69a4c40fdb2b62c779535e4",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-upload.md",
+          "sha256": "20cbd4ce992d67b1fe83526165461abeed73c41f490dcb9a94fa4fe5941140ee",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-delete.md",
+          "sha256": "0e47f7d95496c97c8143f74bcdd829b41a5d5a6ad10c3998c995cdf774497704",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-get.md",
+          "sha256": "7bfe1629ff5f6838dbc251619d9bd7226f3c89e11a97a2c2204357c7354a057f",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-history.md",
+          "sha256": "aa1110d97a19ccd6dfdc78e1a5ac9cb74bbc6d74379a8a22d78bb5de99575294",
+          "owner": "lark-drive"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-drive/references/lark-drive-version-revert.md",
+          "sha256": "c909d6a84cb0e6c783b0685e8c1c4bfe9f79db8a59bac056e60c46b033aacf3e",
+          "owner": "lark-drive"
         }
       ]
     },
@@ -389,6 +1749,11 @@
             {
               "source": "skills/lark-event/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-event/SKILL.md"
+            },
+            {
+              "source": "skills/lark-event/references/lark-event-im.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-event/references/lark-event-im.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -405,8 +1770,13 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-event/SKILL.md",
-          "owner": "lark-event",
-          "sha256": "4129f49bb9091217aa50cc427199f4d5653fc6274313c47f88fdedb34ee9063a"
+          "sha256": "4129f49bb9091217aa50cc427199f4d5653fc6274313c47f88fdedb34ee9063a",
+          "owner": "lark-event"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-event/references/lark-event-im.md",
+          "sha256": "b67c3cad7c1748477f66fd99ebf19dfc8f9b5a773f3a36bb5305ce2c5b66486f",
+          "owner": "lark-event"
         }
       ]
     },
@@ -438,6 +1808,86 @@
             {
               "source": "skills/lark-im/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-im/SKILL.md"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-identity.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-identity.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-messages-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-messages-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-chat-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-flag-cancel.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-cancel.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-flag-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-flag-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-messages-mget.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-mget.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-messages-reply.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-reply.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-messages-resources-download.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-resources-download.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-messages-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-messages-send.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-send.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-reactions.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-reactions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-im/references/lark-im-threads-messages-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-threads-messages-list.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -454,8 +1904,88 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-im/SKILL.md",
-          "owner": "lark-im",
-          "sha256": "67f7cd8ecf045589d578dfc51aeea9c136ef4c8ea1cdd03b392b5650555ad912"
+          "sha256": "67f7cd8ecf045589d578dfc51aeea9c136ef4c8ea1cdd03b392b5650555ad912",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-create.md",
+          "sha256": "2757a5849b8f5426379200209c8141adedd16243ff4a0dcf84e201d6cc9f9f6b",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-identity.md",
+          "sha256": "449708ed9be8b3b4657c685509e9b587c4f728f51b00bdeb08db20941a4135b1",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-list.md",
+          "sha256": "867269726e570ab749938b22f0c5eb4ee177e7a1cfa90de842eef84e58a7a656",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-messages-list.md",
+          "sha256": "a9e250b55143bfa46b92373d1ce0400f68f950500533a5080f21b906b6809474",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-search.md",
+          "sha256": "f84173d20cfcd5d6755cb9f0b4fa13f844a29f0ce64be0077ff13fbd8e09a4fd",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-chat-update.md",
+          "sha256": "5e27243b3e230711107f1bf05b99fe282e8b23b0aaeb411e27a7fdc66f689f4a",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-cancel.md",
+          "sha256": "bc1a242cf265cc8744d3c5e4e326248d797c59b2d37117a353ae523a2166483b",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-create.md",
+          "sha256": "61f13376f14986f61b1e61146ee5d89fbd5c978d574cb13e78e52c71f982761a",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-flag-list.md",
+          "sha256": "1baab8956d29eef137afe9f98c8715ee5bcb4c9987851f2393e798d876d4ba48",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-mget.md",
+          "sha256": "6ee4a509ebe37849fd7b70d0981a9ce5ecb32ee7ca2100561d27dd630402d85f",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-reply.md",
+          "sha256": "24a521c92f249dafba04a73da25a78a3c5483e1e39d0d92a3211e4d171e4d424",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-resources-download.md",
+          "sha256": "54d59b009672bb0533d5eae3bd5496eb6fa559496bfd4a7be96544627f7c36d7",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-search.md",
+          "sha256": "765eaba0e67d23b7bd65cf80a4ca147cf1e7cbf6414efdddb575849221320e28",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-messages-send.md",
+          "sha256": "f41bd266c0f79d1ff033096bf3f84ca1d527cd74ab735e536e35869a0b9adb73",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-reactions.md",
+          "sha256": "97f0cd3b0d3e672f150314fc7e41534b78244af78eeecd34b00949bb765e1945",
+          "owner": "lark-im"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-im/references/lark-im-threads-messages-list.md",
+          "sha256": "820573d2a8e7ce447bdc4189eda6acc635019f50b79a06b61294055f3804a5cc",
+          "owner": "lark-im"
         }
       ]
     },
@@ -487,6 +2017,91 @@
             {
               "source": "skills/lark-mail/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-mail/SKILL.md"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-decline-receipt.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-decline-receipt.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-draft-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-draft-edit.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-edit.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-forward.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-forward.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-message.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-message.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-messages.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-messages.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-reply-all.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply-all.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-reply.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-send-receipt.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send-receipt.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-send.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-share-to-chat.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-share-to-chat.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-signature.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-signature.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-template-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-template-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-thread.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-thread.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-triage.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-triage.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-mail/references/lark-mail-watch.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-watch.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -503,8 +2118,93 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-mail/SKILL.md",
-          "owner": "lark-mail",
-          "sha256": "72d8afb05a8d6bf89796b3b2231ed63da8354e95caa2be59ddf791e97305d477"
+          "sha256": "72d8afb05a8d6bf89796b3b2231ed63da8354e95caa2be59ddf791e97305d477",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-decline-receipt.md",
+          "sha256": "dc888a26f4eda3aa1483f6be81f02eac32d053b41bb6089b3b1badd327053665",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-create.md",
+          "sha256": "0c57bf5ae4f09185aa621f2a708c18ce182d94fad41da40adb5aaa3e37537d74",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-draft-edit.md",
+          "sha256": "7b430dbb16498d4aa260ce730303f01aaf61e6295bb88181cb1a57df31e060b4",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-forward.md",
+          "sha256": "808612b1f493c873558f5f9be03e4b489cfff7b353df5d7fdd6fbb25af7acdab",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-message.md",
+          "sha256": "cc27e13876dad4f47d83d7838267bef75a96ab2870b2e58a0b97bc72a1a72b6a",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-messages.md",
+          "sha256": "908aea214f246a719bcca039bee11ad198796c59a8ee2e239effa09d4050227e",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply-all.md",
+          "sha256": "58d003783bb32886d0524df922268c5f55083f0462a9b9929045acf4f53ab9ce",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-reply.md",
+          "sha256": "674c6be7e699f5c77447aab45213fc66b2192254cc472944ea56cb9f17f799c2",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send-receipt.md",
+          "sha256": "19af1149866916a9d7403f92405cffa70d1cc4e3c364dd54c2d82c45f7736c56",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-send.md",
+          "sha256": "b20381dcf99317fc7fd283feb9d80c50a1261b36a6d815ae8d63f1c47edbc0d0",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-share-to-chat.md",
+          "sha256": "983a642f8305312ee81a98f45760ffe8ad720347bd8c4fbaa55beb38baa05a9e",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-signature.md",
+          "sha256": "fa759bf8b2ee70dcf3ab5403e6f31833d86eb1cf86812dd7c30dd909897416b2",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-create.md",
+          "sha256": "368c9bc14dd4e2cf81f9e0efbc112b695a2c6055fb601cd48b85fd16ef39c02d",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-template-update.md",
+          "sha256": "f819cc2504e4e8898a7fb1fbd4f63b6e0ea07dd3e1ddc14c1649049ba78abc40",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-thread.md",
+          "sha256": "ef0f803f3dc95c4012e55c3da546a9835953e56cbfdbb5fc759a3d277cee4503",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-triage.md",
+          "sha256": "0b5ee4c76aa1fe7a1f6ed7fe246b6c7d83fefd05267fcddbb1e6077355da5833",
+          "owner": "lark-mail"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-mail/references/lark-mail-watch.md",
+          "sha256": "3e9bd88f9b73477165128c84433931734255c1a3d6c540a2e773d644a247be12",
+          "owner": "lark-mail"
         }
       ]
     },
@@ -536,6 +2236,26 @@
             {
               "source": "skills/lark-markdown/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-markdown/SKILL.md"
+            },
+            {
+              "source": "skills/lark-markdown/references/lark-markdown-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-markdown/references/lark-markdown-fetch.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-fetch.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-markdown/references/lark-markdown-overwrite.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-overwrite.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-markdown/references/lark-markdown-patch.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-patch.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -552,8 +2272,28 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-markdown/SKILL.md",
-          "owner": "lark-markdown",
-          "sha256": "ec74e6609dd0d409075abfeca8484426af1b58cc217cfd345c8e4672854b3b85"
+          "sha256": "ec74e6609dd0d409075abfeca8484426af1b58cc217cfd345c8e4672854b3b85",
+          "owner": "lark-markdown"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-create.md",
+          "sha256": "3f4788c0a9e6eb8c19f6e3b9c2173ecb4104867aa8e13836d78a8765b1e3200e",
+          "owner": "lark-markdown"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-fetch.md",
+          "sha256": "0c68f0d56ddd7272485f32f7cf9321171dbdd1be4c4f98e0304beb78038bf2d0",
+          "owner": "lark-markdown"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-overwrite.md",
+          "sha256": "67265b9bc7ca2e97ed966f7bf693e349f10795e567e5e80870ba4b39b1d81bd0",
+          "owner": "lark-markdown"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-markdown/references/lark-markdown-patch.md",
+          "sha256": "4e4a5cc39c87722500dc8f121045f8f7e159cf913ca521bfd129cb5c96c62192",
+          "owner": "lark-markdown"
         }
       ]
     },
@@ -585,6 +2325,21 @@
             {
               "source": "skills/lark-minutes/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-minutes/SKILL.md"
+            },
+            {
+              "source": "skills/lark-minutes/references/lark-minutes-download.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-download.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-minutes/references/lark-minutes-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-minutes/references/lark-minutes-upload.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-upload.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -601,8 +2356,23 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-minutes/SKILL.md",
-          "owner": "lark-minutes",
-          "sha256": "73f533d1d72b6e9e43a8565028d605e173d23f64015352a3dbaa1bd51b4d3348"
+          "sha256": "73f533d1d72b6e9e43a8565028d605e173d23f64015352a3dbaa1bd51b4d3348",
+          "owner": "lark-minutes"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-download.md",
+          "sha256": "c3dae9d73080f32f330d5978d7757c02abba38b24680452731aa6923b42ee2fe",
+          "owner": "lark-minutes"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-search.md",
+          "sha256": "afe1df6f47cad9d254ce2b6a111fe7e7758900b89dacbd410e414311aba510ef",
+          "owner": "lark-minutes"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-minutes/references/lark-minutes-upload.md",
+          "sha256": "3f7914a791f12e2cf4ae2ae512888d8cf92a08f5b87c4b2806b42f34dc642812",
+          "owner": "lark-minutes"
         }
       ]
     },
@@ -634,6 +2404,56 @@
             {
               "source": "skills/lark-okr/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-okr/SKILL.md"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-contentblock.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-contentblock.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-cycle-detail.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-detail.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-cycle-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-entities.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-entities.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-image-upload.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-image-upload.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-progress-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-progress-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-progress-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-progress-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-okr/references/lark-okr-progress-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-update.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -650,8 +2470,58 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-okr/SKILL.md",
-          "owner": "lark-okr",
-          "sha256": "5a7328d1d9501839f0a72e2ac523ffd33d4f8eb1fd056c35d373fee913f680ce"
+          "sha256": "5a7328d1d9501839f0a72e2ac523ffd33d4f8eb1fd056c35d373fee913f680ce",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-contentblock.md",
+          "sha256": "11a75f520d658a9a4c29191e8ccc67f3292dfa07ad2fd998fb31daa70bb8d424",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-detail.md",
+          "sha256": "7bc2c7b1cb9f3b04e3b96dae201f48cbc31406a4e44c9b6c28d13c636b76f8b0",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-cycle-list.md",
+          "sha256": "edd01257f2b02c169ffec485d226ec6515d7448b9d3defb6bc55d221838084cd",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-entities.md",
+          "sha256": "615fa21c04155413700bec22ad11751e6d06a6c45ca74941a8637b4a67032766",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-image-upload.md",
+          "sha256": "4a5324ab2cc5b4ca42d51ef8066ed9e3375c921cf243eb40bbb41d73bb7e7bdd",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-create.md",
+          "sha256": "6180a09a96f86b069af2f6f8822eafa655336f912a5aef32ced5227e6dba8197",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-delete.md",
+          "sha256": "c96a580dc99bdd5e675718cf799870d6d84b7aa9b7f6f5f51c88182f9965d7c6",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-get.md",
+          "sha256": "47b8ead617177fc99b41f66b6e8a0f00397040d3a7fa861c0602385233dbfe68",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-list.md",
+          "sha256": "a9ece8f369ccd1680be1d936dd7fea1421583d9f42202760852bffd23f36585a",
+          "owner": "lark-okr"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-okr/references/lark-okr-progress-update.md",
+          "sha256": "5ab9512f440f12c66de9c1355cf053a9db0f5550c61e65a3a7d18283be5d0bdb",
+          "owner": "lark-okr"
         }
       ]
     },
@@ -720,7 +2590,7 @@
         "last_synced_commit": "315e0ab50c0e6004bb1b790b78cbf7312ef84a78",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -743,13 +2613,90 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/knowledge-and-pm-integrations/lark-shared",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-config-init.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-config-init.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-high-risk-approval.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-high-risk-approval.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-identity-and-permissions.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-identity-and-permissions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-output-contract.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-output-contract.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-update-notice.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-update-notice.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-wiki-token-routing.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-wiki-token-routing.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-shared/SKILL.md",
-          "owner": "lark-shared",
-          "sha256": "59884e9976548bbb0a2f64986c04b8cd21db0e3713ac9ec84a6bb2f373a4c13a"
+          "sha256": "59884e9976548bbb0a2f64986c04b8cd21db0e3713ac9ec84a6bb2f373a4c13a",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-config-init.md",
+          "sha256": "d995546300e59284e223e9be856ff5674056900b86c9ad022c4e9b2bf0f24563",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-high-risk-approval.md",
+          "sha256": "b8bbff0c71d376564f8d6ea640686b08645d6ff4c905aa03c79882b98bd6bf05",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-identity-and-permissions.md",
+          "sha256": "68c8f409ceeb062b4460a63ea4a8822e4150db475b7ca2f4baaf1e67162907f1",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-output-contract.md",
+          "sha256": "8f47ada21810a83de272d1bef088ece187947c2cb0743ded7590d82d8c175699",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-shared-update-notice.md",
+          "sha256": "6e1d08f7338721053087f8292c98302a947ee97358be71a60a7110a3b91e8d3a",
+          "owner": "lark-shared"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-shared/references/lark-wiki-token-routing.md",
+          "sha256": "42ba982e9ebc85aefca3db64a434d08dadba49c5d42d617388964866543f7c79",
+          "owner": "lark-shared"
         }
       ]
     },
@@ -781,6 +2728,56 @@
             {
               "source": "skills/lark-sheets/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-sheets/SKILL.md"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-cell-data.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-data.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-cell-images.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-images.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-cell-style-and-merge.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-style-and-merge.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-dropdown.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-dropdown.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-filter-views.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-filter-views.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-float-images.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-float-images.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-formula.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-formula.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-row-column-management.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-row-column-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-sheet-management.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-sheet-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-sheets/references/lark-sheets-spreadsheet-management.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-spreadsheet-management.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -797,8 +2794,58 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-sheets/SKILL.md",
-          "owner": "lark-sheets",
-          "sha256": "c6f35ea0701e5a9ec89561d288d96b7e4265dbd0cedca8684638ce497c0ef555"
+          "sha256": "c6f35ea0701e5a9ec89561d288d96b7e4265dbd0cedca8684638ce497c0ef555",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-data.md",
+          "sha256": "b5ccf7ed434aa732ef543515dbf627c2885cc6ec952d8af20e9d995638e98276",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-images.md",
+          "sha256": "571411163d6411fb9658face1f7a6d9cf42ebbc93783fdeb9af5ea7d99d34ee7",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-cell-style-and-merge.md",
+          "sha256": "b7039a8aace961ca1f4f1f98ff6e87e64492f3c666e3ac7f0ea737423722bf81",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-dropdown.md",
+          "sha256": "31279b5cc5682be405bae16095e5788ab177dada80fc295e3fbfd46c8184adbc",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-filter-views.md",
+          "sha256": "6ef382e8286474c78832f68a815a56b9a1171a59ba0c7a1ae2cb0cedb7ebeec5",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-float-images.md",
+          "sha256": "431faaac5ea35d7615a4cbef119c89578f9155e7fefb3a11baa5093b4a556638",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-formula.md",
+          "sha256": "82953029dcaf3cea6bb934a0c214da99d7a55b96ac0f3a3204f470e659b22228",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-row-column-management.md",
+          "sha256": "d98c8af2be5bd535f0caedc6f68c9590d3c52220d1d23f86b50d8a5f95dc2126",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-sheet-management.md",
+          "sha256": "cf31c86753be34955dadd47cf631322299795c797ffe691c644c7de47f4fd90c",
+          "owner": "lark-sheets"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-sheets/references/lark-sheets-spreadsheet-management.md",
+          "sha256": "b89b5dfde342294299722a1c45696151981862d8b9c1e1103f000e620c206d98",
+          "owner": "lark-sheets"
         }
       ]
     },
@@ -879,6 +2926,346 @@
             {
               "source": "skills/lark-slides/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-slides/SKILL.md"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/administration--all_hands_meeting.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--all_hands_meeting.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/administration--annual_gala.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--annual_gala.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/administration--company_intro.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--company_intro.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/administration--corporate_culture.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--corporate_culture.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/hr--employee_training.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/hr--employee_training_workshop.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training_workshop.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/hr--onboarding.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--onboarding.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--brand_communication.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_communication.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--brand_logo_design.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_logo_design.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--brand_operations_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_operations_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--business_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--business_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--marketing_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--marketing_strategy.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_strategy.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--product_whitepaper.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--product_whitepaper.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/marketing--roadshow_business_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--roadshow_business_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/misc--book_sharing.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--book_sharing.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/misc--club_event_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--club_event_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/misc--student_career_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--student_career_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--dark_general.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dark_general.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--dept_annual_report.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dept_annual_report.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--light_general.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--light_general.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--project_kickoff.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--project_kickoff.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--quarterly_review.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--quarterly_review.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--work_report.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_report.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--work_summary.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/office--work_summary_report.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary_report.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/operations--brand_logo_design.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_logo_design.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/operations--brand_operations_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_operations_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/operations--marketing_plan.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--marketing_plan.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/operations--product_promotion.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--product_promotion.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--experience_sharing.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--experience_sharing.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--personal_resume.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--personal_resume.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--promotion_defense.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_defense.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--promotion_report.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_report.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--self_intro.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--self_intro.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/personal--teaching_sharing.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--teaching_sharing.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--business_case_analysis.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--business_case_analysis.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--market_analysis.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--market_analysis.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--product_analysis.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_analysis.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--product_intro.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_intro.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--product_promotion.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/assets/templates/product--product_promotion_2.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion_2.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/asset-planning.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/asset-planning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/examples.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-edit-workflows.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-edit-workflows.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-media-upload.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-media-upload.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-replace-slide.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-replace-slide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-xml-presentation-slide-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-xml-presentation-slide-delete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-delete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-xml-presentation-slide-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-xml-presentation-slide-replace.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-replace.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/lark-slides-xml-presentations-get.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentations-get.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/planning-layer.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/planning-layer.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/slide-templates.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/slide-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/slides_demo.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_demo.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/slides_xml_schema_definition.xml",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_xml_schema_definition.xml",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/template-catalog.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/template-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/template-index.json",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/template-index.json",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/troubleshooting.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/troubleshooting.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/validation-checklist.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/validation-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/visual-planning.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/visual-planning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/xml-format-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-format-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/references/xml-schema-quick-ref.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-schema-quick-ref.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/scripts/template_tool.py",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/scripts/template_tool_test.py",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool_test.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/scripts/xml_text_overlap_lint.py",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint.py",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-slides/scripts/xml_text_overlap_lint_test.py",
+              "target": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint_test.py",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -895,8 +3282,348 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-slides/SKILL.md",
-          "owner": "lark-slides",
-          "sha256": "c7c6ba762535ef5013a4168d7ce241947deed5e43e9982d5c0bfdcf480b3b3f3"
+          "sha256": "c7c6ba762535ef5013a4168d7ce241947deed5e43e9982d5c0bfdcf480b3b3f3",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--all_hands_meeting.xml",
+          "sha256": "da2097b75003b64b58b43915a76ae830a71d97adeac29addb74c5e62c2a8cc06",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--annual_gala.xml",
+          "sha256": "f8e379f5d0f51e7f07ad7238c8600d661bcf080019c387fc860ab4bb8ff9f243",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--company_intro.xml",
+          "sha256": "6dbeffcf5eec4c126fdec266d1272bdd58ccf4629cc4e3092d200dfc324237ce",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/administration--corporate_culture.xml",
+          "sha256": "bfd97f8fa63d59db63bf745452e62e54bda5dd655847c43303c393910970a428",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training.xml",
+          "sha256": "704eb2bcc35e307ebe9d2b99f41a0c2db49cc166bb21e25b0bbeba89e60ba536",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--employee_training_workshop.xml",
+          "sha256": "18880d746884b8b2dd82398a747876f9f4d0d1429b9a5d9a5cd6dab3b8168b88",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/hr--onboarding.xml",
+          "sha256": "a23a12505ed3f803b160757427a95939900d3eefdd1afb08f695d074337d331c",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_communication.xml",
+          "sha256": "1b4956197dabc8e3d9ed6df4daeaffd05b88c7768dde663efeb0f778bdcc41b2",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_logo_design.xml",
+          "sha256": "8510b2c63f821f73b70057d71c5be1978efe66723fd39e65500684b6614e56fe",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--brand_operations_plan.xml",
+          "sha256": "1b2a512c8c7eb4483461a224db2e0db0ee76bd3a7336830cc36af32e33fe3bda",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--business_plan.xml",
+          "sha256": "951bee6fcfa23eca451444192f47a9decc53faefe6c4b01d286752718aad2ee7",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_plan.xml",
+          "sha256": "600bbc157ecfc493a6d0c05ee27a82bc6eca5ec9be87d03aef054e2425530301",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--marketing_strategy.xml",
+          "sha256": "fa2d0d80d5076610c0b99d20acaeefb627c17a2ad202efa0ad0eb2f9db69c234",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--product_whitepaper.xml",
+          "sha256": "b09f9fbb73d8434e4206bf237a1447c597db786e851c214bffdb982eb4f09366",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/marketing--roadshow_business_plan.xml",
+          "sha256": "f8299013a1ff1a0420333f8f0d7d4a9bd653a5a2e313aad628617dce2043f41b",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--book_sharing.xml",
+          "sha256": "cc6a910379fafaeee07464fe97f795fc442afbf84b2524c2102fd54aaba74e14",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--club_event_plan.xml",
+          "sha256": "91251a12beeaefcb290e19adc41e0cb6435e95237ac886cad6d38071b2f1b8b2",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/misc--student_career_plan.xml",
+          "sha256": "15a8d986bc5ca0ad621c6157f6744b3b708a1e56cb3e2a298157b2f936eaf112",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dark_general.xml",
+          "sha256": "f6f70cc77e0101811b521b32f38c4331cdc9a56bb91ec987614591a1350bf5bb",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--dept_annual_report.xml",
+          "sha256": "805a48f14e44d867ef8e21b4299275b9019c184fb46ab2772930bed369d21b48",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--light_general.xml",
+          "sha256": "ca3eb82001238023d3d9ccc30f1c776a00ae3908849dc01d02eae28d4535ac19",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--project_kickoff.xml",
+          "sha256": "618219c4c1d1423db8f1b29bfbfca65d57fbeac935f778e7ac5dc7f96d15ce8c",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--quarterly_review.xml",
+          "sha256": "101b445ceda65fa088c62a8e8edf74526c463f32628b6992f76fccfef111f766",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_report.xml",
+          "sha256": "08eb23c24478315b838f907dbbf3ea3edbcb5dce1c5b91a64f46f28ab079829e",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary.xml",
+          "sha256": "e2aff31c704f810f5e3fc0e4caa4cf5047a936f7ff2bde41532d99a07053796c",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/office--work_summary_report.xml",
+          "sha256": "232e54b627d896cbc888a51766ba75884be3f4a473d89c2a31a8e1493e7bc523",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_logo_design.xml",
+          "sha256": "8510b2c63f821f73b70057d71c5be1978efe66723fd39e65500684b6614e56fe",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--brand_operations_plan.xml",
+          "sha256": "1b2a512c8c7eb4483461a224db2e0db0ee76bd3a7336830cc36af32e33fe3bda",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--marketing_plan.xml",
+          "sha256": "600bbc157ecfc493a6d0c05ee27a82bc6eca5ec9be87d03aef054e2425530301",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/operations--product_promotion.xml",
+          "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--experience_sharing.xml",
+          "sha256": "bc2dd06c505d3b03c4a157c6af6e7f6318cc1278440f5b65950b4c7b7621779a",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--personal_resume.xml",
+          "sha256": "eb407262940be201cc63882ec241501c84533ebe2e96dcf2b2fbf79e455de84d",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_defense.xml",
+          "sha256": "77bc6ce1b863085297d5223f1a86a7bc5e88ce72f428740c2c8cd08dfc49166e",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--promotion_report.xml",
+          "sha256": "35e81547a8568280d548567bcf38c965defef256748a2b14bbb652524be73236",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--self_intro.xml",
+          "sha256": "f8c1b89ceaabd29b45d45ad8d20454724e6ae295e1a880cdea412d630bcbaea8",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/personal--teaching_sharing.xml",
+          "sha256": "1b98c2bd93d364a47c0d4445f5418b5954d899968be5032b77110b1f73b7e741",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--business_case_analysis.xml",
+          "sha256": "6a1ee314548e84efb4ff8b36a1ded03e8203ae35b3b6c752e2625f06c5091830",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--market_analysis.xml",
+          "sha256": "287867189b8a1606cfd72eb9b0cc3035be895edfe7cc68968397b50d2451f12f",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_analysis.xml",
+          "sha256": "05a62b00f456e9498bd1a5c8e01ee61c02f38b1b2a6f66b89ce4af3c79d811c3",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_intro.xml",
+          "sha256": "319cf60656a68eaa2b0d64fb8ddc7afe26611fea2bae80275d66e0d1c5f2ad4c",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion.xml",
+          "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/assets/templates/product--product_promotion_2.xml",
+          "sha256": "6bcf07b048f72cf425a0eb68688bc24e699fdc4d2d7237c9e6c7872f91cf5191",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/asset-planning.md",
+          "sha256": "0b7149b3e91f9f86e4488593db547f15ff322cdda5611d4de50316b2f3f33bcb",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/examples.md",
+          "sha256": "3e465212249d8f7ec45460e009d3008aa3995824a82cc0840d81f37c9b333ff3",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-create.md",
+          "sha256": "6c28e8afb6e58e1ace2ebe63afb1943865953a04e9749a51c521a3ab36438045",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-edit-workflows.md",
+          "sha256": "45e597b23a5925a40ffd37212bdf898f5b61630e5a3b3104083bfcc2cae9f439",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-media-upload.md",
+          "sha256": "f99aa38dcf61c99e06161b462c2ab76df71ee7629667404a4f175901a06606b8",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-replace-slide.md",
+          "sha256": "4ee3ddd488512d77279c60b13157ac7a23c885a02d9a0e42d4e710fb896ce8a3",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-create.md",
+          "sha256": "51ab2d0d925242fa43c6f3ac0c8a8c920fceab126bd449c96fabbe20936f0513",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-delete.md",
+          "sha256": "c403f1727e0c5ae0b290d73af604a658e29680396e17a5fe83d4d74991639e7f",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-get.md",
+          "sha256": "dd6c557f4043aadf678a49e93af19adf0669e50eba9aa78fe63c30995c235525",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentation-slide-replace.md",
+          "sha256": "7235ac05f4acc8f8aa5a0230df6ca2edc88169d31dea1025de18f8ec35b69ef5",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/lark-slides-xml-presentations-get.md",
+          "sha256": "a2cbf1fe3d88b21ef56e7b98b35c4c6300f7a9bdaed1d5865b5c792cc907d622",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/planning-layer.md",
+          "sha256": "4b5998424d4b59b77b9028e455cec2ca8159b07fdef4dff5121b36bbd98147d0",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slide-templates.md",
+          "sha256": "8d6e820db415985296c14d87c6ec08cfe154cf4e4e431bb433b1f460b1e374e2",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_demo.xml",
+          "sha256": "331ab7a90fb19a4d27b57a6bf1335dfb73081299d23346ba2888f7b6efd74859",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/slides_xml_schema_definition.xml",
+          "sha256": "e457748005c83d1f636fc421982e8a142e3348c5d851b6472a8d6b4493073b83",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/template-catalog.md",
+          "sha256": "1aa8c0db6788d97ab537f77e415f5befa9d895967e9b8df74a50a9409f3b291f",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/template-index.json",
+          "sha256": "f473026e75283f6f9d61ba715ea0d5c76871393a8390d34cf47c25dba16a3274",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/troubleshooting.md",
+          "sha256": "ece5b2a10c52bcc383a1b8d047bb07d76437e894be2512d92ac39d62b18524ec",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/validation-checklist.md",
+          "sha256": "1e87eb73a6bc70c2fc5ce2d1eb6a92cda2c1a0ba55011bdc36b186453a11ca6b",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/visual-planning.md",
+          "sha256": "7942ba4f297b25868554f39791f2d87382d2c02e505d2c6bf6d977fa8d546e53",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-format-guide.md",
+          "sha256": "ad31703280fa4c51c341dd2970eacefc971fe5301f2012dd984473d40614e59d",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/references/xml-schema-quick-ref.md",
+          "sha256": "24ed1e837fafe121c90260dd55a0ecea96f3517cf42d974ac736afd7af90599e",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool.py",
+          "sha256": "02132b415153ed259811727a5a077b84c2d5960e280b1add3c00c8a0db952956",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/template_tool_test.py",
+          "sha256": "a43a5454b4cd9219fa9723f33edb5a0f7055ec36f585965fee315bf0d5255a7c",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint.py",
+          "sha256": "431567c190b9f3cfb4bcbcc8dd69dcc6d09ce26240dcdaba0f70f878f267884e",
+          "owner": "lark-slides"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-slides/scripts/xml_text_overlap_lint_test.py",
+          "sha256": "1f65bf904b1ea432323d8daae3559fe8c4c303d181bcbcda15c95c3511a7607f",
+          "owner": "lark-slides"
         }
       ]
     },
@@ -928,6 +3655,96 @@
             {
               "source": "skills/lark-task/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-task/SKILL.md"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-assign.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-assign.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-comment.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-comment.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-complete.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-complete.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-followers.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-followers.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-get-my-tasks.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-my-tasks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-get-related-tasks.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-related-tasks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-reminder.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reminder.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-reopen.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reopen.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-set-ancestor.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-set-ancestor.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-subscribe-event.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-subscribe-event.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-tasklist-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-tasklist-members.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-members.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-tasklist-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-search.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-tasklist-task-add.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-task-add.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-task/references/lark-task-upload-attachment.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-upload-attachment.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -944,8 +3761,98 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-task/SKILL.md",
-          "owner": "lark-task",
-          "sha256": "100c05bd9afc6c5a8bca09edbedeee4216544a4d1fbec416edf1c5e7d4455ec6"
+          "sha256": "100c05bd9afc6c5a8bca09edbedeee4216544a4d1fbec416edf1c5e7d4455ec6",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-assign.md",
+          "sha256": "21e7f23794a9b6250e936d747d6e48cfeda1ecd576496a0ccc80b272270719a6",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-comment.md",
+          "sha256": "a214797e0cda20b84e1c7b4fb74e16f09435372a0839a8e0fd4030951c6d975c",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-complete.md",
+          "sha256": "8d80f65403dbfb425bd53de2087d12a39d05dca029987b23cb13fc3197ac64da",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-create.md",
+          "sha256": "657ec7f0426e9d7e7eaeb084451c2561e876a0649aeff701693c7525d8b03363",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-followers.md",
+          "sha256": "3c68ce7dcd2402bd534222bfff79e4de8be5bb1496292c0d7f546cc46b6c8648",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-my-tasks.md",
+          "sha256": "7a2004a93530adb6a5a0cfe8dba996924a15fc43bb4aea19e5c0c048799c1446",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-get-related-tasks.md",
+          "sha256": "f5e8ba3221d29d452c017b38086cb68e52340b281e973077b95ac8a40c6f2d62",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reminder.md",
+          "sha256": "299565d936ffccec2ef3e34dee1fae424d9ea469799d7fc8232a6290a5c1b7bd",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-reopen.md",
+          "sha256": "393c52d0f801a992a59748baf28d8671f8ae63a2a674dbe8e55f99b603b038ac",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-search.md",
+          "sha256": "a666ba6a9c70dee6a06290ed74054a3d751dc0ae098d9d898b74e42e0467b0b6",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-set-ancestor.md",
+          "sha256": "f07dd5a0706f6a95dd83417a4a215903f9dbad3f16c3a2a915d3bd0b850d4fcd",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-subscribe-event.md",
+          "sha256": "a519dea5a52616cb3f1b5f45a83b162d232aa2fa78272fd1707c08feb88946e0",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-create.md",
+          "sha256": "011f4bf1902063f39ebbe18c94790e77dc621dd5d8a0a0318f361a2411d5c9ab",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-members.md",
+          "sha256": "68c21892a5f4fb104fa0f455f4781f427b6766c999e7a8c242b642f1553d2e96",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-search.md",
+          "sha256": "c9a70b4d017bef95f8f779343e3f01e49d2ec01e1af2263f13476d3b918124af",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-tasklist-task-add.md",
+          "sha256": "11dfb8d31bb7c5946e9cd7b881f593b82fc9592c319c0f3139b7b13433edb51b",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-update.md",
+          "sha256": "5ff63ebbf0b5413bf3d4e1c9dab0dac8f1015258b58a315080dc31798eee6bc2",
+          "owner": "lark-task"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-task/references/lark-task-upload-attachment.md",
+          "sha256": "6275490511a6e7cd13c617f3a9332011d309b63d4130342e66ca92ab8a826871",
+          "owner": "lark-task"
         }
       ]
     },
@@ -977,6 +3884,21 @@
             {
               "source": "skills/lark-vc/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-vc/SKILL.md"
+            },
+            {
+              "source": "skills/lark-vc/references/lark-vc-notes.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-notes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-vc/references/lark-vc-recording.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-recording.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-vc/references/lark-vc-search.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-search.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -993,8 +3915,23 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc/SKILL.md",
-          "owner": "lark-vc",
-          "sha256": "fb014718287e5d41381d1697f44b88d8067fcf32c791fff9b1a388bda60cbf1f"
+          "sha256": "fb014718287e5d41381d1697f44b88d8067fcf32c791fff9b1a388bda60cbf1f",
+          "owner": "lark-vc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-notes.md",
+          "sha256": "5668fac9867c52cee0ebc4b3c24c7d711ad770b3b3ed2fac1c1727a526ae166f",
+          "owner": "lark-vc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-recording.md",
+          "sha256": "676951fe9dcd63fb6c81750eac7a599f3fcdf27a227c288812f4f9b77172faa6",
+          "owner": "lark-vc"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc/references/lark-vc-search.md",
+          "sha256": "779357c97ba1be87811d2920890f7ec39e81bcf8fc68448bd02e20add0ca1456",
+          "owner": "lark-vc"
         }
       ]
     },
@@ -1026,6 +3963,21 @@
             {
               "source": "skills/lark-vc-agent/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-vc-agent/SKILL.md"
+            },
+            {
+              "source": "skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-events.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-vc-agent/references/lark-vc-agent-meeting-join.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-join.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-vc-agent/references/lark-vc-agent-meeting-leave.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-leave.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1042,8 +3994,23 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/SKILL.md",
-          "owner": "lark-vc-agent",
-          "sha256": "f68571eb87f2b39a73be134d29f8cd51c68ef21fa3df3421546e81ed2a300328"
+          "sha256": "f68571eb87f2b39a73be134d29f8cd51c68ef21fa3df3421546e81ed2a300328",
+          "owner": "lark-vc-agent"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-events.md",
+          "sha256": "0f6f743baea0ed555b40ae886a3690a905dea5d022f36091d852215d3e1b41e9",
+          "owner": "lark-vc-agent"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-join.md",
+          "sha256": "6c08f172b7035e5a0813eb14e8605d4a97b569e2f392dfa552c968f53d57de2a",
+          "owner": "lark-vc-agent"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-vc-agent/references/lark-vc-agent-meeting-leave.md",
+          "sha256": "e36c4c515621d84d82db77269c30cd4db00ab8c7bbfa7e21adbf3b46267b423f",
+          "owner": "lark-vc-agent"
         }
       ]
     },
@@ -1075,6 +4042,141 @@
             {
               "source": "skills/lark-whiteboard/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/SKILL.md"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/connectors.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/connectors.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/content.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/content.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/image.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/image.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/lark-whiteboard-query.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-query.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/lark-whiteboard-update.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-update.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/layout.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/layout.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/schema.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/schema.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/style.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/style.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/references/typography.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/typography.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/routes/dsl.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/dsl.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/routes/mermaid.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/mermaid.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/routes/svg.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/svg.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/architecture.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/architecture.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/bar-chart.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/bar-chart.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/comparison.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/comparison.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/fishbone.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/fishbone.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/flowchart.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flowchart.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/flywheel.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flywheel.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/funnel.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/funnel.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/line-chart.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/line-chart.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/mermaid.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/mermaid.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/milestone.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/milestone.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/organization.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/organization.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/photo-showcase.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/photo-showcase.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/pyramid.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/pyramid.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/swimlane.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/swimlane.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-whiteboard/scenes/treemap.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/treemap.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1091,8 +4193,143 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/SKILL.md",
-          "owner": "lark-whiteboard",
-          "sha256": "48f80c0e89a78ff96ab7437c2e793ed101e81b5a3a233a5733574656088d81c0"
+          "sha256": "48f80c0e89a78ff96ab7437c2e793ed101e81b5a3a233a5733574656088d81c0",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/connectors.md",
+          "sha256": "c4211b04f7decc0f63422d0f0bb6e47bdaa1fa85ce04ec508fe99d6e880b7db6",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/content.md",
+          "sha256": "8ed9a8b5552f63f7072e14957219eea369a06b4bb7d6ebe8f401df802a0eecf2",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/image.md",
+          "sha256": "5d5b60de1edc20781f4d731e1b523eb5637166ab25e3c4467fe97866eb59820e",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-query.md",
+          "sha256": "818eb2944baea1a1aad6237bbf75a1f638087afa4fed2e6f2d627b9b2a3b900b",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/lark-whiteboard-update.md",
+          "sha256": "9ff34252232198cff159b4e67449975e319d534237ea7e73eec2209156270c3c",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/layout.md",
+          "sha256": "de9b72e8a09675d573f7000ca67187f50316e7b17e896e54b0680aa8409273e0",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/schema.md",
+          "sha256": "6249857554511fdc2bcc1f2cc3375ed640ba583281705530eaf17323e103ccc6",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/style.md",
+          "sha256": "b596a86895b7d6858b14cb8d18e37a842cb0078d774654f50fcd6b37be146752",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/references/typography.md",
+          "sha256": "9df28a4ec089b7bfe894e2ac798d28f992c697b1a1012ce2a4561ca35fcee761",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/dsl.md",
+          "sha256": "7bd2b4601e5788bf1ae45448bfe918cc1927ed832fab654b0ef1447ae1bb3c8c",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/mermaid.md",
+          "sha256": "d1e75a0b63087b09d08778995518bbf7df52b07444aeca81d39ef973f756c157",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/routes/svg.md",
+          "sha256": "c44e986bd730565937eccf79f8e31aebc86e6d3cd851718330fa536669011f29",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/architecture.md",
+          "sha256": "12eed6cca334d58eb31d45c2eba9b8f9a5204597dc56d0dc52bd384f64cf2191",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/bar-chart.md",
+          "sha256": "441f0b732bb519a7315472f59240c5188b14c17f43c564062b913a19b75b7c33",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/comparison.md",
+          "sha256": "8f93eb09b817f4c13f50acacae83b44b10d01996f6e586e610a7ef80d90665ca",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/fishbone.md",
+          "sha256": "92d4a425702c5d10a041af2b81064fa919cabf8da35bd31638a9313add6b553e",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flowchart.md",
+          "sha256": "00c586db0e4c22f10266d8a64866fb15ddbe5a90490ab2444967b9fc7fc74b2c",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/flywheel.md",
+          "sha256": "033a8936a13cee5cc4b7279db3b7babd3ff80d66882e6de5a0615d328403c001",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/funnel.md",
+          "sha256": "5198fc1d84ea27dd4501a8e8a451f390ca3be1373c587bcaf6d2238c28eae2a3",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/line-chart.md",
+          "sha256": "a1d3716eb8ab0cc88df4bf24c62cb7b2f9965eb11c63dd45c5a5e2519e96d3d2",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/mermaid.md",
+          "sha256": "4e8e4d2cd7e94d40369f123034e7fed96f0a367ec0e0924ab2702b692162e8d5",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/milestone.md",
+          "sha256": "a047231f45e8a514a2b198606d1484fe845613d1700dafe0b8e8c02199559c43",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/organization.md",
+          "sha256": "508110eb0b15a400b3d91ec744db31dce5a492c3310f1202b03d02479b1a3ca8",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/photo-showcase.md",
+          "sha256": "30ef8e0373f89cfdca073e5936dbb992461c85027b2ba5a45875b3f9fa54af38",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/pyramid.md",
+          "sha256": "9cd7c1e3c509a8183919ac7b6a10a1a184a2d2e9eca88dcf6800d0b5e3d7a64b",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/swimlane.md",
+          "sha256": "1513ff28e8dd321d3b2ec62403b88e955c736725af815c6263ec34027e628b7b",
+          "owner": "lark-whiteboard"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-whiteboard/scenes/treemap.md",
+          "sha256": "6320fecd2a4cb8f700e2307cf80f7eae9d540e469900c786e238386ca6f58e06",
+          "owner": "lark-whiteboard"
         }
       ]
     },
@@ -1124,6 +4361,36 @@
             {
               "source": "skills/lark-wiki/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lark-wiki/SKILL.md"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-delete-space.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-delete-space.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-move.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-move.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-node-copy.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-copy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-node-create.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-create.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-node-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-list.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/lark-wiki/references/lark-wiki-space-list.md",
+              "target": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-space-list.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1140,8 +4407,38 @@
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lark-wiki/SKILL.md",
-          "owner": "lark-wiki",
-          "sha256": "607e543c15286064aee6399f491876a3000699dce45f78408813133338091a0f"
+          "sha256": "607e543c15286064aee6399f491876a3000699dce45f78408813133338091a0f",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-delete-space.md",
+          "sha256": "c52818ed3106e41d866211db61933707788d694962b5c16f8e354b12bf6f6919",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-move.md",
+          "sha256": "0e7ffcbc7992a2a168a0c1c0ba46dbc0a741db4cfbfa5638ed02132e1d88051d",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-copy.md",
+          "sha256": "dbaa3f65c78e517b580d0f02d4115f8960c65fdeddaa588f60b3d186472a1ded",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-create.md",
+          "sha256": "e0fbb63b55798b200291b65f2295cb67eac89ed069e26fd881ea2e680b32a1d9",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-node-list.md",
+          "sha256": "b855aa44feacc2ba22afef68a9226d215d918911322006bf7aee2edfedcd1a01",
+          "owner": "lark-wiki"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lark-wiki/references/lark-wiki-space-list.md",
+          "sha256": "d4921cfbfaba564217f214b6f87daf7e3ccbfda5b9759f73ab6a999c682913ae",
+          "owner": "lark-wiki"
         }
       ]
     },

--- a/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
+++ b/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
@@ -95,12 +95,14 @@
         {
           "path": "skills/operations-general/linkedin/LICENSE",
           "sha256": "7847c051252042ad9449731b5482c9027395a2501dda2a9efa530637c5a8d4ac",
-          "owner": "linkedin"
+          "owner": "linkedin",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/linkedin/SKILL.md",
           "sha256": "c4730e0b4874454c95fec4f83245a2fb6c3273526fec8bc8f57e4c9b6969af6d",
-          "owner": "linkedin"
+          "owner": "linkedin",
+          "mode": "100644"
         }
       ]
     },
@@ -351,192 +353,230 @@
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/.gitignore",
           "sha256": "e35fd41cd0f0245a7ecd36cac93c9bf42d21634bc515ea5242031905274a4b7c",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
           "sha256": "7847c051252042ad9449731b5482c9027395a2501dda2a9efa530637c5a8d4ac",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/README.md",
           "sha256": "09cf19152d2f416ec45711f83612b7bc8f1a24b44aec4326f7811c1e81594c9c",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/SKILL.md",
           "sha256": "d11562f2dd8887d9e5ea336c76f18118a73482e0b08bf2f76046e1f4495aff21",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-config.md",
           "sha256": "b77e1500187245b43eca79db3637488a61ac42023552a8e696cf7e49079a0c3f",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-import.md",
           "sha256": "28ff2dbf24ecaa6d589ab161e67cc7705e047b690e8fb587320f3616b6693e05",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-setup.md",
           "sha256": "84170ffbffd4ef0f58ddacb73506562c688a1730d4d019b252812172998f9b8a",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-status.md",
           "sha256": "394c3094d631c6c5559c650cb33cd628bc82be18d965561caa5c5113b4501997",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/config/defaults.json",
           "sha256": "716a206f648318d9e520aecd76ec964799d21d8b825a1c10ef3e2380b8137bb9",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/config/qualification-prompt.md",
           "sha256": "2cecc338a33bc02bbe7816ee43b9970376152f5a6e8939bb9e80bb726c5456c7",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/package.json",
           "sha256": "89f6233ce5dd01a546a45562ec77e1e0ae7d376f427325e80b8a5bd95370ee31",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/account.mjs",
           "sha256": "6b99344d184b0028315661759fe07b6346ad99a9acdf8780b3055b970eec2a1b",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/db.mjs",
           "sha256": "fe2a6e61f7887a0537c2a26cc99389cbb91a1df7e74ac71cd7019b0013aa85a5",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/doctor.mjs",
           "sha256": "9d69249fe42406a855ceb7931c0e2ec755c07b27c1b7ecc73d66382c0211d45c",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/export.mjs",
           "sha256": "951d0b7d49e28648831f18bfc9618cd3ed19187f289785ce5c1acb3941605755",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/import.mjs",
           "sha256": "43fb7f8865ff22b24fa92758dff3570f041869c12094635fbff07b1a62f00838",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lead.mjs",
           "sha256": "2302a6d91230d7c9eb3eab4e32aa92be70610f246e7c2630eb88a08d56dd62b4",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/account.mjs",
           "sha256": "b78b006daddc9756e7e16f94ca8ebb957ccf9ef294dfee9251b1014f52fc7426",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/args.mjs",
           "sha256": "6ed5597bec773d323bd1da7f5e016e5cbdf98c8f529c235b3e5800f12531b901",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/cli.mjs",
           "sha256": "36b7f2626d7b25cf950a4e3a894ee626255cd0445545ce69c6e5fb0cbc810c36",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/config.mjs",
           "sha256": "5a2ac410c9141d2c207b1290d9e2e8835227b17abcf0138f4c4cff37a3a9a3a4",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/db.mjs",
           "sha256": "2f662d9340c20284ce067c00f3328b2663b0f12b0a22a1db45fc326a5e774248",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/output.mjs",
           "sha256": "2437ef740f35166a95df07b231d42746ab1083d816c74d485350c844d6025dde",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/paths.mjs",
           "sha256": "5d600f1e99abeee91ee4c9f3e7cf3a94179da2a14a884ad9560af94d6953f260",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/retry.mjs",
           "sha256": "980261895a3dd591594b3c85e41998e3e68be7abcb7cbeafab23086dd8e8d162",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/runs.mjs",
           "sha256": "ca6c8511132e7c2a607d159d1f07ec3f5cdd62e47148a468cc8fe33aba6d580a",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/settings.mjs",
           "sha256": "514ec31664d3c5941b1a42b1ca4dc376326f4fcf7f7ea15c87d179fe69062ac9",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/time.mjs",
           "sha256": "b31ec0ee216784c5870b5f92fc3cd5b24015699f8e51dce072de04ba53ce1dbe",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
           "sha256": "576e0a4cc2038e0264d542a1e5fc3c7c67e10c18a3674f4afb714bd410233e94",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-invite.mjs",
           "sha256": "d758ac42075b65b5fdd08876546a9ad0e4bce3ec40cd27e161792c9516502374",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-pending.mjs",
           "sha256": "656f22887f877056c173e301a2b15b529c7b67586fe86f8d6887eb899dc0ab2e",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-run.mjs",
           "sha256": "10101482be7f07ad7a92604488e03c3bdb78e3e989148f8edbc5a99d6cf31ae0",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/query.mjs",
           "sha256": "cb2171bce6f6dc343ec38adb61da939fee9cfd161c56668670aca6ac608d93ec",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schedule.mjs",
           "sha256": "c915fc21052c6f29d93aebd29d127b9783d025af1f53380fe174d149b367b582",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schema.mjs",
           "sha256": "0204fb5db8ec35d5271915b2995c77c6d41625082b6668bc47c9c57dd302b9ad",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/settings.mjs",
           "sha256": "78483cca1ee11397fc99b6c5531920f07635b69bd41e911da8987e0526101a84",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/status.mjs",
           "sha256": "604ee93730568cb3d8fb0f274166649814cc47bf3244bbc70216172a618344a2",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
           "sha256": "00820ae3d533e90e76c90120a8030aa8187bcc01cb5636ca7a28c57d99f9ee71",
-          "owner": "linkedin-growth"
+          "owner": "linkedin-growth",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
+++ b/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
@@ -44,7 +44,7 @@
         "last_synced_commit": "edd0bdbbb25776e9288186b88969b29175531995",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -67,13 +67,40 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/operations-general/linkedin",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/operations-general/linkedin/LICENSE",
+              "target": "skills/operations-general/linkedin/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/operations-general/linkedin/LICENSE",
+          "sha256": "7847c051252042ad9449731b5482c9027395a2501dda2a9efa530637c5a8d4ac",
+          "owner": "linkedin"
+        },
+        {
           "path": "skills/operations-general/linkedin/SKILL.md",
-          "owner": "linkedin",
-          "sha256": "c4730e0b4874454c95fec4f83245a2fb6c3273526fec8bc8f57e4c9b6969af6d"
+          "sha256": "c4730e0b4874454c95fec4f83245a2fb6c3273526fec8bc8f57e4c9b6969af6d",
+          "owner": "linkedin"
         }
       ]
     },
@@ -93,7 +120,7 @@
         "last_synced_commit": "edd0bdbbb25776e9288186b88969b29175531995",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -103,8 +130,188 @@
           "sync_mode": "monitor",
           "artifacts": [
             {
+              "source": "linkedin-growth/.gitignore",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/.gitignore",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/README.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/README.md",
+              "type": "file"
+            },
+            {
               "source": "linkedin-growth/SKILL.md",
               "target": "skills/growth-operations-xiaohongshu/linkedin-growth/SKILL.md"
+            },
+            {
+              "source": "linkedin-growth/commands/linkedin-growth-config.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-config.md",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/commands/linkedin-growth-import.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-import.md",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/commands/linkedin-growth-setup.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/commands/linkedin-growth-status.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-status.md",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/config/defaults.json",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/config/defaults.json",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/config/qualification-prompt.md",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/config/qualification-prompt.md",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/package.json",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/package.json",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/account.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/account.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/db.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/db.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/doctor.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/doctor.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/export.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/export.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/import.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/import.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lead.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lead.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/account.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/account.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/args.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/args.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/cli.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/cli.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/config.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/config.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/db.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/db.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/output.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/output.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/paths.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/paths.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/retry.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/retry.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/runs.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/runs.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/settings.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/settings.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/lib/time.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/time.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/migrate-notion.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/network-invite.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-invite.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/network-pending.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-pending.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/network-run.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-run.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/query.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/query.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/schedule.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schedule.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/schema.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schema.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/settings.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/settings.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/status.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/status.mjs",
+              "type": "file"
+            },
+            {
+              "source": "linkedin-growth/scripts/tick.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -116,13 +323,220 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/.gitignore",
+          "sha256": "e35fd41cd0f0245a7ecd36cac93c9bf42d21634bc515ea5242031905274a4b7c",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
+          "sha256": "7847c051252042ad9449731b5482c9027395a2501dda2a9efa530637c5a8d4ac",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/README.md",
+          "sha256": "09cf19152d2f416ec45711f83612b7bc8f1a24b44aec4326f7811c1e81594c9c",
+          "owner": "linkedin-growth"
+        },
+        {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/SKILL.md",
-          "owner": "linkedin-growth",
-          "sha256": "d11562f2dd8887d9e5ea336c76f18118a73482e0b08bf2f76046e1f4495aff21"
+          "sha256": "d11562f2dd8887d9e5ea336c76f18118a73482e0b08bf2f76046e1f4495aff21",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-config.md",
+          "sha256": "b77e1500187245b43eca79db3637488a61ac42023552a8e696cf7e49079a0c3f",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-import.md",
+          "sha256": "28ff2dbf24ecaa6d589ab161e67cc7705e047b690e8fb587320f3616b6693e05",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-setup.md",
+          "sha256": "84170ffbffd4ef0f58ddacb73506562c688a1730d4d019b252812172998f9b8a",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/commands/linkedin-growth-status.md",
+          "sha256": "394c3094d631c6c5559c650cb33cd628bc82be18d965561caa5c5113b4501997",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/config/defaults.json",
+          "sha256": "716a206f648318d9e520aecd76ec964799d21d8b825a1c10ef3e2380b8137bb9",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/config/qualification-prompt.md",
+          "sha256": "2cecc338a33bc02bbe7816ee43b9970376152f5a6e8939bb9e80bb726c5456c7",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/package.json",
+          "sha256": "89f6233ce5dd01a546a45562ec77e1e0ae7d376f427325e80b8a5bd95370ee31",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/account.mjs",
+          "sha256": "6b99344d184b0028315661759fe07b6346ad99a9acdf8780b3055b970eec2a1b",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/db.mjs",
+          "sha256": "fe2a6e61f7887a0537c2a26cc99389cbb91a1df7e74ac71cd7019b0013aa85a5",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/doctor.mjs",
+          "sha256": "9d69249fe42406a855ceb7931c0e2ec755c07b27c1b7ecc73d66382c0211d45c",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/export.mjs",
+          "sha256": "951d0b7d49e28648831f18bfc9618cd3ed19187f289785ce5c1acb3941605755",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/import.mjs",
+          "sha256": "43fb7f8865ff22b24fa92758dff3570f041869c12094635fbff07b1a62f00838",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lead.mjs",
+          "sha256": "2302a6d91230d7c9eb3eab4e32aa92be70610f246e7c2630eb88a08d56dd62b4",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/account.mjs",
+          "sha256": "b78b006daddc9756e7e16f94ca8ebb957ccf9ef294dfee9251b1014f52fc7426",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/args.mjs",
+          "sha256": "6ed5597bec773d323bd1da7f5e016e5cbdf98c8f529c235b3e5800f12531b901",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/cli.mjs",
+          "sha256": "36b7f2626d7b25cf950a4e3a894ee626255cd0445545ce69c6e5fb0cbc810c36",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/config.mjs",
+          "sha256": "5a2ac410c9141d2c207b1290d9e2e8835227b17abcf0138f4c4cff37a3a9a3a4",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/db.mjs",
+          "sha256": "2f662d9340c20284ce067c00f3328b2663b0f12b0a22a1db45fc326a5e774248",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/output.mjs",
+          "sha256": "2437ef740f35166a95df07b231d42746ab1083d816c74d485350c844d6025dde",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/paths.mjs",
+          "sha256": "5d600f1e99abeee91ee4c9f3e7cf3a94179da2a14a884ad9560af94d6953f260",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/retry.mjs",
+          "sha256": "980261895a3dd591594b3c85e41998e3e68be7abcb7cbeafab23086dd8e8d162",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/runs.mjs",
+          "sha256": "ca6c8511132e7c2a607d159d1f07ec3f5cdd62e47148a468cc8fe33aba6d580a",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/settings.mjs",
+          "sha256": "514ec31664d3c5941b1a42b1ca4dc376326f4fcf7f7ea15c87d179fe69062ac9",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/lib/time.mjs",
+          "sha256": "b31ec0ee216784c5870b5f92fc3cd5b24015699f8e51dce072de04ba53ce1dbe",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
+          "sha256": "576e0a4cc2038e0264d542a1e5fc3c7c67e10c18a3674f4afb714bd410233e94",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-invite.mjs",
+          "sha256": "d758ac42075b65b5fdd08876546a9ad0e4bce3ec40cd27e161792c9516502374",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-pending.mjs",
+          "sha256": "656f22887f877056c173e301a2b15b529c7b67586fe86f8d6887eb899dc0ab2e",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-run.mjs",
+          "sha256": "10101482be7f07ad7a92604488e03c3bdb78e3e989148f8edbc5a99d6cf31ae0",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/query.mjs",
+          "sha256": "cb2171bce6f6dc343ec38adb61da939fee9cfd161c56668670aca6ac608d93ec",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schedule.mjs",
+          "sha256": "c915fc21052c6f29d93aebd29d127b9783d025af1f53380fe174d149b367b582",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/schema.mjs",
+          "sha256": "0204fb5db8ec35d5271915b2995c77c6d41625082b6668bc47c9c57dd302b9ad",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/settings.mjs",
+          "sha256": "78483cca1ee11397fc99b6c5531920f07635b69bd41e911da8987e0526101a84",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/status.mjs",
+          "sha256": "604ee93730568cb3d8fb0f274166649814cc47bf3244bbc70216172a618344a2",
+          "owner": "linkedin-growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
+          "sha256": "00820ae3d533e90e76c90120a8030aa8187bcc01cb5636ca7a28c57d99f9ee71",
+          "owner": "linkedin-growth"
         }
       ]
     }

--- a/docs/sources/nous-hermes-agent-2026-04.skills.json
+++ b/docs/sources/nous-hermes-agent-2026-04.skills.json
@@ -453,13 +453,70 @@
             "last_checked_at": "2026-05-19",
             "last_synced_at": "2026-05-19"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/knowledge-and-pm-integrations/linear",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/knowledge-and-pm-integrations/linear/LICENSE.txt",
+              "target": "skills/knowledge-and-pm-integrations/linear/LICENSE.txt",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/linear/agents/openai.yaml",
+              "target": "skills/knowledge-and-pm-integrations/linear/agents/openai.yaml",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/linear/assets/linear-small.svg",
+              "target": "skills/knowledge-and-pm-integrations/linear/assets/linear-small.svg",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/linear/assets/linear.png",
+              "target": "skills/knowledge-and-pm-integrations/linear/assets/linear.png",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/knowledge-and-pm-integrations/linear/LICENSE.txt",
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "owner": "linear"
+        },
+        {
           "path": "skills/knowledge-and-pm-integrations/linear/SKILL.md",
-          "owner": "linear",
-          "sha256": "edf4821482e71172b744c38272d733d56596e86e226848392cf5eb39b19422b2"
+          "sha256": "edf4821482e71172b744c38272d733d56596e86e226848392cf5eb39b19422b2",
+          "owner": "linear"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/linear/agents/openai.yaml",
+          "sha256": "9e6f164960e3dd0bc56456538abdf196d9e4fd8b4273be06fe1ef0110fbab9cb",
+          "owner": "linear"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/linear/assets/linear-small.svg",
+          "sha256": "6af9dbc5e58a51e80fcbcee47e5f9bd196a997cc5985c2147a89c908831d327f",
+          "owner": "linear"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/linear/assets/linear.png",
+          "sha256": "be13bf3f97e4437e67cda80979759998fb4f4dcace3cdd6a220ba6a75e1c2a82",
+          "owner": "linear"
         }
       ]
     }

--- a/docs/sources/nous-hermes-agent-2026-04.skills.json
+++ b/docs/sources/nous-hermes-agent-2026-04.skills.json
@@ -63,7 +63,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/llm-wiki/SKILL.md",
           "owner": "llm-wiki",
-          "sha256": "bcec6800ff1eeef9e5a0581f5cb8fbed92322e19b1b9b2a04f4b400006963f45"
+          "sha256": "bcec6800ff1eeef9e5a0581f5cb8fbed92322e19b1b9b2a04f4b400006963f45",
+          "mode": "100644"
         }
       ]
     },
@@ -112,7 +113,8 @@
         {
           "path": "skills/ai-agent-platform/hermes-agent/SKILL.md",
           "owner": "hermes-agent",
-          "sha256": "9377be063868a904734ce45c682dcc0bfcf87d1d8244111f7e05ca6e71e7b896"
+          "sha256": "9377be063868a904734ce45c682dcc0bfcf87d1d8244111f7e05ca6e71e7b896",
+          "mode": "100644"
         }
       ]
     },
@@ -161,7 +163,8 @@
         {
           "path": "skills/openclaw-memory-and-safety/honcho/SKILL.md",
           "owner": "honcho",
-          "sha256": "cb265771e4538a9aaaa9575d48afc50ebc971b4c8345a75c1eb35f620bcff2af"
+          "sha256": "cb265771e4538a9aaaa9575d48afc50ebc971b4c8345a75c1eb35f620bcff2af",
+          "mode": "100644"
         }
       ]
     },
@@ -212,7 +215,8 @@
         {
           "path": "skills/ai-agent-platform/native-mcp/SKILL.md",
           "owner": "native-mcp",
-          "sha256": "618687b72690c0143835b6f33d7f72c5215c6f69bae4153ad0fe90c615df6f25"
+          "sha256": "618687b72690c0143835b6f33d7f72c5215c6f69bae4153ad0fe90c615df6f25",
+          "mode": "100644"
         }
       ]
     },
@@ -261,7 +265,8 @@
         {
           "path": "skills/developer-engineering/codebase-inspection/SKILL.md",
           "owner": "codebase-inspection",
-          "sha256": "fcc53e9961ad3f1fd6654f2d9fe51df1daded532a36f4292dee1564c149edf25"
+          "sha256": "fcc53e9961ad3f1fd6654f2d9fe51df1daded532a36f4292dee1564c149edf25",
+          "mode": "100644"
         }
       ]
     },
@@ -310,7 +315,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/arxiv/SKILL.md",
           "owner": "arxiv",
-          "sha256": "ea98a5d429b4f36a5aebd9356df76010c967e2174d913b8ee6155135f1938f28"
+          "sha256": "ea98a5d429b4f36a5aebd9356df76010c967e2174d913b8ee6155135f1938f28",
+          "mode": "100644"
         }
       ]
     },
@@ -359,7 +365,8 @@
         {
           "path": "skills/knowledge-and-pm-integrations/obsidian/SKILL.md",
           "owner": "obsidian",
-          "sha256": "d646bc39a70a203346707fe62bfc1fa5c311d0fa257b7d17e7d3c03e9f41856b"
+          "sha256": "d646bc39a70a203346707fe62bfc1fa5c311d0fa257b7d17e7d3c03e9f41856b",
+          "mode": "100644"
         }
       ]
     },
@@ -408,7 +415,8 @@
         {
           "path": "skills/ai-agent-platform/mcporter/SKILL.md",
           "owner": "mcporter",
-          "sha256": "c0d87c766ab8e9f8621deda3b3fe13b78ece305b0a71c063dc42c4146cf42598"
+          "sha256": "c0d87c766ab8e9f8621deda3b3fe13b78ece305b0a71c063dc42c4146cf42598",
+          "mode": "100644"
         }
       ]
     },
@@ -496,27 +504,32 @@
         {
           "path": "skills/knowledge-and-pm-integrations/linear/LICENSE.txt",
           "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
-          "owner": "linear"
+          "owner": "linear",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/linear/SKILL.md",
           "sha256": "edf4821482e71172b744c38272d733d56596e86e226848392cf5eb39b19422b2",
-          "owner": "linear"
+          "owner": "linear",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/linear/agents/openai.yaml",
           "sha256": "9e6f164960e3dd0bc56456538abdf196d9e4fd8b4273be06fe1ef0110fbab9cb",
-          "owner": "linear"
+          "owner": "linear",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/linear/assets/linear-small.svg",
           "sha256": "6af9dbc5e58a51e80fcbcee47e5f9bd196a997cc5985c2147a89c908831d327f",
-          "owner": "linear"
+          "owner": "linear",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/linear/assets/linear.png",
           "sha256": "be13bf3f97e4437e67cda80979759998fb4f4dcace3cdd6a220ba6a75e1c2a82",
-          "owner": "linear"
+          "owner": "linear",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/obra-superpowers-2026-04.skills.json
+++ b/docs/sources/obra-superpowers-2026-04.skills.json
@@ -83,7 +83,8 @@
         {
           "path": "skills/ai-workflow/dispatching-parallel-agents/SKILL.md",
           "owner": "dispatching-parallel-agents",
-          "sha256": "ba747816da03a5359702ae2ea8973446ca97ef24d6b2ba8b1a362953309cf64c"
+          "sha256": "ba747816da03a5359702ae2ea8973446ca97ef24d6b2ba8b1a362953309cf64c",
+          "mode": "100644"
         }
       ]
     },
@@ -132,7 +133,8 @@
         {
           "path": "skills/ai-workflow/executing-plans/SKILL.md",
           "owner": "executing-plans",
-          "sha256": "d6d75cbfe7f1b1c750681fd38947f51ba32fa313e65cc2c6b142d898c0f5e3f4"
+          "sha256": "d6d75cbfe7f1b1c750681fd38947f51ba32fa313e65cc2c6b142d898c0f5e3f4",
+          "mode": "100644"
         }
       ]
     },
@@ -181,7 +183,8 @@
         {
           "path": "skills/ai-workflow/finishing-a-development-branch/SKILL.md",
           "owner": "finishing-a-development-branch",
-          "sha256": "535c9ada1f4dfcf344c60a81727178b2438061e1c7ccdca8f8fb5566612f6473"
+          "sha256": "535c9ada1f4dfcf344c60a81727178b2438061e1c7ccdca8f8fb5566612f6473",
+          "mode": "100644"
         }
       ]
     },
@@ -230,7 +233,8 @@
         {
           "path": "skills/ai-workflow/receiving-code-review/SKILL.md",
           "owner": "receiving-code-review",
-          "sha256": "d00f1dfa10f0fd71d87589b18d70b1d74d9272f5fb7728e605d9e424ebf9604d"
+          "sha256": "d00f1dfa10f0fd71d87589b18d70b1d74d9272f5fb7728e605d9e424ebf9604d",
+          "mode": "100644"
         }
       ]
     },
@@ -301,12 +305,14 @@
         {
           "path": "skills/ai-workflow/requesting-code-review/SKILL.md",
           "sha256": "af7127c0378b04a913864597032121a1d1bdc9780b90a7ba97e176cf6a01e1ee",
-          "owner": "requesting-code-review"
+          "owner": "requesting-code-review",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/requesting-code-review/code-reviewer.md",
           "sha256": "b2f2ec7596925fe52dac158fdfbca19b3a7d779d619c481e6706a6c0001662d3",
-          "owner": "requesting-code-review"
+          "owner": "requesting-code-review",
+          "mode": "100644"
         }
       ]
     },
@@ -397,32 +403,38 @@
         {
           "path": "skills/ai-workflow/subagent-driven-development/SKILL.md",
           "sha256": "f9a8d5a6d098835c14f65fcd0cda793f552c3c9d7617af9735b4b8dc8674d2f9",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/subagent-driven-development/code-quality-reviewer-prompt.md",
           "sha256": "2eeb3bf63fccfbee042812dc94e7032048603f0f8c3827b4b53af9e4cef19b30",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/subagent-driven-development/implementer-prompt.md",
           "sha256": "81dd9d5a3fb0b09b96b5829f03b9796842f3199ef7591d1ba1c2db2a515f64d0",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/subagent-driven-development/re-review-prompt.md",
           "sha256": "db0d5849478bc79cbde97b9b2cf0e58b50be8b8ed18464b0252c2bf27b6440a6",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/subagent-driven-development/spec-reviewer-prompt.md",
           "sha256": "631980e472eec5394de8b89b69d432e54fd3f7f523ecf9afa7eb4cda0c9b2baf",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/subagent-driven-development/task-reviewer-prompt.md",
           "sha256": "eea23e33ec570c3041f40e9569fa711d61b8029f9eecf908345138aa1c6e61ab",
-          "owner": "subagent-driven-development"
+          "owner": "subagent-driven-development",
+          "mode": "100644"
         }
       ]
     },
@@ -521,57 +533,68 @@
         {
           "path": "skills/developer-engineering/systematic-debugging/CREATION-LOG.md",
           "sha256": "c24733a5b1821bd6bed1fc950261f0b9f4e90097e0bbb96459d8179713730789",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/SKILL.md",
           "sha256": "c73517217753ebc7697fe030a025a6050c538554b086cf19b0b77b2047dbd49d",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/condition-based-waiting-example.ts",
           "sha256": "40ae5ebe497fdf310200e43fe986552546d0a22837c0d39e855db1cfd33eb88e",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/condition-based-waiting.md",
           "sha256": "e89fec8400d6cd50f43407cec9fab50976ba4d55d0ec2eb51c0bd68036b54c26",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/defense-in-depth.md",
           "sha256": "1e175fb86fc357e58c6aebf5441e481e1b7868b4380c0456b63a17eefbd18ba7",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/find-polluter.sh",
           "sha256": "dd7b8f13c4cc2a24b33ff87b18da9248f3e1c80a085c3316224f69ff0fa5c43c",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/root-cause-tracing.md",
           "sha256": "6b0622269e098ca1399e123e553fd385f0b6412d88ef0e9c4f5a8ea9cf1cec7b",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/test-academic.md",
           "sha256": "fe2ba480d78ac0d686dc025f41c2a32a43d642bf533f91b0c6053a04d35d6486",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/test-pressure-1.md",
           "sha256": "0b6a915db0054577819834c79be9eb614e97bddba10d73768e1fbe91cfed048a",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/test-pressure-2.md",
           "sha256": "b2030aeffba07050e8ad573ddf87486457c4a016a786bb326235bebd856f2016",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/systematic-debugging/test-pressure-3.md",
           "sha256": "96b50a52e2c7989c9cf20fb752c47c1e9a3a70dc362f8f7989f8f5b64dac7708",
-          "owner": "systematic-debugging"
+          "owner": "systematic-debugging",
+          "mode": "100644"
         }
       ]
     },
@@ -620,7 +643,8 @@
         {
           "path": "skills/ai-workflow/using-git-worktrees/SKILL.md",
           "owner": "using-git-worktrees",
-          "sha256": "43fdcea94699a232d7374215cf1e3a51279cd24b5d1440ccdf1d1c0b353af18e"
+          "sha256": "43fdcea94699a232d7374215cf1e3a51279cd24b5d1440ccdf1d1c0b353af18e",
+          "mode": "100644"
         }
       ]
     },
@@ -684,22 +708,26 @@
         {
           "path": "skills/ai-workflow/using-superpowers/SKILL.md",
           "sha256": "fea7fc33e65aea146ba44f295883e4ed2ae78dc7727953f8f4f6612356cf95ec",
-          "owner": "using-superpowers"
+          "owner": "using-superpowers",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-superpowers/references/codex-tools.md",
           "sha256": "9014e6746c9a6d3af9eeb9608f1ad637ee334e5a12d178747e3042937fc3da2b",
-          "owner": "using-superpowers"
+          "owner": "using-superpowers",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-superpowers/references/copilot-tools.md",
           "sha256": "5e0e9248e8bd965a28c8721bed24ddfa44a1ee66a89ee275da4a8260fe636e02",
-          "owner": "using-superpowers"
+          "owner": "using-superpowers",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/using-superpowers/references/gemini-tools.md",
           "sha256": "477239fd7b4868f016662831e0fe840557ce91217f057f742a41af57a53554de",
-          "owner": "using-superpowers"
+          "owner": "using-superpowers",
+          "mode": "100644"
         }
       ]
     },
@@ -748,7 +776,8 @@
         {
           "path": "skills/ai-workflow/verification-before-completion/SKILL.md",
           "owner": "verification-before-completion",
-          "sha256": "7a01a9dec974a1329c87037660e95478d0a9e9237121d31919619d885be9cf12"
+          "sha256": "7a01a9dec974a1329c87037660e95478d0a9e9237121d31919619d885be9cf12",
+          "mode": "100644"
         }
       ]
     },
@@ -844,37 +873,44 @@
         {
           "path": "skills/ai-workflow/writing-skills/SKILL.md",
           "sha256": "fbfc6dbe38412b1cf270675f89228930b70f6057e1d482b76497bc04bb33f159",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/anthropic-best-practices.md",
           "sha256": "217629b356c09c9bd11017c9788e8fc654ca1b32c92d4a51cd490e16dd65e59a",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/examples/CLAUDE_MD_TESTING.md",
           "sha256": "0b379a3415e185d3c434b3ad283d8aa132f3022c2a4f210f168865b5986bcef0",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/graphviz-conventions.dot",
           "sha256": "e2890a593c91370e384b42f2f67b1a6232c9e69dddea7891a0c1c46d7b20b694",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/persuasion-principles.md",
           "sha256": "a51bc9bf75189ea73a27b3fb504a2fdfdb966fb1f7f1cdf03203230a216ccc03",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/render-graphs.js",
           "sha256": "ccda971a87bb185f8febf81c56b556a20d026fa980c17b35fa3e8824fbb37852",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/writing-skills/testing-skills-with-subagents.md",
           "sha256": "c711346852c911b24a84aa161e0cff06a4cd7f4e2fa9e9c0a266cead5afcbade",
-          "owner": "writing-skills"
+          "owner": "writing-skills",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/obra-superpowers-2026-04.skills.json
+++ b/docs/sources/obra-superpowers-2026-04.skills.json
@@ -250,7 +250,7 @@
         "last_synced_commit": "9ccce3bf07a40e45259004a330409ba00970eff7",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -273,13 +273,40 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/requesting-code-review",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/requesting-code-review/code-reviewer.md",
+              "target": "skills/ai-workflow/requesting-code-review/code-reviewer.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/requesting-code-review/SKILL.md",
-          "owner": "requesting-code-review",
-          "sha256": "af7127c0378b04a913864597032121a1d1bdc9780b90a7ba97e176cf6a01e1ee"
+          "sha256": "af7127c0378b04a913864597032121a1d1bdc9780b90a7ba97e176cf6a01e1ee",
+          "owner": "requesting-code-review"
+        },
+        {
+          "path": "skills/ai-workflow/requesting-code-review/code-reviewer.md",
+          "sha256": "b2f2ec7596925fe52dac158fdfbca19b3a7d779d619c481e6706a6c0001662d3",
+          "owner": "requesting-code-review"
         }
       ]
     },
@@ -299,7 +326,7 @@
         "last_synced_commit": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -311,6 +338,21 @@
             {
               "source": "skills/subagent-driven-development/SKILL.md",
               "target": "skills/ai-workflow/subagent-driven-development/SKILL.md"
+            },
+            {
+              "source": "skills/subagent-driven-development/implementer-prompt.md",
+              "target": "skills/ai-workflow/subagent-driven-development/implementer-prompt.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/subagent-driven-development/re-review-prompt.md",
+              "target": "skills/ai-workflow/subagent-driven-development/re-review-prompt.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/subagent-driven-development/task-reviewer-prompt.md",
+              "target": "skills/ai-workflow/subagent-driven-development/task-reviewer-prompt.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -322,13 +364,65 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/subagent-driven-development",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/subagent-driven-development/code-quality-reviewer-prompt.md",
+              "target": "skills/ai-workflow/subagent-driven-development/code-quality-reviewer-prompt.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/subagent-driven-development/spec-reviewer-prompt.md",
+              "target": "skills/ai-workflow/subagent-driven-development/spec-reviewer-prompt.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/subagent-driven-development/SKILL.md",
-          "owner": "subagent-driven-development",
-          "sha256": "f9a8d5a6d098835c14f65fcd0cda793f552c3c9d7617af9735b4b8dc8674d2f9"
+          "sha256": "f9a8d5a6d098835c14f65fcd0cda793f552c3c9d7617af9735b4b8dc8674d2f9",
+          "owner": "subagent-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/subagent-driven-development/code-quality-reviewer-prompt.md",
+          "sha256": "2eeb3bf63fccfbee042812dc94e7032048603f0f8c3827b4b53af9e4cef19b30",
+          "owner": "subagent-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/subagent-driven-development/implementer-prompt.md",
+          "sha256": "81dd9d5a3fb0b09b96b5829f03b9796842f3199ef7591d1ba1c2db2a515f64d0",
+          "owner": "subagent-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/subagent-driven-development/re-review-prompt.md",
+          "sha256": "db0d5849478bc79cbde97b9b2cf0e58b50be8b8ed18464b0252c2bf27b6440a6",
+          "owner": "subagent-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/subagent-driven-development/spec-reviewer-prompt.md",
+          "sha256": "631980e472eec5394de8b89b69d432e54fd3f7f523ecf9afa7eb4cda0c9b2baf",
+          "owner": "subagent-driven-development"
+        },
+        {
+          "path": "skills/ai-workflow/subagent-driven-development/task-reviewer-prompt.md",
+          "sha256": "eea23e33ec570c3041f40e9569fa711d61b8029f9eecf908345138aa1c6e61ab",
+          "owner": "subagent-driven-development"
         }
       ]
     },
@@ -358,8 +452,58 @@
           "sync_mode": "monitor",
           "artifacts": [
             {
+              "source": "skills/systematic-debugging/CREATION-LOG.md",
+              "target": "skills/developer-engineering/systematic-debugging/CREATION-LOG.md",
+              "type": "file"
+            },
+            {
               "source": "skills/systematic-debugging/SKILL.md",
               "target": "skills/developer-engineering/systematic-debugging/SKILL.md"
+            },
+            {
+              "source": "skills/systematic-debugging/condition-based-waiting-example.ts",
+              "target": "skills/developer-engineering/systematic-debugging/condition-based-waiting-example.ts",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/condition-based-waiting.md",
+              "target": "skills/developer-engineering/systematic-debugging/condition-based-waiting.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/defense-in-depth.md",
+              "target": "skills/developer-engineering/systematic-debugging/defense-in-depth.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/find-polluter.sh",
+              "target": "skills/developer-engineering/systematic-debugging/find-polluter.sh",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/root-cause-tracing.md",
+              "target": "skills/developer-engineering/systematic-debugging/root-cause-tracing.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/test-academic.md",
+              "target": "skills/developer-engineering/systematic-debugging/test-academic.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/test-pressure-1.md",
+              "target": "skills/developer-engineering/systematic-debugging/test-pressure-1.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/test-pressure-2.md",
+              "target": "skills/developer-engineering/systematic-debugging/test-pressure-2.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/systematic-debugging/test-pressure-3.md",
+              "target": "skills/developer-engineering/systematic-debugging/test-pressure-3.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -375,9 +519,59 @@
       ],
       "managed_files": [
         {
+          "path": "skills/developer-engineering/systematic-debugging/CREATION-LOG.md",
+          "sha256": "c24733a5b1821bd6bed1fc950261f0b9f4e90097e0bbb96459d8179713730789",
+          "owner": "systematic-debugging"
+        },
+        {
           "path": "skills/developer-engineering/systematic-debugging/SKILL.md",
-          "owner": "systematic-debugging",
-          "sha256": "c73517217753ebc7697fe030a025a6050c538554b086cf19b0b77b2047dbd49d"
+          "sha256": "c73517217753ebc7697fe030a025a6050c538554b086cf19b0b77b2047dbd49d",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/condition-based-waiting-example.ts",
+          "sha256": "40ae5ebe497fdf310200e43fe986552546d0a22837c0d39e855db1cfd33eb88e",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/condition-based-waiting.md",
+          "sha256": "e89fec8400d6cd50f43407cec9fab50976ba4d55d0ec2eb51c0bd68036b54c26",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/defense-in-depth.md",
+          "sha256": "1e175fb86fc357e58c6aebf5441e481e1b7868b4380c0456b63a17eefbd18ba7",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/find-polluter.sh",
+          "sha256": "dd7b8f13c4cc2a24b33ff87b18da9248f3e1c80a085c3316224f69ff0fa5c43c",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/root-cause-tracing.md",
+          "sha256": "6b0622269e098ca1399e123e553fd385f0b6412d88ef0e9c4f5a8ea9cf1cec7b",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/test-academic.md",
+          "sha256": "fe2ba480d78ac0d686dc025f41c2a32a43d642bf533f91b0c6053a04d35d6486",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/test-pressure-1.md",
+          "sha256": "0b6a915db0054577819834c79be9eb614e97bddba10d73768e1fbe91cfed048a",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/test-pressure-2.md",
+          "sha256": "b2030aeffba07050e8ad573ddf87486457c4a016a786bb326235bebd856f2016",
+          "owner": "systematic-debugging"
+        },
+        {
+          "path": "skills/developer-engineering/systematic-debugging/test-pressure-3.md",
+          "sha256": "96b50a52e2c7989c9cf20fb752c47c1e9a3a70dc362f8f7989f8f5b64dac7708",
+          "owner": "systematic-debugging"
         }
       ]
     },
@@ -458,6 +652,21 @@
             {
               "source": "skills/using-superpowers/SKILL.md",
               "target": "skills/ai-workflow/using-superpowers/SKILL.md"
+            },
+            {
+              "source": "skills/using-superpowers/references/codex-tools.md",
+              "target": "skills/ai-workflow/using-superpowers/references/codex-tools.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/using-superpowers/references/copilot-tools.md",
+              "target": "skills/ai-workflow/using-superpowers/references/copilot-tools.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/using-superpowers/references/gemini-tools.md",
+              "target": "skills/ai-workflow/using-superpowers/references/gemini-tools.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -474,8 +683,23 @@
       "managed_files": [
         {
           "path": "skills/ai-workflow/using-superpowers/SKILL.md",
-          "owner": "using-superpowers",
-          "sha256": "fea7fc33e65aea146ba44f295883e4ed2ae78dc7727953f8f4f6612356cf95ec"
+          "sha256": "fea7fc33e65aea146ba44f295883e4ed2ae78dc7727953f8f4f6612356cf95ec",
+          "owner": "using-superpowers"
+        },
+        {
+          "path": "skills/ai-workflow/using-superpowers/references/codex-tools.md",
+          "sha256": "9014e6746c9a6d3af9eeb9608f1ad637ee334e5a12d178747e3042937fc3da2b",
+          "owner": "using-superpowers"
+        },
+        {
+          "path": "skills/ai-workflow/using-superpowers/references/copilot-tools.md",
+          "sha256": "5e0e9248e8bd965a28c8721bed24ddfa44a1ee66a89ee275da4a8260fe636e02",
+          "owner": "using-superpowers"
+        },
+        {
+          "path": "skills/ai-workflow/using-superpowers/references/gemini-tools.md",
+          "sha256": "477239fd7b4868f016662831e0fe840557ce91217f057f742a41af57a53554de",
+          "owner": "using-superpowers"
         }
       ]
     },
@@ -544,7 +768,7 @@
         "last_synced_commit": "4fd9aa2dd5b602a102a1ff4743849642b73655c1",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -556,6 +780,26 @@
             {
               "source": "skills/writing-skills/SKILL.md",
               "target": "skills/ai-workflow/writing-skills/SKILL.md"
+            },
+            {
+              "source": "skills/writing-skills/examples/CLAUDE_MD_TESTING.md",
+              "target": "skills/ai-workflow/writing-skills/examples/CLAUDE_MD_TESTING.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/writing-skills/graphviz-conventions.dot",
+              "target": "skills/ai-workflow/writing-skills/graphviz-conventions.dot",
+              "type": "file"
+            },
+            {
+              "source": "skills/writing-skills/render-graphs.js",
+              "target": "skills/ai-workflow/writing-skills/render-graphs.js",
+              "type": "file"
+            },
+            {
+              "source": "skills/writing-skills/testing-skills-with-subagents.md",
+              "target": "skills/ai-workflow/writing-skills/testing-skills-with-subagents.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -567,13 +811,70 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/writing-skills",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/writing-skills/anthropic-best-practices.md",
+              "target": "skills/ai-workflow/writing-skills/anthropic-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/writing-skills/persuasion-principles.md",
+              "target": "skills/ai-workflow/writing-skills/persuasion-principles.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/writing-skills/SKILL.md",
-          "owner": "writing-skills",
-          "sha256": "fbfc6dbe38412b1cf270675f89228930b70f6057e1d482b76497bc04bb33f159"
+          "sha256": "fbfc6dbe38412b1cf270675f89228930b70f6057e1d482b76497bc04bb33f159",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/anthropic-best-practices.md",
+          "sha256": "217629b356c09c9bd11017c9788e8fc654ca1b32c92d4a51cd490e16dd65e59a",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/examples/CLAUDE_MD_TESTING.md",
+          "sha256": "0b379a3415e185d3c434b3ad283d8aa132f3022c2a4f210f168865b5986bcef0",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/graphviz-conventions.dot",
+          "sha256": "e2890a593c91370e384b42f2f67b1a6232c9e69dddea7891a0c1c46d7b20b694",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/persuasion-principles.md",
+          "sha256": "a51bc9bf75189ea73a27b3fb504a2fdfdb966fb1f7f1cdf03203230a216ccc03",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/render-graphs.js",
+          "sha256": "ccda971a87bb185f8febf81c56b556a20d026fa980c17b35fa3e8824fbb37852",
+          "owner": "writing-skills"
+        },
+        {
+          "path": "skills/ai-workflow/writing-skills/testing-skills-with-subagents.md",
+          "sha256": "c711346852c911b24a84aa161e0cff06a4cd7f4e2fa9e9c0a266cead5afcbade",
+          "owner": "writing-skills"
         }
       ]
     }

--- a/docs/sources/op7418-guizang-ppt-skill-2026-04.skills.json
+++ b/docs/sources/op7418-guizang-ppt-skill-2026-04.skills.json
@@ -140,72 +140,86 @@
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/.gitignore",
           "sha256": "3337b5a532e15c3e79fe9bc5f00d45a0319b2d3e17a12dff9b62f416c6d6a74d",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/CONTRIBUTING.md",
           "sha256": "ed95404a4919ad6bd43f569d0416346a763f93f1bfde400ee49bcb32686cb2ff",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/LICENSE",
           "sha256": "0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/README.en.md",
           "sha256": "9023078e4edfd82492c1e50e71696df4301b65973506976c91cb3e7bc1b88a54",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/README.md",
           "sha256": "58360b425706e29ea79ed8bd3e26f0b322a69926e164a3d223aa24692581698f",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/SKILL.md",
           "sha256": "81b5ae2f3477b29f2e4834787859802aa7defcd46227b77bce457d3d7cf1c390",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/SPONSORS.md",
           "sha256": "11140416d492dfd1ac5dd13e9c7d96da09a310f84ca365c80b98e89f5f0aa185",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/assets/motion.min.js",
           "sha256": "45615c1e7639fb9828942d0689c897e745690b0f6df13022223c9409fc01557c",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/assets/template.html",
           "sha256": "94ca6ad9737c643398abc44133f1bc43235685af07aca6944e65f1788930fbc0",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/references/checklist.md",
           "sha256": "94acc747a73b72862742c2ef574a115dd23317bf1297ee78d30731ae34e8870b",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/references/components.md",
           "sha256": "f5f705ef7e6b3c88d2ec8c2d1d85d6e98442d48340b4a74be1b8c0f3cea3a65c",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/references/image-prompts.md",
           "sha256": "56d46a13f51765290a39f64efae7f25688e109965ddf6554bdad0e1b0c9fdaff",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/references/layouts.md",
           "sha256": "4c3743146af11b258dddca6d97a269e5ec90d446c5332b0da34327b3f6f1dca5",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/guizang-ppt-skill/references/themes.md",
           "sha256": "a4bee3ef7b22d56fb904b0643a117368d85f0265ceccdf5111ad497fe22cc656",
-          "owner": "guizang-ppt-skill"
+          "owner": "guizang-ppt-skill",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/op7418-guizang-ppt-skill-2026-04.skills.json
+++ b/docs/sources/op7418-guizang-ppt-skill-2026-04.skills.json
@@ -29,7 +29,7 @@
         "last_synced_commit": "72837a8513d1145d800095fc3909d6d3057994b8",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -41,6 +41,41 @@
             {
               "source": "SKILL.md",
               "target": "skills/office-white-collar/guizang-ppt-skill/SKILL.md"
+            },
+            {
+              "source": "assets/motion.min.js",
+              "target": "skills/office-white-collar/guizang-ppt-skill/assets/motion.min.js",
+              "type": "file"
+            },
+            {
+              "source": "assets/template.html",
+              "target": "skills/office-white-collar/guizang-ppt-skill/assets/template.html",
+              "type": "file"
+            },
+            {
+              "source": "references/checklist.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/references/checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "references/components.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/references/components.md",
+              "type": "file"
+            },
+            {
+              "source": "references/image-prompts.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/references/image-prompts.md",
+              "type": "file"
+            },
+            {
+              "source": "references/layouts.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/references/layouts.md",
+              "type": "file"
+            },
+            {
+              "source": "references/themes.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/references/themes.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -52,13 +87,125 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/office-white-collar/guizang-ppt-skill",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/.gitignore",
+              "target": "skills/office-white-collar/guizang-ppt-skill/.gitignore",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/CONTRIBUTING.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/CONTRIBUTING.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/LICENSE",
+              "target": "skills/office-white-collar/guizang-ppt-skill/LICENSE",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/README.en.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/README.en.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/README.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/README.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/guizang-ppt-skill/SPONSORS.md",
+              "target": "skills/office-white-collar/guizang-ppt-skill/SPONSORS.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/office-white-collar/guizang-ppt-skill/.gitignore",
+          "sha256": "3337b5a532e15c3e79fe9bc5f00d45a0319b2d3e17a12dff9b62f416c6d6a74d",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/CONTRIBUTING.md",
+          "sha256": "ed95404a4919ad6bd43f569d0416346a763f93f1bfde400ee49bcb32686cb2ff",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/LICENSE",
+          "sha256": "0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/README.en.md",
+          "sha256": "9023078e4edfd82492c1e50e71696df4301b65973506976c91cb3e7bc1b88a54",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/README.md",
+          "sha256": "58360b425706e29ea79ed8bd3e26f0b322a69926e164a3d223aa24692581698f",
+          "owner": "guizang-ppt-skill"
+        },
+        {
           "path": "skills/office-white-collar/guizang-ppt-skill/SKILL.md",
-          "owner": "guizang-ppt-skill",
-          "sha256": "81b5ae2f3477b29f2e4834787859802aa7defcd46227b77bce457d3d7cf1c390"
+          "sha256": "81b5ae2f3477b29f2e4834787859802aa7defcd46227b77bce457d3d7cf1c390",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/SPONSORS.md",
+          "sha256": "11140416d492dfd1ac5dd13e9c7d96da09a310f84ca365c80b98e89f5f0aa185",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/assets/motion.min.js",
+          "sha256": "45615c1e7639fb9828942d0689c897e745690b0f6df13022223c9409fc01557c",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/assets/template.html",
+          "sha256": "94ca6ad9737c643398abc44133f1bc43235685af07aca6944e65f1788930fbc0",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/references/checklist.md",
+          "sha256": "94acc747a73b72862742c2ef574a115dd23317bf1297ee78d30731ae34e8870b",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/references/components.md",
+          "sha256": "f5f705ef7e6b3c88d2ec8c2d1d85d6e98442d48340b4a74be1b8c0f3cea3a65c",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/references/image-prompts.md",
+          "sha256": "56d46a13f51765290a39f64efae7f25688e109965ddf6554bdad0e1b0c9fdaff",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/references/layouts.md",
+          "sha256": "4c3743146af11b258dddca6d97a269e5ec90d446c5332b0da34327b3f6f1dca5",
+          "owner": "guizang-ppt-skill"
+        },
+        {
+          "path": "skills/office-white-collar/guizang-ppt-skill/references/themes.md",
+          "sha256": "a4bee3ef7b22d56fb904b0643a117368d85f0265ceccdf5111ad497fe22cc656",
+          "owner": "guizang-ppt-skill"
         }
       ]
     }

--- a/docs/sources/openclaw-video-2nP0YCjM_hk.skills.json
+++ b/docs/sources/openclaw-video-2nP0YCjM_hk.skills.json
@@ -71,7 +71,8 @@
         {
           "path": "skills/ai-workflow/find-skills/SKILL.md",
           "owner": "find-skills",
-          "sha256": "2b14eec09d81d0c1bed624eabeda7b1642fae5ee33001df3b17c2bc76ded9eb8"
+          "sha256": "2b14eec09d81d0c1bed624eabeda7b1642fae5ee33001df3b17c2bc76ded9eb8",
+          "mode": "100644"
         }
       ]
     },
@@ -206,92 +207,110 @@
         {
           "path": "skills/ai-workflow/skill-creator/LICENSE.txt",
           "owner": "skill-creator",
-          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd"
+          "sha256": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/SKILL.md",
           "owner": "skill-creator",
-          "sha256": "a5a7f96ca64cc391cad89ad0791b5ff96abdd2ea281ed89e75c16a6634955936"
+          "sha256": "a5a7f96ca64cc391cad89ad0791b5ff96abdd2ea281ed89e75c16a6634955936",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/agents/analyzer.md",
           "owner": "skill-creator",
-          "sha256": "bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a"
+          "sha256": "bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/agents/comparator.md",
           "owner": "skill-creator",
-          "sha256": "fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e"
+          "sha256": "fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/agents/grader.md",
           "owner": "skill-creator",
-          "sha256": "57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a"
+          "sha256": "57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/assets/eval_review.html",
           "owner": "skill-creator",
-          "sha256": "ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452"
+          "sha256": "ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/eval-viewer/generate_review.py",
           "owner": "skill-creator",
-          "sha256": "fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb"
+          "sha256": "fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/eval-viewer/viewer.html",
           "owner": "skill-creator",
-          "sha256": "a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa"
+          "sha256": "a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/references/schemas.md",
           "owner": "skill-creator",
-          "sha256": "8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f"
+          "sha256": "8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/__init__.py",
           "owner": "skill-creator",
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/aggregate_benchmark.py",
           "owner": "skill-creator",
-          "sha256": "123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa"
+          "sha256": "123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/generate_report.py",
           "owner": "skill-creator",
-          "sha256": "13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453"
+          "sha256": "13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/improve_description.py",
           "owner": "skill-creator",
-          "sha256": "0dc43232db7ac6361775c894f4a1dbac958cb510c51a1230ff9e7fb30a74a7e8"
+          "sha256": "0dc43232db7ac6361775c894f4a1dbac958cb510c51a1230ff9e7fb30a74a7e8",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/package_skill.py",
           "owner": "skill-creator",
-          "sha256": "1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f"
+          "sha256": "1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/quick_validate.py",
           "owner": "skill-creator",
-          "sha256": "67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365"
+          "sha256": "67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/run_eval.py",
           "owner": "skill-creator",
-          "sha256": "43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f"
+          "sha256": "43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/run_loop.py",
           "owner": "skill-creator",
-          "sha256": "bafdb8e25c740813c735c54bf0489b9e87146da4cf697265927513c5430112d7"
+          "sha256": "bafdb8e25c740813c735c54bf0489b9e87146da4cf697265927513c5430112d7",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/skill-creator/scripts/utils.py",
           "owner": "skill-creator",
-          "sha256": "3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1"
+          "sha256": "3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1",
+          "mode": "100644"
         }
       ]
     },
@@ -379,7 +398,8 @@
         {
           "path": "skills/engineering-workflow-automation/agent-browser/SKILL.md",
           "owner": "agent-browser",
-          "sha256": "481d9840cd780b9bb966b58ca8b035b02eb9202029be07070a79a520ffd4ad81"
+          "sha256": "481d9840cd780b9bb966b58ca8b035b02eb9202029be07070a79a520ffd4ad81",
+          "mode": "100644"
         }
       ]
     },
@@ -429,7 +449,8 @@
         {
           "path": "skills/ai-agent-platform/self-improving-agent/SKILL.md",
           "owner": "self-improving-agent",
-          "sha256": "f72ab46587e8c963916f3bc08779f5b61818b775944c1290121f8db8543dd7e6"
+          "sha256": "f72ab46587e8c963916f3bc08779f5b61818b775944c1290121f8db8543dd7e6",
+          "mode": "100644"
         }
       ]
     },

--- a/docs/sources/reclassified-external-skills-2026-08.skills.json
+++ b/docs/sources/reclassified-external-skills-2026-08.skills.json
@@ -76,7 +76,8 @@
         "last_checked_at": "2026-08-20",
         "last_synced_at": "2026-08-20",
         "last_synced_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
-        "sync_mode": "monitor"
+        "sync_mode": "monitor",
+        "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850"
       },
       "kind": "mirror",
       "sync_mode": "monitor",
@@ -140,7 +141,15 @@
             "path_commit": "1851c8fb09ea8ff0488d48bd7c312abb1bbf5850",
             "content_sha256": "8f35d3e054260a3ff45bcb6162fac6d47074c6b56a2c6f55191815754a697b92",
             "last_checked_at": "2026-08-20",
-            "last_synced_at": "2026-08-20"
+            "last_synced_at": "2026-08-20",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c3e30bcc287d6a1ebdb4ab29c10d344fd1053639",
+              "content_sha256": "a20126646f93d32a8989c3cf4772d59194f405034f7babe7daebeac22b8ab151",
+              "spdx": "MIT",
+              "resolved_commit": "aa8d778811a557a2c28ccadda4cf3d0bd028a4cc",
+              "api_spdx": "MIT"
+            }
           }
         }
       ],
@@ -1301,7 +1310,7 @@
         "last_synced_commit": "8331f910845103c08d51f6ca1d86ebb7d1f745e3",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1340,6 +1349,28 @@
             "last_checked_at": "2026-08-20",
             "last_synced_at": "2026-08-20"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/developer-engineering/supabase",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/developer-engineering/supabase/skills/supabase/CHANGELOG.md",
+              "target": "skills/developer-engineering/supabase/skills/supabase/CHANGELOG.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
@@ -1361,6 +1392,11 @@
         {
           "path": "skills/developer-engineering/supabase/references/skill-feedback.md",
           "sha256": "09ad94c0291735dfc04c92557c8734fa259ec39e1d56bf2bd5c6a6529d838717",
+          "owner": "supabase"
+        },
+        {
+          "path": "skills/developer-engineering/supabase/skills/supabase/CHANGELOG.md",
+          "sha256": "a15c75daf614ec9b2563397d8c1367027fcb1267808e5939e99f459b33d72211",
           "owner": "supabase"
         }
       ]

--- a/docs/sources/reclassified-external-skills-2026-08.skills.json
+++ b/docs/sources/reclassified-external-skills-2026-08.skills.json
@@ -157,47 +157,56 @@
         {
           "path": "skills/developer-engineering/aws-solution-architect/SKILL.md",
           "sha256": "8f35d3e054260a3ff45bcb6162fac6d47074c6b56a2c6f55191815754a697b92",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/assets/expected_output.json",
           "sha256": "0a4dcd8efcea445f6a655fe7e0556030a58971b0f774589a4fc0d7beb5186d84",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/assets/sample_input.json",
           "sha256": "bf63a33234a590c2967e89f3aa919472adaa310526862cc386037f085111b37e",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/references/architecture_patterns.md",
           "sha256": "fceffe1382e8d2dc57333065402c5b61b1e348638d58b2b83134d6d633dbedd9",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/references/best_practices.md",
           "sha256": "075aeadef56f94e2584af32e13021f69043a1e57aba35249a412a9766faccef5",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/references/service_selection.md",
           "sha256": "8bd29cde206714831934a944d775553bd1dede2e7e411aedb40aee75e9a6dbcf",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/scripts/architecture_designer.py",
           "sha256": "cdb9730d20093114d5ef0a541a9194bb861062d4af65557794a8e0fc608eadf9",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/scripts/cost_optimizer.py",
           "sha256": "a129693e7877817e8e8d1167a19637d9c7cfffc19c538a7cbe4e85ccba2a3aba",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/aws-solution-architect/scripts/serverless_stack.py",
           "sha256": "4dc6f81f7fca1cbf62c0146e8f19efc3739e71b32f2092d36b8fea3dee9bc45e",
-          "owner": "aws-solution-architect"
+          "owner": "aws-solution-architect",
+          "mode": "100644"
         }
       ]
     },
@@ -507,267 +516,320 @@
         {
           "path": "skills/devops-sre/azure-kubernetes/SKILL.md",
           "sha256": "256c28e87a23dbb137c4ed2b17eee46540f760ba51087312aa1a9065bf57f11e",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/SKILL.md",
           "sha256": "a963f7e911101d8d8184c34319e251756a68a2156ff13a25a4da4a83978210e9",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/aspnet-core.md",
           "sha256": "e67fdfd98e1544f5473a62c0ac70024d33306f051e2bd7b80f5a4ea0335c8b15",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/django.md",
           "sha256": "33826ede3306b4c2d9894968f79fbc2b8c3835c73c28bdf636efda45f5661da3",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/express.md",
           "sha256": "7fd50a40bc8abff5e22da41714698b80994f41250e72b8e864bfcf36dd8a9efa",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/fastapi.md",
           "sha256": "33ef9f994485797759813d526435e6ccdd02359ceebb043a48aad4f24f883bc3",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/flask.md",
           "sha256": "d8403f95736a0215544f472dbb542269ec9769803487c1ff4ce1b724fcf63d9e",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/go.md",
           "sha256": "4744f03992e3ed175241f1729824b0bcde2c2c2fc75bd85ab9568cb3d5e63528",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/nestjs.md",
           "sha256": "d79dea38ee39735e2f85b71a26a570e476258bd94166fe33aa3f0cfcf7edfa34",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/nextjs.md",
           "sha256": "9faf0bb704d0ae9e5bc797606065853d10fbb18ce7cecf3f9ea278e6a64dc466",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/knowledge-packs/frameworks/spring-boot.md",
           "sha256": "3822a0468c2e22528a26bffc5dcdfe74276bb755a86109dea7c49296e5d86753",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/phases/quick-deploy.md",
           "sha256": "3203e42fd195104c188e585146994f2d88cb7474250623abbb145360c492d737",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/references/base-images.md",
           "sha256": "24e31442c3e6ea40810cb10e1e64fc6fb9d0afea9898bee168c683e2b11931be",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/references/detection.md",
           "sha256": "41804e5e275c0f4e3b1cad11d90a67afd09fb635f699ac89bd6eff81854f0998",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/references/rollback.md",
           "sha256": "be48bb7ed21568fe4b11cfccda269fc7b0c305647acedcbfb23a7468edfa8162",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/references/safeguards.md",
           "sha256": "9f7894df0940a5c839cf8c5fb08d1f0d683d9b9b106e36157d6e91e9c1d8a813",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/references/workload-identity.md",
           "sha256": "342284fd3ad2a24f2c35f3c60a739a76bed44c59341819d55b70849f006977ed",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/dotnet.Dockerfile",
           "sha256": "f0e13016f78487dd8bfaa36febd2a730cb6728f8ac0dcceb6844d148a8f41757",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/dotnet.dockerignore",
           "sha256": "5306cbaeaebe80c763c1037fabf727bd8ef4493c1b6dc11d4d587a93587bc95b",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/go.Dockerfile",
           "sha256": "161d291610c232ec5e2c58c0232174321864fa530107f20663f249f893a2ba33",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/go.dockerignore",
           "sha256": "76f037bb2393f2368d1211aa84df158fe5849324917b7fe10bb305affaac72c7",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/java.Dockerfile",
           "sha256": "a8d0772283ed7ea6905d88589923e9c63db378b679dff40612c14915e8d4e66e",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/java.dockerignore",
           "sha256": "832a7b09580d6e21ad1e9e428650dcdd8555d2dae63d970e461ea2c4003e6927",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/node.Dockerfile",
           "sha256": "21a5925d7462213629279746415c4088593a79174cc00b24d4a5d04b5ead7041",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/node.dockerignore",
           "sha256": "a7d7ff4bdbaefaf3a06dc8546b71b3d6e43c8af7be151f5e431ec1978ab3f2a4",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/python.Dockerfile",
           "sha256": "1df050f85fa1ff0821672ef6ac950974ea52d66c23fc77901d565cb7cd10d8f4",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/python.dockerignore",
           "sha256": "641836812197f5fea8816595ef13b6dfcdc49a078ee883920f9438d3743f4149",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/rust.Dockerfile",
           "sha256": "cf84e7246d43c36015bfbdb5d0f3a96d16bc77892a725cc1956186612c35f70c",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/dockerfiles/rust.dockerignore",
           "sha256": "2c0b055944802d7ae80ae3b37891ab31233ae6bc93fcfc2a17988d5889bf2289",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/github-actions/deploy.yml",
           "sha256": "ed07c82ed48bb296e45d9fe37e44669c2bb0387caf58325eeded5da5eb1bb494",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/configmap.yaml",
           "sha256": "1a90e403f53b5e9542319cffe1d41cce5101f0b85b3d0c04008c4de1c39b17f4",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/deployment.yaml",
           "sha256": "95eed829f21c93256dcb45697cd10bd7dc4698237396b92bf77cbd5c43887fca",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/gateway.yaml",
           "sha256": "a88f09525879b8331bc1dc9f1eb5c5efb898d90ae4e9e468acb8eedbe49819d5",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/hpa.yaml",
           "sha256": "85a69dca61312621f002b7908b2995412c45b794d6638a1191b080655fb0bfe6",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/httproute.yaml",
           "sha256": "b7a20e01dbfe38b1d0c60ad92b77b29dcf6ae338fb2837651cf1305dd7a74866",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/ingress.yaml",
           "sha256": "e6f088b331b0fdf40b2b07f90640354cdb71110ec454a18f88d29c64e6a4b3fa",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/namespace.yaml",
           "sha256": "e77f6a0f68dec95d48405b43908a2eac68c9de4c0a3633fc5b8fd0ed76819a92",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/networkpolicy.yaml",
           "sha256": "c0f5ba2f56628e38c87091658cd551c5ff0ef1353e2c389559f162866511192b",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/pdb.yaml",
           "sha256": "4cbe61ad7e8a8a994bd435253f1218ca8735f08233a7a45968e50873f14ff556",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/service.yaml",
           "sha256": "4174de229b2b7fb318eab0f57f25c05055bab03849aa7c795f49b039e48f4d57",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/k8s/serviceaccount.yaml",
           "sha256": "c4d222b307b80d19c2d86708121329578cd0d39b0f619680a50fcc1824d70ece",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/mermaid/architecture-diagram.md",
           "sha256": "4ba00f2d649e771d2011f48f1c0eb7534c05aa5770239fbec80073b15de524a4",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-app-deploy/templates/mermaid/summary-dashboard.md",
           "sha256": "026641bacf96fdb18ec3c071b9789ab055a610e2c56116fd951bfde7c9b645c2",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/SKILL.md",
           "sha256": "50d594f5b8d3c71d5ff5e0eb983e32cdf7c1f5708562baa270455a0a768afdc3",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/references/common-fixes.md",
           "sha256": "6197c9fdbc3efcc26ef8984803b8a1bcc464443a7b84420c8800e884602befd0",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/references/constraint-spec-v1.yaml",
           "sha256": "51f67a31dab3fcc1bd3b1d82200439451c8f7acf93a4418d423a0c637c874bda",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/references/mcp-integration.md",
           "sha256": "77da9a1a84ba0e48e91c3798772d97791227235b9eeda2fca8cfb9f523eb0737",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/azure-kubernetes-automatic-readiness/references/migration-guide-summary.md",
           "sha256": "81e555345e5b75c7bb9107e97f8a26206a02510378f05e0c1012d4df828244ce",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/references/azure-aks-autoscaler.md",
           "sha256": "715444b6f1fd638c57b0275d822ff9117e99e0f52d6d0dc2d6584fa81c08e967",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/references/azure-aks-rightsizing.md",
           "sha256": "8c9edefed4b07ca3c914732e6fb3b43ff4f43fc93451ad58f169981efd5f4358",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/references/azure-aks-spot.md",
           "sha256": "3e91bb2bc5cb3b11a05bc9dcc4a33e7cc8f1fc3d61bf8c3712cc26cea5f52c11",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/references/azure-aks-vpa.md",
           "sha256": "3dae1c706ebe394f4964b581bd9537fdb7625c3784a03e76bcce52cd7bb80cb6",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/azure-kubernetes/references/cli-reference.md",
           "sha256": "b3c5588bd3abf50244c984f6ee79cfa4d6d157a9ac488a1cc6bf20060087d7f3",
-          "owner": "azure-kubernetes"
+          "owner": "azure-kubernetes",
+          "mode": "100644"
         }
       ]
     },
@@ -817,7 +879,8 @@
         {
           "path": "skills/devops-sre/cc-devops-skills/SKILL.md",
           "sha256": "df66dd75c3ccfae6c1e670286db587855f98300937de8eb6c022e47344607cff",
-          "owner": "cc-devops-skills"
+          "owner": "cc-devops-skills",
+          "mode": "100644"
         }
       ]
     },
@@ -866,7 +929,8 @@
         {
           "path": "skills/developer-engineering/docker-expert/SKILL.md",
           "owner": "docker-expert",
-          "sha256": "17390f0f230cee1a109b5b320cf3f91d02d753c116710e0370a577d082c2f6ff"
+          "sha256": "17390f0f230cee1a109b5b320cf3f91d02d753c116710e0370a577d082c2f6ff",
+          "mode": "100644"
         }
       ]
     },
@@ -915,7 +979,8 @@
         {
           "path": "skills/security-and-reliability/gha-security-review/SKILL.md",
           "owner": "gha-security-review",
-          "sha256": "ccd7b57e9f2a39509b70081b1b8859f2c3250fd510aafdebd57a0becd66645e8"
+          "sha256": "ccd7b57e9f2a39509b70081b1b8859f2c3250fd510aafdebd57a0becd66645e8",
+          "mode": "100644"
         }
       ]
     },
@@ -964,7 +1029,8 @@
         {
           "path": "skills/developer-engineering/kubernetes-specialist/SKILL.md",
           "owner": "kubernetes-specialist",
-          "sha256": "e41b625752f3324784b452dd8102b792c2be28b98e73ba6e703d80df3b111f6c"
+          "sha256": "e41b625752f3324784b452dd8102b792c2be28b98e73ba6e703d80df3b111f6c",
+          "mode": "100644"
         }
       ]
     },
@@ -1013,7 +1079,8 @@
         {
           "path": "skills/developer-engineering/neon-postgres/SKILL.md",
           "owner": "neon-postgres",
-          "sha256": "9e1da5b4b14fe187711ae6c1caa688de15dd82cf48e219fdcb208dd12ed8a5f7"
+          "sha256": "9e1da5b4b14fe187711ae6c1caa688de15dd82cf48e219fdcb208dd12ed8a5f7",
+          "mode": "100644"
         }
       ]
     },
@@ -1062,7 +1129,8 @@
         {
           "path": "skills/developer-engineering/neon-postgres-egress-optimizer/SKILL.md",
           "owner": "neon-postgres-egress-optimizer",
-          "sha256": "2cdb79baa4985f0aeaf737744fbe24a41d606f3241fa6800314f50443f0fadba"
+          "sha256": "2cdb79baa4985f0aeaf737744fbe24a41d606f3241fa6800314f50443f0fadba",
+          "mode": "100644"
         }
       ]
     },
@@ -1117,12 +1185,14 @@
         {
           "path": "skills/developer-engineering/nextjs-app-router/SKILL.md",
           "sha256": "75ea8d7f86c3b80fc096eed53ea5decb4b29e4f1e2cbb61177d15069e7fd2b7e",
-          "owner": "nextjs-app-router"
+          "owner": "nextjs-app-router",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/nextjs-app-router/references/details.md",
           "sha256": "ce694daee93b0bba3373ae77bc3dbe66583807fee394088a24b33b8adae1d96e",
-          "owner": "nextjs-app-router"
+          "owner": "nextjs-app-router",
+          "mode": "100644"
         }
       ]
     },
@@ -1182,17 +1252,20 @@
         {
           "path": "skills/developer-engineering/python-performance/SKILL.md",
           "sha256": "f7747318fa39498c0f2d72295acf0055f86528a1b46c056832e2a0044aee4a3d",
-          "owner": "python-performance"
+          "owner": "python-performance",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/python-performance/references/advanced-patterns.md",
           "sha256": "dc1bca8a377572ba1583316b8288af0e5ca2d2be864dc33889b2d3b1ee5c2abf",
-          "owner": "python-performance"
+          "owner": "python-performance",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/python-performance/references/details.md",
           "sha256": "3d3960a8fbbddb7a3557ae7452fd962fad2c618843d184a5ce02368b14fdc8dc",
-          "owner": "python-performance"
+          "owner": "python-performance",
+          "mode": "100644"
         }
       ]
     },
@@ -1241,7 +1314,8 @@
         {
           "path": "skills/developer-engineering/rust-engineer/SKILL.md",
           "owner": "rust-engineer",
-          "sha256": "1c1849a369afb7184f46c3fda00f42e2fee1c347e5cad19c3e0e6fcd417c6034"
+          "sha256": "1c1849a369afb7184f46c3fda00f42e2fee1c347e5cad19c3e0e6fcd417c6034",
+          "mode": "100644"
         }
       ]
     },
@@ -1290,7 +1364,8 @@
         {
           "path": "skills/security-and-reliability/security-review/SKILL.md",
           "owner": "security-review",
-          "sha256": "9e323d51993b66d987bcbcd8ccb7e2786c845ab8b2f82766ec8953d21588be45"
+          "sha256": "9e323d51993b66d987bcbcd8ccb7e2786c845ab8b2f82766ec8953d21588be45",
+          "mode": "100644"
         }
       ]
     },
@@ -1377,27 +1452,32 @@
         {
           "path": "skills/developer-engineering/supabase/CHANGELOG.md",
           "sha256": "f4c9c7750ea2c9212a05c3f38bc04d66cb2fe037f6b9a3fb6279d53bef152f8e",
-          "owner": "supabase"
+          "owner": "supabase",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase/SKILL.md",
           "sha256": "bf9e3b4c67f1a673bdf3b9bd788e9e2fee823774b4c2ac736a3b0e0352b42183",
-          "owner": "supabase"
+          "owner": "supabase",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase/assets/feedback-issue-template.md",
           "sha256": "ea211aa174c5a096fe76461f25143b8bc23f3bde3adc9e727cda38218cc8c282",
-          "owner": "supabase"
+          "owner": "supabase",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase/references/skill-feedback.md",
           "sha256": "09ad94c0291735dfc04c92557c8734fa259ec39e1d56bf2bd5c6a6529d838717",
-          "owner": "supabase"
+          "owner": "supabase",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase/skills/supabase/CHANGELOG.md",
           "sha256": "a15c75daf614ec9b2563397d8c1367027fcb1267808e5939e99f459b33d72211",
-          "owner": "supabase"
+          "owner": "supabase",
+          "mode": "100644"
         }
       ]
     },
@@ -1622,182 +1702,218 @@
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/CHANGELOG.md",
           "sha256": "751ad110037c85d400018c9894716a04fa46357ff55c22b1169b280752e19e88",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/SKILL.md",
           "sha256": "e8491c364a74548ce39241d776a0d182f6393e8c0ec29b6e08d805366ecc2c3d",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/_contributing.md",
           "sha256": "191e039e7d94764e6073410b513b559f9a594e0fdf0252a30c2a2986df2ab3bc",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/_sections.md",
           "sha256": "c9e992612b422c7122de0b7542ebc2450db283edaab08cfe86c6d657fcccccd5",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/_template.md",
           "sha256": "6299954250f212caabe339d752c3e5313a8e07d1a182a4e4b425baee91df1bd2",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/advanced-full-text-search.md",
           "sha256": "40c2606bbb4c4dce31308f201b24cc7f58c7df05b1d9c6856fe2b888d3b7cf28",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md",
           "sha256": "24cacf6a8bc35901dd566d24502ce8e57f810a5c196b897e61d52726e521d106",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/conn-idle-timeout.md",
           "sha256": "630588902c00fcec59a5988cc5d042f76dcf2c923a535abfd8c47dca205eaed5",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/conn-limits.md",
           "sha256": "11b2a67a7c7679cbbc5d807bbb17e69c98484a581d0c8b929c03408f412b81b2",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/conn-pooling.md",
           "sha256": "88cf086bf98ba865d2e9d0579974e1366b14157619d6a93e7da77be91084e4a5",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/conn-prepared-statements.md",
           "sha256": "174e9332fe3dda5c99b2b00159fb1915ae36c00bab3a7882c14e73e4344e946e",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/data-batch-inserts.md",
           "sha256": "531933b82d6a622d0fae29e0ea80be6fe5d78655adf2804c271ea84a1930de37",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/data-n-plus-one.md",
           "sha256": "21a44905e5b16a42741892ec34bb1bfef124d049b140a76934a9acd0f46f5fc2",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/data-pagination.md",
           "sha256": "73c9fa10a3d439bedea0e11b640bd25bf30dd50f0d9006cf85baf7c3151543fa",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/data-upsert.md",
           "sha256": "2612af83b20a2701dde30ef1f8d7efd26b7e9eef84717226b8f038a2d2150ff7",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/lock-advisory.md",
           "sha256": "c88d259dbf81c3771438f59a165f7eab8acd09999dd370bdf807521c73f35aab",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/lock-deadlock-prevention.md",
           "sha256": "09aee46f51d7178c8e55fe056cd5a94a64ba2c122fe418e6900cd99f297b2347",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/lock-short-transactions.md",
           "sha256": "5aa7f61095916986d39644b446cdbcd2bacca7ef698a3bb50b3f82dd60207602",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/lock-skip-locked.md",
           "sha256": "6c45077f430f29cd9cd8f448c94d578e827e7bd023fcdaf717a756acb116fa4b",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/monitor-explain-analyze.md",
           "sha256": "4cb67ffbf8e57f2e5b380b0beb4242528b513723ce314a2c2ffcf083bd4203d7",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md",
           "sha256": "89dca99d4e894fcbdcac136be7ad9fbc03d1342904f065c1b198dc9cf495f098",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md",
           "sha256": "2892272011710eb49b3f185ec12f15ce9ce4c365792c672f6e2a9c90da426a1a",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/query-composite-indexes.md",
           "sha256": "73e42424e671f0266e74fdb220db3196790f69fb43e2b19c7b9483eb4971b554",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/query-covering-indexes.md",
           "sha256": "daf2a7f0477fb7357b62b5fb5b185b1995a77a186347e45cb780e25e7a7589b6",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/query-index-types.md",
           "sha256": "472a74f22c2df203bd0154999b3a5a0187cca2ab3d9a3978e305bb7c32f1a282",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/query-missing-indexes.md",
           "sha256": "91ad8b0ff4365704b4830a7f077c6f140f7140fd5d3ce5cd0b92b160cf9e25f1",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/query-partial-indexes.md",
           "sha256": "6448982bc8558c6555284958edc331b29239c6a0130e6b4501dd6d4da607a6dd",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-constraints.md",
           "sha256": "90e8efda3e9e81095e642911ad4aae2809d160f29414338fa997253238f510f8",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-data-types.md",
           "sha256": "e01b58c14c7f3f65d8ead580b9a4fcf70b83baaab0f9a5f83c569c9fd113e8c8",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md",
           "sha256": "7587713d12a65a212365459b3d39e4717d8a79e4073b10bd62f1054d8192c0dd",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md",
           "sha256": "4bc80f70865f2390872591f326c8a6be6456a0aeb5a7e5a2475d7cd9d43059ab",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-partitioning.md",
           "sha256": "541e13fbeaf4bb1485c9059d4c9417dbdb766cf16f4237cd63a04ada7ec45b90",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/schema-primary-keys.md",
           "sha256": "3c8beabef82066f9a0838b926da0885117fd2d9a263aaf84cb5ca9e5f0d400e9",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/security-privileges.md",
           "sha256": "095909274a4fb43df785d7144cf674eeb40284d2d45628f14af4108737b93663",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/security-rls-basics.md",
           "sha256": "e04dd1a3a382aafdaaa73fe9f7976352acdde6e90c2a2470d281b94d4f44b096",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/references/security-rls-performance.md",
           "sha256": "2e1faeca7d5746e246b1c78f9492fe2a9cfa41c4d7fa1e23c402d58fa18ea014",
-          "owner": "supabase-postgres-best-practices"
+          "owner": "supabase-postgres-best-practices",
+          "mode": "100644"
         }
       ]
     },
@@ -1857,17 +1973,20 @@
         {
           "path": "skills/developer-engineering/tailwind-design-system/SKILL.md",
           "sha256": "af6eb5191a0d791a3d20ea177836290d2bbdb2cacf7f8cd08d9701eac4d96dff",
-          "owner": "tailwind-design-system"
+          "owner": "tailwind-design-system",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tailwind-design-system/references/advanced-patterns.md",
           "sha256": "40a4a9fa931f4bc95213870ea1fe7c32ce50aacf3531af07954b660c4f51e1a2",
-          "owner": "tailwind-design-system"
+          "owner": "tailwind-design-system",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/tailwind-design-system/references/details.md",
           "sha256": "22e5e4500edc1f11c32871d6aad013b10e34724f29d486f080faea46a95bd6e7",
-          "owner": "tailwind-design-system"
+          "owner": "tailwind-design-system",
+          "mode": "100644"
         }
       ]
     },
@@ -1916,7 +2035,8 @@
         {
           "path": "skills/developer-engineering/terraform-engineer/SKILL.md",
           "owner": "terraform-engineer",
-          "sha256": "d7898eb9cccf409022f4670e04662c0c831860ee8d5b6b6102344d1c43f1b5ad"
+          "sha256": "d7898eb9cccf409022f4670e04662c0c831860ee8d5b6b6102344d1c43f1b5ad",
+          "mode": "100644"
         }
       ]
     },
@@ -2341,382 +2461,458 @@
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/AGENTS.md",
           "sha256": "fc93e7421177bbf869cce892bc60a6c83a4517d974bc3bf65c4e2c1e58a6ccf6",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/README.md",
           "sha256": "9eafb2123d3b8b2aef41fba0db2648a3f4f49996f8c7c8bb2c86263befd8b48a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/SKILL.md",
           "sha256": "965356ccf805f0c6af9f4e8c8cc3951ca60558504393944f87d38dd4e0179d9e",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/metadata.json",
           "sha256": "c4e18bac3290fbe1b471a605867d4df68b03144ea26b8befdbe8f9d8fd124354",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/_sections.md",
           "sha256": "01c59969e4e867f0708c8f8ef9c6d87fab9a07d0586244f429ff84013db8a115",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/_template.md",
           "sha256": "99df2a3ea088c6c22de2484ddc7e964d0e9923846f44c63380343ecc64455442",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/advanced-effect-event-deps.md",
           "sha256": "55ed8f9f27a1bff803d6fa55828176207714b02123cbb97ddb8a90d88024a723",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/advanced-event-handler-refs.md",
           "sha256": "a3097edeecfb2ff6851cd66ed8cdf0617c3c88180504bee824aa6e75a215bbbc",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/advanced-init-once.md",
           "sha256": "3e4dc22173eb0e2b6dcf583e3babd862b8696328f8f59aee7c4d746c5bc05f6c",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/advanced-use-latest.md",
           "sha256": "8a3f64dfe5a77d1564248faf17fe662ae75b55d497a243cb30b38eb07ccbbf9a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-api-routes.md",
           "sha256": "523338540d73427dc14c0cbb19f2741ebccdf8b105a7b2c1b33d2905cf237a42",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-cheap-condition-before-await.md",
           "sha256": "03107c1f70a293cd58a8abc5474c5548e20ea4efdf01b6d45aae7ad0ac1cb32c",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-defer-await.md",
           "sha256": "f3c142d090615abdcc99d31c123be37b31f0f1ed8d9ec9f7789a3bc6883ae0fb",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-dependencies.md",
           "sha256": "16ef469f877e30c6b8e1e1b4bc3e527312fa3c6318cb785a4eca186ea236131a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-parallel.md",
           "sha256": "6d2f841896279e976dfcdc1ac89e70771ac188baadfd43c096b5706cb838b961",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/async-suspense-boundaries.md",
           "sha256": "de05fedac2eb7ae563b887b5a424464ec3dfaf84e5b7797467ebe2a796ac8afc",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-analyzable-paths.md",
           "sha256": "62090b5c815fd71bf1133dce754f51abc16a9456d0ccd025fd627de27726e92a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-barrel-imports.md",
           "sha256": "e648f6d54525f07a691357040ca5bff6ea3424788a91ff63812adb29622a671b",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-conditional.md",
           "sha256": "09c8259c3efb04fc0abb8e412ccbda217c222ae8118516283e571c995fe3a7d4",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-defer-third-party.md",
           "sha256": "3719fb47b191e8db4fe22686ec88448ad5af9e6838585425abbe103d0b642e37",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-dynamic-imports.md",
           "sha256": "401817a7369f315fc5a68a1095742ff7d53d0461906880dc9d64a41495ee1986",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/bundle-preload.md",
           "sha256": "d1f7cc28da7cd5ab249acd287edc5b761afcfb194e9cb62cd44c5f3543db2de2",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/client-event-listeners.md",
           "sha256": "242a873349febc1ce685e85617994784dbab92c2eaa68aed7fed5a83e7680e93",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/client-localstorage-schema.md",
           "sha256": "0fb7cdf9dc93fdf22f87e3669f953fb9d4ac9b0be42eec4a29fe9a2560610b88",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/client-passive-event-listeners.md",
           "sha256": "1f35016f9053de69e884ee9be00654e37979c2ca85f5e57764dc2626ff7acb4b",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/client-swr-dedup.md",
           "sha256": "644652c39c6cc00de8d1c77a7273612e868dc3f7edda30764164c12ec0f764a3",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-batch-dom-css.md",
           "sha256": "480b891b9eaf96e929dc1e964274a4828e3a78009b7d00ccd965a0d425215959",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-cache-function-results.md",
           "sha256": "3daaa11d24f4295cb6be8bc6f407f2ce83cc7b5bd1f0e68891ea8ab835721dc7",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-cache-property-access.md",
           "sha256": "73e47431e74878a927061bf0ddc7cd91a7556cb35d2573f3421e82300d9ae311",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-cache-storage.md",
           "sha256": "11b826b0433898c1ece2d3547010d8e77db9fb240185748c45db91493de9b6cc",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-combine-iterations.md",
           "sha256": "71add08aeeb43091d4ff4c0b2842cce8b4bdef8ad3e732cc034bb5a84827e746",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-early-exit.md",
           "sha256": "925ce5ce87f3347186ca62212f29cc6baa2b8c85a96d2720ad07c3d0abf781c0",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-flatmap-filter.md",
           "sha256": "9e5b166a41914d975bef7635467f8fb32cd98b5c3126c0bc6f163490812fb5f0",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-hoist-regexp.md",
           "sha256": "f9e9aef2f7c2307dd7310f283df85dcada45fc43e9bb941b0c3aa414dec21ec4",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-index-maps.md",
           "sha256": "5df1bdc2cfabb2c98abd55d26762e5c18189535c2e686184f426082e62920391",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-length-check-first.md",
           "sha256": "8b54a311c826b299272f29187fc58bc55772a04c4a72eeb29456ee96dc9fc624",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-min-max-loop.md",
           "sha256": "87dfb67e2f39df6ad8bcfb5b78c5fb364d3c07554ad188a202408d99f3763421",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-request-idle-callback.md",
           "sha256": "ee08f83905b4011abbc33d594033157d77561b5bbd9b36b04f0f409581ffec32",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-set-map-lookups.md",
           "sha256": "a7fd781a6ba9ad49065961b6f9a90ef486bf6b648390e1a08704025f98e1642b",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/js-tosorted-immutable.md",
           "sha256": "d0a5e1b0fec48a0a81397957e2f068e224329f7c42cb5feeed8aae6fa64025e8",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-activity.md",
           "sha256": "1e5e7eaf3555e61d6a2e900089c676527d26259501db5594f59544b6c664f85a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-animate-svg-wrapper.md",
           "sha256": "9c6ae0ca7a51434e803887c64cded760956579a1452ccb80a461a03f9c937c77",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-conditional-render.md",
           "sha256": "2ec2fa23c4148285144687050c52369adba3da2fbe3d486f8d3e0aad8f06f2bc",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-content-visibility.md",
           "sha256": "64eee6d5b916fe74df33363994b27fc7f71bea3bcedc7ee04bda23107ca3e6e4",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-hoist-jsx.md",
           "sha256": "93b229560fae92005ed9a2a829064607b39b2e984e92d221d05b2d41df2b7c0e",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-hydration-no-flicker.md",
           "sha256": "dc7ab358c67c177bca6e6f360fbc935ebe4efa928c0ba3ebd3f9f3d9e2000ca3",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-hydration-suppress-warning.md",
           "sha256": "915bacb934e2927d84b37a3f3d225a47b309ac8f9e494ed2bcb66ce07c5676a2",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-resource-hints.md",
           "sha256": "351b1095d641717b930f1b2253282b7120af3023bc74e06c17675168d4286864",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-script-defer-async.md",
           "sha256": "4cea07b7875ba7fc2c7465ff23b63a2bb334f90aaf2d9293d38d67b05fdb32ab",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-svg-precision.md",
           "sha256": "ed468533f6e95f622859c884b122cf21f9f593ed6bb3d500a54de4b9f9bcb9fb",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rendering-usetransition-loading.md",
           "sha256": "3a1249c3f13026b6f54ab5712c388df219d6af01b12aa542749acd99a46f4bc1",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-defer-reads.md",
           "sha256": "234050a77faf50cb306be10a9e15bd4421134ab5907e75f13e6d78e2bd262dc9",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-dependencies.md",
           "sha256": "17eb5830956fb56486fd3cfc7431f5849d39751730c05ad9e77dd4f0c27169c5",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-derived-state-no-effect.md",
           "sha256": "cb11ec76f50aa7b6847269f02d79b120c889a30d9ecd2c1d578f75144419c77a",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-derived-state.md",
           "sha256": "1c326bb67b01fb084eb00c8911b0a7cff54681c2315b629f88e49b64eaa6481d",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-functional-setstate.md",
           "sha256": "5e68df6b2ae8058e67f476ff1ac67bde159f5a9d18df439e46eabcdeb7b52e58",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-lazy-state-init.md",
           "sha256": "4ae844740f266fc8cbf050701230286624a2440ec5be67b9a63d9edc3c580573",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-memo-with-default-value.md",
           "sha256": "81c47476564ad8a79fc68fc442734255ca7d6829424359464503fda0a9f9a0dd",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-memo.md",
           "sha256": "1f258990c2f27ff6256b3cc5c43300631bb3f0d81f749aed08d07fcdcc131dd1",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-move-effect-to-event.md",
           "sha256": "abc2cbf167bee056743023351e96806a411d3398da8802093620aecf0721f029",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-no-inline-components.md",
           "sha256": "1cc32907a770272524ba682eef9e7efdd8ad4533b6f89b718a1fcd7d1d0eb6a3",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-simple-expression-in-memo.md",
           "sha256": "5bdcf2d1558ba5204e643c887b7b4060f89630969425651eb68e96427d97f800",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-split-combined-hooks.md",
           "sha256": "6f45d703343484ef9acef9388397f3642966ae6a5a258899a0cf1f9977cfbf6c",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-transitions.md",
           "sha256": "60f4033909a62df5e5b8c601494f9e50a562e2f8c1c2d81eac24f38142265f1c",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-use-deferred-value.md",
           "sha256": "8c3579576a61a949884167745dcfaf1d5426ba305cc61fd0a79602d70fda4909",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/rerender-use-ref-transient-values.md",
           "sha256": "f1a649af9d1d0b5c762f6c9c4c1c70c90d7df82aa10296ee87aadb78c1b76c54",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-after-nonblocking.md",
           "sha256": "d0b8d24a3db9f0f65f9e2bddbf230b0e03a5f60e1229d93a4a18f5e7a991c7c2",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-auth-actions.md",
           "sha256": "a2ca8aa102839251c7971ec784560fab943c20b36fe6f80365d4110c13260c23",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-cache-lru.md",
           "sha256": "1924b64561841923b88a657085097a0aeba3e0ba2d5470b9f5c15cc10d6ae70f",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-cache-react.md",
           "sha256": "fddeea6c870bb3da4134b61d54b7d09b83d2603f929b7547cd3dc1dc269edd5c",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-dedup-props.md",
           "sha256": "c2747424cdac46be62f835f245a0aa887b0090b416d28e2ac8676702645eeb37",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-hoist-static-io.md",
           "sha256": "5abea4dd882b13661bd5f7dfb93f9e547d5f08176c61c448ade91b210ed5d49f",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-no-shared-module-state.md",
           "sha256": "4d869bf1cd2f1632e5ca4c0e64b1cf0e71c5f5a0f940bc8a22174d205e735ed7",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-parallel-fetching.md",
           "sha256": "569a2e9fc04f9606686cd75c5894ef8781b502786a7fffe241396846c7733472",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-parallel-nested-fetching.md",
           "sha256": "ad5d9656984d4a959997a2367bf59cc6632297b4634a1dd13a087939d83f30b3",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-best-practices/rules/server-serialization.md",
           "sha256": "f4c7d68b29c82381baad059c4a7f09e868e71ec9c3115a26ad3ae7d24c0dfe1f",
-          "owner": "vercel-react-best-practices"
+          "owner": "vercel-react-best-practices",
+          "mode": "100644"
         }
       ]
     },
@@ -2801,42 +2997,50 @@
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/AGENTS.md",
           "sha256": "847e68771417af6cffd9d3ecd4c9412dae1b2bda559912681e17d5d9aa8da435",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/README.md",
           "sha256": "8e7fd66dd5747c98ce727174bcccfd0db9b5c34621b8011693d267bd384d0714",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/SKILL.md",
           "sha256": "fcd9f463400691cd15ea52e705b7d833836c9c87c6e432c0549c08d2ed3b3ffb",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/metadata.json",
           "sha256": "b1a5ae09f3904dc83dab79f518d033bd98f1e2f55caabfdb5beeeaaf0ca5e4c2",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/references/css-recipes.md",
           "sha256": "41f880f3a62b53b46f1ccc540401e4bc19522dfbd1ecd65d18d0b72fec44e829",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/references/implementation.md",
           "sha256": "f36958ff58ed3b8b7da008df5a59e99a67f46b3a6f590274fdc44b89f017f05d",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/references/nextjs.md",
           "sha256": "1d595c3a9d5270d958db9f2924013ac0602d024d0473582b68c61363b06f7856",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/vercel-react-view-transitions/references/patterns.md",
           "sha256": "970f94c2afb086b8b3ffafd05d223ba71595f20ecd6db671b458db88b247e627",
-          "owner": "vercel-react-view-transitions"
+          "owner": "vercel-react-view-transitions",
+          "mode": "100644"
         }
       ]
     },
@@ -2885,7 +3089,8 @@
         {
           "path": "skills/growth-operations-xiaohongshu/x-twitter-scraper/SKILL.md",
           "owner": "x-twitter-scraper",
-          "sha256": "9d69d9983ee3ab07a51a905c053ddc6cec3b70cb8eabe84dced1a043cea534ef"
+          "sha256": "9d69d9983ee3ab07a51a905c053ddc6cec3b70cb8eabe84dced1a043cea534ef",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/simota-agent-skills-2026-04.skills.json
+++ b/docs/sources/simota-agent-skills-2026-04.skills.json
@@ -235,167 +235,200 @@
         {
           "path": "skills/developer-engineering/builder/SKILL.md",
           "sha256": "047ff3e7cb23cc197ec8c609b455dbd3eb56860ae27d4d632af4a1024f064d16",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/ai-coding-patterns.md",
           "sha256": "f952664fb930ff61717f3132c2520092522d60ff74cd349d2d8508c7e582da98",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/architecture-patterns.md",
           "sha256": "e6ebc5221562546600e41b6c494680b15e2ae7e4145970b9479d065cb540ca33",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/autorun-nexus.md",
           "sha256": "5b806d2b8ee4721c30fe413e40e50f95949868a3f5f4e4f335cf393cae56766b",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/autorun-schema.md",
           "sha256": "77215467ca9e34d195bcbead6bbdf92e078d2001db7118214f865c891d822866",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/cross-language-port.md",
           "sha256": "3b05a96e01fd5e758eba99097671db09e55d19155558577bd340c061bf26c11b",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/domain-modeling.md",
           "sha256": "e2a2a9fbbe86e3161aa507c468a8eaa9eebc348f3a3abd08d5e292b05a6e38df",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/external-integration.md",
           "sha256": "17667b9828f77c8fde707dcbd81cd6d17d5a63e9658b46e9f0423460b651024c",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/frontend-patterns.md",
           "sha256": "7c1354a274a0d78d327ab6caa3893a649d29867dfb8702691a46a3ab2a3f22de",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/implementation-patterns.md",
           "sha256": "648547812c22cc0c7bc52f1cd13cf5bb46b3abae30f9f01a9e013b0e8892a13a",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/kotlin-anti-patterns.md",
           "sha256": "378db6b49299e2d8395dad638c3e7e7cd47dbf5b6d4d30b5d65737c1b293365d",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/kotlin-best-practices.md",
           "sha256": "8e465f5808f2c9425ce11ec9f6adf899385a50881641277386ab4fda96939ea8",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/kotlin-language-spec.md",
           "sha256": "f27a62fd272f62f95a8862eed1882554ed98f7fb18730847844f3f6398286d42",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/language-idioms.md",
           "sha256": "c2d5e0e885c7fcc8f5bb459be9780a8f18af758eb78043e14d90163f2b595e94",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/pair-programming.md",
           "sha256": "3e5ed2b160cdf154f6add39ccfed822e2fb5ff4660ec21c9ae9a9f9fb206d091",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/process-and-examples.md",
           "sha256": "554cbe900ecc64bcb9828df2783a7449739dd54fd04cbfe6eb5618fe40d4fdcb",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/rust-anti-patterns.md",
           "sha256": "22c76386a7dc97e9d83fed299cc57cabb3c1093887c3fbddbe7dc4f559a9a631",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/rust-best-practices.md",
           "sha256": "aca37c65e39097dee4d47d875a47e82389094e786ed63260c6b055e1aa858866",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/rust-language-spec.md",
           "sha256": "cc09abb70ad692a94432e0ac06da56eeb39eb2f973718c84096be7ad64c77c3e",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/swift-anti-patterns.md",
           "sha256": "54a15aede2e6d231fce7f50c067ed3e074445f54560a6ca2cb3c4cbbd60076a9",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/swift-best-practices.md",
           "sha256": "617826b60ac66955a5294a1e850ac4636262ca1fd69c5fbbbada7096236e14cd",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/swift-language-spec.md",
           "sha256": "a97ece9a2ee7112033e84f646b689e0c27c6dadd8f0493a474f25b986102c10d",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/reference/targeted-patch.md",
           "sha256": "05591c831d21a713cb6c5496c738e54610caa183324abcf14e99dee91ea125a0",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/architecture-patterns.md",
           "sha256": "e6ebc5221562546600e41b6c494680b15e2ae7e4145970b9479d065cb540ca33",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/autorun-nexus.md",
           "sha256": "5b806d2b8ee4721c30fe413e40e50f95949868a3f5f4e4f335cf393cae56766b",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/cross-language-port.md",
           "sha256": "3b05a96e01fd5e758eba99097671db09e55d19155558577bd340c061bf26c11b",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/domain-modeling.md",
           "sha256": "2f2140860a8cd89d403de64ead46510a9ec80a9ac553665855496c102f855ec5",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/external-integration.md",
           "sha256": "17667b9828f77c8fde707dcbd81cd6d17d5a63e9658b46e9f0423460b651024c",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/frontend-patterns.md",
           "sha256": "7c1354a274a0d78d327ab6caa3893a649d29867dfb8702691a46a3ab2a3f22de",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/implementation-patterns.md",
           "sha256": "59c4e1e947c518188046328bf3ab3dde38fd2273f340becd5bd78e13c21d5754",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/language-idioms.md",
           "sha256": "d0bd170c306d49e32f2046f0ae87ececf0b38d98d2275b71fd97521008eafd96",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/process-and-examples.md",
           "sha256": "554cbe900ecc64bcb9828df2783a7449739dd54fd04cbfe6eb5618fe40d4fdcb",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/builder/references/targeted-patch.md",
           "sha256": "05591c831d21a713cb6c5496c738e54610caa183324abcf14e99dee91ea125a0",
-          "owner": "builder"
+          "owner": "builder",
+          "mode": "100644"
         }
       ]
     },
@@ -651,197 +684,236 @@
         {
           "path": "skills/developer-engineering/gateway/SKILL.md",
           "sha256": "63f8f6edc7643d0a21f2d8eedf93c38f2234a6f4550060ab586e3bf50a16dc5a",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/ai-api-patterns.md",
           "sha256": "44a9e6513babec58ace8a701238a9188109e524888b30eb4ff95021c7b20c664",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-auth-patterns.md",
           "sha256": "16983c8cc68c72922fd935d41072e6a4806e9b73048092036384958b6ec6e8c5",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-decision-tree.md",
           "sha256": "5116ac69b8431ab37b9aac524e41041c69d1e495695615f72ccf349c4d3aa210",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-design-anti-patterns.md",
           "sha256": "97e74a8273a49d4953648b0f03a357969d22876ab25860e8df42690b9436797a",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-design-principles.md",
           "sha256": "e7c4e754c95e9e38e91d00631a3daf229242abd5bb7491d4e5566334131fa2fc",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-review-checklist.md",
           "sha256": "6bb9fcb17cc98365839a72dc97e90442ef7ef8869f07e3fc9b29caf0d9cbaebb",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-security-anti-patterns.md",
           "sha256": "184dbcb66a459c426bc37f4aa19e7b89b96ebc3a0679d4b4c998c7a0e7aab491",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/api-security-patterns.md",
           "sha256": "8c344626e920284163c034b41fe197fa976df795e1597de968e519f54985c696",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/autorun-schema.md",
           "sha256": "1f00ccbfc30ddc107b0bed2f806ea5155a9121804676260c7a0e3eda61314c47",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/breaking-change-detection.md",
           "sha256": "07a90b9ca182cce2d699311c0e1851b9b924c1cde3f80005c29f8a728e25bc8a",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/deprecation-policy.md",
           "sha256": "3cedce8d40844ba5eb748ee669dea0afd6240edfa0c8d748d43e03f20ed4d3ba",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/error-pagination.md",
           "sha256": "1efdc73ff3b0b315ceef73028965b1630376f45cbe39a4615f6ab8b7f97dfb27",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/graphql-design.md",
           "sha256": "f1ee14746203886d9a84fafcb02836f207cd13415284d96f02ca5b872bd97f60",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/graphql-spec-anti-patterns.md",
           "sha256": "0a2d1b3e8c73e7d33bc5ab3c6a7da51cfdfbc4a0c7e15c4e82f69056c6ddbd8e",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/openapi-templates.md",
           "sha256": "80b3b531d5269c5fbf763f9e74ee503a3973e491cef2298725d893bb1bc9eb54",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/output-format-template.md",
           "sha256": "70de1bd13eb4ee98aae250d72d19aa2465d032ce8baf0008a6511c3d4c4825f2",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/rate-limit-patterns.md",
           "sha256": "4b83dd087f1b6c3343a5be74e2f50f6d281f9ad5d7d052282f0d87d5bc29df3f",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/rest-api-design.md",
           "sha256": "cd50c1aa89fc8d8674b43e55f481bb7da5a1c5d90c3b00a14b3f3521f040a44b",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/versioning-governance-anti-patterns.md",
           "sha256": "cd29ff2100f38f9122c110090a2ef5fc71982773a4f911aa5171b34919d4a468",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/versioning-strategies.md",
           "sha256": "bc898ef58b448cfca952c9bcf65a54b67ce34581b30aeb3b4ef35b4eb887a387",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/reference/webhook-design.md",
           "sha256": "dbe5246d78866bfa78ac048eb78dd278819da39a65be0164b8d8a7adf49f8113",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/ai-api-patterns.md",
           "sha256": "0ae4e07aee1e273341ebfe99412e6fc26adecbc9c369e0a1d0d0d85bf0ac9a28",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-decision-tree.md",
           "sha256": "6f58734f401039673299152fe820597b2ac5689e0d08190422171acac2981f4a",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-design-anti-patterns.md",
           "sha256": "03f895ce91fa6781848fdef49e0deb764b60b4f1d5a70a7021f61c2b48dcc8cd",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-design-principles.md",
           "sha256": "e7c4e754c95e9e38e91d00631a3daf229242abd5bb7491d4e5566334131fa2fc",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-review-checklist.md",
           "sha256": "6bb9fcb17cc98365839a72dc97e90442ef7ef8869f07e3fc9b29caf0d9cbaebb",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-security-anti-patterns.md",
           "sha256": "b4c0b5f84a4bd49a0f65fe34a9d7d7e0830855280e71ca5d337cc74ad57c1a5c",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/api-security-patterns.md",
           "sha256": "a32b1460ee680cf332df6cece219db69a97ceb1d564c46db31d5714f1a539fbb",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/breaking-change-detection.md",
           "sha256": "07a90b9ca182cce2d699311c0e1851b9b924c1cde3f80005c29f8a728e25bc8a",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/error-pagination-ratelimit.md",
           "sha256": "81f02ff9e5e43783f9d9253b1a4dd80f97ca6580af5c77b4322de5e2fb11a044",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/graphql-design.md",
           "sha256": "13432d971a247a228789d343d5a17f3d64e010b7cd2e976c77d24e20f06d61fe",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/graphql-spec-anti-patterns.md",
           "sha256": "cc8b133cdd7da4acae3fb7330cb202278f48e412b0ccebd1b483b10d58745f42",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/openapi-templates.md",
           "sha256": "53fee4276c61a7ce96f2a9a609c2dba1707ff2e75e993615a014d116b1e85401",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/output-format-template.md",
           "sha256": "70de1bd13eb4ee98aae250d72d19aa2465d032ce8baf0008a6511c3d4c4825f2",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/rest-api-design.md",
           "sha256": "3e3b45d44252e92f1e962b783092991a21a0c189df8e3b9228867481de8dddf9",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/versioning-governance-anti-patterns.md",
           "sha256": "f95ef540fc8d3b28a8b6a5fedd0466b25f6cab47989870c59169efa3644e0cf9",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/versioning-strategies.md",
           "sha256": "40a0653f26257581e3bf14e9b397e09e4b9a374152a2a4de509194393c949ddb",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/gateway/references/webhook-design.md",
           "sha256": "a77fcc1632bc7e64c8713df6d39803031e836a55ff2c9263924b0c66798a5e51",
-          "owner": "gateway"
+          "owner": "gateway",
+          "mode": "100644"
         }
       ]
     },
@@ -1062,162 +1134,194 @@
         {
           "path": "skills/developer-engineering/schema/SKILL.md",
           "sha256": "d4a7b682ff78f0207e6af03ad3724c954809a6eb2a5b76cdcfc369691043c337",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/advanced-patterns.md",
           "sha256": "f9390f14627705b60ee5bd67f4a859f289a2ca1468d9af0314f8c439ce23be1f",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/audit-log-schema.md",
           "sha256": "ec3f508f46cfd3e23327610ddcb8f7444f700fb1ec2f6f5155984fb954647f06",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/autorun-schema.md",
           "sha256": "04c33e538ef47f5d08a0971ca7cf6d3c9dd74bafbbc30fba18996e35a7ad7bbe",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/data-modeling-anti-patterns.md",
           "sha256": "6a9210e153c4a2a484018736461fdc0921c172a6100e2689ee386eb840a7a37e",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/event-sourcing-schema.md",
           "sha256": "f883d6a402aa253d39bd4334e70ff7775afd02ad662318d8a81920e717eb4995",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/index-performance-anti-patterns.md",
           "sha256": "9744fbbbcca7cc2e49db194c8b5f8bf26e331faaba241dbc412b7273e54c888a",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/index-strategies.md",
           "sha256": "aec4caf417c980931dedc2213cd90b469d981c169e1cb90f7f00f49e6134dcab",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/migration-deployment-anti-patterns.md",
           "sha256": "b84abf60db43bad2083c41646ae3a717d1ceae512ffd3b85c8c5dd2d3d76246f",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/migration-patterns.md",
           "sha256": "ab8913d0c44697507148094e6cd60ec9d91c8ac96808580d7de9e1041c73fb1d",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/migration-rollback.md",
           "sha256": "b8ec94a5197a9db077b7387e5b7e92e0d93e84020b970cdc60adcac9b7981e06",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/multi-tenant-patterns.md",
           "sha256": "b138b6a3f8c9144b39bf374af5e211e8a73da12326fc2f52ff1a938787fb282b",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/normalization-guide.md",
           "sha256": "02c3db15c971117d81341cf6ff8d6798204f0c98219c673c2be66e27f5a1cd37",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/partition-strategies.md",
           "sha256": "fa9d9e5a028c8b6f10b33f02b109624c95857baa2a522a2d7b61d17e3e37a787",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/postgresql17-features.md",
           "sha256": "3caa0db1f5da92569bdac5fd877b7f78b572465bc0747f19bf3f852e03084da3",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/postgresql18-features.md",
           "sha256": "03a325bf7c23804bee937c937fb164d82a445a45f9457e4e386f21433780de3c",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/schema-design-anti-patterns.md",
           "sha256": "45cd931466797aee1c67266139e68982bc6da48623b400b526204ff364d86a76",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/schema-examples.md",
           "sha256": "efe0e3302123326d7a9a426d2fd404dface4b8fea26f9350d2e3ae9fa93b5ed5",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/reference/soft-delete-patterns.md",
           "sha256": "b96a159031e185ba1ba98e1844c480a34eb812d71106ec8fab927eb1f4b09f68",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/advanced-patterns.md",
           "sha256": "3f3f4526ae7653aaa047151385fe54473c70fdce789e8c8ed38ed79e4b75ddbf",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/data-modeling-anti-patterns.md",
           "sha256": "6a9210e153c4a2a484018736461fdc0921c172a6100e2689ee386eb840a7a37e",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/index-performance-anti-patterns.md",
           "sha256": "9744fbbbcca7cc2e49db194c8b5f8bf26e331faaba241dbc412b7273e54c888a",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/index-strategies.md",
           "sha256": "aec4caf417c980931dedc2213cd90b469d981c169e1cb90f7f00f49e6134dcab",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/migration-deployment-anti-patterns.md",
           "sha256": "b84abf60db43bad2083c41646ae3a717d1ceae512ffd3b85c8c5dd2d3d76246f",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/migration-patterns.md",
           "sha256": "5b9a0bc053b59dae56c5c2c5c4bb015421abd27ac16a5977ec221e97bbe04661",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/migration-rollback.md",
           "sha256": "b8ec94a5197a9db077b7387e5b7e92e0d93e84020b970cdc60adcac9b7981e06",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/multi-tenant-patterns.md",
           "sha256": "4e701533b38caaed377301f16d0a62e981d8e9174e956147a12154e0f836dc88",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/normalization-guide.md",
           "sha256": "02c3db15c971117d81341cf6ff8d6798204f0c98219c673c2be66e27f5a1cd37",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/partition-strategies.md",
           "sha256": "52d114091dc83ba9cb8a99a747d5dd7d0c8e0fc75965451e1f8b2f85531d94ed",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/postgresql17-features.md",
           "sha256": "c6b4a9f825c1d06f31ace563104b19b0ea25974f9d89735726e0766488c97e51",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/schema-design-anti-patterns.md",
           "sha256": "45cd931466797aee1c67266139e68982bc6da48623b400b526204ff364d86a76",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/schema/references/schema-examples.md",
           "sha256": "efe0e3302123326d7a9a426d2fd404dface4b8fea26f9350d2e3ae9fa93b5ed5",
-          "owner": "schema"
+          "owner": "schema",
+          "mode": "100644"
         }
       ]
     },
@@ -1803,527 +1907,632 @@
         {
           "path": "skills/ai-workflow/nexus/SKILL.md",
           "sha256": "28390e8951da7626ff04c0dd2223cc593e789292e657d7b6dea711027b675273",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/acceptance-recipe.md",
           "sha256": "f5dfe0ff2a6b26fa0ed689045b809df18d50fa3459fd61592c24775b5e7f45fb",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/adaptive-prompt-policy.md",
           "sha256": "5b300d5eb8ee09b3280a79816253996b163ce700c0e34e9d5201caedaa4c686c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/agent-chains.md",
           "sha256": "cc0efa26e84de903a4bd96372b50efe97bbc314a629c2405478b874a41d12c93",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/agent-communication-anti-patterns.md",
           "sha256": "abdba88213478d820f302043cae9aba238f28da836595b0e4f4c6e74ad92c8e0",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/agent-disambiguation.md",
           "sha256": "242a3bb58302ee4c7316746908abf7838771b8e75701efaf28b096420c61ca52",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/anneal-recipe.md",
           "sha256": "8a17704be975a717c0144a3de4b0b05d196769cf26758033a6514c1c6e7ee067",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/apex-recipe-flow.mmd",
           "sha256": "c02b084b42a394de6d06efc62b5a948211b2c207cb8ae291307f27d3cb2e386c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/apex-recipe.md",
           "sha256": "9b5081b800baa61ba48bdf21e01626e1c5bdf213f2f2314b48546874f7132ddc",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/apex-walkthrough.md",
           "sha256": "1d859085a11424a691172394501621286e250827c98601ed71d30cc742993d91",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/autonomy-quality-protocol.md",
           "sha256": "73642a35a74ecec52bbcbe04e1e05c01230bf4cdb520d427fa9e84ee67af020c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/autorun-schema.md",
           "sha256": "595c45ea385d6758b0ec09acaf88c0134d87d930e357cbd78f70c93be1484026",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/cartograph-recipe.md",
           "sha256": "0f4ca5318022529ca257e68e23b0f3f46703d9ad60a62d9490c8555607fc1707",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/charter-recipe.md",
           "sha256": "cfb3b37faba6d18f3a1546fbb347b2df4b8fee778a18df7f1765237f2a98a73a",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/chronicle-recipe.md",
           "sha256": "da86813329a396ea6da47f80cd66083ba743624bc02fc2d0a44ab3f3b4336485",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/clone-recipe.md",
           "sha256": "67def5fcb65f142be28b2a28018e00251f03ccf44acbb52203223d57ae9666ba",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/confidence-scoring.md",
           "sha256": "b30895f98191b211533643626165b4a644d5eea5e568d3546d2c098b6dd0df3b",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/conflict-resolution.md",
           "sha256": "1e088031f5b0b4b5a253b9cc783fc8d716872cec854a42fad3caede48bf9dc44",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/context-strategy.md",
           "sha256": "691e2cb379e2f89ed0348d7f529c704d6fde23d72f51a35fc7b314ffdeb6ff82",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/converge-recipe.md",
           "sha256": "c3a07b0f46f523baad8e26643e789698ceecc8defdfc2430c21faadb69887401",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/delve-recipe.md",
           "sha256": "3a822195c0dd3f5cc1cd490e78efed0eef1564319e010973a5a109734fe46c55",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/dialogue-protocol.md",
           "sha256": "148d5d5d225a84d320e394ea2d6a0e6beab17ecea80b2d89839ba72351136a0d",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/doc-quality-protocol.md",
           "sha256": "5d159b9ae8407daae35450af86e4622be43a83dbaaf97b76ce95e646a956a8be",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/enact-recipe.md",
           "sha256": "376429c460a8ec4db93a17eeb0f5adef901568b152188420a11fe305e7b9b97b",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/error-handling.md",
           "sha256": "2080e2aca789576ce6832e5170bd915a6af65cfc9b7746e7452667447544d2d0",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/essential-recipe-flow.mmd",
           "sha256": "f4aba7481c6299c85dd962629f8a63dc229d955527be551a830c90570c53f989",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/evaluator-loop-protocol.md",
           "sha256": "8c98e925636da12857d7a82621cad4087bb5c910598010868057769342a14952",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/execution-layers.md",
           "sha256": "85784b32acd3ead9e58f0ede6ab4455ec6e4c3bd26b845647d65056e253670a1",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/execution-phases.md",
           "sha256": "1d04801a7c13d57d1126ce5a007656119b4662415a27c426a42996a3765e8237",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/feature-impact-simulate.md",
           "sha256": "722601b4f212d750ad829a18089ca5a7f3de50127a475747ef9e463b34f3a664",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/fuse-recipe.md",
           "sha256": "6c0c496ddbd6e25798a3ebb4b8d4dd193e445aed6236f1b8f9d87361aaafbcec",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/gedanken-recipe.md",
           "sha256": "0de194f9c3af582a6a52161baeb1d65e15615aa1b23e992ebc350eead5226aeb",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/goal-recipe.md",
           "sha256": "54671094e4571264f0dcc0daa6b59ef3bc9582f39ef8c1bcedc33fe05cf3f5d9",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/graft-recipe.md",
           "sha256": "7b4a8433692fc626d271082aa2ed837797566d3e19e5bdd14fcbdc77a0049177",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/growth-acceptance-recipe.md",
           "sha256": "035299b69aa6158709f7f64883bbee7f955fdef226b417d2707c5a7ee86ae1eb",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/guardrails.md",
           "sha256": "b9566a2b7eaccc0f8ca01e7789976f2712d20c10a9d4ab68268c6e9b8eff1f7e",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/hallmark-recipe.md",
           "sha256": "b364f10b4c88d2ac18eda9ca64ffbbaac2c0220b06f1f049cc0b4f213d937c35",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/handoff-validation.md",
           "sha256": "262b802a4b8c04d3370ec3b254dfe4860aac968481cf328225f9862d4918c5e9",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/hub-authoring.md",
           "sha256": "4db276e7700599bf6ae9d0b9f4769cba5b18056f0771d3fc60ba53f6339c70d8",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/inline-recipes.md",
           "sha256": "aeed866d02a3ca044c09ec268733f3a8c8f5cce7f6288012d88bf28bdcb5bfdc",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/intent-clarification.md",
           "sha256": "c181246ba3b30f5077ce5c12d3dc30b3766391797c243c4c6ab5019d5cd3fa6e",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/killer-recipe-flow.mmd",
           "sha256": "a7fbeb480bfa8357ee38e259933c1e748f97ffe3e086c844d4ca5e58da8415c2",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/layer-recipe.md",
           "sha256": "0e236e823dc5447d703bad00cdb74bbb71c4bc6a9c96e2b2ba7f1d875c64af53",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/loop-engineering-primitives.md",
           "sha256": "359585c6ac7e2e499d22c3ecb1fefb27c3f352c0f101296fc48fe9453882e98a",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/loop-recipe.md",
           "sha256": "d4bdb3d43f62e10ae46895cd7d8de1aa66b956f973012f6ffed286fb78969072",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/managed-agents-mapping.md",
           "sha256": "5ca291d7dc73d73600c88ca29dd2725a6e17bd27c2eb3d9430b74fe0b55dffaf",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/marquee-recipe.md",
           "sha256": "943351aea7936cad02cc54cf525881fc1573ade90bba3c11c87240c5dc09d01c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/migrate-recipe.md",
           "sha256": "b5b6efe965dc42993ea8fffa078ed4e3b7d2f71b6a060816a3cc21c29fcf1d48",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/newsroom-recipe.md",
           "sha256": "303e5f2daf104c4d8b3f2ee9c9d7337784ceb4808b8f2a043761cfe756a6044a",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/official-skill-categories.md",
           "sha256": "8a775a188776d4f78e95cc6607aa977f4f2c99b886678c3d1aae5b2e1f535eaa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/orchestration-anti-patterns.md",
           "sha256": "bda1b16b6747a8e113a7346af3ae27d259e986fb64ca07f8c65e195b1b488b18",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/orchestration-patterns.md",
           "sha256": "185cc016a9eb64041866f587f59aba1665f1a385684230313c09695be8bb3279",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/output-formats.md",
           "sha256": "c4f6353955ffc1595575f2b557c9decdb064e6a2d7c05fe08af56c3678b091d1",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/pack-subcommand.md",
           "sha256": "d17e5e7622dba0116dd35e231a8425669df930b883c34e9e412e00e52077d206",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/package-recipe.md",
           "sha256": "ed20679cc2bcfa4ad7e6eace92974853f4163d546d9089db86efc995441495cd",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/playable-recipe.md",
           "sha256": "316e4f7bf6d5b3dd642e4844fe91f891f79f5cc5cad7ac2b6286e8e83cc8ad3c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/podium-recipe.md",
           "sha256": "8267a5fd9ea3f156af20d33aa6b563c1972a76f7beab34c1688710a92bc0e2e5",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/proactive-mode.md",
           "sha256": "a4af4b8106a3fecdbf462585bfbc973060eae1fa801dadea77be31695187faa3",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/production-reliability-anti-patterns.md",
           "sha256": "973880055f5c10c96fdb5a1a0895a39765b1d3414f6a17eea4b2cade1047276f",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/quality-iteration.md",
           "sha256": "f9efac55f2315bca31a6b170bcf229995f328758f75624ae1a3570a2f27e2c5a",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/rebrand-recipe.md",
           "sha256": "17c4ff6f549c03c6b50cdeec5acb9aade0367b75906ea31c4869a4d6bd7acd3f",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/recipe-contract.md",
           "sha256": "f4a7d1d3183459f90d8d307aaee0eb1a9b659f0ba84f3546d73ca226cd899d3e",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/recipes-detail.md",
           "sha256": "c52b5bc2af2bb70ca82b93ab3255ceb08b4abd7b536a1afb0dc8282905dcdaf4",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/research-grounding.md",
           "sha256": "bd4a49f6bf2a52f48d6ccc5374d36350b8d3ce20a71141d37047b0dfc26cabaa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/restyle-recipe.md",
           "sha256": "1e720a55047f66fba991985e0b6c86bf7a6f99d9c1c9feaaae62284f18c96628",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/routing-explanation.md",
           "sha256": "b80c81606c3e0a17d3a1ccd46bf2be9812514481510ace43ba80ce0a57898fd9",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/routing-learning.md",
           "sha256": "51381fae487822d85ae5c8758a89d577cb19546fd1c3e53eda9dd69ac4119bc6",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/routing-matrix.md",
           "sha256": "ff7fb5e3c2e19d9684c5ba56b32467ce5aff432a2a50c8632d3b40a60afe947c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/runway-recipe.md",
           "sha256": "f2b8567eeb960d21cc1a59eecb018698640ba0b5c2ac2c138321c318b126d804",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/signal-keywords.md",
           "sha256": "c3888d15d22dff16dc8b1866b0114d13653e95d3f0951a79fcc7db2e9b76cf63",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/spec-recipe.md",
           "sha256": "90ddd6711fa976d5e2b5573fd720ff386a7b5f87ddc5228bd0c34e05d5c8d4b0",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/summit-recipe-flow.mmd",
           "sha256": "3548024b37aef4644ebc8bde342564a82767afef749fdfb54d79e50e886f98f5",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/summit-recipe.md",
           "sha256": "a47ee200e315010c0bb47bc41c36100799feb5898af8d41d5f6e465a62e9fd1d",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/task-battery.md",
           "sha256": "bdc59fa72156d36cd095c372453dff5941a1c4c04ab65cb5a98e72fb1618cdc1",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/task-routing-anti-patterns.md",
           "sha256": "dcb59b605a4f12b2e8a11e28a0e01306a0a73f164c3e8b4385e14e2e87b4bafa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/transmute-recipe.md",
           "sha256": "8e000e86b5e6ace69f1586630c3a0719b7556639068f0699024cfa5dc9aa011a",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/venture-recipe.md",
           "sha256": "1f988a463cc11dfb6835c5266578e9a8348cd0f74a1db70326c44f8d79568daa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/verdict-gate.md",
           "sha256": "2273ff483bda4eb905fae29ac606ef464c4a67877fa4e0a4ae12c83d86352fdb",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/reference/wish-recipe.md",
           "sha256": "9ec2956ee5a028e3c66ea335ffddd5ca69a68e9865c64b102bd13c84330032c7",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/agent-chains.md",
           "sha256": "e59a3569e64e18cbaf59d50fc1602db964d7f5c4d571523c6548e276e99cfb97",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/agent-communication-anti-patterns.md",
           "sha256": "abdba88213478d820f302043cae9aba238f28da836595b0e4f4c6e74ad92c8e0",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/agent-disambiguation.md",
           "sha256": "cfa85b13123a454135488f1cd8c939ef9a24525f2516da6319860b18fcc728fa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/auto-decision.md",
           "sha256": "6514148b51c2461f7f4f5ada0cd08bdded0c28d41baa34c86e6ccef799dfd999",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/conflict-resolution.md",
           "sha256": "32676b78d414bf0d7d6de87b19f571569ee5b41229c6074e1c94166da8d8962c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/context-scoring.md",
           "sha256": "1a0ff1b474ef2fa5669bbcd279e8ff8c9f500c45e55f117cbb1b1f15936d7ac8",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/context-strategy.md",
           "sha256": "3c60fa434d2236925dede9012acec26cbdea8c5e17fe8e7d76feb665b70dd5db",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/error-handling.md",
           "sha256": "dfbd0d6abcb32893ac3cfb037704c425a8e1093ac5b16829a4711f14b8339d55",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/evaluator-loop.md",
           "sha256": "f35a917fcbc14f59222def1eb2bc7ef6c7894d5a0bfc6e4f397d3e585b58128d",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/execution-phases.md",
           "sha256": "2e9e3e0fe38651b11ce9f25d4ca142a7be94cc903f8803238334d920b265fd77",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/guardrails.md",
           "sha256": "81df9ada69e87202a08445c5c59965b869f72f7993265cd80397918c312bf878",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/handoff-validation.md",
           "sha256": "20eb981f3a9a66d0a9049814c5cdc589aa0fed91a049e073ea8a36c5fa21f119",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/intent-clarification.md",
           "sha256": "70b1253fb82cc4fd7ae5ab1c68a638092ad991833b9d88e1d28e6078dfcecbf1",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/official-skill-categories.md",
           "sha256": "90d2fa5eb9702af39120259063509603d6c3170bc974a930425ef7c9bd59987d",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/orchestration-anti-patterns.md",
           "sha256": "bda1b16b6747a8e113a7346af3ae27d259e986fb64ca07f8c65e195b1b488b18",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/orchestration-patterns.md",
           "sha256": "30d037c75c09d95c645dd8f4f22949c7c083ef5d7f08a116d9d83c33b9fd8b4c",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/output-formats.md",
           "sha256": "eedc82e1ad4623dee95b15435dad5f0c64778c20a308afe8ed6c218ce0fd5398",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/proactive-mode.md",
           "sha256": "788afd71530b7d44a741409e9ae3b68b6009fbb0ce2fcf1d4a8f8d4177813419",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/production-reliability-anti-patterns.md",
           "sha256": "973880055f5c10c96fdb5a1a0895a39765b1d3414f6a17eea4b2cade1047276f",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/quality-iteration.md",
           "sha256": "83fc081b48846ab84ffb929171575ca641034f769a86b0fb815a6175c261e9e5",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/routing-explanation.md",
           "sha256": "781ce8b9545d425a72c5593e136d35b7b0a442d89f5a78b4b3803fea0fa36828",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/routing-learning.md",
           "sha256": "c024ff51b7b96920fda25cdbc452e73d61af42ac65fa465cb539902c90a90a87",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/routing-matrix.md",
           "sha256": "64d9689bb44e8ff463f503162be1fcd28840847ca8c368b3d1d03f5208c2cd01",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/rubric-system.md",
           "sha256": "00093e3d9333e8bec7f43874e36aedcc6e3fbda1f9593c82811b445099efea71",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/sprint-contract.md",
           "sha256": "b184c038a6ac0a2ec2d1137f850ebebd712dca0ef33c49b45182e13446afe6d1",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nexus/references/task-routing-anti-patterns.md",
           "sha256": "dcb59b605a4f12b2e8a11e28a0e01306a0a73f164c3e8b4385e14e2e87b4bafa",
-          "owner": "nexus"
+          "owner": "nexus",
+          "mode": "100644"
         }
       ]
     },
@@ -2524,142 +2733,170 @@
         {
           "path": "skills/ai-workflow/sherpa/SKILL.md",
           "sha256": "401f7a166a5291c9848f54d566aa65ec2eddc6ca8c491d77d67ad1d1bce5dcf7",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/anti-drift.md",
           "sha256": "14f0f3dca177a64943fc2055a85f170fd30028839d7f1976b1eb6901d88ffbfa",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/atomic-step-decomposition.md",
           "sha256": "a47e9fd901715e933e2324b7be41fd7965012e09be8c4816a02469f52e7a171d",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/autorun-schema.md",
           "sha256": "4e48ec4d7093a1bfa07dfc8ae1d9798b287026608bc04536b9c4ca22e6b9c975",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/context-switching-anti-patterns.md",
           "sha256": "dff0cf61e2b7623745b839c8df92bab170fa51a526d50fc4193692b73f26811e",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/emergency-protocols.md",
           "sha256": "217a64682d60d5a9fde60a7ed2ce81bc7b5a933446e7693def77ef537606d3dc",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/estimation-planning-anti-patterns.md",
           "sha256": "4b083e338ed2ef3a4f359e7bbb8b5e32a25166382224da06677d967849511ea1",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/execution-learning.md",
           "sha256": "6958bcb010eea07efb59be6b4b23c1d0825cab4597a791615ae7e0b3a31271cc",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/progress-tracking.md",
           "sha256": "331d3f984b5d4fb6db07223b473d589a5fe69ba45f719bfcb20fd8427653d181",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/risk-and-weather.md",
           "sha256": "d0b66b78bc9243db61005b114aee8d6ec104672b2084fbaa6fee107f50bb7a71",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/scope-creep-execution-anti-patterns.md",
           "sha256": "8683e85bdb58f61b48d7beaf4aaaf703899decd12785d333412495c0c67b5cbd",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/task-breakdown.md",
           "sha256": "8754d37cab37331828b255c45dba57d5cbd17ae426d7860c47384bf427bd7ba5",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/task-decomposition-anti-patterns.md",
           "sha256": "253d109e934708b5fd610c392c9107853f7a141951f457728129e8f62fc40600",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/vertical-slice.md",
           "sha256": "8a29da731d0e4baf69359739ce425c2d0b6193dd2f5fd9e2aa5d8868da265198",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/reference/walking-skeleton.md",
           "sha256": "1f7204f6a8d98597975525996a809f758d8fcef53a5160fa5e1fb1a48e9e0e4a",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/anti-drift.md",
           "sha256": "14f0f3dca177a64943fc2055a85f170fd30028839d7f1976b1eb6901d88ffbfa",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/atomic-step-decomposition.md",
           "sha256": "5111fcedccdf7090c4bc5204c5fc1af630b4835d07e85cdabacbb3bfaf1dc510",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/context-switching-anti-patterns.md",
           "sha256": "dff0cf61e2b7623745b839c8df92bab170fa51a526d50fc4193692b73f26811e",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/emergency-protocols.md",
           "sha256": "217a64682d60d5a9fde60a7ed2ce81bc7b5a933446e7693def77ef537606d3dc",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/estimation-planning-anti-patterns.md",
           "sha256": "4b083e338ed2ef3a4f359e7bbb8b5e32a25166382224da06677d967849511ea1",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/execution-learning.md",
           "sha256": "6958bcb010eea07efb59be6b4b23c1d0825cab4597a791615ae7e0b3a31271cc",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/progress-tracking.md",
           "sha256": "331d3f984b5d4fb6db07223b473d589a5fe69ba45f719bfcb20fd8427653d181",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/risk-and-weather.md",
           "sha256": "d0b66b78bc9243db61005b114aee8d6ec104672b2084fbaa6fee107f50bb7a71",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/scope-creep-execution-anti-patterns.md",
           "sha256": "8683e85bdb58f61b48d7beaf4aaaf703899decd12785d333412495c0c67b5cbd",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/task-breakdown.md",
           "sha256": "c8ac8da20d8f6ba8e0e906414272782d7b60ffa230be09ba9c871a294d3fabc6",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/task-decomposition-anti-patterns.md",
           "sha256": "6cf39d0d8eeb08d450913f057345ca52730c5fbf0f95f83408b5a21f9fc2255b",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/vertical-slice.md",
           "sha256": "8a29da731d0e4baf69359739ce425c2d0b6193dd2f5fd9e2aa5d8868da265198",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/sherpa/references/walking-skeleton.md",
           "sha256": "1f7204f6a8d98597975525996a809f758d8fcef53a5160fa5e1fb1a48e9e0e4a",
-          "owner": "sherpa"
+          "owner": "sherpa",
+          "mode": "100644"
         }
       ]
     },
@@ -2840,122 +3077,146 @@
         {
           "path": "skills/ai-workflow/rally/SKILL.md",
           "sha256": "5de2a64b2942f3bf814763fef587ceea61030c99a75bd6f47ba4bfee821d8637",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/agent-teams-api-reference.md",
           "sha256": "2651849e1c7147e98f1f78081eb9c24e2918595796fcc2ec5d5d280b6e4bf74e",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/anti-patterns-failure-modes.md",
           "sha256": "e6e00c65df02cc68df9969382e533f8a6128a2872d627d2e2ba5e29af65a45a5",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/autorun-schema.md",
           "sha256": "94dad992a5231113cc9fc02686d636417586f56370982a158561054929b0746d",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/communication-patterns.md",
           "sha256": "6f6ec560c182080af9dbbf797c6d9385eba956447d6c4c2d6dbfe055717e90f0",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/file-ownership-protocol.md",
           "sha256": "1b42ccd9f6660db9d2e601ac5ce3cf8d5d4c4c46fad079e6db5533dc51e90e96",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/framework-landscape.md",
           "sha256": "5c9af27879005489df51eaf8751deb413f419168462a5c0d216775d704be0ed6",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/integration-patterns.md",
           "sha256": "778faabaeb9f641ce5f2f16c6e8a4693e98896e06c80fa3a426f422de3082fab",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/lifecycle-management.md",
           "sha256": "b62f882f5c2eec6120992e699847edbabc474985ac6f29ad2a8678a1f8a6654f",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/orchestration-patterns.md",
           "sha256": "e82deb5084749b37441fb3166d5cfa8d65c01d391c87c92d4c386026b15fa279",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/parallel-learning.md",
           "sha256": "bda7c37549dfcbe919f15861b7d60528b248cbac38ec80a1a81e478980b186c5",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/resilience-cost-optimization.md",
           "sha256": "f731db20d59a336caaf0b458108345b11e36ba4204d1c7d60fa73a2d05c1ad2c",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/reference/team-design-patterns.md",
           "sha256": "63d89b1c48b08e68df3c9a01acb45e3969a608af22bb587e47cfbfa5ab758876",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/agent-teams-api-reference.md",
           "sha256": "f51f75371ec338c4f5ec414a5f37420ca3b368726361ebd1b869477fe845097a",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/anti-patterns-failure-modes.md",
           "sha256": "e6e00c65df02cc68df9969382e533f8a6128a2872d627d2e2ba5e29af65a45a5",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/communication-patterns.md",
           "sha256": "1dd8e6cf60de8eda9020f735d08b02d56ed3e73e4bc766f15a93c45c068f5ff6",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/file-ownership-protocol.md",
           "sha256": "1b42ccd9f6660db9d2e601ac5ce3cf8d5d4c4c46fad079e6db5533dc51e90e96",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/framework-landscape.md",
           "sha256": "09b4a67f025fdf815d9920eff4cc695c9b70f6b2702f045439813f3f01809e95",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/integration-patterns.md",
           "sha256": "5489e43dacb147b0c98e8356d073c5ba7914632f800f5a6b9d6f628b82e84c42",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/lifecycle-management.md",
           "sha256": "2e3b0b111881604a2caf4572c60e5e7c7378ae4ef2768b17a8294784e34204e3",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/orchestration-patterns.md",
           "sha256": "e82deb5084749b37441fb3166d5cfa8d65c01d391c87c92d4c386026b15fa279",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/parallel-learning.md",
           "sha256": "f49e80466de2bab22c0a7ef02bed7d4c3d2d734ad1aec27f0d7b9a6411f52a16",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/resilience-cost-optimization.md",
           "sha256": "f731db20d59a336caaf0b458108345b11e36ba4204d1c7d60fa73a2d05c1ad2c",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/rally/references/team-design-patterns.md",
           "sha256": "ba5f48a83a76d9a3fd35a38573ec4dd1ee370c9168eba07b4a5edbee9a9e563d",
-          "owner": "rally"
+          "owner": "rally",
+          "mode": "100644"
         }
       ]
     },
@@ -3121,107 +3382,128 @@
         {
           "path": "skills/ai-agent-platform/oracle/SKILL.md",
           "sha256": "1d724258fd1fc34d6a193175a21a0b1ed3a78d6ee5ef08f3cc1e310797dcb18e",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/advanced-tool-use.md",
           "sha256": "6438bb42a9bdcd11eee7eb12472f35a6cf33a54a3910b7f9066ddf2d3037a2b6",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/agent-design.md",
           "sha256": "476d4cb4921e9ab1b5a33b3d923ccb720a469991ae224666d94f98e0a96afb92",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/ai-safety-guardrails.md",
           "sha256": "b3fe290f1fb0043d5f92fc478bc65de4cea2efa139debaeb827703416608a811",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/autorun-schema.md",
           "sha256": "d567290100356330ac7d8e45cb37c3ed8905e4a6d3a36bf82262b362c617faeb",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/cost-optimization.md",
           "sha256": "6890f0b436e0919b7b7bc991880f47f10fd92f4ff03b90fc00cfa9ae49f6ac35",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/embedding-strategy.md",
           "sha256": "6af984b6d68fae6951d2c8e10e3a2d5a88f276731069cabec2bfc7ac251288ac",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/evaluation-observability.md",
           "sha256": "63c60ec3dced10bd243d8acb1b4872b0f4f5d91d743009aed7e9f3c9f4c15293",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/llm-application-patterns.md",
           "sha256": "59d943d5a8f22c2f385f78bafe50f34bc7fb7544e4fba18d1225e5ad1877f480",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/llm-production-anti-patterns.md",
           "sha256": "52164d3ff09ea6fad4b25c3c24793f403896a91f846ee8bf219c291a522d4c8a",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/prompt-engineering.md",
           "sha256": "c4dba76e9d4877e66d49af81370b387aed39993dc11d7bc548daf515a3a7b9de",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/reference/rag-design-anti-patterns.md",
           "sha256": "11c19ccbb7da64c5268e2c76f588cc9aad74eddcb585987792c5e222ba37a0b5",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/agent-design.md",
           "sha256": "476d4cb4921e9ab1b5a33b3d923ccb720a469991ae224666d94f98e0a96afb92",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/ai-safety-guardrails.md",
           "sha256": "b3fe290f1fb0043d5f92fc478bc65de4cea2efa139debaeb827703416608a811",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/cost-optimization.md",
           "sha256": "ba992203b863cbfcd72c2d1fa99753bad521944a763a06d0daf1db2fe8b62ef9",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/embedding-strategy.md",
           "sha256": "6af984b6d68fae6951d2c8e10e3a2d5a88f276731069cabec2bfc7ac251288ac",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/evaluation-observability.md",
           "sha256": "63c60ec3dced10bd243d8acb1b4872b0f4f5d91d743009aed7e9f3c9f4c15293",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/llm-application-patterns.md",
           "sha256": "8ffc6633cec3084c21f4f8be9d642610cd57f22690829191551b3f4a95c6b609",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/llm-production-anti-patterns.md",
           "sha256": "52164d3ff09ea6fad4b25c3c24793f403896a91f846ee8bf219c291a522d4c8a",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/prompt-engineering.md",
           "sha256": "6b6348750e57f0a0ae64f74ccff6df1ef1a71defbd8a444de8e181b5c380851f",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/oracle/references/rag-design-anti-patterns.md",
           "sha256": "0a72ef92b18191c7aee60c01c305696619693e66ddc810896de93c4679da9511",
-          "owner": "oracle"
+          "owner": "oracle",
+          "mode": "100644"
         }
       ]
     },
@@ -3329,62 +3611,74 @@
         {
           "path": "skills/ai-agent-platform/arena/SKILL.md",
           "sha256": "27cc6209f458801f59a5335269e05f034a87407fe3c626d4ba10e1f563995257",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/ai-code-quality-assurance.md",
           "sha256": "d16da0ab9d3f34c040152982585068db7cffefe49abada939408f47608ce52c8",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/collaborate-mode-guide.md",
           "sha256": "c922485635860e5ef265db0d2e885a4c48e7154e902e055ed02fd1d5566c6e8c",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/competitive-development-patterns.md",
           "sha256": "8fe85f18bf6d9c62ef000f5978d93c6f798d7ea9ecb5311ea6844de64b93c153",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/decision-templates.md",
           "sha256": "2930e69d1ea3a3bcad1e68bc467790d83d5ec866fce098d3f21a90daafdd4a2f",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/engine-cli-guide.md",
           "sha256": "79e929cd4651ea125aae839fa6da397bf33fd4eb9231663f13bc43ca57e25c23",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/engine-prompt-optimization.md",
           "sha256": "99fe3ef273361bd39ea9e5f8f6ebfac4e77979f3b3a76c1ac631f61abe830fd9",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/evaluation-framework.md",
           "sha256": "a4162440e3594adce1d071774a38342aab841bd4b994dabc5090039f6818fcbd",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/execution-learning.md",
           "sha256": "148e4908a4fa372745d068db61e0eda2df2a2b5648dc9727f9b7a71d758df32d",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/multi-engine-anti-patterns.md",
           "sha256": "4272e7ab850e8c137c4c17605859df73a98d3f1b9ed9714edc8b37bbfa2638d4",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/question-templates.md",
           "sha256": "7cc57e9988ffadab0142251a4ca2be677ba32f43763d35a2bb29f047435d5764",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/arena/references/team-mode-guide.md",
           "sha256": "839248be3d943aecb528c9d61d86c66ee0f922da5df8ac40370672eba912aafa",
-          "owner": "arena"
+          "owner": "arena",
+          "mode": "100644"
         }
       ]
     },
@@ -3575,132 +3869,158 @@
         {
           "path": "skills/ai-agent-platform/sigil/SKILL.md",
           "sha256": "0a03430c1dd26c57c765ef7eea0f308f4c0da00166576528b72c8f74fd3e5d38",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/advanced-patterns.md",
           "sha256": "4e5711df6f77a62b19c3a6053f37230583b9de8ea3db745a7b2bb1cf50cd3c5c",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/autorun-schema.md",
           "sha256": "e6e38a5b79486516ac168a854b7e614ac669973559f7cdc879aa4f311a68e410",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/claude-code-skills-api.md",
           "sha256": "e5e657cc52ab049955acf12dc7f7164126cafaa7b5e15a48135f5b601ee6aaaa",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/claude-md-best-practices.md",
           "sha256": "f5e38959115325d74954d6962ae1e29b575532a42a82f2a55ab42e643d91b139",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/context-analysis.md",
           "sha256": "7333239ca9a7e61f81e00ff301780572ffaef555be839096795bb47d5ea5fbed",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/cross-tool-rules-landscape.md",
           "sha256": "647fa96f50f81ff0b9ad7e9af3f09a2530059cd9c80bc6a6ccc682aa4eb28f9a",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/evolution-patterns.md",
           "sha256": "74ca22137c5a595ae3f1a2303172d00353039373f4b37ed262af4373a48e9202",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/meta-prompting-self-improvement.md",
           "sha256": "995d27a49d4bdd596b904f56775344cf17ae84a43ed19bee226cd140c9f3506d",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/official-skill-guide.md",
           "sha256": "a3621c3c965fc0b6449f2966dc8688ea56efa20aedc5d607e1960dea6742a9f2",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/skill-catalog.md",
           "sha256": "34cb9901cc8f9388862cddec72052033b85f76675c2be9ec45a887e4f1e8170e",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/skill-effectiveness.md",
           "sha256": "0cd7d914012d8ae8307b667b2e102d9b0bd4b42738b07eb27444ca517c58ef30",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/skill-templates.md",
           "sha256": "09aa4095699488948ef50779cdd3dc11e15d7d118239a2af9785c9f9b606c3c3",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/reference/validation-rules.md",
           "sha256": "d9059910ec26451d89c84be65e4a2ccdb0a16e0abfd70a224ff5e53a4c660484",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/advanced-patterns.md",
           "sha256": "4e5711df6f77a62b19c3a6053f37230583b9de8ea3db745a7b2bb1cf50cd3c5c",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/claude-code-skills-api.md",
           "sha256": "16446db19b3057acb3d7d7b18ef8015366acd6504fd53e778fcd5e7032869bb1",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/claude-md-best-practices.md",
           "sha256": "f5e38959115325d74954d6962ae1e29b575532a42a82f2a55ab42e643d91b139",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/context-analysis.md",
           "sha256": "7333239ca9a7e61f81e00ff301780572ffaef555be839096795bb47d5ea5fbed",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/cross-tool-rules-landscape.md",
           "sha256": "41abd71021841aa77d50b163aa5ed48483d076cbd7be4a0fd0f92986ab63a106",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/evolution-patterns.md",
           "sha256": "74ca22137c5a595ae3f1a2303172d00353039373f4b37ed262af4373a48e9202",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/meta-prompting-self-improvement.md",
           "sha256": "4cb633f606d59ee61ae8888f0f28dfe4b6c1fbf34aea96a56dd1ec942e1887b3",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/official-skill-guide.md",
           "sha256": "1abd69095fe6b393d0573733d3735efafc1ccc43f3c20add652e50950771b0cb",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/skill-catalog.md",
           "sha256": "34cb9901cc8f9388862cddec72052033b85f76675c2be9ec45a887e4f1e8170e",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/skill-effectiveness.md",
           "sha256": "826f876cdfea82dc3874b20165c31fe827688abe2b231c2b2537ba05d8188e41",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/skill-templates.md",
           "sha256": "00e744298ed23cbb80b3bf91e0752709978b72b15267c147e78199f02e4c1649",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-agent-platform/sigil/references/validation-rules.md",
           "sha256": "5347078e7a6e3faff4896f4d4f6d4962da572bde9da9828dedaa536f34f11870",
-          "owner": "sigil"
+          "owner": "sigil",
+          "mode": "100644"
         }
       ]
     },
@@ -3991,232 +4311,278 @@
         {
           "path": "skills/engineering-workflow-automation/guardian/SKILL.md",
           "sha256": "ffb8f542d6a405c59a17b849b2405c17cb05c9f02d85c3974b818a83f15244d4",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/autorun-mode.md",
           "sha256": "be20f6f744ff6f7dbed7624dac4ea13036d95a7c59636a8cdc7ddc288ba5b3b8",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/autorun-schema.md",
           "sha256": "90d26e71f6e33f21b13b7d17ee95756e1301afde14732901bfb1c6f5b0a9283c",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/branch-health.md",
           "sha256": "c9ccdf1f58a57e7f1e89887c1eba0d75ea684be27c7026538525793e51931e89",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/branching-strategies.md",
           "sha256": "d1b6c7a0ba56ef4265d4fced2822525992996190cdfbe6c0f3ecd638e2f8641a",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/code-review-guide.md",
           "sha256": "97914ae6ad77f0941e3512cf8e9852e0877d8d937bcb58672d421f7bc00af994",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/collaboration-routing.md",
           "sha256": "6bb278302397378252f0016077db588679c5485c1a591d52170173cd3a961152",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/commit-analysis.md",
           "sha256": "6832be7c96428b63aad08586332b1975f89b61a25aeb08b72cfc25952716c5b4",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/commit-conventions.md",
           "sha256": "db9e5520f003aa0092c09b2f863dfbf17eeebbab7252ae6c4b6442257a125908",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/coverage-integration.md",
           "sha256": "67d23199fcac4d9842f6d7ea8acd594b9312571f5bd71bfb1a4aded91756ba13",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/git-automation.md",
           "sha256": "5646d8e86a4d1d4d3d19ac8f74e34b549d03c805419df459c4f252dea08b6502",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/git-recipes.md",
           "sha256": "a30bbca5c9bb82f41b58751767d8163695d1e220f1afd8e718ef66cb2f075939",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/history-audit.md",
           "sha256": "11fbd988d1dae51cb398c705ff1ba735fa85d1eea64c278dcd5addb4b0d33f7e",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/history-reshape.md",
           "sha256": "a0f207bfa4eba8dc4c9ee79f4d768ee1babb01851bb0788520ef84f3a77c265d",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/learning-loop.md",
           "sha256": "80281b1d2c3863c639885b0e2980893977de8e24485ea6498618734359154f29",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/output-templates.md",
           "sha256": "614d5163f1f5b0b36789005eb7f4d03925ab4a0054b92aa9177c43c7fe178acd",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/pr-quality-scoring.md",
           "sha256": "679a5314595943c035ad4a8dbfa0952eaaa9facec449e156e911325a2c0e2fec",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/pr-ship-flow.md",
           "sha256": "fb572288c4591642bc2c97a8a1fb7fc583ba7958944a27074d3e2d09dc05b3b8",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/pr-split-strategy.md",
           "sha256": "7b4b536c905b9706ee0616d2cf60c5face578447b054b36fd3a6368cedda2ff9",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/pr-workflow-patterns.md",
           "sha256": "d2bf981b65f23c8ba422d5eb6c657fd5bd97fff7afb6930eeed65d6829cd8a20",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/predictive-quality-gate.md",
           "sha256": "7c163cdcc5ea1233306c98c065d2319765ed447af4dbc76499df504a5f75259f",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/risk-assessment.md",
           "sha256": "dce0644093582d7ac6bd931304ed911a5be32ec7635d564115f41641ce47ba4f",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/security-analysis.md",
           "sha256": "ca7d17582644e3ab84dc5abb3b25c487ea5c84f153f003d1b8cf82ec10e14fe2",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/reference/squash-optimization.md",
           "sha256": "58a2d6ade09b3978098e62ce67ad80904f4204901e20dc5215eb1cf87164b207",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/autorun-mode.md",
           "sha256": "be20f6f744ff6f7dbed7624dac4ea13036d95a7c59636a8cdc7ddc288ba5b3b8",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/branch-health.md",
           "sha256": "c9ccdf1f58a57e7f1e89887c1eba0d75ea684be27c7026538525793e51931e89",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/branching-strategies.md",
           "sha256": "d1b6c7a0ba56ef4265d4fced2822525992996190cdfbe6c0f3ecd638e2f8641a",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/code-review-guide.md",
           "sha256": "97914ae6ad77f0941e3512cf8e9852e0877d8d937bcb58672d421f7bc00af994",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/collaboration-patterns.md",
           "sha256": "81035a577930408aa86738eb1c47cf5a735a050fe7202b1e92af5351e6ea7459",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/commit-analysis.md",
           "sha256": "22a6c49b3de49c273d9809dfce9e37d27b1aba1e9252dacc3e9164cc52988ca9",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/commit-conventions.md",
           "sha256": "db9e5520f003aa0092c09b2f863dfbf17eeebbab7252ae6c4b6442257a125908",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/coverage-integration.md",
           "sha256": "67d23199fcac4d9842f6d7ea8acd594b9312571f5bd71bfb1a4aded91756ba13",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/git-automation.md",
           "sha256": "5646d8e86a4d1d4d3d19ac8f74e34b549d03c805419df459c4f252dea08b6502",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/git-recipes.md",
           "sha256": "a30bbca5c9bb82f41b58751767d8163695d1e220f1afd8e718ef66cb2f075939",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/handoff-router.md",
           "sha256": "48123038321e2e06496d00ee0b339872f3de13374e3f2480d30c2fe7154d0ccc",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/history-audit.md",
           "sha256": "11fbd988d1dae51cb398c705ff1ba735fa85d1eea64c278dcd5addb4b0d33f7e",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/history-reshape.md",
           "sha256": "a0f207bfa4eba8dc4c9ee79f4d768ee1babb01851bb0788520ef84f3a77c265d",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/learning-loop.md",
           "sha256": "80281b1d2c3863c639885b0e2980893977de8e24485ea6498618734359154f29",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/output-templates.md",
           "sha256": "198de16802d3572053a4918b0a6b0a5db3c8ba1f1e70bc423b24090600bc4f47",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/pr-quality-scoring.md",
           "sha256": "679a5314595943c035ad4a8dbfa0952eaaa9facec449e156e911325a2c0e2fec",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/pr-split-strategy.md",
           "sha256": "7b4b536c905b9706ee0616d2cf60c5face578447b054b36fd3a6368cedda2ff9",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/pr-workflow-patterns.md",
           "sha256": "784bc2d790f9ebab1e41add7fcc623019cf7df19067a7577848c9a20248155ef",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/predictive-quality-gate.md",
           "sha256": "7c163cdcc5ea1233306c98c065d2319765ed447af4dbc76499df504a5f75259f",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/risk-assessment.md",
           "sha256": "dce0644093582d7ac6bd931304ed911a5be32ec7635d564115f41641ce47ba4f",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/security-analysis.md",
           "sha256": "ca7d17582644e3ab84dc5abb3b25c487ea5c84f153f003d1b8cf82ec10e14fe2",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/guardian/references/squash-optimization.md",
           "sha256": "58a2d6ade09b3978098e62ce67ad80904f4204901e20dc5215eb1cf87164b207",
-          "owner": "guardian"
+          "owner": "guardian",
+          "mode": "100644"
         }
       ]
     },
@@ -4497,222 +4863,266 @@
         {
           "path": "skills/engineering-workflow-automation/harvest/SKILL.md",
           "sha256": "8d8c7edf2bfcb0cfeb76515cff6a766144d3e60fa43a7b329f8af3814ef4b987",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/autorun-schema.md",
           "sha256": "d83acbd4fca1d86c806cb0cb906f70f518cfbd1a4fef3947f81c6be9b6a56a34",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/caching-strategy.md",
           "sha256": "0f17e7582c4e55a6df8f7160110850a407f9ec89740836e7aa853c6d45d4b12d",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/changelog-best-practices.md",
           "sha256": "b48dc8cff4c667feccc86821b190afc2e2acd6c3c36407b15a64245f925d3ed9",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/client-report-templates.md",
           "sha256": "b708f02c81cfac9c4304d41dd31e0b6c291c008849f10e358ba9d9ae9f9daaa9",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/dora-metrics.md",
           "sha256": "e719b3a1cfeae9f741aea91287882768772ff3447eb50ad4e7c4b6cac5273912",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/engineering-metrics-pitfalls.md",
           "sha256": "b8ca45882765180a164eb5796e26ed69091abeae23a2d87799f57bb7c34737fb",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/error-handling.md",
           "sha256": "81b907dacd8ca7bfe538b5e2b76bc882a7dc7377e8ce940d442b5328c490ad14",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/estimation-anti-patterns.md",
           "sha256": "66e3b12a06931760a2392d25a05691f06ccafdcda97ed4f9572159757bf5dd79",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/gh-commands.md",
           "sha256": "93b44998a31dc60fef2cbc5ee99a97e9c9e78a0afa3fdac4018a63200a032b23",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/okr-linkage.md",
           "sha256": "522b2933ebdff8b422e3bb858182756829b731df8e1ae4e3d0644cf28d80b15a",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/outbound-handoffs.md",
           "sha256": "d438d3e746009ce907c9e40b9163fa925c8fab6b9c23add706495e1ab6bad0f1",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/pdf-export-guide.md",
           "sha256": "d21233be228da684d1c3770853a190e3f66428adb02663fbc61680ed3a0caa7c",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/pr-stats-analysis.md",
           "sha256": "546bd6b2b72c0fdbcf1c404e4986c9c2a674910b97244aee7e0d5f141b46f0b1",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/report-templates.md",
           "sha256": "cf255fd00a7e40477cb4f231616f76d5e16c8736d77420f1125025f4ab526afe",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/reporting-anti-patterns.md",
           "sha256": "ad8cab4c346125457c1c444f1771ff4d17b3c702c9e0c2ed673b9386e66ec8b8",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/retrospective-voice.md",
           "sha256": "004e3565ee28a1806f23f7c624c1e7e4fff6d70226fb318ce30723b1e571241c",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/reference/work-hours.md",
           "sha256": "e9690b6ba38dc696ad9557f5e3585c52a1f969caf922c7d9850ddc8e87480a70",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/caching-strategy.md",
           "sha256": "fddd9f344d37f66523c85330d4e0cf1bc3219b508443f5590993a28273daaef6",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/changelog-best-practices.md",
           "sha256": "573d14e057c4d06356de021c72afd0ea047e00a93f0f8e3a59803627abdf2087",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/client-report-templates.md",
           "sha256": "5cd6f088da2c03f3ba3a8b67649d877497bb602c0cbb5b502ab7c8059dc04df2",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/dora-metrics.md",
           "sha256": "862f722b775e46b566a585aa5d4f3ba5e1400ff52445d22f459bb4ee092e86f5",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/engineering-metrics-pitfalls.md",
           "sha256": "63a602f9ced6ae52e7e9740f09c562be2a4d50a02af8184361bbe4998ebe48e5",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/error-handling.md",
           "sha256": "3151cb60060c3ac46ca01bc2fa3c507910926bcaa2dc68aa4e8c02d82fe525d0",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/estimation-anti-patterns.md",
           "sha256": "f44bd9b7494ba7c6e8ae95ca729ce782c09a219651103c7ccde6c6dc4c3db3db",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/gh-commands.md",
           "sha256": "87573c827a6f09b33275a639e1bca5b777fa98cad1b61df6fdb7f3413e3e87d8",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/okr-linkage.md",
           "sha256": "b203e135b65dbcbf90aba3d214a451d83e2f1cd918dca9b4a9fa4bd0fba1401d",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/outbound-handoffs.md",
           "sha256": "ba631eb5d22f9fc742819e49d013ef6a76ddbcdee3ca3283dce704bc447a0453",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/pdf-export-guide.md",
           "sha256": "690b3e72fe5dd0acc4c9b9c88543312a330053d58de102ef4aadcfba1d01afac",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/pr-stats-analysis.md",
           "sha256": "13f4b748406887d99c39ebbcf5e52bcd86d8f03a2c554b6f283ba08dc2157b9b",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/report-templates.md",
           "sha256": "e39bb5af4f822a0df55e8fcbf07077e49c6863abf7e1c88130de8820c5476721",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/reporting-anti-patterns.md",
           "sha256": "d6541e4648bfa1ae4fc8de2c96f989095e96a47b091a1dc3d0a192f33455c264",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/retrospective-voice.md",
           "sha256": "ebc4ea9af3e73400feb5b66c6959d32a83efbf6f01c78c9bfb243036808a47ba",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/references/work-hours.md",
           "sha256": "788b86edd5c8ace8856aed8b1f3a942c4d046643ca7901e3745cdaeb75e4c729",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.html",
           "sha256": "fb28517f9cc4f7b6ecc3b181e5bc68eb5ae320602568ee49b1d8133f2e6b531f",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.md",
           "sha256": "45de2e7edf69ae4229236ada4000be759b0a00fa4280af168e446a4f71d9c86c",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/samples/pr-summary-2026-01-31.md",
           "sha256": "a83f7fb1b16bbd4c5f0a7364a8027990e10edd2bb03d69ed5824f2cb9f794018",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/samples/release-notes-v0.2.0.md",
           "sha256": "93e6538c7800b81add78c8988e57bd530a929dc06a1690cd4060b58394e75612",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/samples/work-report-simota-2026-01-31.md",
           "sha256": "794fdf8d11736de6d189cb755ae07a702b5f7a7686a202cda31a0b7c6348c6a3",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
           "sha256": "191cd0266edd13be4084ae45114117842d17427fcca276665e6692192de83f9a",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100755"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/scripts/html-to-pdf.sh",
           "sha256": "337a01144d733b319a6e030476f37052a4b95f864ca6ebbe00b7cd6a1c7566e1",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100755"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/scripts/puppeteer-pdf.js",
           "sha256": "115b6f4b4ba717ca539bf566d81492c7253a32ac5d33d7a63a5ebddf505f4571",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/styles/harvest-style.css",
           "sha256": "a34870b062bbd7d9cef43f7a1c43c886ece6529bb3368b56348a8d44ff17b695",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/templates/client-report.html",
           "sha256": "845cd256464a8834859c6198340d824d0b28a91ff58d2813a80d9e5f9aacd67d",
-          "owner": "harvest"
+          "owner": "harvest",
+          "mode": "100644"
         }
       ]
     },
@@ -4858,87 +5268,104 @@
         {
           "path": "skills/engineering-workflow-automation/latch/SKILL.md",
           "sha256": "4899f718e5440ad4e35e5f958cd6915076700d86a9854bf7b7803c1db1003277",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/claude-md-update-proposer.md",
           "sha256": "262866e0dbaddb939d651352be45068222333ac973d08aaef59989bca6c6fa9f",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/debugging-guide.md",
           "sha256": "9a9d03cca7f8f0b8664c2eb1999e70bc2d909e795e0e37bde3d33d98e2a288df",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/event-catalog.md",
           "sha256": "b693289e7df3cbd30723124cb1a176af350e99d90b415de451672ef6f765f7c6",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/hook-recipes.md",
           "sha256": "4d515e8e3a57b16e2871dcdbb29899669ffe529a948728700afbcceee5db7f01",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/hook-system.md",
           "sha256": "8d4a55f1e1f25166f10619d7efdd540405561e70bf04fe07e74cee9170a7c6bf",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/loop-automation-context.md",
           "sha256": "823bd728dae4664d1169d700d34abe628173ae808a3b99f701c86351783adf0d",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/nexus-integration.md",
           "sha256": "1cdb73312af748b73261707db9f22ee74d0117631237bfcb6715a04b31075173",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/notification-hook.md",
           "sha256": "84b11523642403616be3f72eaab094ffd197cce262e78d35e6a7d9ca6d4fa3ea",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/security-guard-hook.md",
           "sha256": "241fc08195b4b3fd579b52b1a141794d142378d8c32fcdc86a25b88aac3727aa",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/sessionstart-hook.md",
           "sha256": "f72551fbcd0f470c1b24b148f7c72f985ed945e08f98e6fa2d2d0fb8ba2df3b2",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/skill-quarantine-hook.md",
           "sha256": "5dacfa797c72f01312df57897774a4fa2cf1d158917ea3e846e4601e16fb7be1",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/reference/skill-usage-telemetry.md",
           "sha256": "ad9d023a34826640a85e0f66ad63bc0c8dee7c1575ecd329bd549c30f2221e15",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/references/debugging-guide.md",
           "sha256": "9a9d03cca7f8f0b8664c2eb1999e70bc2d909e795e0e37bde3d33d98e2a288df",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/references/hook-recipes.md",
           "sha256": "dd88918c21cfb8ed05a0d613bf01b900cf03df29e60bd92ad6cf294cf89b8e47",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/references/hook-system.md",
           "sha256": "8d4a55f1e1f25166f10619d7efdd540405561e70bf04fe07e74cee9170a7c6bf",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         },
         {
           "path": "skills/engineering-workflow-automation/latch/references/nexus-integration.md",
           "sha256": "1cdb73312af748b73261707db9f22ee74d0117631237bfcb6715a04b31075173",
-          "owner": "latch"
+          "owner": "latch",
+          "mode": "100644"
         }
       ]
     },
@@ -5139,142 +5566,170 @@
         {
           "path": "skills/devops-sre/beacon/SKILL.md",
           "sha256": "e1a740d96916fd15117f79c9a105dc0ec5aee6a0a25fec7a43196ba1d3007a76",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/alerting-strategy.md",
           "sha256": "c87244549571e7d153920981f619d71f9097ab508719d98385db8c6a9fd01987",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/autorun-schema.md",
           "sha256": "e8e6893650e1742c7f161981d0f2454dc6d797a780af93bbadde4318b6dd287c",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/capacity-planning.md",
           "sha256": "7665629633808ef8cedb5dda72f3c0d3d28e30ac6dfcd39f1da42644af98d0cd",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/dashboard-design.md",
           "sha256": "d6d411442573166ec024169fac3ad45ca3db164e165bf83f2c9249cad7aedfbe",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/golden-signals.md",
           "sha256": "3c719ae91eeaa09d93f03cecd74cb73286d09a5f5bf283b3040fb8531facd96e",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/incident-learning-postmortem.md",
           "sha256": "246f7d92cc598fb140ea9df73866bf629457d00ee1ad205115ebf01b69409a31",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/llm-observability.md",
           "sha256": "bc07a535a4d8a7a63b95246632b2bdf6ab9c32177d9cf43bea9c54b53f995d48",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/logging-design.md",
           "sha256": "59ef9a7f5915bd745d28238d7fe66e6033960d4e7055b3f1a6aac251a18621d0",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/opentelemetry-best-practices.md",
           "sha256": "088ff70876b2958f7a5c0089ac7eae647175e88414d843a77313f370a355c8bc",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/platform-observability.md",
           "sha256": "4e29ee67ca2cf58d77031a984bb4a9034b40080297740f22cfaccc7be9f1d77c",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/reliability-review.md",
           "sha256": "b9b7f2b971bac48e51cbc96c41396f0e113edd223bec11a672aae2b17313b8aa",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/slo-sli-design.md",
           "sha256": "dc16baee2d779ad864eb10b6d52bee8cdb28afff0d1eb32b7164e5129d8adc3f",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/toil-automation.md",
           "sha256": "5c4f02476fd3e61887d5df4cd83ccad656329c41ea081f813a7386fa1782e37f",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/reference/toil-reduction.md",
           "sha256": "0694872b8e1b487a6b6bdc8fa0895f89ca4487e145d5828736dd981213399ff3",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/alerting-strategy.md",
           "sha256": "b9904d57511fca02b42fba21997e217e3af5b2b471f42971f8def171007c83db",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/capacity-planning.md",
           "sha256": "7665629633808ef8cedb5dda72f3c0d3d28e30ac6dfcd39f1da42644af98d0cd",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/dashboard-design.md",
           "sha256": "6ec27eaf4eaa54f3c903bca3f9983f4eb2d0a4825a91003c9da4e18d4a1f2e3f",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/golden-signals.md",
           "sha256": "3c719ae91eeaa09d93f03cecd74cb73286d09a5f5bf283b3040fb8531facd96e",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/incident-learning-postmortem.md",
           "sha256": "a5fcaf58c8b27fae736d2a4b2fa2cf382e05d011383c054c0c5d209dbed99fdc",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/llm-observability.md",
           "sha256": "45d2f5e07cdd4059f4194f7903761d6261f3e7c2ec378581ef42a9f9a3a1bcc0",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/logging-design.md",
           "sha256": "59ef9a7f5915bd745d28238d7fe66e6033960d4e7055b3f1a6aac251a18621d0",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/opentelemetry-best-practices.md",
           "sha256": "088ff70876b2958f7a5c0089ac7eae647175e88414d843a77313f370a355c8bc",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/platform-observability.md",
           "sha256": "4e29ee67ca2cf58d77031a984bb4a9034b40080297740f22cfaccc7be9f1d77c",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/reliability-review.md",
           "sha256": "b9b7f2b971bac48e51cbc96c41396f0e113edd223bec11a672aae2b17313b8aa",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/slo-sli-design.md",
           "sha256": "dc16baee2d779ad864eb10b6d52bee8cdb28afff0d1eb32b7164e5129d8adc3f",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/toil-automation.md",
           "sha256": "5c4f02476fd3e61887d5df4cd83ccad656329c41ea081f813a7386fa1782e37f",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/beacon/references/toil-reduction.md",
           "sha256": "0694872b8e1b487a6b6bdc8fa0895f89ca4487e145d5828736dd981213399ff3",
-          "owner": "beacon"
+          "owner": "beacon",
+          "mode": "100644"
         }
       ]
     },
@@ -5415,82 +5870,98 @@
         {
           "path": "skills/devops-sre/triage/SKILL.md",
           "sha256": "23bdbe807afe7312d536ec40c672d2c74c4647f8a79906eb912eff75c4120116",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/autorun-schema.md",
           "sha256": "cc2abb908e801bddde1f03ac5c915462adbebd593667de66043ac24e390f1f9c",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/collaboration-flows.md",
           "sha256": "615ea9e356a49a5e49a26e6ede8847c64f31a401fd9474fa14fe49ede11480b5",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/escalation-matrix.md",
           "sha256": "3e37bd6f785c21d46a8d76d5cb9e1ee619147cd4f0148e43c16007f74a59d50d",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/first-response.md",
           "sha256": "e0b7fc760dd0fe636f7b1613b2579b77d3a3d7fdffa161b4c7f80837973f3804",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/incident-communications.md",
           "sha256": "200a80f16d19dbe7697e2b64f085d8b0dd5cd8262b1b4207f60843dac1e1d16c",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/postmortem-templates.md",
           "sha256": "443cc3cce6ef2e4ffab79df78cac08326ead0a9b6248d34b2272c908e1791ddf",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/response-workflow.md",
           "sha256": "940d4a4afba9293b547515e34b6178181972eabc4c40b7251308184f9f748dec",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/reference/runbooks-communication.md",
           "sha256": "9a24c482b027e3a0ce3a88b76f42d3faae24dd4a1e4c823d202d7b43e6194b05",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/collaboration-flows.md",
           "sha256": "615ea9e356a49a5e49a26e6ede8847c64f31a401fd9474fa14fe49ede11480b5",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/escalation-matrix.md",
           "sha256": "3e37bd6f785c21d46a8d76d5cb9e1ee619147cd4f0148e43c16007f74a59d50d",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/first-response.md",
           "sha256": "2891b394a68dc8bccaa4e6cd9c45eba756bbdcbf18e6d11c5557cc6230a412d9",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/incident-communications.md",
           "sha256": "200a80f16d19dbe7697e2b64f085d8b0dd5cd8262b1b4207f60843dac1e1d16c",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/postmortem-templates.md",
           "sha256": "dbc066d54f558cad5c568dc81801b237d0759c0f886e134b7b7aabcfb58bc06c",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/response-workflow.md",
           "sha256": "08fdfe1309797e10f4e6a37bbbe3e4ce15c2362e086e01fb83934131147d0e63",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/triage/references/runbooks-communication.md",
           "sha256": "9a24c482b027e3a0ce3a88b76f42d3faae24dd4a1e4c823d202d7b43e6194b05",
-          "owner": "triage"
+          "owner": "triage",
+          "mode": "100644"
         }
       ]
     },
@@ -5661,112 +6132,134 @@
         {
           "path": "skills/devops-sre/gear/SKILL.md",
           "sha256": "ab6419da527e54f335efea4afd0bb40d639186ab2a8c7d5a0c0f022d9ce74ee5",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/alert-configuration.md",
           "sha256": "06e05d4c3ccc8a7226e3b5dfb4bd5699b23c033ce7c618ef754d8fb7a21dad71",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/autorun-schema.md",
           "sha256": "f243a7e45e2926d1c81afecbd1ea000cb08d8c2fb5ec12f1bc59b51fb4099a17",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/dependency-management.md",
           "sha256": "eeb6916865f40790a431ea579193d6db4a09ca55bc3d91a2c868bb7e7958f538",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/docker-patterns.md",
           "sha256": "0c4f932bb12347207ff56e3b5b3d9a3d1add1b6bd34313532de217b01de9df13",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/github-actions.md",
           "sha256": "16494360513f4f99e6cc8d9e50bf0b465172a6ff1be23e133ec0b9f58f007b95",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/kubernetes-config.md",
           "sha256": "827e30497226676ec07624eee6ef0b16a5d498ef883d5039216ce7dbf9d17ac6",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/monorepo-guide.md",
           "sha256": "e6c2a6c380a0957a78d96766a612da28c577dea76b6d849578b8bca767809385",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/nexus-integration.md",
           "sha256": "327a85507177284aa758d77d85c903d9bb87a000a7a9f153cef35bdd4f42aa7f",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/observability.md",
           "sha256": "a8cc782c5e7d91111e6e721967579bf5ce99ce4306db637f98128c1110fa3355",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/secrets-management.md",
           "sha256": "bbd84fc13b0c189b1eb010c886137e6f31f2efcfdd13886d9322a1b5f74dab86",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/reference/troubleshooting.md",
           "sha256": "43e2b7cd8ca34bae0da27477d7cffcb2cf522979af1fb1cd6e35428ab654d975",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/alert-configuration.md",
           "sha256": "06e05d4c3ccc8a7226e3b5dfb4bd5699b23c033ce7c618ef754d8fb7a21dad71",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/dependency-management.md",
           "sha256": "e56aea3ac38837147d45651585c78197790264f2716e9ca2065b17e2ff28220e",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/docker-patterns.md",
           "sha256": "cb3c6d4a9dfa8fb63527da0a861ba8b440c9b084f7f09c6ae29e6df185a18767",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/github-actions.md",
           "sha256": "be972e0ec2d62e2de30b3a81d19c0ee63606c56c5b7bc1c942a16c78d2310194",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/kubernetes-config.md",
           "sha256": "827e30497226676ec07624eee6ef0b16a5d498ef883d5039216ce7dbf9d17ac6",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/monorepo-guide.md",
           "sha256": "e6c2a6c380a0957a78d96766a612da28c577dea76b6d849578b8bca767809385",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/nexus-integration.md",
           "sha256": "9ff4ddf0609912c9918ae7c328bde1eb25d6cc846487c55460bdb2f87eaa098c",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/observability.md",
           "sha256": "ae3184f41b14b30e5226614545321a409472fc54968404cbabe241b0faab5542",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/secrets-management.md",
           "sha256": "bbd84fc13b0c189b1eb010c886137e6f31f2efcfdd13886d9322a1b5f74dab86",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         },
         {
           "path": "skills/devops-sre/gear/references/troubleshooting.md",
           "sha256": "43e2b7cd8ca34bae0da27477d7cffcb2cf522979af1fb1cd6e35428ab654d975",
-          "owner": "gear"
+          "owner": "gear",
+          "mode": "100644"
         }
       ]
     },
@@ -5952,127 +6445,152 @@
         {
           "path": "skills/finance-investing/ledger/SKILL.md",
           "sha256": "341d43ad5014be4f209e455276edd6563a6004a0457e3ca8c54b2b46062b97d2",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/ai-gpu-cost.md",
           "sha256": "f22a9d1f1c0c43dc711b0b754143fa45174a381d86a76e21eddfc595155860ee",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/autorun-schema.md",
           "sha256": "eb337d8981125fad8c12289dac182136c7199d5b2dd448bc44d86246dc2d398a",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/cloud-pricing-models.md",
           "sha256": "0cacbd01c8f68bfa54fe35dd0a0208654bcea02a76f423bdd63440accada9522",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/cost-anomaly-detection.md",
           "sha256": "e611ec0631076f31e3c0a6577c3cbcac6f541cac0ce7977df5c6177a0e546ffa",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/cost-governance.md",
           "sha256": "a78a8ab46e8c7caf897b6bd8a7d85bddf3a8faaa29246af7df9dc4412a317dc3",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/cost-tagging-strategy.md",
           "sha256": "a49a6d41fa35d3b83b8d11873a02eb50a113c6515185ab44f9743bb72d160d87",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/cost-visibility.md",
           "sha256": "789dff308027ed7edc503af455d74bcc5bee9948028d3e2719b6deb9d52f854b",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/finops-framework.md",
           "sha256": "38131924470088fc9bf3c19ed1455fc5e0258df1414b77f822a01d1b020ddfbd",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/greenops-sustainability.md",
           "sha256": "30fc518f3501d087738c6b4faecf09cbac5f3501b669d8840ec9160fde938ad8",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/handoff-formats.md",
           "sha256": "68f8da7971fd9f745670d709366d0947b5e18b9b4a197e289c66a7260f4a9e47",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/iac-cost-estimation.md",
           "sha256": "9b86a9dac2a2483725bba5e62fbc3a7fa798821ec02be1ff8c80d1537be5e265",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/optimization-strategies.md",
           "sha256": "082e7accf6d20bdbab21dab0a4ca89aa692da459b743a8a280662496cfbbfc45",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/reserved-savings-plans.md",
           "sha256": "0b6e1671b9ab8b591eae083e57d7789690610bcd53017bdd34970a10a2159394",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/reference/unit-economics.md",
           "sha256": "1e70e4f1ea193f81ef9896cd486f37b93b83aa57f1e7475626897038d830f0cd",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/ai-gpu-cost.md",
           "sha256": "f22a9d1f1c0c43dc711b0b754143fa45174a381d86a76e21eddfc595155860ee",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/cloud-pricing-models.md",
           "sha256": "7e4f4b95e793d53c80a9866829bb7d5a4cbaf58ccb690797bb178af1cc2dfe89",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/cost-anomaly-detection.md",
           "sha256": "340e623681f21c7279feeb1eca267e5ae57f124c318acaf96d78e57fe2a5e272",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/cost-governance.md",
           "sha256": "1e200074adde526d5670d56bc6bea403faf4cde342b109462cffee02bc4a45a6",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/cost-tagging-strategy.md",
           "sha256": "8b999eab5669335a64af1fb708a96c70fc6a5e5a3656f6761ef0bd93f8cb8421",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/cost-visibility.md",
           "sha256": "dc69a432ccf4d8d38ff592960367650c172492e79bcd02a4371fdb6f20cfe5d5",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/handoff-formats.md",
           "sha256": "f23e90b459ddca05960c33735ed47633ac223a8104931cf7adf44c47d2f5db4c",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/iac-cost-estimation.md",
           "sha256": "2aefbccf62467a89d49d535c4a1bb0e5acab7688f7cb9bd6c071ad9020694fa7",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/optimization-strategies.md",
           "sha256": "d04ed5a57451456ba4fa2135d9e4d8a2fca5c866fb550ecebbab8ceb4fec19d5",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/ledger/references/reserved-savings-plans.md",
           "sha256": "a6264c964bbdcf4810503ec70258acea8297f3bb7060502981a5b60f0e780c2f",
-          "owner": "ledger"
+          "owner": "ledger",
+          "mode": "100644"
         }
       ]
     },
@@ -6308,177 +6826,212 @@
         {
           "path": "skills/finance-investing/helm/SKILL.md",
           "sha256": "ea82fb0d9a4c705cde015814acd99bc9f63655228175ae594d7ab81128e2e1ba",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/autorun-schema.md",
           "sha256": "c487c3df119fe0ba53eae11b5eec04236f3f5cd7a84c23892d06c118511e31cf",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/blue-ocean-strategy.md",
           "sha256": "e45a38796fc07e4b0ab19e11b525b7130d6f46eb7e8aaa401f4ae4a44a0494b7",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/business-model-canvas.md",
           "sha256": "fa057050d391f3382b339d3183c21e1b65a8587be8bf8306b44addc1e1f88ec0",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/cognitive-biases.md",
           "sha256": "35fe03ea65289a52ad6e44ad7c357a1d02b0b6ca176eabbf8c79e81cb8508748",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/data-inputs.md",
           "sha256": "d5bb5f7ff95bc90cb2c3d31618a5e593bcc3d9b736553e42c1c3ee9e743f0f43",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/disruption-detection.md",
           "sha256": "e4c510d3c59066844150e9f774a2a8981e5c7813be0deee0595c68a7471daeea",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/financial-modeling-pitfalls.md",
           "sha256": "d0bdbca68c49789eff60a1d50ad16eebd3e383ea45f049604999b2ab434c4692",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/frameworks.md",
           "sha256": "01cc3501b40f319a3393ae4a6dd121b520251fa925ad9a9d015034e6a45654cc",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/jobs-to-be-done.md",
           "sha256": "a3b18a8526a195b9653bf813b048d4c261035b7d719a4197adc0325e9b1120f4",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/market-sizing-strategy.md",
           "sha256": "f81aeed3109aaff8bdcecd6cd1463102b1d0a40c21d97013013db38af23f2384",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/output-templates.md",
           "sha256": "4f66b80d2ca5eeee8599e54acfb7336f74dc7e930690b5071bbd52dc841ef59a",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/scenario-planning-pitfalls.md",
           "sha256": "25b35bee24aed6b15b39014d66e85c48832418435c40d0ba3782b57038a95d56",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/simulation-patterns.md",
           "sha256": "01e95031d34fa530c7999e6b20792f9f59a76da5395ab6d44ca944eb8684a76f",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/strategic-anti-patterns.md",
           "sha256": "f57f800db5b6727454ddffcfd7b6db8e269c72890737d59b3a63d182e79b4fb1",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/strategic-calibration.md",
           "sha256": "df0ddf86c6f5cc296f4326219bcf1ee95ffdfe775ae0282a68f5076ba784b322",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/strategy-monitoring.md",
           "sha256": "3e069201680893386fa6b80fbc8580b7884f6b1890f3fa8f04fdef65e955bb89",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/wardley-mapping.md",
           "sha256": "ebf6c4f0aa26b2a3ad371a20ed696016df78dda34eb59a9643209dd64b86f6ff",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/reference/wargaming-simulation.md",
           "sha256": "d139aeb7ce01d780f8ca5dc530fb1ff80b7dddcf8b7f75ba78f86a72cb4d3f4c",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/blue-ocean-strategy.md",
           "sha256": "309367b4990ef111f8d669b9a7bb14afca9e8e62fdd1d99194cbfcb2083fa55b",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/cognitive-biases.md",
           "sha256": "eeeb6655b9bba92e5e5d02c8e631dfd8bc504f8efba10217ac9f7c8bbdc1ad66",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/data-inputs.md",
           "sha256": "14e16ae1f0a25396e6e3a7ca09abefe18ef5073ecbcb81c37b92f1cff32e7eea",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/disruption-detection.md",
           "sha256": "778b0db5d5674a26543ac59d98866c3b27d083ddd3c8789aba15e61a0ccac1d3",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/financial-modeling-pitfalls.md",
           "sha256": "dbe01c68c759a49a5a03ba2552bfeb615bc717a5414f2602b5be441e6b3f4f4d",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/frameworks.md",
           "sha256": "16d624158a974e66f1375e46e675593262a6347534428987d1fef39141c52b5f",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/jobs-to-be-done.md",
           "sha256": "8d10c4c5175a4946a3b305581d714ec325e62596adbd3b02e0c364531c51c1f0",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/market-sizing-strategy.md",
           "sha256": "5c6a3778907eeed8c21ef6c064bf44733d7d8015c44486db35ab5e4d9c4c7bc5",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/output-templates.md",
           "sha256": "f413c589902112c6c1800f27b91099afc97fdc06221c012bc233f6434e27b0d1",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/scenario-planning-pitfalls.md",
           "sha256": "d795922d4b977c41f46b2b43c6355bbf2d41ab42c8afb9f0173735104a1fc8d3",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/simulation-patterns.md",
           "sha256": "01e95031d34fa530c7999e6b20792f9f59a76da5395ab6d44ca944eb8684a76f",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/strategic-anti-patterns.md",
           "sha256": "e75ea3db50ac7c21cb098ad58de1479e427e0eea771090e071349832ace93338",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/strategic-calibration.md",
           "sha256": "bbc959bcbb5c1bddb94111aeeebc7331ae242cc5cbbc7a02e64c92b1514c9cbd",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/strategy-monitoring.md",
           "sha256": "3e069201680893386fa6b80fbc8580b7884f6b1890f3fa8f04fdef65e955bb89",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/wardley-mapping.md",
           "sha256": "e2f841cc38a7a9c6ff723e766c55fd1dcaf30c23ad19642a2da95158789fb614",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/helm/references/wargaming-simulation.md",
           "sha256": "b1c0118efd840bdf0e0a7a89e26a528ba2c516b0700f6c1d800619cfc61672de",
-          "owner": "helm"
+          "owner": "helm",
+          "mode": "100644"
         }
       ]
     },
@@ -6581,57 +7134,68 @@
         {
           "path": "skills/finance-investing/levy/SKILL.md",
           "sha256": "5c819e57a2d68dd72b12aba1a81a2df57e37753350e500553d71a88a993414ab",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/bookkeeping-patterns.md",
           "sha256": "8e18ee2914cdd622c5f10dd75cc417859187436475328d4231254bb5b0aeb892",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/deduction-catalog.md",
           "sha256": "ab7589acc6505eb1ce6758955955c85e961e2a8a7bea38d6088d59023eb60a07",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/disclaimer-templates.md",
           "sha256": "ac286c3438563699c1d3c62ba5a7e0e45c3a1469f95f36c60f421531c7c2b90b",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/e-tax-screen-guide.md",
           "sha256": "b8d55dcba9a65362224d6e9713d642b2308a0f9dbf375f19c37fe32929a4c7a1",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/filing-guide.md",
           "sha256": "1a0a2f661aa13ac91f5c31cba02090c5034a4b7e67d0be9b4f26bd7e075b15f6",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/filing-requirements.md",
           "sha256": "29e8f73f51628194e8ea613a90a15fc04d10c2e1f0a4dd629eca437de8021553",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/income-classification.md",
           "sha256": "f933a68039e47dda738f3adb34427c2ef286b3a060b4e44756c70ff2c5b08d90",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/interaction-triggers.md",
           "sha256": "68f9c605a4f7328358e6556c4ae3003e324cc5dd5aac1313653bb0b16ab25431",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/salary-plus-side-business.md",
           "sha256": "dd4c43ee00ddd858eca5b7182e80ce25ac3608727516f4067b63ed5b00af70fa",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         },
         {
           "path": "skills/finance-investing/levy/references/tax-calculation.md",
           "sha256": "5d4518ea72f6f3a8bb91f196579ac43ff2b46f41133bf4cc47eda722ed638ea5",
-          "owner": "levy"
+          "owner": "levy",
+          "mode": "100644"
         }
       ]
     },
@@ -6812,122 +7376,146 @@
         {
           "path": "skills/growth-operations-xiaohongshu/growth/SKILL.md",
           "sha256": "779e10ed0aa0a71b7d204ce8c413e412900c6ce2fcf890cc1b5f497c037025e1",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/autorun-schema.md",
           "sha256": "01447de2dd800a7014e22525378365a156ba502295f44db10b963c52ee0697f0",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/channel-lifecycle-planning.md",
           "sha256": "14b801aa25f8c2dd91a5d616e7698af9b7ce2d27d0641bcfe87e5dac840f167f",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/code-standards.md",
           "sha256": "4d72e7e8b6d98a1f95a3b8eb17201f5aaf20b17c184f79552877a7f9c47e35be",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/content-architecture.md",
           "sha256": "9c8bb882173d94e6a240712a919d8802970d25cd57316b6447f317bfb9b1d714",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals-deep.md",
           "sha256": "f0e41111b9182d299dda289ab2babb1fdec79ae0808562176279754e0c2767d4",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals.md",
           "sha256": "eb4e4a042791a1178ed0ada231a777c7f71318ea80ac1fca4e77961d6032a5d8",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/cro-patterns.md",
           "sha256": "2076fd3732922594c70e5afd1cf2996a05bd0b76228dc1e2524cf207a846bced",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/geo-optimization.md",
           "sha256": "d0ac3a7c8b198a882d48939fc8525a2d7026097c7ba5575f09ca22f22db73596",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/json-ld-templates.md",
           "sha256": "0eaeddc8d7b42835ef60055ba7ec1afb1ea21e33a3a9ecee4cdf495d7c26eae1",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/keyword-research.md",
           "sha256": "453d443b1a96dbe9b9b0174385c3cf85ebac8e251bf888cd311906a0fe2504be",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/ogp-social-templates.md",
           "sha256": "10908dfce3a53cc62b9fe3ee1cf1ef7e3ab78835127f39683f9cc8cee5285ddc",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/ogp-twitter-card-guide.md",
           "sha256": "18b20d87e8786ae798f00e9c469c6caee0f991a14725106b4e378a76fa56b792",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-audit.md",
           "sha256": "bbb07e14ac84a71a0d5e73411c85515cb66bd5808376156b1be9d94913f01dfa",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-checklist.md",
           "sha256": "f289925a0f4c86be5bac35be78e73d80fef0d789767a7b31b9ce410528d00855",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-detailed-checklist.md",
           "sha256": "d465229cecc42e4c2028c6537ad1d3dbd430e24c8812846d9f719cbd87841027",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/code-standards.md",
           "sha256": "4d72e7e8b6d98a1f95a3b8eb17201f5aaf20b17c184f79552877a7f9c47e35be",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/core-web-vitals.md",
           "sha256": "47ff9e2ae0f4a83d603f35938233cf144d5d3c0d2de673a77c471c86c19f4f1d",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/cro-patterns.md",
           "sha256": "f22e1bc07b166dfb6d0ac48ad4466a4e9149cea166cbedaffd0b976849a6c01b",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/json-ld-templates.md",
           "sha256": "1c288ce091c88403d8a8f85fd0435259e21c7ffe1ea134fdb8fcc881ef428ff1",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/ogp-social-templates.md",
           "sha256": "ccde06215c9da3f170401a5bacc8eb2cd9ad7fbe9bda2b84814835bb1eb36dc9",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/ogp-twitter-card-guide.md",
           "sha256": "c6f11146033094dd63c10ea3d5d1ab9ea10c9b6b9f79e0cb0a3e76706511e39b",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/seo-checklist.md",
           "sha256": "b8c6651307099a8ff38847638c1584f1e990b1d2fce78eaf016456d58674b74f",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/growth/references/seo-detailed-checklist.md",
           "sha256": "d465229cecc42e4c2028c6537ad1d3dbd430e24c8812846d9f719cbd87841027",
-          "owner": "growth"
+          "owner": "growth",
+          "mode": "100644"
         }
       ]
     },
@@ -7168,182 +7756,218 @@
         {
           "path": "skills/growth-operations-xiaohongshu/compete/SKILL.md",
           "sha256": "11bc68f52ad02f5df7a0a66d5a67217c126e8b04aeb159883727d11390ceccff",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/ai-powered-ci-platforms.md",
           "sha256": "664ffde4a600ef95c2b2ccf857ab6cee5e1555c4ca9b87444d703b4ead4fbcdf",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/analysis-templates.md",
           "sha256": "759c0fc4f902ad9b0c547ae753aac1ea97be5bf60e65c27929005e1cf282e140",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/autorun-schema.md",
           "sha256": "cfa754f4febdd25290287f1c08684154b63fe04f720c82caf444f5f8d6a0dcef",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/battle-card.md",
           "sha256": "6ea4eae5037e371ae23c40ce513d96cdac6021b4ae9476e09ea49363400e115e",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/benchmarks-thresholds.md",
           "sha256": "3d6daa93c546b15409a621a472cf13cd228f34d5ea5e0f5beafd78adb5d6d88a",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/brand-equity.md",
           "sha256": "5efd2e4d547a8f2b1fd43aef02638ea23fc5a9d4fff9b94045bb83b5aa94872a",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/ci-anti-patterns-biases.md",
           "sha256": "eaaa6a648df6197e1d8e85eeae44ca728f97cbe94fac92e55a57e2c0ca2b2d99",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/competitive-moats-category-design.md",
           "sha256": "550eda32e9305377863200d1d96ce088f6d3f6a17a24dfd70cb481d89180b6aa",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/competitive-wargaming.md",
           "sha256": "9ea9de3ff4f09f6b5f97335fef61c6e0e5f9ca05e11bcd513a829c2117f48001",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/deep-osint-signals.md",
           "sha256": "0238d36d837ef71c832b67b868a3ab8245bb6f7ed90086ba38db303b7aed7b99",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/ecosystem-mapping.md",
           "sha256": "2d69978150bfd32f7dc04f30da8bf618f8cac96c672778175c71274ea510720b",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-calibration.md",
           "sha256": "373b0fcf6ecbbf454c2dd1df9808d72f93272eb5a8fe0e05ec99bf159d2fcee5",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-gathering.md",
           "sha256": "d6eb3324e73585c9a75dd3d985056597356803d0d687ebef1a22ce4005abe549",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/market-sizing.md",
           "sha256": "65374e083419fad5f714274213f6e0d2a8d7dfe7eb0fb7c14598b367f619d321",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/moat-7-powers.md",
           "sha256": "4e0d9d4c4f060d894298e5fe361fb142ccbf4fbd82a115548683a18587454613",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/modern-win-loss-analysis.md",
           "sha256": "8cf21c8a433886ebf8dc4d63e4f6d455f9c4d82d01b883fa00293fcf51c7ac31",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/multi-engine-mode.md",
           "sha256": "f61a7583962438340b1e1dbc76ea60760ed789602c16d9dcb5db4508e4775d01",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/playbooks.md",
           "sha256": "4eb5a793e14c05008d0c036a3d791d5726ba66cacac22e517d06704faa4b22ed",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/tri-engine-compete.md",
           "sha256": "a85dc2c30845bc3daa4914205a46bdec4b59a96f763e90736c8dccb40daf8954",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/reference/winloss-analysis.md",
           "sha256": "a9e9e29ca3c386d0cd8bd77e09fc79c25ff63fc4878bbfbbc9e40fd6c41d073c",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/ai-powered-ci-platforms.md",
           "sha256": "664ffde4a600ef95c2b2ccf857ab6cee5e1555c4ca9b87444d703b4ead4fbcdf",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/analysis-templates.md",
           "sha256": "1680884183e88cf74b6bcf65efbb9f2f1dae54fa5ab2d1357bd84eb5664289e1",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/battle-card.md",
           "sha256": "93828d9c761bf2b6ae127c54073a315c652852c6f7c2b807a9600441bb42b5e7",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/ci-anti-patterns-biases.md",
           "sha256": "eaaa6a648df6197e1d8e85eeae44ca728f97cbe94fac92e55a57e2c0ca2b2d99",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/competitive-moats-category-design.md",
           "sha256": "550eda32e9305377863200d1d96ce088f6d3f6a17a24dfd70cb481d89180b6aa",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/competitive-wargaming.md",
           "sha256": "9ea9de3ff4f09f6b5f97335fef61c6e0e5f9ca05e11bcd513a829c2117f48001",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/deep-osint-signals.md",
           "sha256": "0238d36d837ef71c832b67b868a3ab8245bb6f7ed90086ba38db303b7aed7b99",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/ecosystem-mapping.md",
           "sha256": "2d69978150bfd32f7dc04f30da8bf618f8cac96c672778175c71274ea510720b",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/intelligence-calibration.md",
           "sha256": "373b0fcf6ecbbf454c2dd1df9808d72f93272eb5a8fe0e05ec99bf159d2fcee5",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/intelligence-gathering.md",
           "sha256": "d6eb3324e73585c9a75dd3d985056597356803d0d687ebef1a22ce4005abe549",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/market-sizing.md",
           "sha256": "65374e083419fad5f714274213f6e0d2a8d7dfe7eb0fb7c14598b367f619d321",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/moat-7-powers.md",
           "sha256": "8ae12b0763ce589df3704814423e7aa1279672142585a366b9dce6a9765573f1",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/modern-win-loss-analysis.md",
           "sha256": "8cf21c8a433886ebf8dc4d63e4f6d455f9c4d82d01b883fa00293fcf51c7ac31",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/playbooks.md",
           "sha256": "dd46804e13b98def7c4ff64dd8deea40f25871479f55fd64f168785062c7dbc0",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/compete/references/winloss-analysis.md",
           "sha256": "1b917a3f0703f31424cb65e3ea77c168a726d5e5bcf9720ccfd215e617130eca",
-          "owner": "compete"
+          "owner": "compete",
+          "mode": "100644"
         }
       ]
     },
@@ -7554,152 +8178,182 @@
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/SKILL.md",
           "sha256": "ba3a7bc644aaf6058534ab9ee2810cdcc63d136933baa3081ea2d2826c673df5",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/activation-design.md",
           "sha256": "15ff654bbc9a70c7e450d0b1d9fd41d9da8828257b8e587dac6858e5d4cc1d22",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/alerts-anomaly-detection.md",
           "sha256": "e94f11832bfd208f029cd1d87abffe21aa2a3b91c2783b05cd99219b5233d24a",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/attribution-modeling.md",
           "sha256": "cd49a0138e67352dcd3371e9c54cb86624b23143a30ada1618216ae99540b6d0",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/autorun-schema.md",
           "sha256": "edd7dd9e755f00efd900bbdfc63c5e845627486a63d50cc5f5aa9ad4178f4cb2",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/code-standards.md",
           "sha256": "abc0ec96c64b368430a2403a8f699fa233171c9ab10b79b74f6f9c6331dfa59f",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/dashboard-spec.md",
           "sha256": "ff2ce161a4a590a863dd26b60376ce5a12827507aebba2bd919053ce6b5edc7c",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/data-quality.md",
           "sha256": "d1169e9aeaafc13cd2f801df74da6d16818b401ec0a59114db064d9904e42c65",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/event-schema.md",
           "sha256": "e1c8d1135f341e33d95dd87f0389738a994109f442fbdc2abb383dd5fe8a5693",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/funnel-cohort-analysis.md",
           "sha256": "6378d082bbc37f2f7a0732a9f2067733c676b8998529653acb5682c547faf0cc",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/metrics-frameworks.md",
           "sha256": "81b4355573bb07c34be315224d08c4f1c5e496b3b68ebc596ab29199c7c173c9",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/north-star-deep-dive.md",
           "sha256": "7d33b6ca8aa475f7481644e1d706c074b36f75a11256be5343520e6a35505541",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/platform-integration.md",
           "sha256": "a4f602f021b7beb2e45a7add92bffe44cae4d75468720e3fd3db4f8576bb7b81",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/privacy-consent.md",
           "sha256": "53a186b84da2fae9393bc271cb849750f88af71c377d31013d82ea9c6830284e",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/product-qualified-leads.md",
           "sha256": "6b666ce0c39168866e60721100326108ffd6f7fc935c623b2c124d8045f10303",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/retention-curve-analysis.md",
           "sha256": "f39ecd0a866f80a8d4402451d2b15754e533d4274734beea50ba63b876a9c509",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/reference/revenue-analytics.md",
           "sha256": "d048c20e9ab65f7d50b9f33cdbf606c1c569025c10b6f039c416efb76594819f",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/activation-design.md",
           "sha256": "02fba46af0b94295babe699a8bdcc686bff6038aa21ffa088a9363368ef42fed",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/alerts-anomaly-detection.md",
           "sha256": "fbd4badd5b7307cba81455264aa7c9f2c046b43f83a50442753377d51cd14c22",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/code-standards.md",
           "sha256": "abc0ec96c64b368430a2403a8f699fa233171c9ab10b79b74f6f9c6331dfa59f",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/dashboard-spec.md",
           "sha256": "ff2ce161a4a590a863dd26b60376ce5a12827507aebba2bd919053ce6b5edc7c",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/data-quality.md",
           "sha256": "2ce93339397f4afba2ac39532c95409904b5194188f0d00781ab13a4c8816eca",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/event-schema.md",
           "sha256": "6b453d0bbe036156977b7c229b4c5103464c6fe55ed1dfa3cc9fa4c0f70d9fe6",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/funnel-cohort-analysis.md",
           "sha256": "e0861386182d0d2fc1631796677e09040f822a7eb6067ad542de0dbb4c6ec4b2",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/metrics-frameworks.md",
           "sha256": "81b4355573bb07c34be315224d08c4f1c5e496b3b68ebc596ab29199c7c173c9",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/north-star-deep-dive.md",
           "sha256": "2198adbc4ee5a1964f6f163fb5e39f75cfcafc52d3f01848ec832728828c5d7c",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/platform-integration.md",
           "sha256": "ff4559655f5a407839743d48755dbbac1a2631b1f311ab781b6f01c627921926",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/privacy-consent.md",
           "sha256": "65c2e83c26fe094286cc9b7f45d53956c16a6454d2ae216396962e488b5d586a",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/retention-curve-analysis.md",
           "sha256": "5d8a4548cbb6bdaf661b5390e84915fe6091c75c2a21f1c95efa82fd3990ca46",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         },
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/references/revenue-analytics.md",
           "sha256": "3f0c34562054589d6bc248ef4bf65e34f8d39d686b54c7a943663953e8a0fa99",
-          "owner": "pulse"
+          "owner": "pulse",
+          "mode": "100644"
         }
       ]
     },
@@ -7920,162 +8574,194 @@
         {
           "path": "skills/office-white-collar/morph/README.md",
           "sha256": "0d79677be87485d42e013ee159066693eac3aa708ec2aafc998ae2fcb136fb2c",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/SKILL.md",
           "sha256": "860dcb6731d95b887979e1d4616e63c8eca19cc7f4ca0415c59d5d98ed76ed7c",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/accessibility-guide.md",
           "sha256": "5f358f9e7cc3f76c7e3989080c936dd6404bc4508d22229b1ce7ebb74361ebf7",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/advanced-features.md",
           "sha256": "5720149200da00f5031d3e0ed79ea814c702c187e7b5d31eb3efc3755c9f0595",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/autorun-schema.md",
           "sha256": "99a731e452ec4304db40fa9891664f45f63a7b75c7ec56ec59c5bb3668593add",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/batch-conversion-pipeline.md",
           "sha256": "4458f4f9efbbb75752f5eefe108265d7753f596890e69e1a0f636e20c67c3f59",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/conversion-calibration.md",
           "sha256": "8a49f5565c0853cd3c0ca88a618fff64100f206899786f132dc10ca3cb488a06",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/conversion-matrix.md",
           "sha256": "2a5933a59185850a25c8ce8886f65f9709d607135f072aac407c25f9cdb5f9d5",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/conversion-pipeline-anti-patterns.md",
           "sha256": "7d227f25fecfc73a09738d24f9568b9bb170d229ce317fc4651fee96aeb63cb3",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/conversion-workflow.md",
           "sha256": "2c22c78e97259bdaaa2bf64738eee4d115b3ff754ef4e1b05af0956f2c1a39a3",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/css-print-anti-patterns.md",
           "sha256": "ab50746fd02fd9cf1a9dfa06ffd3c9fb0923477f001edcac5850808fb19f91f2",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/epub-generation.md",
           "sha256": "4046a15b1572c0e27773459c06bb508048e3378236f14f16444130f60c8221f2",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/format-conversion-anti-patterns.md",
           "sha256": "2626022e962120d2fddd7a0114c583e0c0398bc916193e60db260e5a9fea3d09",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/japanese-typography.md",
           "sha256": "9adfc518285f527bcf1b4b62cb4ce8b748d1158cc38fe43f2171f4cf462ca712",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/latex-typesetting.md",
           "sha256": "b8601e924bfc1ffb5b3f6b4a4af2b924fd5ad26f274470e82ad744e4fd0a60fb",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/pandoc-recipes.md",
           "sha256": "b4c98d7657814d7c7d4e3070aa9408101ea9748d37ecc452e220d5b824b49c0f",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/pdf-accessibility-anti-patterns.md",
           "sha256": "b5760d58b758d9a853270c80d7b01c3033ea75b0dbaebf8927485d45438b8f52",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/quality-assurance.md",
           "sha256": "70b6185f9dd9580079d068c26c91dce154f32351bf33038b2d2a4a7d10d3f388",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/reference/template-library.md",
           "sha256": "fadadb9d8f0e287a018dbc156874da6619b8add658ac7fe79a25a8e0c4a64360",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/accessibility-guide.md",
           "sha256": "5f358f9e7cc3f76c7e3989080c936dd6404bc4508d22229b1ce7ebb74361ebf7",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/advanced-features.md",
           "sha256": "5720149200da00f5031d3e0ed79ea814c702c187e7b5d31eb3efc3755c9f0595",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/conversion-calibration.md",
           "sha256": "26c1997be5b44d5fde8d55b1d9ff4b323409481f751a123488f3bbf47f5e3fab",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/conversion-matrix.md",
           "sha256": "123ee032d3098b5ef0467ec5f334a193f2972bef7d4f9ba5f3099e9d0679de3f",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/conversion-pipeline-anti-patterns.md",
           "sha256": "7d227f25fecfc73a09738d24f9568b9bb170d229ce317fc4651fee96aeb63cb3",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/conversion-workflow.md",
           "sha256": "2c22c78e97259bdaaa2bf64738eee4d115b3ff754ef4e1b05af0956f2c1a39a3",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/css-print-anti-patterns.md",
           "sha256": "ab50746fd02fd9cf1a9dfa06ffd3c9fb0923477f001edcac5850808fb19f91f2",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/format-conversion-anti-patterns.md",
           "sha256": "2626022e962120d2fddd7a0114c583e0c0398bc916193e60db260e5a9fea3d09",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/japanese-typography.md",
           "sha256": "9adfc518285f527bcf1b4b62cb4ce8b748d1158cc38fe43f2171f4cf462ca712",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/pandoc-recipes.md",
           "sha256": "eecdd70431c1ebcc351e3bf6d0157dca5e9878f47ce9529ce40fdbe353cddd40",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/pdf-accessibility-anti-patterns.md",
           "sha256": "b5760d58b758d9a853270c80d7b01c3033ea75b0dbaebf8927485d45438b8f52",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/quality-assurance.md",
           "sha256": "32806129fe895806b2ddb1bada72e2d7124809126d0257439dfe2a590a5f21f8",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/morph/references/template-library.md",
           "sha256": "fadadb9d8f0e287a018dbc156874da6619b8add658ac7fe79a25a8e0c4a64360",
-          "owner": "morph"
+          "owner": "morph",
+          "mode": "100644"
         }
       ]
     },
@@ -8191,57 +8877,68 @@
         {
           "path": "skills/office-white-collar/stage/SKILL.md",
           "sha256": "b447bd9c82f16482f0bb756805eb57592d36f577d94c61b270470cf306f4746a",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/autorun-schema.md",
           "sha256": "71075451ce0248c50268ad349c3a9f7c58348d93ffcf843f7e6db4e8f0526ec5",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/examples.md",
           "sha256": "97fd389513af91de5f8243bb214ab478d0b8033e408814422c02f5ff6c923b44",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/handoffs.md",
           "sha256": "92dba8c08263ca9dc817b9b20d193867e003aa2f4f3c7f002f4fb23f848ce67e",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/narrative-arc-design.md",
           "sha256": "2d103632f1624efacc5a326037e977e805ab9fd89dd720aee73799a43f63dfb9",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/patterns.md",
           "sha256": "72958df67905a1152a2baa7e5cb2c0579eaae160adc756a0db4c589d7f9fc735",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/rehearsal-delivery.md",
           "sha256": "6b16fd2c5fd0805a6f0cd818105dbfccb04cb3a0684d2e81260cafbe4ce91b42",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/reference/slide-visual-design.md",
           "sha256": "9c6b3fb2e20d28c1242fff8c974cfdd67f7e62e9267ab4aec0f005e99b53ee76",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/references/examples.md",
           "sha256": "c3cde26f3db606c11f27ab7720f0bda68ad1d0ff3c7742799334d8c3eb4e1508",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/references/handoffs.md",
           "sha256": "be92271134b47bea3f319749d3e27e975477583f18b3edcff4e27400f7f0b958",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/stage/references/patterns.md",
           "sha256": "cf08ec074dcfd198d2602256e3ca63423c3c47e421be89273776145fdda5ebbd",
-          "owner": "stage"
+          "owner": "stage",
+          "mode": "100644"
         }
       ]
     },
@@ -8334,47 +9031,56 @@
         {
           "path": "skills/office-white-collar/prism/SKILL.md",
           "sha256": "ae3ca9e2b7c62d7975075297fe51e82fc8f4e22d47fb049a5f77a1871e587532",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/content-quality-anti-patterns.md",
           "sha256": "f27418d7091ca26b3f09dbfdf567b6ff68b53affa65dbe9a1ca3fd1c36569353",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/format-audience-anti-patterns.md",
           "sha256": "060fd8af39c103f1d8d8beeda477f4b9b3c7937a3e0c8cde33aba55fc57ca55b",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/prompt-catalog.md",
           "sha256": "123cdcd18122570576d0454ada208b1f0d2f4176fb0c96d10c1c591a8c8565d5",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/prompt-effectiveness.md",
           "sha256": "511cc2aa30e0721fbc5dd0aee3399a7e680f070323b5a7abda5cd76841b7e916",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/quality-evaluation.md",
           "sha256": "ee9c27259664641b733ee1dcb4423695255ed0bff0f7503d1dc7024904324d87",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/source-curation-anti-patterns.md",
           "sha256": "05c16d9a9ab24e9af877d48cbdda6794616d31fa28e21378561e6e0d271ea3d9",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/source-preparation.md",
           "sha256": "e57cc733e4b336287d390b7127e2aad585f76768e7f378c40afa2eb4d63bad56",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         },
         {
           "path": "skills/office-white-collar/prism/references/steering-prompt-anti-patterns.md",
           "sha256": "4e2a014b292b2d127f7312eb335266423a0f9d5e58ab220de9c60c0cd11f2f8d",
-          "owner": "prism"
+          "owner": "prism",
+          "mode": "100644"
         }
       ]
     },
@@ -8495,62 +9201,74 @@
         {
           "path": "skills/knowledge-and-pm-integrations/lore/SKILL.md",
           "sha256": "fb7bd941f0c701b497e0bfa34d9699492650763653d2c233d567d71ebd22e571",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/autorun-schema.md",
           "sha256": "b0ec38ed8cab61e016c0d9bbc48991d529f27ecab809d4e060a5ef14902cdaee",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/decay-detection.md",
           "sha256": "fe533881610e13c4c8e65d71ada1dc06230704da0b1bac4baab2e5b171c7c3f8",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/knowledge-synthesis.md",
           "sha256": "02642a4b9c379373beed61d42ef57efd1a8d6cd1f41caa66133bec33a210451a",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/official-pattern-taxonomy.md",
           "sha256": "6c59e02fe83a8a11b1e7009c75dbf89e9f223c6209c2ee9c1946a6947ecf89e1",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/pattern-taxonomy.md",
           "sha256": "1609f443fd322b1dd408bc061bb23634d1d42b98f3caad355a4b8d9687e94372",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/reference/propagation-protocol.md",
           "sha256": "418940b2135ca78dcb752731ee9e09070f3f6a20cc939eb9bdeaa152ab12d216",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/references/decay-detection.md",
           "sha256": "1e618bfe1fcba3d5b091885d9eae7f6eebe5e1ac40a016c95ddd24f800ce4e6d",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/references/knowledge-synthesis.md",
           "sha256": "de0325a27e06790a0cc75c413445db62b4212ec44396aea0276c4a19878fafb8",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/references/official-pattern-taxonomy.md",
           "sha256": "d64cea77961b26bbc9b4317b06f1a0e83123716c4b3cf5d7f1273af19eaceced",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/references/pattern-taxonomy.md",
           "sha256": "1609f443fd322b1dd408bc061bb23634d1d42b98f3caad355a4b8d9687e94372",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/lore/references/propagation-protocol.md",
           "sha256": "82cca7b4d78394129e65e94ec112e56d8aae4dc7714c94d7b74fe03633f0c96e",
-          "owner": "lore"
+          "owner": "lore",
+          "mode": "100644"
         }
       ]
     },
@@ -8691,82 +9409,98 @@
         {
           "path": "skills/knowledge-and-pm-integrations/tome/SKILL.md",
           "sha256": "b08b6824ec78031e81c480135b50ba7520402353b2ff4dd6b38e013ff756af74",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/autorun-schema.md",
           "sha256": "9bb417a202c1a9239ab24e01f2fdebdd601ecc48af5450b054997018f9cfb7af",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/coding-kata.md",
           "sha256": "a3f55261362daf3afa1e974fbb4d2ce438f60f81dcf7055e6347fcde74713db9",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/examples.md",
           "sha256": "4d1c8d0a86646dff4f889c5c80daff261bc5f04c34a1d7ed06c6dd3f4f740eb3",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/handoffs.md",
           "sha256": "769a063b83074c93b3fd65705dfc70f4895083f9e95d42059d8293742928dcd1",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/output-templates.md",
           "sha256": "7f80ea109c86774963e36d09909d63d756d24ff67e75eb862b2469a9cf32fb0c",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/patterns.md",
           "sha256": "4cddb3f6a9f1c14e17c85c9edec164d933746e7d6095a9eca221c510c2748eeb",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/quickstart-guide.md",
           "sha256": "86031aa86c6bab606f03e7722fe4b1d1e9794c302955fbadc2e15665b291134e",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/reference/worked-example.md",
           "sha256": "6fb1e4dfad15f54e7cdf99cde71a485094a177f67b8f7d9a6b32eeb99d16250b",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/coding-kata.md",
           "sha256": "3b890fa0aeca88e748869343ee6f23c2e161ec45ab35849f6e5f6cd32e31e078",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/examples.md",
           "sha256": "4d1c8d0a86646dff4f889c5c80daff261bc5f04c34a1d7ed06c6dd3f4f740eb3",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/handoffs.md",
           "sha256": "015a6d45a06807b8528cf53b02d315ed5c685db982c9e182e55fb3a603c278ef",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/output-templates.md",
           "sha256": "06364bcb55f94e1368adab6f16829bed10a764b6bee64b8f6c8e82a78076c19c",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/patterns.md",
           "sha256": "ec207149c0189b376254eed2db13303a033478bb43830b543b3ab3f64fc9ad83",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/quickstart-guide.md",
           "sha256": "6dcd9afec54693d7b4dd6d63a4d1383cdf23728df6a9bc3fdb2e4ebf1fd7d3ae",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/tome/references/worked-example.md",
           "sha256": "6fb1e4dfad15f54e7cdf99cde71a485094a177f67b8f7d9a6b32eeb99d16250b",
-          "owner": "tome"
+          "owner": "tome",
+          "mode": "100644"
         }
       ]
     },
@@ -8977,152 +9711,182 @@
         {
           "path": "skills/knowledge-and-pm-integrations/grove/SKILL.md",
           "sha256": "47dc3ecced05082f8bfb20e8459b11f426b0edf5d3c26d5c288ce1a85986d310",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/anti-patterns.md",
           "sha256": "4d46f9c90c808d4233476a4526686f39c77b01898c2d62df22813a93bf028cd9",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/audit-commands.md",
           "sha256": "03380fab0c21af0aeb9b4b847d269dd5d64e491a52a513482c68d02e429cb651",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/autorun-schema.md",
           "sha256": "45a2508eaee83a58aad15220078ed4424222564e1e1eeb0be015066a3d46105f",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/codebase-organization-anti-patterns.md",
           "sha256": "d96adae82df6c3fc2efd35691cc87af80fdb9695d77323b92195b2cea2b3482e",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/cultural-dna.md",
           "sha256": "c7b2cef346d20dfd728a27feebb9f211883a98037174d4619eb034ad44bff65c",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/directory-templates.md",
           "sha256": "90f4e6ac02510f1ba1b5a39db708da929aa3b358fe1136c0bee2129223ca61a5",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/docs-structure.md",
           "sha256": "742a0f9b981009770d0e6230539ba3e4f0d205fd0732ba32f129c411cb93f758",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/documentation-architecture-anti-patterns.md",
           "sha256": "6082c6a09cc1c03a9e377df7c4ce8a0a32e4f54ee2bb9edb6329f7a0f6576f37",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/migration-strategies.md",
           "sha256": "8daf1ee9abf25cf87adb249e5864d1c3983bbca40c1f76d6b48f35d27f6e4dbe",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-health.md",
           "sha256": "d2094b0c54b7bc21ac5d12f6f226dc680edda36790d803b9e9999d2952f08c42",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-strategy-anti-patterns.md",
           "sha256": "854ad2d506d583d609ac656e559fbef4d5b19089fb646eeab951bd279dfcb47d",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-structure.md",
           "sha256": "99ec8fd0cce93788284f90c57103106c603554a6404961feb99b59080617b7c4",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/project-scaffolding-anti-patterns.md",
           "sha256": "666e2ae9f6cc2deef76cf604acc8631d511e5d0b9404a5f2f0bcfe9efd646b40",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/scripts-organization.md",
           "sha256": "3f0c7e6a46c7c41c9c2eec4229d6744afe700b2dcff3ead213e928716c3e87d6",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/reference/tests-layout.md",
           "sha256": "25acdf2e3015007bb956f03110909af1fd4cc8e72c273ab892e71b194014c104",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/anti-patterns.md",
           "sha256": "4d46f9c90c808d4233476a4526686f39c77b01898c2d62df22813a93bf028cd9",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/audit-commands.md",
           "sha256": "03380fab0c21af0aeb9b4b847d269dd5d64e491a52a513482c68d02e429cb651",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/codebase-organization-anti-patterns.md",
           "sha256": "d96adae82df6c3fc2efd35691cc87af80fdb9695d77323b92195b2cea2b3482e",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/cultural-dna.md",
           "sha256": "c7b2cef346d20dfd728a27feebb9f211883a98037174d4619eb034ad44bff65c",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/directory-templates.md",
           "sha256": "90f4e6ac02510f1ba1b5a39db708da929aa3b358fe1136c0bee2129223ca61a5",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/docs-structure.md",
           "sha256": "742a0f9b981009770d0e6230539ba3e4f0d205fd0732ba32f129c411cb93f758",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/documentation-architecture-anti-patterns.md",
           "sha256": "6082c6a09cc1c03a9e377df7c4ce8a0a32e4f54ee2bb9edb6329f7a0f6576f37",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/migration-strategies.md",
           "sha256": "8daf1ee9abf25cf87adb249e5864d1c3983bbca40c1f76d6b48f35d27f6e4dbe",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-health.md",
           "sha256": "d2094b0c54b7bc21ac5d12f6f226dc680edda36790d803b9e9999d2952f08c42",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-strategy-anti-patterns.md",
           "sha256": "e6f6f5586164255df373114dd2a15b1fc464f020f327063e916a011faa08219f",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-structure.md",
           "sha256": "99ec8fd0cce93788284f90c57103106c603554a6404961feb99b59080617b7c4",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/project-scaffolding-anti-patterns.md",
           "sha256": "666e2ae9f6cc2deef76cf604acc8631d511e5d0b9404a5f2f0bcfe9efd646b40",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/scripts-organization.md",
           "sha256": "3f0c7e6a46c7c41c9c2eec4229d6744afe700b2dcff3ead213e928716c3e87d6",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         },
         {
           "path": "skills/knowledge-and-pm-integrations/grove/references/tests-layout.md",
           "sha256": "25acdf2e3015007bb956f03110909af1fd4cc8e72c273ab892e71b194014c104",
-          "owner": "grove"
+          "owner": "grove",
+          "mode": "100644"
         }
       ]
     },
@@ -9268,87 +10032,104 @@
         {
           "path": "skills/operations-general/crest/SKILL.md",
           "sha256": "2f47a7d387886315e8b842918350daec5bf35392bf3538a81f6dfc7a18ac9acb",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/ai-era-strategy.md",
           "sha256": "1b7beb87b603f0cb4ebd251dfd0dc21c3f907497a1c338d15e52542d6b773e4d",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/amplification-playbook.md",
           "sha256": "7504ccf5137fc1ff1e16925ea5127296fc98fa1c5d30efe6fe14769e0ec94028",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/anti-patterns.md",
           "sha256": "ba1bf1841044d6afeccafe83b86fdff8862881355061e4b47e8efb15f71fc90b",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/autorun-schema.md",
           "sha256": "18d4b7ba82071ba7478e3a6caaf48c7aaccb4876b9c400b1356e54a85dfa13e3",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/channel-templates.md",
           "sha256": "631840abf73d272d20b24e092c67dd6c647e92374bc2487ec2c21a7563541aeb",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/metrics-guide.md",
           "sha256": "5e3b5339ea46d6605b4e9465855c3d55afd0ef27bc767a304c15ae4f4c1b5a27",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/multi-platform-bio.md",
           "sha256": "ca9570a1c3509a7106589ba66deb096f0e48d9eb6a2d9c12e154ae6e42ed76a3",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/portfolio-architecture.md",
           "sha256": "7641cfe1c0806712d6f87d81ab57f4a8f510259e85b79290db80e0629f3afef1",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/positioning-frameworks.md",
           "sha256": "2432e5ad601d4e3433a51c406d35ffb50200fa81eae861217ab6d77176d0c9e0",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/reference/topic-dna.md",
           "sha256": "640958ea77b1d5ac97c510b6567ef074e3cb23026a13f947f2c7e75380f8780a",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/ai-era-strategy.md",
           "sha256": "3296a34a34da3f6398ad9cde87177e10db485505abbe90a20485b728f5882a38",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/amplification-playbook.md",
           "sha256": "ffb4e043f3e8e550b28346447cef5e73be144945c834a24ad29a0f00f939dc54",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/anti-patterns.md",
           "sha256": "ba1bf1841044d6afeccafe83b86fdff8862881355061e4b47e8efb15f71fc90b",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/channel-templates.md",
           "sha256": "0ee51bd446eb5840f509c40775138e8f208864acb5fc42f57b927115fd33a79b",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/metrics-guide.md",
           "sha256": "d10c13d8e0f5ac393e4682efcc17ed92652d0705da618d8b7dfe0bb551db263e",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/crest/references/positioning-frameworks.md",
           "sha256": "2432e5ad601d4e3433a51c406d35ffb50200fa81eae861217ab6d77176d0c9e0",
-          "owner": "crest"
+          "owner": "crest",
+          "mode": "100644"
         }
       ]
     },
@@ -9539,132 +10320,158 @@
         {
           "path": "skills/operations-general/hearth/SKILL.md",
           "sha256": "e654afdb9b4e522eac6205306269ff6ced61108bcc64ea79cecd5f0abbfda1fc",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/autorun-schema.md",
           "sha256": "c05bda9ac954a2b4ba6775d8ba3261f36134bffa6b394ace0a26bfc7c1720065",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/dotfile-management.md",
           "sha256": "c15d2e8477b89b5d27d647a548e3bd8c331bd4975ae614e9fc43ac6ac0926f2b",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/dotfile-security-anti-patterns.md",
           "sha256": "8999997cfdba876186e72ac1b9f6570fbecc8f0730cc677fa6f94994801b4b9d",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/editor-configs.md",
           "sha256": "be9d0f2496e0bb18f965cc1267839a061d3220b6112e840259e7e30edefb1fee",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/editor-terminal-anti-patterns.md",
           "sha256": "1431bc45a673cb3f2322df69fd18e58b835342dc437e0d9bd2b47e4dad5e56fc",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/environment-workflow-anti-patterns.md",
           "sha256": "cc139ed47b7a3b3512383b3dad3429ee41b5e372357a42025340f25b02ee55e4",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/git-personal-config.md",
           "sha256": "7f65f0a4f3dd8c323e77c6fca2bd053098879e2dcca572f3ccd1e33d754a28c3",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/shell-config-anti-patterns.md",
           "sha256": "1818a2bef5ef53fb843009a00576fdf2bd98d8b7ac9debdaeedb4e0b13c348f8",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/shell-configs.md",
           "sha256": "4b9eb653dab93a0dc383d0e055c9bca90527ba2c5d3c5678b026e29a6a59b1b4",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/shellfn-functions-env.md",
           "sha256": "93f4cee0aba51c8aa77ff16b51886e63dc76e23198b02db4e8fe9568433dd96a",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/terminal-configs.md",
           "sha256": "88052e6ccb8ac472177e55ecbdbfdfbb2f08123c775b6f45d9c79b3088e1e514",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/tmux-starship.md",
           "sha256": "c515e54f5acf711c62b1778ddae99e198fb47ee4a9b6ff06a0b7d3177fc336c9",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/reference/vscode-editor-config.md",
           "sha256": "6e5d6636175d38e1c6bfe02ec658a12ca668664db7689f29cbbf7b7f96cb961a",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/dotfile-management.md",
           "sha256": "c15d2e8477b89b5d27d647a548e3bd8c331bd4975ae614e9fc43ac6ac0926f2b",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/dotfile-security-anti-patterns.md",
           "sha256": "8999997cfdba876186e72ac1b9f6570fbecc8f0730cc677fa6f94994801b4b9d",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/editor-configs.md",
           "sha256": "be9d0f2496e0bb18f965cc1267839a061d3220b6112e840259e7e30edefb1fee",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/editor-terminal-anti-patterns.md",
           "sha256": "1431bc45a673cb3f2322df69fd18e58b835342dc437e0d9bd2b47e4dad5e56fc",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/environment-workflow-anti-patterns.md",
           "sha256": "cc139ed47b7a3b3512383b3dad3429ee41b5e372357a42025340f25b02ee55e4",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/git-personal-config.md",
           "sha256": "7f65f0a4f3dd8c323e77c6fca2bd053098879e2dcca572f3ccd1e33d754a28c3",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/shell-config-anti-patterns.md",
           "sha256": "1818a2bef5ef53fb843009a00576fdf2bd98d8b7ac9debdaeedb4e0b13c348f8",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/shell-configs.md",
           "sha256": "ddfee3c5f5bd0b4d68c63d7ed10f51c320178754ba608a3681cd17e7e3c598e9",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/shellfn-functions-env.md",
           "sha256": "93f4cee0aba51c8aa77ff16b51886e63dc76e23198b02db4e8fe9568433dd96a",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/terminal-configs.md",
           "sha256": "88052e6ccb8ac472177e55ecbdbfdfbb2f08123c775b6f45d9c79b3088e1e514",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/tmux-starship.md",
           "sha256": "c515e54f5acf711c62b1778ddae99e198fb47ee4a9b6ff06a0b7d3177fc336c9",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         },
         {
           "path": "skills/operations-general/hearth/references/vscode-editor-config.md",
           "sha256": "49d747ee359944115b8ece125730a643898feace93cf37b3326b50bb9ab595d7",
-          "owner": "hearth"
+          "owner": "hearth",
+          "mode": "100644"
         }
       ]
     },
@@ -9717,7 +10524,8 @@
         {
           "path": "skills/operations-general/dawn/SKILL.md",
           "owner": "dawn",
-          "sha256": "abc5e009bc5ce9733e3464601a1bd93f3404b87dc7380391dfa9f41fdd30b183"
+          "sha256": "abc5e009bc5ce9733e3464601a1bd93f3404b87dc7380391dfa9f41fdd30b183",
+          "mode": "100644"
         }
       ]
     },
@@ -9868,92 +10676,110 @@
         {
           "path": "skills/product-design/voice/SKILL.md",
           "sha256": "901dab76e7da3111593d9fca1c6f32102806825a8028fc21819fd4ea52e4f22a",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/autorun-schema.md",
           "sha256": "5f76137183fc0caafdf4f4cf852583ff044a9f27a7c2db93c143840636efc04c",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/csat-ces-measurement.md",
           "sha256": "ca22d8c2903e954da1cf5b198e218744cc52d14f02aa485f94967dc1d4002e95",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/csat-ces-surveys.md",
           "sha256": "55079c91e36fb3b5c5b0a239e187463d69d03aa5fc1bbda6472756dc460aa01d",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/exit-survey.md",
           "sha256": "0077542505641a32eea803b369ea4ac587d2cf9b60001363b349e6c35d3012ca",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/feedback-widget-analysis.md",
           "sha256": "9d5863c6f418ad00798cdcacc612998c1ab8e45b30c644aa6897e2e1784129a9",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/kano-model.md",
           "sha256": "a8425e76ac8dda04797e0fbe184f2ef51de3a308fac4f49cf9b5d2f9b89bf124",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/multi-channel-synthesis.md",
           "sha256": "16c5ced6b4c7d5df4f298a315b8539364817c174466334499b081b6cab5cd5dc",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/nps-survey.md",
           "sha256": "b81736d258178bf7588079f160d39663d2521d78d3a6ffcccc34e803a9ff8e65",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/reference/thematic-coding.md",
           "sha256": "bd21e0fe4876d1b77c8b2863be7a0b2cc8655f8bc7e32025b148c76936a66e84",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/csat-ces-measurement.md",
           "sha256": "a2e04fb842fabc61b48df1cce0070e8ddb2fae4e4b2c10ff5195c770296fd020",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/csat-ces-surveys.md",
           "sha256": "55079c91e36fb3b5c5b0a239e187463d69d03aa5fc1bbda6472756dc460aa01d",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/exit-survey.md",
           "sha256": "04cb85d26e8627df6dad34a5e102c778f1ab1f5a5e299afcd83d3ffe4842f963",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/feedback-widget-analysis.md",
           "sha256": "5df3420cd65eabe1210988e79c898a416d04dcec65660d7a659aeaf4e6b6c5bb",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/kano-model.md",
           "sha256": "4789bdf5b36d0b8c4f727d1bb8a069634569b0c72e190fe5f8cbacf961900784",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/multi-channel-synthesis.md",
           "sha256": "46215c8657a474fb722d89d5106e049bd1b907f3c4219b3e6c6eeabeb633d102",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/nps-survey.md",
           "sha256": "f3cb924ea027b5d12f641fe22d01ca21918f9257a52cf6b4ea2b910c6e325ee1",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/voice/references/thematic-coding.md",
           "sha256": "2ea663bc62ed340a472f0c80af3cb56be3f269416d7b27d6d63b3eb49746b6ce",
-          "owner": "voice"
+          "owner": "voice",
+          "mode": "100644"
         }
       ]
     },
@@ -10094,82 +10920,98 @@
         {
           "path": "skills/product-design/trace/SKILL.md",
           "sha256": "a9c94a690a83d85385623d96eed0a74ea52ab20a4313a4f3c89e968f6a4d3a23",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/autorun-schema.md",
           "sha256": "29a53b3ab41687c3b78d6a36c082d2ecb387492a66fd6cf381c1404f260ac291",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/frustration-signals.md",
           "sha256": "dc21de6d309bf0dfcdafb3f8220e0c3b34ca81dafff60303c0aa94181bf16d66",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/funnel-dropoff.md",
           "sha256": "f78b53103f1a2b0c58ec0bca7d724857dd76e237420f604ef932a364015e0cc5",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/heatmap-synthesis.md",
           "sha256": "76ef391d45b72f36a91977631abf574299825a4f3c07b81a47e7b41a86702c81",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/persona-integration.md",
           "sha256": "47de43bdb1e623902107bc6e23a2196d375ac432bf3df9d0c43daf00ceb559db",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/rageclick-detection.md",
           "sha256": "6e69be43dd1789e52d578f51cc7628801aacc36ee6029e616b4b54c71e9599b5",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/report-templates.md",
           "sha256": "7bd748757fea5f0f072d05d930783fce698329786bab53f9a80f6a2e6af62d7f",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/reference/session-analysis.md",
           "sha256": "571a2af802afb6c2622face98101c90bdcb5c038a6f37dcab000e9f03ff758b3",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/frustration-signals.md",
           "sha256": "569f5a06ccd522b1b8d092efb5e1713b49bb3f6e4429c4404f8f19af71abfa02",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/funnel-dropoff.md",
           "sha256": "28271a5bd6d26340b79f3344a03c6083c6c689bc89ef9d3e79dbbe33feb3f59d",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/heatmap-synthesis.md",
           "sha256": "76ef391d45b72f36a91977631abf574299825a4f3c07b81a47e7b41a86702c81",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/persona-integration.md",
           "sha256": "cd9e73776455e8487c2ae5c7cc08ab961b8f2452e0ae0cfc2afd71f3839100e1",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/rageclick-detection.md",
           "sha256": "6e69be43dd1789e52d578f51cc7628801aacc36ee6029e616b4b54c71e9599b5",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/report-templates.md",
           "sha256": "b94fe278cee70c53c37d261c2be500db6bcdb405b04acf81d05a83b8e1970f93",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/trace/references/session-analysis.md",
           "sha256": "eda5c41884e50fb234cd96e77f97ed8904455fed96c1e5a1a5c10b2c035d09b9",
-          "owner": "trace"
+          "owner": "trace",
+          "mode": "100644"
         }
       ]
     },
@@ -10282,67 +11124,80 @@
         {
           "path": "skills/product-design/researcher/SKILL.md",
           "sha256": "d32fb51129858c00d7748d78d77ed6fd53543f98af28b2666ce404d9b6a57565",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/ai-assisted-research.md",
           "sha256": "ebc3d32d103e3a88ce4ef8c8aafda83776c63e299e61b59fbbcae7b5cc7974e1",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/analysis-and-synthesis.md",
           "sha256": "425278cb0fc9d51493d9196614af4b0523d36525a495e3f467641cf3f8f375ef",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/bias-checklist.md",
           "sha256": "5dc65152173d10f86870cdb2074446b8a013a381e390d8600ec6a1d5facb5ca7",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/cards-ia-validation.md",
           "sha256": "9f246676095d6dc29ba01942bd88edcc8e1b6d422f594b29eee9700e60b01a59",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/continuous-discovery-mixed-methods.md",
           "sha256": "5a7c51509f2f6f6bfa188512d04620b31aefecacc23f1981c89bd2afed538bb8",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/diary-longitudinal-study.md",
           "sha256": "f6dbc90efecab4b9651bfbe9c471eb5ce03e752995d27d630e60a2dd1c03a67e",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/interview-guide.md",
           "sha256": "ec227246f55f8441c6e6fba041170d7ad45dd91611d8e7a78169b5102808387e",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/participant-screening.md",
           "sha256": "748e2be9afc328b3eb295a00f1ef75a0110b2edd5776afa2f169506b49185a55",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/research-anti-patterns-impact.md",
           "sha256": "7de2c12505ee03da04fb54cf64e68cd4c8b7fb4af6ba37fb637dcf570bab877e",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/research-calibration.md",
           "sha256": "d61d090708b3f0be602b772cd1d255fb05dbef51913fd59a494758855e308191",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/research-ops-democratization.md",
           "sha256": "ddae48654e2b94fc3592effdf0a0fd2d70b8d208283d80987e989a7a88ebaf3c",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         },
         {
           "path": "skills/product-design/researcher/references/survey-quantitative-design.md",
           "sha256": "ca2db3e98d3b09b8c55e706aec6b337a68ec6ab9d97caa00d4b68206044d5910",
-          "owner": "researcher"
+          "owner": "researcher",
+          "mode": "100644"
         }
       ]
     },
@@ -10483,82 +11338,98 @@
         {
           "path": "skills/security-and-reliability/breach/SKILL.md",
           "sha256": "01e0081d3f8ff15cf74b884cadfefe581ed2808baca3898600005752565e1975",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/ai-red-teaming.md",
           "sha256": "ef11a8074dac433a739667f4dee61be8d991de4486c476e93520960e58ec15d2",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/attack-playbooks.md",
           "sha256": "43eb4f18315fc92c96379ab09315f67117a2652d4555f27cfa51bd0b663baeb2",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/autorun-schema.md",
           "sha256": "79d22d39ecf82192fad335429995ad936ee8c400577b760d2c55122295c842cd",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/handoffs.md",
           "sha256": "a6babeceb2ce7ed53b6bf14902e64832641b07b1c06a4c3291726775c923be4e",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/phishing-campaign-design.md",
           "sha256": "21ef3a342859193ffe3b642e43661519e907cab489199707af25db95777a829a",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/social-engineering-design.md",
           "sha256": "c4a0ecacf7df6218c52688340a416d0134efd2a036fc2f9d2c9b071f43389e13",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/supply-chain-attack-design.md",
           "sha256": "f4424ba01e7316d57f143f7ab701b99a0b728372128ec97ff652cc51676c1014",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/reference/threat-modeling.md",
           "sha256": "f1d28cab4863216bffdf8bcf9845d0851b15cb4c6f2bcb920b4729d7a0c6c5c2",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/ai-red-teaming.md",
           "sha256": "7cf54ba9215f1601244f3c85de85226cb723788bde2c0b0e464251c4ad3e5932",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/attack-playbooks.md",
           "sha256": "693a185e5a3f23d0d422c539a0730bed80be04628e87e0aa6fe857faa6925a79",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/handoffs.md",
           "sha256": "a6babeceb2ce7ed53b6bf14902e64832641b07b1c06a4c3291726775c923be4e",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/phishing-campaign-design.md",
           "sha256": "d7bd7caa1aa514910720da572ff7f5b002a24443a9a89eb27c29495447c2ec6c",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/social-engineering-design.md",
           "sha256": "31937a11bbaa5852ee1ca6b7402c14210a122bb580d4f91d361566fb8d92a37e",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/supply-chain-attack-design.md",
           "sha256": "56dc91b3e11cef086f552c67449ab6748666c3ed463146b1119dc8a6273022cb",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/breach/references/threat-modeling.md",
           "sha256": "25e1ac61752fd32dc1618cbe130a0c78e539fb80dbbee0e26b1a8b50906908b6",
-          "owner": "breach"
+          "owner": "breach",
+          "mode": "100644"
         }
       ]
     },
@@ -10689,72 +11560,86 @@
         {
           "path": "skills/security-and-reliability/cloak/SKILL.md",
           "sha256": "7c3a0e49e6f2d75569ec96e994625040d3dc98f27a654b2776fd5d8e8ebc7e2b",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/appi-japan.md",
           "sha256": "4b2a4217408db800a7fb858164894d408261e133341fc2dcc2295a2a649416c3",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/autorun-schema.md",
           "sha256": "23bae450067424fb08ceba6dabd4044e328fddfff869c51f128f51d3bbe39bf0",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/ccpa-cpra.md",
           "sha256": "7dc021467da2f3b8c7de42e2ad3874ad78c67d5474872117d5c925ad46560c38",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/implementation-patterns.md",
           "sha256": "f042c8e2f3194092d6d806e315b1261532e57a819c226a9a0fb6c4cbdaccbe50",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/pii-detection.md",
           "sha256": "7ffd07c4e449e42ddee2bdcc71180dbb06cb09470f2376fe531e9deeb67d9b9c",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/privacy-regulations.md",
           "sha256": "c199706d20f704225a6f237f8314ee32ac7a293cd080346a40d00bfa7c8d6f11",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/reference/pseudonymization-techniques.md",
           "sha256": "5035b5d3621594e3d29fce6e3a798d6471c6427c22dd806e04e8b852f706190f",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/appi-japan.md",
           "sha256": "8203a4786bcbaa04383dc0c15eee3fcdc6526c6dbe74e511e5415622e2ae8fd4",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/ccpa-cpra.md",
           "sha256": "6f09a18cba90aed9a1863611a1de325c6cd4d44e52b298b6a354652e59f9fe6d",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/implementation-patterns.md",
           "sha256": "f042c8e2f3194092d6d806e315b1261532e57a819c226a9a0fb6c4cbdaccbe50",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/pii-detection.md",
           "sha256": "7ffd07c4e449e42ddee2bdcc71180dbb06cb09470f2376fe531e9deeb67d9b9c",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/privacy-regulations.md",
           "sha256": "56df63f29f0cf03c6587425876236c38c9a38a1419cbe1d4e96c9d9c2443f0fe",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/cloak/references/pseudonymization-techniques.md",
           "sha256": "e01604bd465d0f3c380cb50fefc98781f08ac3e3d6dae9cab6db6cdfc05c627a",
-          "owner": "cloak"
+          "owner": "cloak",
+          "mode": "100644"
         }
       ]
     },
@@ -10852,52 +11737,62 @@
         {
           "path": "skills/security-and-reliability/comply/SKILL.md",
           "sha256": "3e588304796dac5afc5df08915376e5b91bc80542d42259422b360e2d2e0187c",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/audit-readiness.md",
           "sha256": "75dbbfc38155dcde4d0ae2eb6138974862a4ed2db081c96e27d2931c8bd2ff35",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/audit-trail-design.md",
           "sha256": "bc753bf1d34eb6a299b828317e7b0791451ec3490bd66dce70fe99ca2421bb9e",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/compliance-reporting.md",
           "sha256": "4c27c878ddc9f2d782ec0783790efd30d14d51d939a16d5cc6e72a176c4232b1",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/control-mapping.md",
           "sha256": "dfd01e78a018b6765c9c730b68d060e8ff70e083a690a0fd8c082e054bb4f734",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/gdpr-eu-ai-act.md",
           "sha256": "74090e7f865a786108620dd088c334d4db84d107e0ffb02375afcdb05dc3e6d7",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/handoff-formats.md",
           "sha256": "a95a3c2abd18878597f9589bc345698da2165f09615dd48e5074e73464b39ca0",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/policy-as-code.md",
           "sha256": "e568ec3d8e019f4c58482b40525970c632765e0bab21be30f9b6920f9e6bc7f7",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/regulatory-frameworks.md",
           "sha256": "c9abf9a6b49be4edbedc773f26d0d6894c64dd1d44aaed3563d9901df7d9884a",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         },
         {
           "path": "skills/security-and-reliability/comply/references/vendor-risk-assessment.md",
           "sha256": "5a85d060f62eaa8f95cd8efade27a042669292f544f571780ac0a18f50093659",
-          "owner": "comply"
+          "owner": "comply",
+          "mode": "100644"
         }
       ]
     },
@@ -11043,87 +11938,104 @@
         {
           "path": "skills/multimodal-media/sketch/SKILL.md",
           "sha256": "b59f59e44e4ad6c71413defa13f02d9729a1d8a962e96ff00799718f677c6de1",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/api-integration.md",
           "sha256": "8713811d4c8bc1e9ee435d5f90ca84a20c24e293014d81b3da7d7fd4eeb78e09",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/autorun-schema.md",
           "sha256": "255307a890f963fad3b7d52df39d68a6b0b47a67cd9e5e554654aa3a3ec51021",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/batch-generation.md",
           "sha256": "b1db674e0739fe4e524341d24ccc4bf8203a93b5e7c2afc10cbd77df6089f9fb",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/cinematic-prompting.md",
           "sha256": "80f9cb323151001c69f6ed3ae62e6e84b86809db39b234af86bf095066e8fc0e",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/content-policy-guardrails.md",
           "sha256": "255b61e671d51e84dc4797f40f1364b64316c69e458e3a3973c694404223242d",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/examples.md",
           "sha256": "d15f3593d12810f5a02af39802594c63a97b6eaf7d890bacf45e580588c09187",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/prompt-patterns.md",
           "sha256": "7ff9ceaa1ccaeef20a2ab7745b09d95824ce01d143837d12513b44bf86724ae1",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/provenance-disclosure.md",
           "sha256": "92977e8c8165865996d7f8cc06c1d8dd2e027e061a67a18e847093f1b4547a49",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/style-transfer.md",
           "sha256": "7ff76434a976ef5c1bce865453d11b576ca4a03e9127406cdeee72fee165ed0b",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/reference/upscale-postprocess.md",
           "sha256": "d92271ecef11f6e27c754bf65702fd2f833631af6030a39435e37382c998a3b6",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/api-integration.md",
           "sha256": "8225b0f7aefd21c751d832b8564033f27c01544166abee06548946123ab15e95",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/batch-generation.md",
           "sha256": "7792fe1905e37b7b12b0cf448288b650f6c7054e155396d21e172ea38c498ab2",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/examples.md",
           "sha256": "d15f3593d12810f5a02af39802594c63a97b6eaf7d890bacf45e580588c09187",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/prompt-patterns.md",
           "sha256": "7ff9ceaa1ccaeef20a2ab7745b09d95824ce01d143837d12513b44bf86724ae1",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/style-transfer.md",
           "sha256": "7ff76434a976ef5c1bce865453d11b576ca4a03e9127406cdeee72fee165ed0b",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/sketch/references/upscale-postprocess.md",
           "sha256": "bfc8f3ce48aa1a2a549e74cc9f086793af04d70ab1e4430284d184239d4e652c",
-          "owner": "sketch"
+          "owner": "sketch",
+          "mode": "100644"
         }
       ]
     },
@@ -11206,37 +12118,44 @@
         {
           "path": "skills/multimodal-media/clay/SKILL.md",
           "sha256": "1bf8f74ab113d8bb812adbb14dd4d91ec2e10664d700a0be576097cc68adc0d3",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/anti-patterns.md",
           "sha256": "f2f9e3abc3513d56660e7d9dc828b8cf01979c024dd8ac9551b96d338278ddb6",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/api-integration.md",
           "sha256": "5f20f97a4685c2ab39bd65955181c82488b0d52118444084e52bb5c8408236c7",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/code-patterns.md",
           "sha256": "d186d879d7299259f90f3aac8de3ecde546099a48ef37b4e0fa4cf074caa786a",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/game-pipeline.md",
           "sha256": "361efa5e7c21af22798b49000bbdb934224a4a3c3b3b76d3ccf4db9778215d67",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/prompt-engineering.md",
           "sha256": "d1d366e7801d952bce99242b76c66deaf18b9bb96b79651d9a94c9b64b6daec6",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/clay/references/quality-validation.md",
           "sha256": "eea16c21254ed88df9b4c57d293b50388307f20eb736b5415ac017470fbf05cd",
-          "owner": "clay"
+          "owner": "clay",
+          "mode": "100644"
         }
       ]
     },
@@ -11324,42 +12243,50 @@
         {
           "path": "skills/multimodal-media/tone/SKILL.md",
           "sha256": "7606feb663d1be1e32e0718d609940f7648c328eef0a1afb90e57024f110941d",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/anti-patterns.md",
           "sha256": "f6f1336aa69afcb9ee562e8de2369d6e8ecd70450aa655de5a0322c2c51fe0f8",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/api-integration.md",
           "sha256": "76d8e1476ba3a620cb85b5c9a079d79c6138dd20a3647622d134f0b3c44e3f84",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/format-optimization.md",
           "sha256": "f7f8548ff1e0e8e295581df7c00f73123d5b9404092e9df64be47ff52006b4db",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/game-audio-practices.md",
           "sha256": "4e9169a9e190000a70a4f37953d35912056d4a88b677ae97f4d0bdc9191b8808",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/middleware-integration.md",
           "sha256": "181cbc40ee7114d6179c51393bbbc9df76ed84992a959a7775f3559c6f9a8347",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/model-setup.md",
           "sha256": "8afcf6bbb3b1d75e089e3ccd06e5fdb54c439395955a8eede81a64264f8f002c",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         },
         {
           "path": "skills/multimodal-media/tone/references/suno-prompt-guide.md",
           "sha256": "ddf0f87f49d3d2aca04a43931fa80450d60e8ab81afca617345e696a841c32a2",
-          "owner": "tone"
+          "owner": "tone",
+          "mode": "100644"
         }
       ]
     },
@@ -11590,172 +12517,206 @@
         {
           "path": "skills/deployment-platforms/scaffold/SKILL.md",
           "sha256": "23d47d528279c7530347c07d87774c4ef6b83d419d06e7751b149eb641a52852",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/autorun-schema.md",
           "sha256": "d7619b88d5754e282e1f44f7ac56804e45477c770ce49b7debd840353204e6cd",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/aws-specialist.md",
           "sha256": "c35effae9eb71d4e3b13eb19c751185d464ea887cf2b671fdea6686101b4a7ec",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/cdk-scaffolding.md",
           "sha256": "bc6a3b79ca4816f6659ec7e42a0eb9c72a12ac27731f5617beefd1002b1718f6",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/cloud-infrastructure-anti-patterns.md",
           "sha256": "ff21c098ea9835fc13b1ef03ab71d1de99a13019c8695675c42bfdaa3421d12a",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/cost-estimation.md",
           "sha256": "1f74500c466bc39533645f6a98065e324f7d496699cc48fb3abaa85ccee051c2",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/cost-finops-anti-patterns.md",
           "sha256": "6d92c6b12dfa9739840ac52a79b6f119e400a8049bc294187302c8e54082daf0",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/docker-compose-templates.md",
           "sha256": "eb9deb20685c70a201dd5cc46af941fa522ac7e4fdff5c900e8d8e5d67275aea",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/docker-environment-anti-patterns.md",
           "sha256": "ef5dc2668359ac017495f726f2bc1c9ce070004330923ac97fe924ae437f650e",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/gcp-specialist.md",
           "sha256": "2bd6daa557c20175c3da5d4316cc8a4dfc0fc80b7b3ff49da7afbee45dde4bdd",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/helm-chart-authoring.md",
           "sha256": "d1e1dcbed4d4f1f2a25ec2b3ef0a4a142bb902c2d7f492a0413963ceb9163146",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/k8s-manifest-scaffolding.md",
           "sha256": "dd4627decb99df15c772d6c9c50df4e78a78b1059e379cee6d8bda388abf5772",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/multicloud-patterns.md",
           "sha256": "f4d5d248e57dc14493eb5177e1f525761128ce24d882b19f4c40a82217d16e8b",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/security-and-cost.md",
           "sha256": "7e5dc97a78bc83eae5d00454a799f5ffdfc6d1ab6c0a3dd6601fd6af3eaee4e4",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/terraform-compliance.md",
           "sha256": "89bbaf1692beed73a746444b509569d78ef9cf53589e43cdb40cedb6e35faf56",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/terraform-iac-anti-patterns.md",
           "sha256": "93233524b6052412121871794c1e0d30f80aad6265ef2bd229a08664dfb15f6f",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/terraform-modules.md",
           "sha256": "0e5bde71cab18c95d6d66931226172c2d6db2c3f40ab0b42f084ffff60fdd765",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/reference/terraform-operations.md",
           "sha256": "290332e085b2539ca1190297b35d0ddf09ede5400d2cca951efae4007a3487e3",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/aws-specialist.md",
           "sha256": "c35effae9eb71d4e3b13eb19c751185d464ea887cf2b671fdea6686101b4a7ec",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/cdk-scaffolding.md",
           "sha256": "bc6a3b79ca4816f6659ec7e42a0eb9c72a12ac27731f5617beefd1002b1718f6",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/cloud-infrastructure-anti-patterns.md",
           "sha256": "ff21c098ea9835fc13b1ef03ab71d1de99a13019c8695675c42bfdaa3421d12a",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/cost-estimation.md",
           "sha256": "1f74500c466bc39533645f6a98065e324f7d496699cc48fb3abaa85ccee051c2",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/cost-finops-anti-patterns.md",
           "sha256": "6d92c6b12dfa9739840ac52a79b6f119e400a8049bc294187302c8e54082daf0",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/docker-compose-templates.md",
           "sha256": "eb9deb20685c70a201dd5cc46af941fa522ac7e4fdff5c900e8d8e5d67275aea",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/docker-environment-anti-patterns.md",
           "sha256": "ef5dc2668359ac017495f726f2bc1c9ce070004330923ac97fe924ae437f650e",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/gcp-specialist.md",
           "sha256": "2bd6daa557c20175c3da5d4316cc8a4dfc0fc80b7b3ff49da7afbee45dde4bdd",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/helm-chart-authoring.md",
           "sha256": "d1e1dcbed4d4f1f2a25ec2b3ef0a4a142bb902c2d7f492a0413963ceb9163146",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/k8s-manifest-scaffolding.md",
           "sha256": "ee6b0ad863803aaba45f49ee68c0fff87cd49ab3dc2125d1efbf5d24ddc9e1e0",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/multicloud-patterns.md",
           "sha256": "f4d5d248e57dc14493eb5177e1f525761128ce24d882b19f4c40a82217d16e8b",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/security-and-cost.md",
           "sha256": "7e5dc97a78bc83eae5d00454a799f5ffdfc6d1ab6c0a3dd6601fd6af3eaee4e4",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/terraform-compliance.md",
           "sha256": "89bbaf1692beed73a746444b509569d78ef9cf53589e43cdb40cedb6e35faf56",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/terraform-iac-anti-patterns.md",
           "sha256": "3d794f576bcc5d9caabd463226e72971c9bb1475453cc1aa61c6ce4858793452",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/terraform-modules.md",
           "sha256": "f84055b3c20a9774c47d5704c899e1bbd4bd35bb2229e06bb0a6ee7611304fa9",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/scaffold/references/terraform-operations.md",
           "sha256": "290332e085b2539ca1190297b35d0ddf09ede5400d2cca951efae4007a3487e3",
-          "owner": "scaffold"
+          "owner": "scaffold",
+          "mode": "100644"
         }
       ]
     },
@@ -11956,142 +12917,170 @@
         {
           "path": "skills/deployment-platforms/pipe/SKILL.md",
           "sha256": "559b95dd83f242f04ef351418563630d7c3f5df7f718cc9b8971e96707fe014b",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/advanced-patterns.md",
           "sha256": "e27fe4077509496b895fb9d0176cec4bce825167c4cc413dd520eb642b15724f",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/automation-recipes.md",
           "sha256": "a7dddfc21a89c8323bd4ad0df4864d59162bb8648df959a11f386ea13bf03a15",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/autorun-schema.md",
           "sha256": "3d9848f4d1176e74c66f79f9d80800dc0317248492a804ff2c1bce1ad0b3cbd8",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/cache-strategy.md",
           "sha256": "a189440a7cb40c48b4c3d39d55609f601df408bebb15701a0b18de58f18727fb",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/gha-secrets.md",
           "sha256": "a1e223abe3e94eb57f4c8adf53d3845bb0d86c4eee4386adfd20f64ff359f9c6",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/matrix-strategy.md",
           "sha256": "545e3159c963fdfa2b35ac212054a0e364a3067c3df356452846c68c5dea3acc",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/performance-and-caching.md",
           "sha256": "9cb6a9165d1fc4c94ba8c7195e052800963a46089af45cecc33183177f5160a1",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/performance-cost-anti-patterns.md",
           "sha256": "09b4601ad70346f4f7a332c2af926374921e82d645c847ce31efc32d048ab265",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/reusable-and-composite.md",
           "sha256": "b66d5770fb59c7aff8c1084772d222d0d3025ec302ba5b5270fd6c20efb0dcc3",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/reusable-maintenance-anti-patterns.md",
           "sha256": "36d67af7cf566cee2daf382a3b64e08bf5835ad802c97972efdfe246fea1e6cf",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/security-anti-patterns.md",
           "sha256": "0d574ca53d997ab2add7b35d2053d2b54f330ed26ed2ace98142cd305e65e4b0",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/security-hardening.md",
           "sha256": "10bd284d4e5a4779a3e513a7d96caff594fb8a91a538b311fdc14ff2a4ccf2b9",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/triggers-and-events.md",
           "sha256": "ae4e974b1f9633fc18ac2626f704142270537b41e21f633202ddef7db2d904bf",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/reference/workflow-design-anti-patterns.md",
           "sha256": "8f6993aea1b9842f9674b8eed7bb3eac867f22727998a5ab9566bac91391960c",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/advanced-patterns.md",
           "sha256": "e27fe4077509496b895fb9d0176cec4bce825167c4cc413dd520eb642b15724f",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/automation-recipes.md",
           "sha256": "a7dddfc21a89c8323bd4ad0df4864d59162bb8648df959a11f386ea13bf03a15",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/cache-strategy.md",
           "sha256": "a189440a7cb40c48b4c3d39d55609f601df408bebb15701a0b18de58f18727fb",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/gha-secrets.md",
           "sha256": "a1e223abe3e94eb57f4c8adf53d3845bb0d86c4eee4386adfd20f64ff359f9c6",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/matrix-strategy.md",
           "sha256": "545e3159c963fdfa2b35ac212054a0e364a3067c3df356452846c68c5dea3acc",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/performance-and-caching.md",
           "sha256": "79c39c810cd639f51627c1af7b0bf024c84d2c5a4881945177e7c700c0110463",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/performance-cost-anti-patterns.md",
           "sha256": "09b4601ad70346f4f7a332c2af926374921e82d645c847ce31efc32d048ab265",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/reusable-and-composite.md",
           "sha256": "b66d5770fb59c7aff8c1084772d222d0d3025ec302ba5b5270fd6c20efb0dcc3",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/reusable-maintenance-anti-patterns.md",
           "sha256": "36d67af7cf566cee2daf382a3b64e08bf5835ad802c97972efdfe246fea1e6cf",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/security-anti-patterns.md",
           "sha256": "0d574ca53d997ab2add7b35d2053d2b54f330ed26ed2ace98142cd305e65e4b0",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/security-hardening.md",
           "sha256": "1c0f5927a45f9d215fc06b539a3d6b1546c7c7cc5dd0fabc77bcbe986ac6fb70",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/triggers-and-events.md",
           "sha256": "153e486a1c9a74d95be63fb0fd41516bb1f8b36cadbc614f8cb10d42c386c5cc",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/pipe/references/workflow-design-anti-patterns.md",
           "sha256": "8f6993aea1b9842f9674b8eed7bb3eac867f22727998a5ab9566bac91391960c",
-          "owner": "pipe"
+          "owner": "pipe",
+          "mode": "100644"
         }
       ]
     },
@@ -12222,72 +13211,86 @@
         {
           "path": "skills/deployment-platforms/shard/SKILL.md",
           "sha256": "6b913b113ca8562aeafad557959931a92fe32d7871c43c90ec7e64780c0dc626",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/autorun-schema.md",
           "sha256": "1fa33b77a6a98b3394f932318b1a96164e786a68129c0b3a716ed4c1fbb924e0",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/examples.md",
           "sha256": "ebc16d08af440a75b5dd1099abdc9899ad4ee78abf5148bbb76239f9f85b3f13",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/handoffs.md",
           "sha256": "6aacae154e386f9b0fb9d3b5fecc9415b542affa0942bc8806fe19579c9708c8",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/patterns.md",
           "sha256": "f66520e8096ebfd7e9ba1deaf9b1822fae4e9c5f57a40accb9b7999de5a1e236",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/tenant-migration.md",
           "sha256": "bd6e85c7b83934fd799d7da210d6d97ad4a9dede07e4965ac7bc41ffa6c0fd71",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/tenant-provisioning.md",
           "sha256": "1d156ae88789b6de7c575a3b2c4bdc57887082026770d7fcc9ebde07573b6a49",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/reference/tenant-quota-throttling.md",
           "sha256": "d46892547d31f2e38ccb550027545dccb5e38b3d22d5e49ae41c8734c11ddfbb",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/examples.md",
           "sha256": "ebc16d08af440a75b5dd1099abdc9899ad4ee78abf5148bbb76239f9f85b3f13",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/handoffs.md",
           "sha256": "6aacae154e386f9b0fb9d3b5fecc9415b542affa0942bc8806fe19579c9708c8",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/patterns.md",
           "sha256": "d18970fa50576b7f4c74234ab8640ba16aa145497916f750f66de0dcc0082703",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/tenant-migration.md",
           "sha256": "bd6e85c7b83934fd799d7da210d6d97ad4a9dede07e4965ac7bc41ffa6c0fd71",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/tenant-provisioning.md",
           "sha256": "358bb41b89bbce97d3934a310aca8f55ac67d37220fa338e20e6048e43a4f5e3",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         },
         {
           "path": "skills/deployment-platforms/shard/references/tenant-quota-throttling.md",
           "sha256": "d46892547d31f2e38ccb550027545dccb5e38b3d22d5e49ae41c8734c11ddfbb",
-          "owner": "shard"
+          "owner": "shard",
+          "mode": "100644"
         }
       ]
     },
@@ -12463,117 +13466,140 @@
         {
           "path": "skills/openclaw-memory-and-safety/cast/SKILL.md",
           "sha256": "614ffa2160bab1085b7fa7bdb449843a15b74144a9b3fc223808a158ad742f86",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/archetype-mapping.md",
           "sha256": "f5502b48af8701f056d46b9dc216119d65aa979f2fcd37f31efd23d159b60c6b",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/autorun-schema.md",
           "sha256": "b62c6c9c3940f92ec23f4e65728bda4f917396c2e0181f877e3a27a786072e85",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/collaboration-formats.md",
           "sha256": "5a4ef3d3e750bfeccdbb90428f3c004bdcf484886f2b4f23faaf09b985653e92",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/distribution-adapters.md",
           "sha256": "bbe33387fc19bed54b7abbc751df98c82e983966e7447c1f55d0703e7c2a92b1",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/evolution-engine.md",
           "sha256": "a8e929b1a06671462f2cce1b860465c4aac11604cc0215f5a31e6812ff2c9fc3",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/generation-workflows.md",
           "sha256": "d3110f88d180630d8b3de5a073045d25320548c0136babc847328fae45d1c066",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/persona-bias-audit.md",
           "sha256": "cce0daee811a891f7ac1601bba8062b9c49950b137b987e03437ee23a026f2ce",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/persona-governance.md",
           "sha256": "ecbf1b9afcffacf3d47ebad087653c8952f65975e8c33940b33a17808bf6bb0d",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/persona-model.md",
           "sha256": "6979b9829f9e894f4df76bf980d97d36233a200cabdc44a8d4e2ec7e49378243",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/persona-validation.md",
           "sha256": "248de474423baffe97a5490af109e981f4d665f1c513dac990853503b2fc1215",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/registry-spec.md",
           "sha256": "aef70d93cb00b82183e30a79e6a51b0a8c26d665d0f2f000bac10e7cc304b609",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/segmentation-methods.md",
           "sha256": "38c3877733a4a8da2a52c4a4a5c48792f2bee96498129d753519f4a29b83b245",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/reference/speak-engine.md",
           "sha256": "a44a43f4895cfbb32df31d0561ab92006350a2c04a3232713d39c6c659146a21",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/collaboration-formats.md",
           "sha256": "c0bbcbef6a6147a286a216a5727f6d903b0bc14623a4b86ef63df44841d59c4b",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/distribution-adapters.md",
           "sha256": "c24abf4d75e38ff64e15c53c3443ac0958fb3b120a7cfc287838ff3a4d8aeeb6",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/evolution-engine.md",
           "sha256": "12780a6fb073669e6f8a8b4d02b072c71b8d13961c6b929a3cbfd36093322a5c",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/generation-workflows.md",
           "sha256": "a2d0fbdd2361494ce467ec3a4a2b3cbba0a75cf35e036639315c80fd4eba5b92",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/persona-governance.md",
           "sha256": "9e3241dc08ef1f5b19b38ba46973a00d00522067ad77dc9bdeedf08eb52d87d2",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/persona-model.md",
           "sha256": "6979b9829f9e894f4df76bf980d97d36233a200cabdc44a8d4e2ec7e49378243",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/persona-validation.md",
           "sha256": "6a018d4dc90a6a18a36d3fbbe7b602cc749b58c2fe82bc880c6d3fca6ca01b43",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/registry-spec.md",
           "sha256": "aef70d93cb00b82183e30a79e6a51b0a8c26d665d0f2f000bac10e7cc304b609",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/cast/references/speak-engine.md",
           "sha256": "f937c2ba6492d6d594d142c95b3da031e1b0572904b8e0d33d8341dfcd0d1467",
-          "owner": "cast"
+          "owner": "cast",
+          "mode": "100644"
         }
       ]
     },
@@ -12714,82 +13740,98 @@
         {
           "path": "skills/openclaw-memory-and-safety/omen/SKILL.md",
           "sha256": "06b17ff5138e3ff89a07fa56b630e76cf4d72520ec371123b4744eb6b3ddbd8e",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/autorun-schema.md",
           "sha256": "3268c0e83d7969969edfc299271acf1a6207b1777a34728490297e0cdf2685cd",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/bowtie-diagram.md",
           "sha256": "e762ef59ebc8cfb7d72db4580284648b035e890b32bfd510b61579140ebb8f90",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/failure-frameworks.md",
           "sha256": "7fcc90c62fd1769465abd28ff0b73d9452c3b68571b8f8835f102db4c2e6b4dd",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/fault-tree-analysis.md",
           "sha256": "b8da68f5981aef68a621da90acfafb8a6d1de5d5b23ffb2017f337a9f9b8b306",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/fix-prompt-generation.md",
           "sha256": "e9a781e028f50a0899db0187d3d20b8ceb19277817e90b1d34b0ac1e87c227a9",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/hazop-methodology.md",
           "sha256": "08cd42ecb60b219c237546471dadc6e26d54020200169ba33d20dd3fa756cba2",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/output-templates.md",
           "sha256": "ba4eea3ad1914cedae8e297247bebfe34d25232681418bb12956bd7c1328d527",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/scoring-methodology.md",
           "sha256": "b9013546e15a43acfda2abfd25e5955f1e77aada657816f93ad03747f91536ce",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/reference/tri-engine-failure.md",
           "sha256": "5a7fd5d0cafb5194b0b1aa8a12bd84aa75e002356ee3c6141ca153f3007daebc",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/bowtie-diagram.md",
           "sha256": "e762ef59ebc8cfb7d72db4580284648b035e890b32bfd510b61579140ebb8f90",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/failure-frameworks.md",
           "sha256": "7fcc90c62fd1769465abd28ff0b73d9452c3b68571b8f8835f102db4c2e6b4dd",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/fault-tree-analysis.md",
           "sha256": "ffeff141caa1fcd0aa4ba1e990269fc0bbf822753f2d18502a379eaf9bdf67c5",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/hazop-methodology.md",
           "sha256": "c5e22d174ed1adbdf6301b7942a3c90543677dda646b090a726228ea7a366929",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/output-templates.md",
           "sha256": "a38fdd8399fbf60e0ad12a83b15983b9bcaddc8d43f130f02ceeeed48f3cb1e6",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/omen/references/scoring-methodology.md",
           "sha256": "b9013546e15a43acfda2abfd25e5955f1e77aada657816f93ad03747f91536ce",
-          "owner": "omen"
+          "owner": "omen",
+          "mode": "100644"
         }
       ]
     },
@@ -12882,47 +13924,56 @@
         {
           "path": "skills/openclaw-memory-and-safety/warden/SKILL.md",
           "sha256": "3f09ad867923ccac18df034a7290cf1fb08f198dde7caed3086f8a848abf522d",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/agency-user-control.md",
           "sha256": "2cf59c27d116daf5cc3d6536c677fb8eac3fe01d180468bd426cfb7d2ab48036",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/design-litmus-check.md",
           "sha256": "fdfc020be40f9d6bd7f9cb33d7fea6bdbaf01e7c12d23726935c29b123024de6",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/examples.md",
           "sha256": "6def01030a42648825c27d301afd070d53aea63e886124eb0113e23efdd8bfa7",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/experience-emotional-quality.md",
           "sha256": "a26748dbd4fe55940287d8302913ff10df9641743bce66a10e7eac420627e01e",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/identity-brand-voice.md",
           "sha256": "ffe0a09e3487f5aa48922a83807fd18f71bff4e703aebcd8582c82e02a1adc5f",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/patterns.md",
           "sha256": "332b973790db8e95c4882109feeaf24208ae181358c0bf56be5e3f7f1582ee4b",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/ux-agent-matrix.md",
           "sha256": "5ddd0b9d17888f2e8a889881970e89c3addf05fd55141afc58c5f94e11da6dbe",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         },
         {
           "path": "skills/openclaw-memory-and-safety/warden/references/vaire-framework.md",
           "sha256": "98316b24ed441a16f2415bf2cd693d6e232589d492310b2b6d7790daaef8c5fb",
-          "owner": "warden"
+          "owner": "warden",
+          "mode": "100644"
         }
       ]
     },
@@ -13083,102 +14134,122 @@
         {
           "path": "skills/task-understanding-decomposition/lens/SKILL.md",
           "sha256": "8bf3f52555332d54743f8d111484027a2892b7b75fd9b125ba54183f7856f141",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/autorun-schema.md",
           "sha256": "7dbbb3c389c8fd6c56238be7d8753ef1b92cf3508a49d8034d03972d1375a5b6",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/change-hotspot.md",
           "sha256": "77085a0cfe0a59e41a5c2e299c3b76d9ab1f46f3af18b4d3adb932552fee848c",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/code-evolution.md",
           "sha256": "8fc2b526586c7ea00c9a4cc1e1bd05427f47f31b1f932d584c3535bdf63c2e63",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/complexity-assessment.md",
           "sha256": "17e19dfbe2a74348966e6518fa8b6d3ed2141501c1172f4999b6fff6bc83c007",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/comprehension-research.md",
           "sha256": "94849ff62bc2565c425e138f33f655e095f7d870ff4643bd1f4982fdbb63a364",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/dependency-graph.md",
           "sha256": "cda609319bccf7edf53b1950067de6e3c881816130a8df8bb334edf03c84296d",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/investigation-budget.md",
           "sha256": "3fa91bed32c95183fc6fbb669979e798e84e14388d23d5a7676a4716ca47e795",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/investigation-patterns.md",
           "sha256": "7ee68d290d0f1efbcb19e744d7b29bb0a9361c88d290253711be3c4f4cc96e3f",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/lens-framework.md",
           "sha256": "27b7a02a9955636188c40536a634c7ab7409f5cc3355290d46bc04f61153d93c",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/output-formats.md",
           "sha256": "153201cf45d452aabf76b8d75d2c886f4a0c357bf00e840c52666e783596842a",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/qa-mode.md",
           "sha256": "0716b252da41b90274794dd977845822e4df853e88528c9f9b6aeab188381a23",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/recipes-detail.md",
           "sha256": "bba8cc4863ac87405b65bf0e20399c3bf516d0a88a424173ff307d17cb757c52",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/reference/search-strategies.md",
           "sha256": "ce289ab80470b8f7ffc63300c1df9460c1d2894736355edbfa12f74ee7ac48ca",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/complexity-assessment.md",
           "sha256": "17e19dfbe2a74348966e6518fa8b6d3ed2141501c1172f4999b6fff6bc83c007",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/investigation-budget.md",
           "sha256": "3fa91bed32c95183fc6fbb669979e798e84e14388d23d5a7676a4716ca47e795",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/investigation-patterns.md",
           "sha256": "7ee68d290d0f1efbcb19e744d7b29bb0a9361c88d290253711be3c4f4cc96e3f",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/lens-framework.md",
           "sha256": "27b7a02a9955636188c40536a634c7ab7409f5cc3355290d46bc04f61153d93c",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/output-formats.md",
           "sha256": "153201cf45d452aabf76b8d75d2c886f4a0c357bf00e840c52666e783596842a",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/lens/references/search-strategies.md",
           "sha256": "ce289ab80470b8f7ffc63300c1df9460c1d2894736355edbfa12f74ee7ac48ca",
-          "owner": "lens"
+          "owner": "lens",
+          "mode": "100644"
         }
       ]
     },
@@ -13424,187 +14495,224 @@
         {
           "path": "skills/task-understanding-decomposition/scout/SKILL.md",
           "sha256": "ab6593544ac8fb1c5c9e910ede6b014910cbe9413afb5f798726ccac41affba5",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/5whys-rca.md",
           "sha256": "aa4373b9ccf2d5b9d3ddca99733a485bf106c735b4b8fdfa258f2b81cd577108",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/advanced-reproduction-triage.md",
           "sha256": "9dca5a5cd5e2296cfae9ce623483065b5fce529e8cd678a9beb1f750e7453d31",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/bug-patterns.md",
           "sha256": "d94ac563d2af6082c916128e4251d36e8ab2f3d875e9092c2e82e99c3d67e0e7",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/debug-strategies.md",
           "sha256": "c1a2795aa747af39512fa1d7b3f8d7508ee71b6414df13420bcdbbdfa9df7fbc",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/debugging-anti-patterns.md",
           "sha256": "66a99a7faefa5cb21bb6de3c1e94035111f719b2d9d0b5ca2d4eade008a8c508",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/fishbone-6m.md",
           "sha256": "f76741f6150a73d3af98e047a83189ba20a0c6b511f75150d7137a5a80c9398d",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/fix-prompt-generation.md",
           "sha256": "c2920d441acba66e82aea275144501e3f176d404eb91f67c64e6e6658c816880",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/flake-investigation.md",
           "sha256": "c57ac42c36d2efb20e010557e9e5d60b88eb776d90ea57fef9b33b8d68392f70",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/frontend-debugging.md",
           "sha256": "b472a4faf0ddfc0c0061ad41b9e395bd7c76ca29d85d56d16ca2128718e8dca9",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/git-bisect.md",
           "sha256": "e92edb30fed1d19a11be9505dc069a2abe0c7c43fc7e261bdb86ee73be7e5dcb",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/handoff-formats.md",
           "sha256": "7cad34c97af695a54a0ee7a880cd211373e35ff8562d8e8b4125af3d3d2c0ec3",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/memory-investigation.md",
           "sha256": "c69f6af7b8fb4380547343f444121615e592eb02381ae73aa632340b7af1ccf7",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/modern-rca-methodology.md",
           "sha256": "33695ccbb68a0cd77856da4a79fdf62f72e269e6fbec643da4e158d81983ec6a",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/multi-engine-mode.md",
           "sha256": "3fcb54febbf045477db25339d3e708d920088eb94fdeb42efcb944436be2a5d0",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/observability-debugging.md",
           "sha256": "e3e317930643b7ed019ba340302d857787e4ccfe93425a0f25dea6d8d020d341",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/output-format.md",
           "sha256": "3e8fdaa5fb6763ea19d79e5ae587196a573a51a9e3052f4380676831e4ecbddf",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/perf-investigation.md",
           "sha256": "aec6d34717683f9baa223af691b68c44b117da9a59db228c686be20642520f29",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/reproduction-templates.md",
           "sha256": "f41c831bf18d6a8de9f2838a2d446865041097c49ac20455836bfc345efa84ce",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/timeline-reconstruction.md",
           "sha256": "a1e4a1a2d3e06ff8a66ea45ea5f93bf4a1e45682e5d20a38d28b901fd519c764",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/tri-engine-investigate.md",
           "sha256": "f810c492c50ee5e2f151f9704a614e6d9ea3ae7e6468ccc78f34c5b9ba4517c6",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/vague-report-handling.md",
           "sha256": "9152b515afb3257d03863671043dc87501061794148bfb2bbc1b1f20afd3320a",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/reference/video-bug-analysis.md",
           "sha256": "ef63483b5e572921c520a6ebc286a5846f58f55e19ca0338fed25abf49ed63d1",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/advanced-reproduction-triage.md",
           "sha256": "9dca5a5cd5e2296cfae9ce623483065b5fce529e8cd678a9beb1f750e7453d31",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/bug-patterns.md",
           "sha256": "d94ac563d2af6082c916128e4251d36e8ab2f3d875e9092c2e82e99c3d67e0e7",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/debug-strategies.md",
           "sha256": "c1a2795aa747af39512fa1d7b3f8d7508ee71b6414df13420bcdbbdfa9df7fbc",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/debugging-anti-patterns.md",
           "sha256": "66a99a7faefa5cb21bb6de3c1e94035111f719b2d9d0b5ca2d4eade008a8c508",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/flake-investigation.md",
           "sha256": "9a4b742188de3008a1ca1b8b007b40022242dd41ba5d406d334d495ae70e0e3e",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/frontend-debugging.md",
           "sha256": "7efc8637e8c28001e4067b87784bfdc15196dd907b73cde6a24b7b65911f2346",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/git-bisect.md",
           "sha256": "e92edb30fed1d19a11be9505dc069a2abe0c7c43fc7e261bdb86ee73be7e5dcb",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/memory-investigation.md",
           "sha256": "dc9ecc3a548aaeb2096ba6ff12cfbbc6608b57650886b56e916eecc51f1c77dd",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/modern-rca-methodology.md",
           "sha256": "7a0e0b30a2565f5a7be7504ad18b11270007fb44ee335b404d9671a00fd8314f",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/observability-debugging.md",
           "sha256": "e3e317930643b7ed019ba340302d857787e4ccfe93425a0f25dea6d8d020d341",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/output-format.md",
           "sha256": "47e76a689ff370a246e6043da8787d2c6b5228abc82108f3cb42fd866e315418",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/perf-investigation.md",
           "sha256": "670b2fafaa46e6db7e2ad110ac0adfd61803d90e8db1687893087a23a9a5344d",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/reproduction-templates.md",
           "sha256": "f41c831bf18d6a8de9f2838a2d446865041097c49ac20455836bfc345efa84ce",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/scout/references/vague-report-handling.md",
           "sha256": "9152b515afb3257d03863671043dc87501061794148bfb2bbc1b1f20afd3320a",
-          "owner": "scout"
+          "owner": "scout",
+          "mode": "100644"
         }
       ]
     },
@@ -13755,92 +14863,110 @@
         {
           "path": "skills/task-understanding-decomposition/ripple/SKILL.md",
           "sha256": "83f2fe5a02e0bfbe5c8e72e9c99a53098720f6504a4177da787e8b2d8c10d2d4",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/analysis-techniques.md",
           "sha256": "dcf66ede92e5eb93bc3d665fb558c4749377fdb12fbf28b85328f26788e866aa",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/autorun-schema.md",
           "sha256": "9ea173f7b6c9ade56f16a978ce9de344e448f0cc46b879fce5ef760dab4f1108",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/blast-radius-quant.md",
           "sha256": "a22c3ae344dfa4edae85de3a726ce580067b57a5f0f8187c15a4a203f40ee064",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/canary-scope-design.md",
           "sha256": "8c222d0cde16b1d756f73fbd301e53089413254261376fafd08cd15cb946884b",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/cascade-analysis.md",
           "sha256": "daa3b0818650ae670a2af1d11639d904e76ed89bd04dff60a6a440ad76e0fc96",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/consistency-report-template.md",
           "sha256": "b5cde4b9b55658778b1ba0ddcdc08864b2e68a071c8f55beeeaf6a945ff191df",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/impact-report-template.md",
           "sha256": "8868550b96bd444aaeeb10cf87c09214e50bb0bee262cb0da7ef103110822e46",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/ripple-analysis-template.md",
           "sha256": "afefa162b1d1f3b28e2d223ec543d1b93fa697f369381d09f811162b352bd573",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/reference/rollback-plan-design.md",
           "sha256": "9aa8e5a7ec30158b4e8268cb17534d421d3952a27fcadf558fb539353f1511e7",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/analysis-techniques.md",
           "sha256": "dcf66ede92e5eb93bc3d665fb558c4749377fdb12fbf28b85328f26788e866aa",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/blast-radius-quant.md",
           "sha256": "77c4a93df7a9806f4dff4adca66ff1716bb13b46744e3edbfd2b0bf8ce61c902",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/canary-scope-design.md",
           "sha256": "8c222d0cde16b1d756f73fbd301e53089413254261376fafd08cd15cb946884b",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/cascade-analysis.md",
           "sha256": "56f4755eb3dec9b06bb11c218bbe73419e9d4ddba2d45de192f2ef593606c06e",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/consistency-report-template.md",
           "sha256": "b5cde4b9b55658778b1ba0ddcdc08864b2e68a071c8f55beeeaf6a945ff191df",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/impact-report-template.md",
           "sha256": "8868550b96bd444aaeeb10cf87c09214e50bb0bee262cb0da7ef103110822e46",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/ripple-analysis-template.md",
           "sha256": "afefa162b1d1f3b28e2d223ec543d1b93fa697f369381d09f811162b352bd573",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         },
         {
           "path": "skills/task-understanding-decomposition/ripple/references/rollback-plan-design.md",
           "sha256": "9aa8e5a7ec30158b4e8268cb17534d421d3952a27fcadf558fb539353f1511e7",
-          "owner": "ripple"
+          "owner": "ripple",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/sources/simota-agent-skills-2026-04.skills.json
+++ b/docs/sources/simota-agent-skills-2026-04.skills.json
@@ -29,7 +29,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -41,6 +41,116 @@
             {
               "source": "builder/SKILL.md",
               "target": "skills/developer-engineering/builder/SKILL.md"
+            },
+            {
+              "source": "builder/reference/ai-coding-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/ai-coding-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/architecture-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/architecture-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/autorun-nexus.md",
+              "target": "skills/developer-engineering/builder/reference/autorun-nexus.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/autorun-schema.md",
+              "target": "skills/developer-engineering/builder/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/cross-language-port.md",
+              "target": "skills/developer-engineering/builder/reference/cross-language-port.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/domain-modeling.md",
+              "target": "skills/developer-engineering/builder/reference/domain-modeling.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/external-integration.md",
+              "target": "skills/developer-engineering/builder/reference/external-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/frontend-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/frontend-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/implementation-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/implementation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/kotlin-anti-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/kotlin-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/kotlin-best-practices.md",
+              "target": "skills/developer-engineering/builder/reference/kotlin-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/kotlin-language-spec.md",
+              "target": "skills/developer-engineering/builder/reference/kotlin-language-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/language-idioms.md",
+              "target": "skills/developer-engineering/builder/reference/language-idioms.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/pair-programming.md",
+              "target": "skills/developer-engineering/builder/reference/pair-programming.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/process-and-examples.md",
+              "target": "skills/developer-engineering/builder/reference/process-and-examples.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/rust-anti-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/rust-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/rust-best-practices.md",
+              "target": "skills/developer-engineering/builder/reference/rust-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/rust-language-spec.md",
+              "target": "skills/developer-engineering/builder/reference/rust-language-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/swift-anti-patterns.md",
+              "target": "skills/developer-engineering/builder/reference/swift-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/swift-best-practices.md",
+              "target": "skills/developer-engineering/builder/reference/swift-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/swift-language-spec.md",
+              "target": "skills/developer-engineering/builder/reference/swift-language-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "builder/reference/targeted-patch.md",
+              "target": "skills/developer-engineering/builder/reference/targeted-patch.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -52,13 +162,240 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/developer-engineering/builder",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/developer-engineering/builder/references/architecture-patterns.md",
+              "target": "skills/developer-engineering/builder/references/architecture-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/autorun-nexus.md",
+              "target": "skills/developer-engineering/builder/references/autorun-nexus.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/cross-language-port.md",
+              "target": "skills/developer-engineering/builder/references/cross-language-port.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/domain-modeling.md",
+              "target": "skills/developer-engineering/builder/references/domain-modeling.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/external-integration.md",
+              "target": "skills/developer-engineering/builder/references/external-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/frontend-patterns.md",
+              "target": "skills/developer-engineering/builder/references/frontend-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/implementation-patterns.md",
+              "target": "skills/developer-engineering/builder/references/implementation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/language-idioms.md",
+              "target": "skills/developer-engineering/builder/references/language-idioms.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/process-and-examples.md",
+              "target": "skills/developer-engineering/builder/references/process-and-examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/builder/references/targeted-patch.md",
+              "target": "skills/developer-engineering/builder/references/targeted-patch.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/developer-engineering/builder/SKILL.md",
-          "owner": "builder",
-          "sha256": "047ff3e7cb23cc197ec8c609b455dbd3eb56860ae27d4d632af4a1024f064d16"
+          "sha256": "047ff3e7cb23cc197ec8c609b455dbd3eb56860ae27d4d632af4a1024f064d16",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/ai-coding-patterns.md",
+          "sha256": "f952664fb930ff61717f3132c2520092522d60ff74cd349d2d8508c7e582da98",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/architecture-patterns.md",
+          "sha256": "e6ebc5221562546600e41b6c494680b15e2ae7e4145970b9479d065cb540ca33",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/autorun-nexus.md",
+          "sha256": "5b806d2b8ee4721c30fe413e40e50f95949868a3f5f4e4f335cf393cae56766b",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/autorun-schema.md",
+          "sha256": "77215467ca9e34d195bcbead6bbdf92e078d2001db7118214f865c891d822866",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/cross-language-port.md",
+          "sha256": "3b05a96e01fd5e758eba99097671db09e55d19155558577bd340c061bf26c11b",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/domain-modeling.md",
+          "sha256": "e2a2a9fbbe86e3161aa507c468a8eaa9eebc348f3a3abd08d5e292b05a6e38df",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/external-integration.md",
+          "sha256": "17667b9828f77c8fde707dcbd81cd6d17d5a63e9658b46e9f0423460b651024c",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/frontend-patterns.md",
+          "sha256": "7c1354a274a0d78d327ab6caa3893a649d29867dfb8702691a46a3ab2a3f22de",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/implementation-patterns.md",
+          "sha256": "648547812c22cc0c7bc52f1cd13cf5bb46b3abae30f9f01a9e013b0e8892a13a",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/kotlin-anti-patterns.md",
+          "sha256": "378db6b49299e2d8395dad638c3e7e7cd47dbf5b6d4d30b5d65737c1b293365d",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/kotlin-best-practices.md",
+          "sha256": "8e465f5808f2c9425ce11ec9f6adf899385a50881641277386ab4fda96939ea8",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/kotlin-language-spec.md",
+          "sha256": "f27a62fd272f62f95a8862eed1882554ed98f7fb18730847844f3f6398286d42",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/language-idioms.md",
+          "sha256": "c2d5e0e885c7fcc8f5bb459be9780a8f18af758eb78043e14d90163f2b595e94",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/pair-programming.md",
+          "sha256": "3e5ed2b160cdf154f6add39ccfed822e2fb5ff4660ec21c9ae9a9f9fb206d091",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/process-and-examples.md",
+          "sha256": "554cbe900ecc64bcb9828df2783a7449739dd54fd04cbfe6eb5618fe40d4fdcb",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/rust-anti-patterns.md",
+          "sha256": "22c76386a7dc97e9d83fed299cc57cabb3c1093887c3fbddbe7dc4f559a9a631",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/rust-best-practices.md",
+          "sha256": "aca37c65e39097dee4d47d875a47e82389094e786ed63260c6b055e1aa858866",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/rust-language-spec.md",
+          "sha256": "cc09abb70ad692a94432e0ac06da56eeb39eb2f973718c84096be7ad64c77c3e",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/swift-anti-patterns.md",
+          "sha256": "54a15aede2e6d231fce7f50c067ed3e074445f54560a6ca2cb3c4cbbd60076a9",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/swift-best-practices.md",
+          "sha256": "617826b60ac66955a5294a1e850ac4636262ca1fd69c5fbbbada7096236e14cd",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/swift-language-spec.md",
+          "sha256": "a97ece9a2ee7112033e84f646b689e0c27c6dadd8f0493a474f25b986102c10d",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/reference/targeted-patch.md",
+          "sha256": "05591c831d21a713cb6c5496c738e54610caa183324abcf14e99dee91ea125a0",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/architecture-patterns.md",
+          "sha256": "e6ebc5221562546600e41b6c494680b15e2ae7e4145970b9479d065cb540ca33",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/autorun-nexus.md",
+          "sha256": "5b806d2b8ee4721c30fe413e40e50f95949868a3f5f4e4f335cf393cae56766b",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/cross-language-port.md",
+          "sha256": "3b05a96e01fd5e758eba99097671db09e55d19155558577bd340c061bf26c11b",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/domain-modeling.md",
+          "sha256": "2f2140860a8cd89d403de64ead46510a9ec80a9ac553665855496c102f855ec5",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/external-integration.md",
+          "sha256": "17667b9828f77c8fde707dcbd81cd6d17d5a63e9658b46e9f0423460b651024c",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/frontend-patterns.md",
+          "sha256": "7c1354a274a0d78d327ab6caa3893a649d29867dfb8702691a46a3ab2a3f22de",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/implementation-patterns.md",
+          "sha256": "59c4e1e947c518188046328bf3ab3dde38fd2273f340becd5bd78e13c21d5754",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/language-idioms.md",
+          "sha256": "d0bd170c306d49e32f2046f0ae87ececf0b38d98d2275b71fd97521008eafd96",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/process-and-examples.md",
+          "sha256": "554cbe900ecc64bcb9828df2783a7449739dd54fd04cbfe6eb5618fe40d4fdcb",
+          "owner": "builder"
+        },
+        {
+          "path": "skills/developer-engineering/builder/references/targeted-patch.md",
+          "sha256": "05591c831d21a713cb6c5496c738e54610caa183324abcf14e99dee91ea125a0",
+          "owner": "builder"
         }
       ]
     },
@@ -78,7 +415,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -90,6 +427,111 @@
             {
               "source": "gateway/SKILL.md",
               "target": "skills/developer-engineering/gateway/SKILL.md"
+            },
+            {
+              "source": "gateway/reference/ai-api-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/ai-api-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-auth-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/api-auth-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-decision-tree.md",
+              "target": "skills/developer-engineering/gateway/reference/api-decision-tree.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-design-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/api-design-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-design-principles.md",
+              "target": "skills/developer-engineering/gateway/reference/api-design-principles.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-review-checklist.md",
+              "target": "skills/developer-engineering/gateway/reference/api-review-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-security-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/api-security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/api-security-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/api-security-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/autorun-schema.md",
+              "target": "skills/developer-engineering/gateway/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/breaking-change-detection.md",
+              "target": "skills/developer-engineering/gateway/reference/breaking-change-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/deprecation-policy.md",
+              "target": "skills/developer-engineering/gateway/reference/deprecation-policy.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/error-pagination.md",
+              "target": "skills/developer-engineering/gateway/reference/error-pagination.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/graphql-design.md",
+              "target": "skills/developer-engineering/gateway/reference/graphql-design.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/graphql-spec-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/graphql-spec-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/openapi-templates.md",
+              "target": "skills/developer-engineering/gateway/reference/openapi-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/output-format-template.md",
+              "target": "skills/developer-engineering/gateway/reference/output-format-template.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/rate-limit-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/rate-limit-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/rest-api-design.md",
+              "target": "skills/developer-engineering/gateway/reference/rest-api-design.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/versioning-governance-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/reference/versioning-governance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/versioning-strategies.md",
+              "target": "skills/developer-engineering/gateway/reference/versioning-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "gateway/reference/webhook-design.md",
+              "target": "skills/developer-engineering/gateway/reference/webhook-design.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -101,13 +543,305 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/developer-engineering/gateway",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/developer-engineering/gateway/references/ai-api-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/ai-api-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-decision-tree.md",
+              "target": "skills/developer-engineering/gateway/references/api-decision-tree.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-design-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/api-design-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-design-principles.md",
+              "target": "skills/developer-engineering/gateway/references/api-design-principles.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-review-checklist.md",
+              "target": "skills/developer-engineering/gateway/references/api-review-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-security-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/api-security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/api-security-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/api-security-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/breaking-change-detection.md",
+              "target": "skills/developer-engineering/gateway/references/breaking-change-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/error-pagination-ratelimit.md",
+              "target": "skills/developer-engineering/gateway/references/error-pagination-ratelimit.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/graphql-design.md",
+              "target": "skills/developer-engineering/gateway/references/graphql-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/graphql-spec-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/graphql-spec-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/openapi-templates.md",
+              "target": "skills/developer-engineering/gateway/references/openapi-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/output-format-template.md",
+              "target": "skills/developer-engineering/gateway/references/output-format-template.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/rest-api-design.md",
+              "target": "skills/developer-engineering/gateway/references/rest-api-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/versioning-governance-anti-patterns.md",
+              "target": "skills/developer-engineering/gateway/references/versioning-governance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/versioning-strategies.md",
+              "target": "skills/developer-engineering/gateway/references/versioning-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/gateway/references/webhook-design.md",
+              "target": "skills/developer-engineering/gateway/references/webhook-design.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/developer-engineering/gateway/SKILL.md",
-          "owner": "gateway",
-          "sha256": "63f8f6edc7643d0a21f2d8eedf93c38f2234a6f4550060ab586e3bf50a16dc5a"
+          "sha256": "63f8f6edc7643d0a21f2d8eedf93c38f2234a6f4550060ab586e3bf50a16dc5a",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/ai-api-patterns.md",
+          "sha256": "44a9e6513babec58ace8a701238a9188109e524888b30eb4ff95021c7b20c664",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-auth-patterns.md",
+          "sha256": "16983c8cc68c72922fd935d41072e6a4806e9b73048092036384958b6ec6e8c5",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-decision-tree.md",
+          "sha256": "5116ac69b8431ab37b9aac524e41041c69d1e495695615f72ccf349c4d3aa210",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-design-anti-patterns.md",
+          "sha256": "97e74a8273a49d4953648b0f03a357969d22876ab25860e8df42690b9436797a",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-design-principles.md",
+          "sha256": "e7c4e754c95e9e38e91d00631a3daf229242abd5bb7491d4e5566334131fa2fc",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-review-checklist.md",
+          "sha256": "6bb9fcb17cc98365839a72dc97e90442ef7ef8869f07e3fc9b29caf0d9cbaebb",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-security-anti-patterns.md",
+          "sha256": "184dbcb66a459c426bc37f4aa19e7b89b96ebc3a0679d4b4c998c7a0e7aab491",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/api-security-patterns.md",
+          "sha256": "8c344626e920284163c034b41fe197fa976df795e1597de968e519f54985c696",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/autorun-schema.md",
+          "sha256": "1f00ccbfc30ddc107b0bed2f806ea5155a9121804676260c7a0e3eda61314c47",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/breaking-change-detection.md",
+          "sha256": "07a90b9ca182cce2d699311c0e1851b9b924c1cde3f80005c29f8a728e25bc8a",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/deprecation-policy.md",
+          "sha256": "3cedce8d40844ba5eb748ee669dea0afd6240edfa0c8d748d43e03f20ed4d3ba",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/error-pagination.md",
+          "sha256": "1efdc73ff3b0b315ceef73028965b1630376f45cbe39a4615f6ab8b7f97dfb27",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/graphql-design.md",
+          "sha256": "f1ee14746203886d9a84fafcb02836f207cd13415284d96f02ca5b872bd97f60",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/graphql-spec-anti-patterns.md",
+          "sha256": "0a2d1b3e8c73e7d33bc5ab3c6a7da51cfdfbc4a0c7e15c4e82f69056c6ddbd8e",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/openapi-templates.md",
+          "sha256": "80b3b531d5269c5fbf763f9e74ee503a3973e491cef2298725d893bb1bc9eb54",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/output-format-template.md",
+          "sha256": "70de1bd13eb4ee98aae250d72d19aa2465d032ce8baf0008a6511c3d4c4825f2",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/rate-limit-patterns.md",
+          "sha256": "4b83dd087f1b6c3343a5be74e2f50f6d281f9ad5d7d052282f0d87d5bc29df3f",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/rest-api-design.md",
+          "sha256": "cd50c1aa89fc8d8674b43e55f481bb7da5a1c5d90c3b00a14b3f3521f040a44b",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/versioning-governance-anti-patterns.md",
+          "sha256": "cd29ff2100f38f9122c110090a2ef5fc71982773a4f911aa5171b34919d4a468",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/versioning-strategies.md",
+          "sha256": "bc898ef58b448cfca952c9bcf65a54b67ce34581b30aeb3b4ef35b4eb887a387",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/reference/webhook-design.md",
+          "sha256": "dbe5246d78866bfa78ac048eb78dd278819da39a65be0164b8d8a7adf49f8113",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/ai-api-patterns.md",
+          "sha256": "0ae4e07aee1e273341ebfe99412e6fc26adecbc9c369e0a1d0d0d85bf0ac9a28",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-decision-tree.md",
+          "sha256": "6f58734f401039673299152fe820597b2ac5689e0d08190422171acac2981f4a",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-design-anti-patterns.md",
+          "sha256": "03f895ce91fa6781848fdef49e0deb764b60b4f1d5a70a7021f61c2b48dcc8cd",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-design-principles.md",
+          "sha256": "e7c4e754c95e9e38e91d00631a3daf229242abd5bb7491d4e5566334131fa2fc",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-review-checklist.md",
+          "sha256": "6bb9fcb17cc98365839a72dc97e90442ef7ef8869f07e3fc9b29caf0d9cbaebb",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-security-anti-patterns.md",
+          "sha256": "b4c0b5f84a4bd49a0f65fe34a9d7d7e0830855280e71ca5d337cc74ad57c1a5c",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/api-security-patterns.md",
+          "sha256": "a32b1460ee680cf332df6cece219db69a97ceb1d564c46db31d5714f1a539fbb",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/breaking-change-detection.md",
+          "sha256": "07a90b9ca182cce2d699311c0e1851b9b924c1cde3f80005c29f8a728e25bc8a",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/error-pagination-ratelimit.md",
+          "sha256": "81f02ff9e5e43783f9d9253b1a4dd80f97ca6580af5c77b4322de5e2fb11a044",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/graphql-design.md",
+          "sha256": "13432d971a247a228789d343d5a17f3d64e010b7cd2e976c77d24e20f06d61fe",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/graphql-spec-anti-patterns.md",
+          "sha256": "cc8b133cdd7da4acae3fb7330cb202278f48e412b0ccebd1b483b10d58745f42",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/openapi-templates.md",
+          "sha256": "53fee4276c61a7ce96f2a9a609c2dba1707ff2e75e993615a014d116b1e85401",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/output-format-template.md",
+          "sha256": "70de1bd13eb4ee98aae250d72d19aa2465d032ce8baf0008a6511c3d4c4825f2",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/rest-api-design.md",
+          "sha256": "3e3b45d44252e92f1e962b783092991a21a0c189df8e3b9228867481de8dddf9",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/versioning-governance-anti-patterns.md",
+          "sha256": "f95ef540fc8d3b28a8b6a5fedd0466b25f6cab47989870c59169efa3644e0cf9",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/versioning-strategies.md",
+          "sha256": "40a0653f26257581e3bf14e9b397e09e4b9a374152a2a4de509194393c949ddb",
+          "owner": "gateway"
+        },
+        {
+          "path": "skills/developer-engineering/gateway/references/webhook-design.md",
+          "sha256": "a77fcc1632bc7e64c8713df6d39803031e836a55ff2c9263924b0c66798a5e51",
+          "owner": "gateway"
         }
       ]
     },
@@ -127,7 +861,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -139,6 +873,96 @@
             {
               "source": "schema/SKILL.md",
               "target": "skills/developer-engineering/schema/SKILL.md"
+            },
+            {
+              "source": "schema/reference/advanced-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/audit-log-schema.md",
+              "target": "skills/developer-engineering/schema/reference/audit-log-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/autorun-schema.md",
+              "target": "skills/developer-engineering/schema/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/data-modeling-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/data-modeling-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/event-sourcing-schema.md",
+              "target": "skills/developer-engineering/schema/reference/event-sourcing-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/index-performance-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/index-performance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/index-strategies.md",
+              "target": "skills/developer-engineering/schema/reference/index-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/migration-deployment-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/migration-deployment-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/migration-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/migration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/migration-rollback.md",
+              "target": "skills/developer-engineering/schema/reference/migration-rollback.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/multi-tenant-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/multi-tenant-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/normalization-guide.md",
+              "target": "skills/developer-engineering/schema/reference/normalization-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/partition-strategies.md",
+              "target": "skills/developer-engineering/schema/reference/partition-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/postgresql17-features.md",
+              "target": "skills/developer-engineering/schema/reference/postgresql17-features.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/postgresql18-features.md",
+              "target": "skills/developer-engineering/schema/reference/postgresql18-features.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/schema-design-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/schema-design-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/schema-examples.md",
+              "target": "skills/developer-engineering/schema/reference/schema-examples.md",
+              "type": "file"
+            },
+            {
+              "source": "schema/reference/soft-delete-patterns.md",
+              "target": "skills/developer-engineering/schema/reference/soft-delete-patterns.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -150,13 +974,250 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/developer-engineering/schema",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/developer-engineering/schema/references/advanced-patterns.md",
+              "target": "skills/developer-engineering/schema/references/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/data-modeling-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/references/data-modeling-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/index-performance-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/references/index-performance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/index-strategies.md",
+              "target": "skills/developer-engineering/schema/references/index-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/migration-deployment-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/references/migration-deployment-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/migration-patterns.md",
+              "target": "skills/developer-engineering/schema/references/migration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/migration-rollback.md",
+              "target": "skills/developer-engineering/schema/references/migration-rollback.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/multi-tenant-patterns.md",
+              "target": "skills/developer-engineering/schema/references/multi-tenant-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/normalization-guide.md",
+              "target": "skills/developer-engineering/schema/references/normalization-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/partition-strategies.md",
+              "target": "skills/developer-engineering/schema/references/partition-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/postgresql17-features.md",
+              "target": "skills/developer-engineering/schema/references/postgresql17-features.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/schema-design-anti-patterns.md",
+              "target": "skills/developer-engineering/schema/references/schema-design-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/developer-engineering/schema/references/schema-examples.md",
+              "target": "skills/developer-engineering/schema/references/schema-examples.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/developer-engineering/schema/SKILL.md",
-          "owner": "schema",
-          "sha256": "d4a7b682ff78f0207e6af03ad3724c954809a6eb2a5b76cdcfc369691043c337"
+          "sha256": "d4a7b682ff78f0207e6af03ad3724c954809a6eb2a5b76cdcfc369691043c337",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/advanced-patterns.md",
+          "sha256": "f9390f14627705b60ee5bd67f4a859f289a2ca1468d9af0314f8c439ce23be1f",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/audit-log-schema.md",
+          "sha256": "ec3f508f46cfd3e23327610ddcb8f7444f700fb1ec2f6f5155984fb954647f06",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/autorun-schema.md",
+          "sha256": "04c33e538ef47f5d08a0971ca7cf6d3c9dd74bafbbc30fba18996e35a7ad7bbe",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/data-modeling-anti-patterns.md",
+          "sha256": "6a9210e153c4a2a484018736461fdc0921c172a6100e2689ee386eb840a7a37e",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/event-sourcing-schema.md",
+          "sha256": "f883d6a402aa253d39bd4334e70ff7775afd02ad662318d8a81920e717eb4995",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/index-performance-anti-patterns.md",
+          "sha256": "9744fbbbcca7cc2e49db194c8b5f8bf26e331faaba241dbc412b7273e54c888a",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/index-strategies.md",
+          "sha256": "aec4caf417c980931dedc2213cd90b469d981c169e1cb90f7f00f49e6134dcab",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/migration-deployment-anti-patterns.md",
+          "sha256": "b84abf60db43bad2083c41646ae3a717d1ceae512ffd3b85c8c5dd2d3d76246f",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/migration-patterns.md",
+          "sha256": "ab8913d0c44697507148094e6cd60ec9d91c8ac96808580d7de9e1041c73fb1d",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/migration-rollback.md",
+          "sha256": "b8ec94a5197a9db077b7387e5b7e92e0d93e84020b970cdc60adcac9b7981e06",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/multi-tenant-patterns.md",
+          "sha256": "b138b6a3f8c9144b39bf374af5e211e8a73da12326fc2f52ff1a938787fb282b",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/normalization-guide.md",
+          "sha256": "02c3db15c971117d81341cf6ff8d6798204f0c98219c673c2be66e27f5a1cd37",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/partition-strategies.md",
+          "sha256": "fa9d9e5a028c8b6f10b33f02b109624c95857baa2a522a2d7b61d17e3e37a787",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/postgresql17-features.md",
+          "sha256": "3caa0db1f5da92569bdac5fd877b7f78b572465bc0747f19bf3f852e03084da3",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/postgresql18-features.md",
+          "sha256": "03a325bf7c23804bee937c937fb164d82a445a45f9457e4e386f21433780de3c",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/schema-design-anti-patterns.md",
+          "sha256": "45cd931466797aee1c67266139e68982bc6da48623b400b526204ff364d86a76",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/schema-examples.md",
+          "sha256": "efe0e3302123326d7a9a426d2fd404dface4b8fea26f9350d2e3ae9fa93b5ed5",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/reference/soft-delete-patterns.md",
+          "sha256": "b96a159031e185ba1ba98e1844c480a34eb812d71106ec8fab927eb1f4b09f68",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/advanced-patterns.md",
+          "sha256": "3f3f4526ae7653aaa047151385fe54473c70fdce789e8c8ed38ed79e4b75ddbf",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/data-modeling-anti-patterns.md",
+          "sha256": "6a9210e153c4a2a484018736461fdc0921c172a6100e2689ee386eb840a7a37e",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/index-performance-anti-patterns.md",
+          "sha256": "9744fbbbcca7cc2e49db194c8b5f8bf26e331faaba241dbc412b7273e54c888a",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/index-strategies.md",
+          "sha256": "aec4caf417c980931dedc2213cd90b469d981c169e1cb90f7f00f49e6134dcab",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/migration-deployment-anti-patterns.md",
+          "sha256": "b84abf60db43bad2083c41646ae3a717d1ceae512ffd3b85c8c5dd2d3d76246f",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/migration-patterns.md",
+          "sha256": "5b9a0bc053b59dae56c5c2c5c4bb015421abd27ac16a5977ec221e97bbe04661",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/migration-rollback.md",
+          "sha256": "b8ec94a5197a9db077b7387e5b7e92e0d93e84020b970cdc60adcac9b7981e06",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/multi-tenant-patterns.md",
+          "sha256": "4e701533b38caaed377301f16d0a62e981d8e9174e956147a12154e0f836dc88",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/normalization-guide.md",
+          "sha256": "02c3db15c971117d81341cf6ff8d6798204f0c98219c673c2be66e27f5a1cd37",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/partition-strategies.md",
+          "sha256": "52d114091dc83ba9cb8a99a747d5dd7d0c8e0fc75965451e1f8b2f85531d94ed",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/postgresql17-features.md",
+          "sha256": "c6b4a9f825c1d06f31ace563104b19b0ea25974f9d89735726e0766488c97e51",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/schema-design-anti-patterns.md",
+          "sha256": "45cd931466797aee1c67266139e68982bc6da48623b400b526204ff364d86a76",
+          "owner": "schema"
+        },
+        {
+          "path": "skills/developer-engineering/schema/references/schema-examples.md",
+          "sha256": "efe0e3302123326d7a9a426d2fd404dface4b8fea26f9350d2e3ae9fa93b5ed5",
+          "owner": "schema"
         }
       ]
     },
@@ -176,7 +1237,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -188,6 +1249,396 @@
             {
               "source": "nexus/SKILL.md",
               "target": "skills/ai-workflow/nexus/SKILL.md"
+            },
+            {
+              "source": "nexus/reference/acceptance-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/acceptance-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/adaptive-prompt-policy.md",
+              "target": "skills/ai-workflow/nexus/reference/adaptive-prompt-policy.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/agent-chains.md",
+              "target": "skills/ai-workflow/nexus/reference/agent-chains.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/agent-communication-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/reference/agent-communication-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/agent-disambiguation.md",
+              "target": "skills/ai-workflow/nexus/reference/agent-disambiguation.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/anneal-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/anneal-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/apex-recipe-flow.mmd",
+              "target": "skills/ai-workflow/nexus/reference/apex-recipe-flow.mmd",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/apex-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/apex-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/apex-walkthrough.md",
+              "target": "skills/ai-workflow/nexus/reference/apex-walkthrough.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/autonomy-quality-protocol.md",
+              "target": "skills/ai-workflow/nexus/reference/autonomy-quality-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/autorun-schema.md",
+              "target": "skills/ai-workflow/nexus/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/cartograph-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/cartograph-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/charter-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/charter-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/chronicle-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/chronicle-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/clone-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/clone-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/confidence-scoring.md",
+              "target": "skills/ai-workflow/nexus/reference/confidence-scoring.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/conflict-resolution.md",
+              "target": "skills/ai-workflow/nexus/reference/conflict-resolution.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/context-strategy.md",
+              "target": "skills/ai-workflow/nexus/reference/context-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/converge-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/converge-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/delve-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/delve-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/dialogue-protocol.md",
+              "target": "skills/ai-workflow/nexus/reference/dialogue-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/doc-quality-protocol.md",
+              "target": "skills/ai-workflow/nexus/reference/doc-quality-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/enact-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/enact-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/error-handling.md",
+              "target": "skills/ai-workflow/nexus/reference/error-handling.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/essential-recipe-flow.mmd",
+              "target": "skills/ai-workflow/nexus/reference/essential-recipe-flow.mmd",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/evaluator-loop-protocol.md",
+              "target": "skills/ai-workflow/nexus/reference/evaluator-loop-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/execution-layers.md",
+              "target": "skills/ai-workflow/nexus/reference/execution-layers.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/execution-phases.md",
+              "target": "skills/ai-workflow/nexus/reference/execution-phases.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/feature-impact-simulate.md",
+              "target": "skills/ai-workflow/nexus/reference/feature-impact-simulate.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/fuse-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/fuse-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/gedanken-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/gedanken-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/goal-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/goal-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/graft-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/graft-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/growth-acceptance-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/growth-acceptance-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/guardrails.md",
+              "target": "skills/ai-workflow/nexus/reference/guardrails.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/hallmark-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/hallmark-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/handoff-validation.md",
+              "target": "skills/ai-workflow/nexus/reference/handoff-validation.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/hub-authoring.md",
+              "target": "skills/ai-workflow/nexus/reference/hub-authoring.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/inline-recipes.md",
+              "target": "skills/ai-workflow/nexus/reference/inline-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/intent-clarification.md",
+              "target": "skills/ai-workflow/nexus/reference/intent-clarification.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/killer-recipe-flow.mmd",
+              "target": "skills/ai-workflow/nexus/reference/killer-recipe-flow.mmd",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/layer-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/layer-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/loop-engineering-primitives.md",
+              "target": "skills/ai-workflow/nexus/reference/loop-engineering-primitives.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/loop-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/loop-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/managed-agents-mapping.md",
+              "target": "skills/ai-workflow/nexus/reference/managed-agents-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/marquee-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/marquee-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/migrate-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/migrate-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/newsroom-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/newsroom-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/official-skill-categories.md",
+              "target": "skills/ai-workflow/nexus/reference/official-skill-categories.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/orchestration-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/reference/orchestration-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/orchestration-patterns.md",
+              "target": "skills/ai-workflow/nexus/reference/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/output-formats.md",
+              "target": "skills/ai-workflow/nexus/reference/output-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/pack-subcommand.md",
+              "target": "skills/ai-workflow/nexus/reference/pack-subcommand.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/package-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/package-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/playable-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/playable-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/podium-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/podium-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/proactive-mode.md",
+              "target": "skills/ai-workflow/nexus/reference/proactive-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/production-reliability-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/reference/production-reliability-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/quality-iteration.md",
+              "target": "skills/ai-workflow/nexus/reference/quality-iteration.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/rebrand-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/rebrand-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/recipe-contract.md",
+              "target": "skills/ai-workflow/nexus/reference/recipe-contract.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/recipes-detail.md",
+              "target": "skills/ai-workflow/nexus/reference/recipes-detail.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/research-grounding.md",
+              "target": "skills/ai-workflow/nexus/reference/research-grounding.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/restyle-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/restyle-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/routing-explanation.md",
+              "target": "skills/ai-workflow/nexus/reference/routing-explanation.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/routing-learning.md",
+              "target": "skills/ai-workflow/nexus/reference/routing-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/routing-matrix.md",
+              "target": "skills/ai-workflow/nexus/reference/routing-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/runway-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/runway-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/signal-keywords.md",
+              "target": "skills/ai-workflow/nexus/reference/signal-keywords.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/spec-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/spec-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/summit-recipe-flow.mmd",
+              "target": "skills/ai-workflow/nexus/reference/summit-recipe-flow.mmd",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/summit-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/summit-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/task-battery.md",
+              "target": "skills/ai-workflow/nexus/reference/task-battery.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/task-routing-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/reference/task-routing-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/transmute-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/transmute-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/venture-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/venture-recipe.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/verdict-gate.md",
+              "target": "skills/ai-workflow/nexus/reference/verdict-gate.md",
+              "type": "file"
+            },
+            {
+              "source": "nexus/reference/wish-recipe.md",
+              "target": "skills/ai-workflow/nexus/reference/wish-recipe.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -199,13 +1650,680 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/nexus",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/nexus/references/agent-chains.md",
+              "target": "skills/ai-workflow/nexus/references/agent-chains.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/agent-communication-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/references/agent-communication-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/agent-disambiguation.md",
+              "target": "skills/ai-workflow/nexus/references/agent-disambiguation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/auto-decision.md",
+              "target": "skills/ai-workflow/nexus/references/auto-decision.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/conflict-resolution.md",
+              "target": "skills/ai-workflow/nexus/references/conflict-resolution.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/context-scoring.md",
+              "target": "skills/ai-workflow/nexus/references/context-scoring.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/context-strategy.md",
+              "target": "skills/ai-workflow/nexus/references/context-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/error-handling.md",
+              "target": "skills/ai-workflow/nexus/references/error-handling.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/evaluator-loop.md",
+              "target": "skills/ai-workflow/nexus/references/evaluator-loop.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/execution-phases.md",
+              "target": "skills/ai-workflow/nexus/references/execution-phases.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/guardrails.md",
+              "target": "skills/ai-workflow/nexus/references/guardrails.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/handoff-validation.md",
+              "target": "skills/ai-workflow/nexus/references/handoff-validation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/intent-clarification.md",
+              "target": "skills/ai-workflow/nexus/references/intent-clarification.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/official-skill-categories.md",
+              "target": "skills/ai-workflow/nexus/references/official-skill-categories.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/orchestration-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/references/orchestration-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/nexus/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/output-formats.md",
+              "target": "skills/ai-workflow/nexus/references/output-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/proactive-mode.md",
+              "target": "skills/ai-workflow/nexus/references/proactive-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/production-reliability-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/references/production-reliability-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/quality-iteration.md",
+              "target": "skills/ai-workflow/nexus/references/quality-iteration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/routing-explanation.md",
+              "target": "skills/ai-workflow/nexus/references/routing-explanation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/routing-learning.md",
+              "target": "skills/ai-workflow/nexus/references/routing-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/routing-matrix.md",
+              "target": "skills/ai-workflow/nexus/references/routing-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/rubric-system.md",
+              "target": "skills/ai-workflow/nexus/references/rubric-system.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/sprint-contract.md",
+              "target": "skills/ai-workflow/nexus/references/sprint-contract.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nexus/references/task-routing-anti-patterns.md",
+              "target": "skills/ai-workflow/nexus/references/task-routing-anti-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/nexus/SKILL.md",
-          "owner": "nexus",
-          "sha256": "28390e8951da7626ff04c0dd2223cc593e789292e657d7b6dea711027b675273"
+          "sha256": "28390e8951da7626ff04c0dd2223cc593e789292e657d7b6dea711027b675273",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/acceptance-recipe.md",
+          "sha256": "f5dfe0ff2a6b26fa0ed689045b809df18d50fa3459fd61592c24775b5e7f45fb",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/adaptive-prompt-policy.md",
+          "sha256": "5b300d5eb8ee09b3280a79816253996b163ce700c0e34e9d5201caedaa4c686c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/agent-chains.md",
+          "sha256": "cc0efa26e84de903a4bd96372b50efe97bbc314a629c2405478b874a41d12c93",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/agent-communication-anti-patterns.md",
+          "sha256": "abdba88213478d820f302043cae9aba238f28da836595b0e4f4c6e74ad92c8e0",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/agent-disambiguation.md",
+          "sha256": "242a3bb58302ee4c7316746908abf7838771b8e75701efaf28b096420c61ca52",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/anneal-recipe.md",
+          "sha256": "8a17704be975a717c0144a3de4b0b05d196769cf26758033a6514c1c6e7ee067",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/apex-recipe-flow.mmd",
+          "sha256": "c02b084b42a394de6d06efc62b5a948211b2c207cb8ae291307f27d3cb2e386c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/apex-recipe.md",
+          "sha256": "9b5081b800baa61ba48bdf21e01626e1c5bdf213f2f2314b48546874f7132ddc",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/apex-walkthrough.md",
+          "sha256": "1d859085a11424a691172394501621286e250827c98601ed71d30cc742993d91",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/autonomy-quality-protocol.md",
+          "sha256": "73642a35a74ecec52bbcbe04e1e05c01230bf4cdb520d427fa9e84ee67af020c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/autorun-schema.md",
+          "sha256": "595c45ea385d6758b0ec09acaf88c0134d87d930e357cbd78f70c93be1484026",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/cartograph-recipe.md",
+          "sha256": "0f4ca5318022529ca257e68e23b0f3f46703d9ad60a62d9490c8555607fc1707",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/charter-recipe.md",
+          "sha256": "cfb3b37faba6d18f3a1546fbb347b2df4b8fee778a18df7f1765237f2a98a73a",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/chronicle-recipe.md",
+          "sha256": "da86813329a396ea6da47f80cd66083ba743624bc02fc2d0a44ab3f3b4336485",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/clone-recipe.md",
+          "sha256": "67def5fcb65f142be28b2a28018e00251f03ccf44acbb52203223d57ae9666ba",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/confidence-scoring.md",
+          "sha256": "b30895f98191b211533643626165b4a644d5eea5e568d3546d2c098b6dd0df3b",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/conflict-resolution.md",
+          "sha256": "1e088031f5b0b4b5a253b9cc783fc8d716872cec854a42fad3caede48bf9dc44",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/context-strategy.md",
+          "sha256": "691e2cb379e2f89ed0348d7f529c704d6fde23d72f51a35fc7b314ffdeb6ff82",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/converge-recipe.md",
+          "sha256": "c3a07b0f46f523baad8e26643e789698ceecc8defdfc2430c21faadb69887401",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/delve-recipe.md",
+          "sha256": "3a822195c0dd3f5cc1cd490e78efed0eef1564319e010973a5a109734fe46c55",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/dialogue-protocol.md",
+          "sha256": "148d5d5d225a84d320e394ea2d6a0e6beab17ecea80b2d89839ba72351136a0d",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/doc-quality-protocol.md",
+          "sha256": "5d159b9ae8407daae35450af86e4622be43a83dbaaf97b76ce95e646a956a8be",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/enact-recipe.md",
+          "sha256": "376429c460a8ec4db93a17eeb0f5adef901568b152188420a11fe305e7b9b97b",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/error-handling.md",
+          "sha256": "2080e2aca789576ce6832e5170bd915a6af65cfc9b7746e7452667447544d2d0",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/essential-recipe-flow.mmd",
+          "sha256": "f4aba7481c6299c85dd962629f8a63dc229d955527be551a830c90570c53f989",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/evaluator-loop-protocol.md",
+          "sha256": "8c98e925636da12857d7a82621cad4087bb5c910598010868057769342a14952",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/execution-layers.md",
+          "sha256": "85784b32acd3ead9e58f0ede6ab4455ec6e4c3bd26b845647d65056e253670a1",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/execution-phases.md",
+          "sha256": "1d04801a7c13d57d1126ce5a007656119b4662415a27c426a42996a3765e8237",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/feature-impact-simulate.md",
+          "sha256": "722601b4f212d750ad829a18089ca5a7f3de50127a475747ef9e463b34f3a664",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/fuse-recipe.md",
+          "sha256": "6c0c496ddbd6e25798a3ebb4b8d4dd193e445aed6236f1b8f9d87361aaafbcec",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/gedanken-recipe.md",
+          "sha256": "0de194f9c3af582a6a52161baeb1d65e15615aa1b23e992ebc350eead5226aeb",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/goal-recipe.md",
+          "sha256": "54671094e4571264f0dcc0daa6b59ef3bc9582f39ef8c1bcedc33fe05cf3f5d9",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/graft-recipe.md",
+          "sha256": "7b4a8433692fc626d271082aa2ed837797566d3e19e5bdd14fcbdc77a0049177",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/growth-acceptance-recipe.md",
+          "sha256": "035299b69aa6158709f7f64883bbee7f955fdef226b417d2707c5a7ee86ae1eb",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/guardrails.md",
+          "sha256": "b9566a2b7eaccc0f8ca01e7789976f2712d20c10a9d4ab68268c6e9b8eff1f7e",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/hallmark-recipe.md",
+          "sha256": "b364f10b4c88d2ac18eda9ca64ffbbaac2c0220b06f1f049cc0b4f213d937c35",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/handoff-validation.md",
+          "sha256": "262b802a4b8c04d3370ec3b254dfe4860aac968481cf328225f9862d4918c5e9",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/hub-authoring.md",
+          "sha256": "4db276e7700599bf6ae9d0b9f4769cba5b18056f0771d3fc60ba53f6339c70d8",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/inline-recipes.md",
+          "sha256": "aeed866d02a3ca044c09ec268733f3a8c8f5cce7f6288012d88bf28bdcb5bfdc",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/intent-clarification.md",
+          "sha256": "c181246ba3b30f5077ce5c12d3dc30b3766391797c243c4c6ab5019d5cd3fa6e",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/killer-recipe-flow.mmd",
+          "sha256": "a7fbeb480bfa8357ee38e259933c1e748f97ffe3e086c844d4ca5e58da8415c2",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/layer-recipe.md",
+          "sha256": "0e236e823dc5447d703bad00cdb74bbb71c4bc6a9c96e2b2ba7f1d875c64af53",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/loop-engineering-primitives.md",
+          "sha256": "359585c6ac7e2e499d22c3ecb1fefb27c3f352c0f101296fc48fe9453882e98a",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/loop-recipe.md",
+          "sha256": "d4bdb3d43f62e10ae46895cd7d8de1aa66b956f973012f6ffed286fb78969072",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/managed-agents-mapping.md",
+          "sha256": "5ca291d7dc73d73600c88ca29dd2725a6e17bd27c2eb3d9430b74fe0b55dffaf",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/marquee-recipe.md",
+          "sha256": "943351aea7936cad02cc54cf525881fc1573ade90bba3c11c87240c5dc09d01c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/migrate-recipe.md",
+          "sha256": "b5b6efe965dc42993ea8fffa078ed4e3b7d2f71b6a060816a3cc21c29fcf1d48",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/newsroom-recipe.md",
+          "sha256": "303e5f2daf104c4d8b3f2ee9c9d7337784ceb4808b8f2a043761cfe756a6044a",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/official-skill-categories.md",
+          "sha256": "8a775a188776d4f78e95cc6607aa977f4f2c99b886678c3d1aae5b2e1f535eaa",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/orchestration-anti-patterns.md",
+          "sha256": "bda1b16b6747a8e113a7346af3ae27d259e986fb64ca07f8c65e195b1b488b18",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/orchestration-patterns.md",
+          "sha256": "185cc016a9eb64041866f587f59aba1665f1a385684230313c09695be8bb3279",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/output-formats.md",
+          "sha256": "c4f6353955ffc1595575f2b557c9decdb064e6a2d7c05fe08af56c3678b091d1",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/pack-subcommand.md",
+          "sha256": "d17e5e7622dba0116dd35e231a8425669df930b883c34e9e412e00e52077d206",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/package-recipe.md",
+          "sha256": "ed20679cc2bcfa4ad7e6eace92974853f4163d546d9089db86efc995441495cd",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/playable-recipe.md",
+          "sha256": "316e4f7bf6d5b3dd642e4844fe91f891f79f5cc5cad7ac2b6286e8e83cc8ad3c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/podium-recipe.md",
+          "sha256": "8267a5fd9ea3f156af20d33aa6b563c1972a76f7beab34c1688710a92bc0e2e5",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/proactive-mode.md",
+          "sha256": "a4af4b8106a3fecdbf462585bfbc973060eae1fa801dadea77be31695187faa3",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/production-reliability-anti-patterns.md",
+          "sha256": "973880055f5c10c96fdb5a1a0895a39765b1d3414f6a17eea4b2cade1047276f",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/quality-iteration.md",
+          "sha256": "f9efac55f2315bca31a6b170bcf229995f328758f75624ae1a3570a2f27e2c5a",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/rebrand-recipe.md",
+          "sha256": "17c4ff6f549c03c6b50cdeec5acb9aade0367b75906ea31c4869a4d6bd7acd3f",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/recipe-contract.md",
+          "sha256": "f4a7d1d3183459f90d8d307aaee0eb1a9b659f0ba84f3546d73ca226cd899d3e",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/recipes-detail.md",
+          "sha256": "c52b5bc2af2bb70ca82b93ab3255ceb08b4abd7b536a1afb0dc8282905dcdaf4",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/research-grounding.md",
+          "sha256": "bd4a49f6bf2a52f48d6ccc5374d36350b8d3ce20a71141d37047b0dfc26cabaa",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/restyle-recipe.md",
+          "sha256": "1e720a55047f66fba991985e0b6c86bf7a6f99d9c1c9feaaae62284f18c96628",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/routing-explanation.md",
+          "sha256": "b80c81606c3e0a17d3a1ccd46bf2be9812514481510ace43ba80ce0a57898fd9",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/routing-learning.md",
+          "sha256": "51381fae487822d85ae5c8758a89d577cb19546fd1c3e53eda9dd69ac4119bc6",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/routing-matrix.md",
+          "sha256": "ff7fb5e3c2e19d9684c5ba56b32467ce5aff432a2a50c8632d3b40a60afe947c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/runway-recipe.md",
+          "sha256": "f2b8567eeb960d21cc1a59eecb018698640ba0b5c2ac2c138321c318b126d804",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/signal-keywords.md",
+          "sha256": "c3888d15d22dff16dc8b1866b0114d13653e95d3f0951a79fcc7db2e9b76cf63",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/spec-recipe.md",
+          "sha256": "90ddd6711fa976d5e2b5573fd720ff386a7b5f87ddc5228bd0c34e05d5c8d4b0",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/summit-recipe-flow.mmd",
+          "sha256": "3548024b37aef4644ebc8bde342564a82767afef749fdfb54d79e50e886f98f5",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/summit-recipe.md",
+          "sha256": "a47ee200e315010c0bb47bc41c36100799feb5898af8d41d5f6e465a62e9fd1d",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/task-battery.md",
+          "sha256": "bdc59fa72156d36cd095c372453dff5941a1c4c04ab65cb5a98e72fb1618cdc1",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/task-routing-anti-patterns.md",
+          "sha256": "dcb59b605a4f12b2e8a11e28a0e01306a0a73f164c3e8b4385e14e2e87b4bafa",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/transmute-recipe.md",
+          "sha256": "8e000e86b5e6ace69f1586630c3a0719b7556639068f0699024cfa5dc9aa011a",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/venture-recipe.md",
+          "sha256": "1f988a463cc11dfb6835c5266578e9a8348cd0f74a1db70326c44f8d79568daa",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/verdict-gate.md",
+          "sha256": "2273ff483bda4eb905fae29ac606ef464c4a67877fa4e0a4ae12c83d86352fdb",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/reference/wish-recipe.md",
+          "sha256": "9ec2956ee5a028e3c66ea335ffddd5ca69a68e9865c64b102bd13c84330032c7",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/agent-chains.md",
+          "sha256": "e59a3569e64e18cbaf59d50fc1602db964d7f5c4d571523c6548e276e99cfb97",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/agent-communication-anti-patterns.md",
+          "sha256": "abdba88213478d820f302043cae9aba238f28da836595b0e4f4c6e74ad92c8e0",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/agent-disambiguation.md",
+          "sha256": "cfa85b13123a454135488f1cd8c939ef9a24525f2516da6319860b18fcc728fa",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/auto-decision.md",
+          "sha256": "6514148b51c2461f7f4f5ada0cd08bdded0c28d41baa34c86e6ccef799dfd999",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/conflict-resolution.md",
+          "sha256": "32676b78d414bf0d7d6de87b19f571569ee5b41229c6074e1c94166da8d8962c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/context-scoring.md",
+          "sha256": "1a0ff1b474ef2fa5669bbcd279e8ff8c9f500c45e55f117cbb1b1f15936d7ac8",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/context-strategy.md",
+          "sha256": "3c60fa434d2236925dede9012acec26cbdea8c5e17fe8e7d76feb665b70dd5db",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/error-handling.md",
+          "sha256": "dfbd0d6abcb32893ac3cfb037704c425a8e1093ac5b16829a4711f14b8339d55",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/evaluator-loop.md",
+          "sha256": "f35a917fcbc14f59222def1eb2bc7ef6c7894d5a0bfc6e4f397d3e585b58128d",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/execution-phases.md",
+          "sha256": "2e9e3e0fe38651b11ce9f25d4ca142a7be94cc903f8803238334d920b265fd77",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/guardrails.md",
+          "sha256": "81df9ada69e87202a08445c5c59965b869f72f7993265cd80397918c312bf878",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/handoff-validation.md",
+          "sha256": "20eb981f3a9a66d0a9049814c5cdc589aa0fed91a049e073ea8a36c5fa21f119",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/intent-clarification.md",
+          "sha256": "70b1253fb82cc4fd7ae5ab1c68a638092ad991833b9d88e1d28e6078dfcecbf1",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/official-skill-categories.md",
+          "sha256": "90d2fa5eb9702af39120259063509603d6c3170bc974a930425ef7c9bd59987d",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/orchestration-anti-patterns.md",
+          "sha256": "bda1b16b6747a8e113a7346af3ae27d259e986fb64ca07f8c65e195b1b488b18",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/orchestration-patterns.md",
+          "sha256": "30d037c75c09d95c645dd8f4f22949c7c083ef5d7f08a116d9d83c33b9fd8b4c",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/output-formats.md",
+          "sha256": "eedc82e1ad4623dee95b15435dad5f0c64778c20a308afe8ed6c218ce0fd5398",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/proactive-mode.md",
+          "sha256": "788afd71530b7d44a741409e9ae3b68b6009fbb0ce2fcf1d4a8f8d4177813419",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/production-reliability-anti-patterns.md",
+          "sha256": "973880055f5c10c96fdb5a1a0895a39765b1d3414f6a17eea4b2cade1047276f",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/quality-iteration.md",
+          "sha256": "83fc081b48846ab84ffb929171575ca641034f769a86b0fb815a6175c261e9e5",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/routing-explanation.md",
+          "sha256": "781ce8b9545d425a72c5593e136d35b7b0a442d89f5a78b4b3803fea0fa36828",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/routing-learning.md",
+          "sha256": "c024ff51b7b96920fda25cdbc452e73d61af42ac65fa465cb539902c90a90a87",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/routing-matrix.md",
+          "sha256": "64d9689bb44e8ff463f503162be1fcd28840847ca8c368b3d1d03f5208c2cd01",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/rubric-system.md",
+          "sha256": "00093e3d9333e8bec7f43874e36aedcc6e3fbda1f9593c82811b445099efea71",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/sprint-contract.md",
+          "sha256": "b184c038a6ac0a2ec2d1137f850ebebd712dca0ef33c49b45182e13446afe6d1",
+          "owner": "nexus"
+        },
+        {
+          "path": "skills/ai-workflow/nexus/references/task-routing-anti-patterns.md",
+          "sha256": "dcb59b605a4f12b2e8a11e28a0e01306a0a73f164c3e8b4385e14e2e87b4bafa",
+          "owner": "nexus"
         }
       ]
     },
@@ -225,7 +2343,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -237,6 +2355,76 @@
             {
               "source": "sherpa/SKILL.md",
               "target": "skills/ai-workflow/sherpa/SKILL.md"
+            },
+            {
+              "source": "sherpa/reference/anti-drift.md",
+              "target": "skills/ai-workflow/sherpa/reference/anti-drift.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/atomic-step-decomposition.md",
+              "target": "skills/ai-workflow/sherpa/reference/atomic-step-decomposition.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/autorun-schema.md",
+              "target": "skills/ai-workflow/sherpa/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/context-switching-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/reference/context-switching-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/emergency-protocols.md",
+              "target": "skills/ai-workflow/sherpa/reference/emergency-protocols.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/estimation-planning-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/reference/estimation-planning-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/execution-learning.md",
+              "target": "skills/ai-workflow/sherpa/reference/execution-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/progress-tracking.md",
+              "target": "skills/ai-workflow/sherpa/reference/progress-tracking.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/risk-and-weather.md",
+              "target": "skills/ai-workflow/sherpa/reference/risk-and-weather.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/scope-creep-execution-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/reference/scope-creep-execution-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/task-breakdown.md",
+              "target": "skills/ai-workflow/sherpa/reference/task-breakdown.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/task-decomposition-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/reference/task-decomposition-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/vertical-slice.md",
+              "target": "skills/ai-workflow/sherpa/reference/vertical-slice.md",
+              "type": "file"
+            },
+            {
+              "source": "sherpa/reference/walking-skeleton.md",
+              "target": "skills/ai-workflow/sherpa/reference/walking-skeleton.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -248,13 +2436,230 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/sherpa",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/sherpa/references/anti-drift.md",
+              "target": "skills/ai-workflow/sherpa/references/anti-drift.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/atomic-step-decomposition.md",
+              "target": "skills/ai-workflow/sherpa/references/atomic-step-decomposition.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/context-switching-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/references/context-switching-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/emergency-protocols.md",
+              "target": "skills/ai-workflow/sherpa/references/emergency-protocols.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/estimation-planning-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/references/estimation-planning-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/execution-learning.md",
+              "target": "skills/ai-workflow/sherpa/references/execution-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/progress-tracking.md",
+              "target": "skills/ai-workflow/sherpa/references/progress-tracking.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/risk-and-weather.md",
+              "target": "skills/ai-workflow/sherpa/references/risk-and-weather.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/scope-creep-execution-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/references/scope-creep-execution-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/task-breakdown.md",
+              "target": "skills/ai-workflow/sherpa/references/task-breakdown.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/task-decomposition-anti-patterns.md",
+              "target": "skills/ai-workflow/sherpa/references/task-decomposition-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/vertical-slice.md",
+              "target": "skills/ai-workflow/sherpa/references/vertical-slice.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/sherpa/references/walking-skeleton.md",
+              "target": "skills/ai-workflow/sherpa/references/walking-skeleton.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/sherpa/SKILL.md",
-          "owner": "sherpa",
-          "sha256": "401f7a166a5291c9848f54d566aa65ec2eddc6ca8c491d77d67ad1d1bce5dcf7"
+          "sha256": "401f7a166a5291c9848f54d566aa65ec2eddc6ca8c491d77d67ad1d1bce5dcf7",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/anti-drift.md",
+          "sha256": "14f0f3dca177a64943fc2055a85f170fd30028839d7f1976b1eb6901d88ffbfa",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/atomic-step-decomposition.md",
+          "sha256": "a47e9fd901715e933e2324b7be41fd7965012e09be8c4816a02469f52e7a171d",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/autorun-schema.md",
+          "sha256": "4e48ec4d7093a1bfa07dfc8ae1d9798b287026608bc04536b9c4ca22e6b9c975",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/context-switching-anti-patterns.md",
+          "sha256": "dff0cf61e2b7623745b839c8df92bab170fa51a526d50fc4193692b73f26811e",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/emergency-protocols.md",
+          "sha256": "217a64682d60d5a9fde60a7ed2ce81bc7b5a933446e7693def77ef537606d3dc",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/estimation-planning-anti-patterns.md",
+          "sha256": "4b083e338ed2ef3a4f359e7bbb8b5e32a25166382224da06677d967849511ea1",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/execution-learning.md",
+          "sha256": "6958bcb010eea07efb59be6b4b23c1d0825cab4597a791615ae7e0b3a31271cc",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/progress-tracking.md",
+          "sha256": "331d3f984b5d4fb6db07223b473d589a5fe69ba45f719bfcb20fd8427653d181",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/risk-and-weather.md",
+          "sha256": "d0b66b78bc9243db61005b114aee8d6ec104672b2084fbaa6fee107f50bb7a71",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/scope-creep-execution-anti-patterns.md",
+          "sha256": "8683e85bdb58f61b48d7beaf4aaaf703899decd12785d333412495c0c67b5cbd",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/task-breakdown.md",
+          "sha256": "8754d37cab37331828b255c45dba57d5cbd17ae426d7860c47384bf427bd7ba5",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/task-decomposition-anti-patterns.md",
+          "sha256": "253d109e934708b5fd610c392c9107853f7a141951f457728129e8f62fc40600",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/vertical-slice.md",
+          "sha256": "8a29da731d0e4baf69359739ce425c2d0b6193dd2f5fd9e2aa5d8868da265198",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/reference/walking-skeleton.md",
+          "sha256": "1f7204f6a8d98597975525996a809f758d8fcef53a5160fa5e1fb1a48e9e0e4a",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/anti-drift.md",
+          "sha256": "14f0f3dca177a64943fc2055a85f170fd30028839d7f1976b1eb6901d88ffbfa",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/atomic-step-decomposition.md",
+          "sha256": "5111fcedccdf7090c4bc5204c5fc1af630b4835d07e85cdabacbb3bfaf1dc510",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/context-switching-anti-patterns.md",
+          "sha256": "dff0cf61e2b7623745b839c8df92bab170fa51a526d50fc4193692b73f26811e",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/emergency-protocols.md",
+          "sha256": "217a64682d60d5a9fde60a7ed2ce81bc7b5a933446e7693def77ef537606d3dc",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/estimation-planning-anti-patterns.md",
+          "sha256": "4b083e338ed2ef3a4f359e7bbb8b5e32a25166382224da06677d967849511ea1",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/execution-learning.md",
+          "sha256": "6958bcb010eea07efb59be6b4b23c1d0825cab4597a791615ae7e0b3a31271cc",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/progress-tracking.md",
+          "sha256": "331d3f984b5d4fb6db07223b473d589a5fe69ba45f719bfcb20fd8427653d181",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/risk-and-weather.md",
+          "sha256": "d0b66b78bc9243db61005b114aee8d6ec104672b2084fbaa6fee107f50bb7a71",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/scope-creep-execution-anti-patterns.md",
+          "sha256": "8683e85bdb58f61b48d7beaf4aaaf703899decd12785d333412495c0c67b5cbd",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/task-breakdown.md",
+          "sha256": "c8ac8da20d8f6ba8e0e906414272782d7b60ffa230be09ba9c871a294d3fabc6",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/task-decomposition-anti-patterns.md",
+          "sha256": "6cf39d0d8eeb08d450913f057345ca52730c5fbf0f95f83408b5a21f9fc2255b",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/vertical-slice.md",
+          "sha256": "8a29da731d0e4baf69359739ce425c2d0b6193dd2f5fd9e2aa5d8868da265198",
+          "owner": "sherpa"
+        },
+        {
+          "path": "skills/ai-workflow/sherpa/references/walking-skeleton.md",
+          "sha256": "1f7204f6a8d98597975525996a809f758d8fcef53a5160fa5e1fb1a48e9e0e4a",
+          "owner": "sherpa"
         }
       ]
     },
@@ -274,7 +2679,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -286,6 +2691,66 @@
             {
               "source": "rally/SKILL.md",
               "target": "skills/ai-workflow/rally/SKILL.md"
+            },
+            {
+              "source": "rally/reference/agent-teams-api-reference.md",
+              "target": "skills/ai-workflow/rally/reference/agent-teams-api-reference.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/anti-patterns-failure-modes.md",
+              "target": "skills/ai-workflow/rally/reference/anti-patterns-failure-modes.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/autorun-schema.md",
+              "target": "skills/ai-workflow/rally/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/communication-patterns.md",
+              "target": "skills/ai-workflow/rally/reference/communication-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/file-ownership-protocol.md",
+              "target": "skills/ai-workflow/rally/reference/file-ownership-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/framework-landscape.md",
+              "target": "skills/ai-workflow/rally/reference/framework-landscape.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/integration-patterns.md",
+              "target": "skills/ai-workflow/rally/reference/integration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/lifecycle-management.md",
+              "target": "skills/ai-workflow/rally/reference/lifecycle-management.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/orchestration-patterns.md",
+              "target": "skills/ai-workflow/rally/reference/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/parallel-learning.md",
+              "target": "skills/ai-workflow/rally/reference/parallel-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/resilience-cost-optimization.md",
+              "target": "skills/ai-workflow/rally/reference/resilience-cost-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "rally/reference/team-design-patterns.md",
+              "target": "skills/ai-workflow/rally/reference/team-design-patterns.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -297,13 +2762,200 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/rally",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/rally/references/agent-teams-api-reference.md",
+              "target": "skills/ai-workflow/rally/references/agent-teams-api-reference.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/anti-patterns-failure-modes.md",
+              "target": "skills/ai-workflow/rally/references/anti-patterns-failure-modes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/communication-patterns.md",
+              "target": "skills/ai-workflow/rally/references/communication-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/file-ownership-protocol.md",
+              "target": "skills/ai-workflow/rally/references/file-ownership-protocol.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/framework-landscape.md",
+              "target": "skills/ai-workflow/rally/references/framework-landscape.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/integration-patterns.md",
+              "target": "skills/ai-workflow/rally/references/integration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/lifecycle-management.md",
+              "target": "skills/ai-workflow/rally/references/lifecycle-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/orchestration-patterns.md",
+              "target": "skills/ai-workflow/rally/references/orchestration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/parallel-learning.md",
+              "target": "skills/ai-workflow/rally/references/parallel-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/resilience-cost-optimization.md",
+              "target": "skills/ai-workflow/rally/references/resilience-cost-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/rally/references/team-design-patterns.md",
+              "target": "skills/ai-workflow/rally/references/team-design-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/rally/SKILL.md",
-          "owner": "rally",
-          "sha256": "5de2a64b2942f3bf814763fef587ceea61030c99a75bd6f47ba4bfee821d8637"
+          "sha256": "5de2a64b2942f3bf814763fef587ceea61030c99a75bd6f47ba4bfee821d8637",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/agent-teams-api-reference.md",
+          "sha256": "2651849e1c7147e98f1f78081eb9c24e2918595796fcc2ec5d5d280b6e4bf74e",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/anti-patterns-failure-modes.md",
+          "sha256": "e6e00c65df02cc68df9969382e533f8a6128a2872d627d2e2ba5e29af65a45a5",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/autorun-schema.md",
+          "sha256": "94dad992a5231113cc9fc02686d636417586f56370982a158561054929b0746d",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/communication-patterns.md",
+          "sha256": "6f6ec560c182080af9dbbf797c6d9385eba956447d6c4c2d6dbfe055717e90f0",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/file-ownership-protocol.md",
+          "sha256": "1b42ccd9f6660db9d2e601ac5ce3cf8d5d4c4c46fad079e6db5533dc51e90e96",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/framework-landscape.md",
+          "sha256": "5c9af27879005489df51eaf8751deb413f419168462a5c0d216775d704be0ed6",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/integration-patterns.md",
+          "sha256": "778faabaeb9f641ce5f2f16c6e8a4693e98896e06c80fa3a426f422de3082fab",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/lifecycle-management.md",
+          "sha256": "b62f882f5c2eec6120992e699847edbabc474985ac6f29ad2a8678a1f8a6654f",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/orchestration-patterns.md",
+          "sha256": "e82deb5084749b37441fb3166d5cfa8d65c01d391c87c92d4c386026b15fa279",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/parallel-learning.md",
+          "sha256": "bda7c37549dfcbe919f15861b7d60528b248cbac38ec80a1a81e478980b186c5",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/resilience-cost-optimization.md",
+          "sha256": "f731db20d59a336caaf0b458108345b11e36ba4204d1c7d60fa73a2d05c1ad2c",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/reference/team-design-patterns.md",
+          "sha256": "63d89b1c48b08e68df3c9a01acb45e3969a608af22bb587e47cfbfa5ab758876",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/agent-teams-api-reference.md",
+          "sha256": "f51f75371ec338c4f5ec414a5f37420ca3b368726361ebd1b869477fe845097a",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/anti-patterns-failure-modes.md",
+          "sha256": "e6e00c65df02cc68df9969382e533f8a6128a2872d627d2e2ba5e29af65a45a5",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/communication-patterns.md",
+          "sha256": "1dd8e6cf60de8eda9020f735d08b02d56ed3e73e4bc766f15a93c45c068f5ff6",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/file-ownership-protocol.md",
+          "sha256": "1b42ccd9f6660db9d2e601ac5ce3cf8d5d4c4c46fad079e6db5533dc51e90e96",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/framework-landscape.md",
+          "sha256": "09b4a67f025fdf815d9920eff4cc695c9b70f6b2702f045439813f3f01809e95",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/integration-patterns.md",
+          "sha256": "5489e43dacb147b0c98e8356d073c5ba7914632f800f5a6b9d6f628b82e84c42",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/lifecycle-management.md",
+          "sha256": "2e3b0b111881604a2caf4572c60e5e7c7378ae4ef2768b17a8294784e34204e3",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/orchestration-patterns.md",
+          "sha256": "e82deb5084749b37441fb3166d5cfa8d65c01d391c87c92d4c386026b15fa279",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/parallel-learning.md",
+          "sha256": "f49e80466de2bab22c0a7ef02bed7d4c3d2d734ad1aec27f0d7b9a6411f52a16",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/resilience-cost-optimization.md",
+          "sha256": "f731db20d59a336caaf0b458108345b11e36ba4204d1c7d60fa73a2d05c1ad2c",
+          "owner": "rally"
+        },
+        {
+          "path": "skills/ai-workflow/rally/references/team-design-patterns.md",
+          "sha256": "ba5f48a83a76d9a3fd35a38573ec4dd1ee370c9168eba07b4a5edbee9a9e563d",
+          "owner": "rally"
         }
       ]
     },
@@ -323,7 +2975,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -335,6 +2987,61 @@
             {
               "source": "oracle/SKILL.md",
               "target": "skills/ai-agent-platform/oracle/SKILL.md"
+            },
+            {
+              "source": "oracle/reference/advanced-tool-use.md",
+              "target": "skills/ai-agent-platform/oracle/reference/advanced-tool-use.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/agent-design.md",
+              "target": "skills/ai-agent-platform/oracle/reference/agent-design.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/ai-safety-guardrails.md",
+              "target": "skills/ai-agent-platform/oracle/reference/ai-safety-guardrails.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/autorun-schema.md",
+              "target": "skills/ai-agent-platform/oracle/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/cost-optimization.md",
+              "target": "skills/ai-agent-platform/oracle/reference/cost-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/embedding-strategy.md",
+              "target": "skills/ai-agent-platform/oracle/reference/embedding-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/evaluation-observability.md",
+              "target": "skills/ai-agent-platform/oracle/reference/evaluation-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/llm-application-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/reference/llm-application-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/llm-production-anti-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/reference/llm-production-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/prompt-engineering.md",
+              "target": "skills/ai-agent-platform/oracle/reference/prompt-engineering.md",
+              "type": "file"
+            },
+            {
+              "source": "oracle/reference/rag-design-anti-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/reference/rag-design-anti-patterns.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -346,13 +3053,175 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-agent-platform/oracle",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-agent-platform/oracle/references/agent-design.md",
+              "target": "skills/ai-agent-platform/oracle/references/agent-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/ai-safety-guardrails.md",
+              "target": "skills/ai-agent-platform/oracle/references/ai-safety-guardrails.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/cost-optimization.md",
+              "target": "skills/ai-agent-platform/oracle/references/cost-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/embedding-strategy.md",
+              "target": "skills/ai-agent-platform/oracle/references/embedding-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/evaluation-observability.md",
+              "target": "skills/ai-agent-platform/oracle/references/evaluation-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/llm-application-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/references/llm-application-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/llm-production-anti-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/references/llm-production-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/prompt-engineering.md",
+              "target": "skills/ai-agent-platform/oracle/references/prompt-engineering.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/oracle/references/rag-design-anti-patterns.md",
+              "target": "skills/ai-agent-platform/oracle/references/rag-design-anti-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-agent-platform/oracle/SKILL.md",
-          "owner": "oracle",
-          "sha256": "1d724258fd1fc34d6a193175a21a0b1ed3a78d6ee5ef08f3cc1e310797dcb18e"
+          "sha256": "1d724258fd1fc34d6a193175a21a0b1ed3a78d6ee5ef08f3cc1e310797dcb18e",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/advanced-tool-use.md",
+          "sha256": "6438bb42a9bdcd11eee7eb12472f35a6cf33a54a3910b7f9066ddf2d3037a2b6",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/agent-design.md",
+          "sha256": "476d4cb4921e9ab1b5a33b3d923ccb720a469991ae224666d94f98e0a96afb92",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/ai-safety-guardrails.md",
+          "sha256": "b3fe290f1fb0043d5f92fc478bc65de4cea2efa139debaeb827703416608a811",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/autorun-schema.md",
+          "sha256": "d567290100356330ac7d8e45cb37c3ed8905e4a6d3a36bf82262b362c617faeb",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/cost-optimization.md",
+          "sha256": "6890f0b436e0919b7b7bc991880f47f10fd92f4ff03b90fc00cfa9ae49f6ac35",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/embedding-strategy.md",
+          "sha256": "6af984b6d68fae6951d2c8e10e3a2d5a88f276731069cabec2bfc7ac251288ac",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/evaluation-observability.md",
+          "sha256": "63c60ec3dced10bd243d8acb1b4872b0f4f5d91d743009aed7e9f3c9f4c15293",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/llm-application-patterns.md",
+          "sha256": "59d943d5a8f22c2f385f78bafe50f34bc7fb7544e4fba18d1225e5ad1877f480",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/llm-production-anti-patterns.md",
+          "sha256": "52164d3ff09ea6fad4b25c3c24793f403896a91f846ee8bf219c291a522d4c8a",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/prompt-engineering.md",
+          "sha256": "c4dba76e9d4877e66d49af81370b387aed39993dc11d7bc548daf515a3a7b9de",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/reference/rag-design-anti-patterns.md",
+          "sha256": "11c19ccbb7da64c5268e2c76f588cc9aad74eddcb585987792c5e222ba37a0b5",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/agent-design.md",
+          "sha256": "476d4cb4921e9ab1b5a33b3d923ccb720a469991ae224666d94f98e0a96afb92",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/ai-safety-guardrails.md",
+          "sha256": "b3fe290f1fb0043d5f92fc478bc65de4cea2efa139debaeb827703416608a811",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/cost-optimization.md",
+          "sha256": "ba992203b863cbfcd72c2d1fa99753bad521944a763a06d0daf1db2fe8b62ef9",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/embedding-strategy.md",
+          "sha256": "6af984b6d68fae6951d2c8e10e3a2d5a88f276731069cabec2bfc7ac251288ac",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/evaluation-observability.md",
+          "sha256": "63c60ec3dced10bd243d8acb1b4872b0f4f5d91d743009aed7e9f3c9f4c15293",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/llm-application-patterns.md",
+          "sha256": "8ffc6633cec3084c21f4f8be9d642610cd57f22690829191551b3f4a95c6b609",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/llm-production-anti-patterns.md",
+          "sha256": "52164d3ff09ea6fad4b25c3c24793f403896a91f846ee8bf219c291a522d4c8a",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/prompt-engineering.md",
+          "sha256": "6b6348750e57f0a0ae64f74ccff6df1ef1a71defbd8a444de8e181b5c380851f",
+          "owner": "oracle"
+        },
+        {
+          "path": "skills/ai-agent-platform/oracle/references/rag-design-anti-patterns.md",
+          "sha256": "0a72ef92b18191c7aee60c01c305696619693e66ddc810896de93c4679da9511",
+          "owner": "oracle"
         }
       ]
     },
@@ -388,6 +3257,61 @@
             {
               "source": "arena/SKILL.md",
               "target": "skills/ai-agent-platform/arena/SKILL.md"
+            },
+            {
+              "source": "arena/references/ai-code-quality-assurance.md",
+              "target": "skills/ai-agent-platform/arena/references/ai-code-quality-assurance.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/collaborate-mode-guide.md",
+              "target": "skills/ai-agent-platform/arena/references/collaborate-mode-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/competitive-development-patterns.md",
+              "target": "skills/ai-agent-platform/arena/references/competitive-development-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/decision-templates.md",
+              "target": "skills/ai-agent-platform/arena/references/decision-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/engine-cli-guide.md",
+              "target": "skills/ai-agent-platform/arena/references/engine-cli-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/engine-prompt-optimization.md",
+              "target": "skills/ai-agent-platform/arena/references/engine-prompt-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/evaluation-framework.md",
+              "target": "skills/ai-agent-platform/arena/references/evaluation-framework.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/execution-learning.md",
+              "target": "skills/ai-agent-platform/arena/references/execution-learning.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/multi-engine-anti-patterns.md",
+              "target": "skills/ai-agent-platform/arena/references/multi-engine-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/question-templates.md",
+              "target": "skills/ai-agent-platform/arena/references/question-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "arena/references/team-mode-guide.md",
+              "target": "skills/ai-agent-platform/arena/references/team-mode-guide.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -404,8 +3328,63 @@
       "managed_files": [
         {
           "path": "skills/ai-agent-platform/arena/SKILL.md",
-          "owner": "arena",
-          "sha256": "27cc6209f458801f59a5335269e05f034a87407fe3c626d4ba10e1f563995257"
+          "sha256": "27cc6209f458801f59a5335269e05f034a87407fe3c626d4ba10e1f563995257",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/ai-code-quality-assurance.md",
+          "sha256": "d16da0ab9d3f34c040152982585068db7cffefe49abada939408f47608ce52c8",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/collaborate-mode-guide.md",
+          "sha256": "c922485635860e5ef265db0d2e885a4c48e7154e902e055ed02fd1d5566c6e8c",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/competitive-development-patterns.md",
+          "sha256": "8fe85f18bf6d9c62ef000f5978d93c6f798d7ea9ecb5311ea6844de64b93c153",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/decision-templates.md",
+          "sha256": "2930e69d1ea3a3bcad1e68bc467790d83d5ec866fce098d3f21a90daafdd4a2f",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/engine-cli-guide.md",
+          "sha256": "79e929cd4651ea125aae839fa6da397bf33fd4eb9231663f13bc43ca57e25c23",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/engine-prompt-optimization.md",
+          "sha256": "99fe3ef273361bd39ea9e5f8f6ebfac4e77979f3b3a76c1ac631f61abe830fd9",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/evaluation-framework.md",
+          "sha256": "a4162440e3594adce1d071774a38342aab841bd4b994dabc5090039f6818fcbd",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/execution-learning.md",
+          "sha256": "148e4908a4fa372745d068db61e0eda2df2a2b5648dc9727f9b7a71d758df32d",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/multi-engine-anti-patterns.md",
+          "sha256": "4272e7ab850e8c137c4c17605859df73a98d3f1b9ed9714edc8b37bbfa2638d4",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/question-templates.md",
+          "sha256": "7cc57e9988ffadab0142251a4ca2be677ba32f43763d35a2bb29f047435d5764",
+          "owner": "arena"
+        },
+        {
+          "path": "skills/ai-agent-platform/arena/references/team-mode-guide.md",
+          "sha256": "839248be3d943aecb528c9d61d86c66ee0f922da5df8ac40370672eba912aafa",
+          "owner": "arena"
         }
       ]
     },
@@ -425,7 +3404,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -437,6 +3416,71 @@
             {
               "source": "sigil/SKILL.md",
               "target": "skills/ai-agent-platform/sigil/SKILL.md"
+            },
+            {
+              "source": "sigil/reference/advanced-patterns.md",
+              "target": "skills/ai-agent-platform/sigil/reference/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/autorun-schema.md",
+              "target": "skills/ai-agent-platform/sigil/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/claude-code-skills-api.md",
+              "target": "skills/ai-agent-platform/sigil/reference/claude-code-skills-api.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/claude-md-best-practices.md",
+              "target": "skills/ai-agent-platform/sigil/reference/claude-md-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/context-analysis.md",
+              "target": "skills/ai-agent-platform/sigil/reference/context-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/cross-tool-rules-landscape.md",
+              "target": "skills/ai-agent-platform/sigil/reference/cross-tool-rules-landscape.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/evolution-patterns.md",
+              "target": "skills/ai-agent-platform/sigil/reference/evolution-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/meta-prompting-self-improvement.md",
+              "target": "skills/ai-agent-platform/sigil/reference/meta-prompting-self-improvement.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/official-skill-guide.md",
+              "target": "skills/ai-agent-platform/sigil/reference/official-skill-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/skill-catalog.md",
+              "target": "skills/ai-agent-platform/sigil/reference/skill-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/skill-effectiveness.md",
+              "target": "skills/ai-agent-platform/sigil/reference/skill-effectiveness.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/skill-templates.md",
+              "target": "skills/ai-agent-platform/sigil/reference/skill-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "sigil/reference/validation-rules.md",
+              "target": "skills/ai-agent-platform/sigil/reference/validation-rules.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -448,13 +3492,215 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-agent-platform/sigil",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-agent-platform/sigil/references/advanced-patterns.md",
+              "target": "skills/ai-agent-platform/sigil/references/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/claude-code-skills-api.md",
+              "target": "skills/ai-agent-platform/sigil/references/claude-code-skills-api.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/claude-md-best-practices.md",
+              "target": "skills/ai-agent-platform/sigil/references/claude-md-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/context-analysis.md",
+              "target": "skills/ai-agent-platform/sigil/references/context-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/cross-tool-rules-landscape.md",
+              "target": "skills/ai-agent-platform/sigil/references/cross-tool-rules-landscape.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/evolution-patterns.md",
+              "target": "skills/ai-agent-platform/sigil/references/evolution-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/meta-prompting-self-improvement.md",
+              "target": "skills/ai-agent-platform/sigil/references/meta-prompting-self-improvement.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/official-skill-guide.md",
+              "target": "skills/ai-agent-platform/sigil/references/official-skill-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/skill-catalog.md",
+              "target": "skills/ai-agent-platform/sigil/references/skill-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/skill-effectiveness.md",
+              "target": "skills/ai-agent-platform/sigil/references/skill-effectiveness.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/skill-templates.md",
+              "target": "skills/ai-agent-platform/sigil/references/skill-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-agent-platform/sigil/references/validation-rules.md",
+              "target": "skills/ai-agent-platform/sigil/references/validation-rules.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-agent-platform/sigil/SKILL.md",
-          "owner": "sigil",
-          "sha256": "0a03430c1dd26c57c765ef7eea0f308f4c0da00166576528b72c8f74fd3e5d38"
+          "sha256": "0a03430c1dd26c57c765ef7eea0f308f4c0da00166576528b72c8f74fd3e5d38",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/advanced-patterns.md",
+          "sha256": "4e5711df6f77a62b19c3a6053f37230583b9de8ea3db745a7b2bb1cf50cd3c5c",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/autorun-schema.md",
+          "sha256": "e6e38a5b79486516ac168a854b7e614ac669973559f7cdc879aa4f311a68e410",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/claude-code-skills-api.md",
+          "sha256": "e5e657cc52ab049955acf12dc7f7164126cafaa7b5e15a48135f5b601ee6aaaa",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/claude-md-best-practices.md",
+          "sha256": "f5e38959115325d74954d6962ae1e29b575532a42a82f2a55ab42e643d91b139",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/context-analysis.md",
+          "sha256": "7333239ca9a7e61f81e00ff301780572ffaef555be839096795bb47d5ea5fbed",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/cross-tool-rules-landscape.md",
+          "sha256": "647fa96f50f81ff0b9ad7e9af3f09a2530059cd9c80bc6a6ccc682aa4eb28f9a",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/evolution-patterns.md",
+          "sha256": "74ca22137c5a595ae3f1a2303172d00353039373f4b37ed262af4373a48e9202",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/meta-prompting-self-improvement.md",
+          "sha256": "995d27a49d4bdd596b904f56775344cf17ae84a43ed19bee226cd140c9f3506d",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/official-skill-guide.md",
+          "sha256": "a3621c3c965fc0b6449f2966dc8688ea56efa20aedc5d607e1960dea6742a9f2",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/skill-catalog.md",
+          "sha256": "34cb9901cc8f9388862cddec72052033b85f76675c2be9ec45a887e4f1e8170e",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/skill-effectiveness.md",
+          "sha256": "0cd7d914012d8ae8307b667b2e102d9b0bd4b42738b07eb27444ca517c58ef30",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/skill-templates.md",
+          "sha256": "09aa4095699488948ef50779cdd3dc11e15d7d118239a2af9785c9f9b606c3c3",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/reference/validation-rules.md",
+          "sha256": "d9059910ec26451d89c84be65e4a2ccdb0a16e0abfd70a224ff5e53a4c660484",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/advanced-patterns.md",
+          "sha256": "4e5711df6f77a62b19c3a6053f37230583b9de8ea3db745a7b2bb1cf50cd3c5c",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/claude-code-skills-api.md",
+          "sha256": "16446db19b3057acb3d7d7b18ef8015366acd6504fd53e778fcd5e7032869bb1",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/claude-md-best-practices.md",
+          "sha256": "f5e38959115325d74954d6962ae1e29b575532a42a82f2a55ab42e643d91b139",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/context-analysis.md",
+          "sha256": "7333239ca9a7e61f81e00ff301780572ffaef555be839096795bb47d5ea5fbed",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/cross-tool-rules-landscape.md",
+          "sha256": "41abd71021841aa77d50b163aa5ed48483d076cbd7be4a0fd0f92986ab63a106",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/evolution-patterns.md",
+          "sha256": "74ca22137c5a595ae3f1a2303172d00353039373f4b37ed262af4373a48e9202",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/meta-prompting-self-improvement.md",
+          "sha256": "4cb633f606d59ee61ae8888f0f28dfe4b6c1fbf34aea96a56dd1ec942e1887b3",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/official-skill-guide.md",
+          "sha256": "1abd69095fe6b393d0573733d3735efafc1ccc43f3c20add652e50950771b0cb",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/skill-catalog.md",
+          "sha256": "34cb9901cc8f9388862cddec72052033b85f76675c2be9ec45a887e4f1e8170e",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/skill-effectiveness.md",
+          "sha256": "826f876cdfea82dc3874b20165c31fe827688abe2b231c2b2537ba05d8188e41",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/skill-templates.md",
+          "sha256": "00e744298ed23cbb80b3bf91e0752709978b72b15267c147e78199f02e4c1649",
+          "owner": "sigil"
+        },
+        {
+          "path": "skills/ai-agent-platform/sigil/references/validation-rules.md",
+          "sha256": "5347078e7a6e3faff4896f4d4f6d4962da572bde9da9828dedaa536f34f11870",
+          "owner": "sigil"
         }
       ]
     },
@@ -474,7 +3720,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -486,6 +3732,121 @@
             {
               "source": "guardian/SKILL.md",
               "target": "skills/engineering-workflow-automation/guardian/SKILL.md"
+            },
+            {
+              "source": "guardian/reference/autorun-mode.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/autorun-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/autorun-schema.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/branch-health.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/branch-health.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/branching-strategies.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/branching-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/code-review-guide.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/code-review-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/collaboration-routing.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/collaboration-routing.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/commit-analysis.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/commit-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/commit-conventions.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/commit-conventions.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/coverage-integration.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/coverage-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/git-automation.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/git-automation.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/git-recipes.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/git-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/history-audit.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/history-audit.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/history-reshape.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/history-reshape.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/learning-loop.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/learning-loop.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/output-templates.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/pr-quality-scoring.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/pr-quality-scoring.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/pr-ship-flow.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/pr-ship-flow.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/pr-split-strategy.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/pr-split-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/pr-workflow-patterns.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/pr-workflow-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/predictive-quality-gate.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/predictive-quality-gate.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/risk-assessment.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/risk-assessment.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/security-analysis.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/security-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "guardian/reference/squash-optimization.md",
+              "target": "skills/engineering-workflow-automation/guardian/reference/squash-optimization.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -497,13 +3858,365 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/engineering-workflow-automation/guardian",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/autorun-mode.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/autorun-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/branch-health.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/branch-health.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/branching-strategies.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/branching-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/code-review-guide.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/code-review-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/collaboration-patterns.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/collaboration-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/commit-analysis.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/commit-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/commit-conventions.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/commit-conventions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/coverage-integration.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/coverage-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/git-automation.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/git-automation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/git-recipes.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/git-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/handoff-router.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/handoff-router.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/history-audit.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/history-audit.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/history-reshape.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/history-reshape.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/learning-loop.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/learning-loop.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/output-templates.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/pr-quality-scoring.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/pr-quality-scoring.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/pr-split-strategy.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/pr-split-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/pr-workflow-patterns.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/pr-workflow-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/predictive-quality-gate.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/predictive-quality-gate.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/risk-assessment.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/risk-assessment.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/security-analysis.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/security-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/guardian/references/squash-optimization.md",
+              "target": "skills/engineering-workflow-automation/guardian/references/squash-optimization.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/engineering-workflow-automation/guardian/SKILL.md",
-          "owner": "guardian",
-          "sha256": "ffb8f542d6a405c59a17b849b2405c17cb05c9f02d85c3974b818a83f15244d4"
+          "sha256": "ffb8f542d6a405c59a17b849b2405c17cb05c9f02d85c3974b818a83f15244d4",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/autorun-mode.md",
+          "sha256": "be20f6f744ff6f7dbed7624dac4ea13036d95a7c59636a8cdc7ddc288ba5b3b8",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/autorun-schema.md",
+          "sha256": "90d26e71f6e33f21b13b7d17ee95756e1301afde14732901bfb1c6f5b0a9283c",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/branch-health.md",
+          "sha256": "c9ccdf1f58a57e7f1e89887c1eba0d75ea684be27c7026538525793e51931e89",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/branching-strategies.md",
+          "sha256": "d1b6c7a0ba56ef4265d4fced2822525992996190cdfbe6c0f3ecd638e2f8641a",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/code-review-guide.md",
+          "sha256": "97914ae6ad77f0941e3512cf8e9852e0877d8d937bcb58672d421f7bc00af994",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/collaboration-routing.md",
+          "sha256": "6bb278302397378252f0016077db588679c5485c1a591d52170173cd3a961152",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/commit-analysis.md",
+          "sha256": "6832be7c96428b63aad08586332b1975f89b61a25aeb08b72cfc25952716c5b4",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/commit-conventions.md",
+          "sha256": "db9e5520f003aa0092c09b2f863dfbf17eeebbab7252ae6c4b6442257a125908",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/coverage-integration.md",
+          "sha256": "67d23199fcac4d9842f6d7ea8acd594b9312571f5bd71bfb1a4aded91756ba13",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/git-automation.md",
+          "sha256": "5646d8e86a4d1d4d3d19ac8f74e34b549d03c805419df459c4f252dea08b6502",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/git-recipes.md",
+          "sha256": "a30bbca5c9bb82f41b58751767d8163695d1e220f1afd8e718ef66cb2f075939",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/history-audit.md",
+          "sha256": "11fbd988d1dae51cb398c705ff1ba735fa85d1eea64c278dcd5addb4b0d33f7e",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/history-reshape.md",
+          "sha256": "a0f207bfa4eba8dc4c9ee79f4d768ee1babb01851bb0788520ef84f3a77c265d",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/learning-loop.md",
+          "sha256": "80281b1d2c3863c639885b0e2980893977de8e24485ea6498618734359154f29",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/output-templates.md",
+          "sha256": "614d5163f1f5b0b36789005eb7f4d03925ab4a0054b92aa9177c43c7fe178acd",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/pr-quality-scoring.md",
+          "sha256": "679a5314595943c035ad4a8dbfa0952eaaa9facec449e156e911325a2c0e2fec",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/pr-ship-flow.md",
+          "sha256": "fb572288c4591642bc2c97a8a1fb7fc583ba7958944a27074d3e2d09dc05b3b8",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/pr-split-strategy.md",
+          "sha256": "7b4b536c905b9706ee0616d2cf60c5face578447b054b36fd3a6368cedda2ff9",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/pr-workflow-patterns.md",
+          "sha256": "d2bf981b65f23c8ba422d5eb6c657fd5bd97fff7afb6930eeed65d6829cd8a20",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/predictive-quality-gate.md",
+          "sha256": "7c163cdcc5ea1233306c98c065d2319765ed447af4dbc76499df504a5f75259f",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/risk-assessment.md",
+          "sha256": "dce0644093582d7ac6bd931304ed911a5be32ec7635d564115f41641ce47ba4f",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/security-analysis.md",
+          "sha256": "ca7d17582644e3ab84dc5abb3b25c487ea5c84f153f003d1b8cf82ec10e14fe2",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/reference/squash-optimization.md",
+          "sha256": "58a2d6ade09b3978098e62ce67ad80904f4204901e20dc5215eb1cf87164b207",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/autorun-mode.md",
+          "sha256": "be20f6f744ff6f7dbed7624dac4ea13036d95a7c59636a8cdc7ddc288ba5b3b8",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/branch-health.md",
+          "sha256": "c9ccdf1f58a57e7f1e89887c1eba0d75ea684be27c7026538525793e51931e89",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/branching-strategies.md",
+          "sha256": "d1b6c7a0ba56ef4265d4fced2822525992996190cdfbe6c0f3ecd638e2f8641a",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/code-review-guide.md",
+          "sha256": "97914ae6ad77f0941e3512cf8e9852e0877d8d937bcb58672d421f7bc00af994",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/collaboration-patterns.md",
+          "sha256": "81035a577930408aa86738eb1c47cf5a735a050fe7202b1e92af5351e6ea7459",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/commit-analysis.md",
+          "sha256": "22a6c49b3de49c273d9809dfce9e37d27b1aba1e9252dacc3e9164cc52988ca9",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/commit-conventions.md",
+          "sha256": "db9e5520f003aa0092c09b2f863dfbf17eeebbab7252ae6c4b6442257a125908",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/coverage-integration.md",
+          "sha256": "67d23199fcac4d9842f6d7ea8acd594b9312571f5bd71bfb1a4aded91756ba13",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/git-automation.md",
+          "sha256": "5646d8e86a4d1d4d3d19ac8f74e34b549d03c805419df459c4f252dea08b6502",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/git-recipes.md",
+          "sha256": "a30bbca5c9bb82f41b58751767d8163695d1e220f1afd8e718ef66cb2f075939",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/handoff-router.md",
+          "sha256": "48123038321e2e06496d00ee0b339872f3de13374e3f2480d30c2fe7154d0ccc",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/history-audit.md",
+          "sha256": "11fbd988d1dae51cb398c705ff1ba735fa85d1eea64c278dcd5addb4b0d33f7e",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/history-reshape.md",
+          "sha256": "a0f207bfa4eba8dc4c9ee79f4d768ee1babb01851bb0788520ef84f3a77c265d",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/learning-loop.md",
+          "sha256": "80281b1d2c3863c639885b0e2980893977de8e24485ea6498618734359154f29",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/output-templates.md",
+          "sha256": "198de16802d3572053a4918b0a6b0a5db3c8ba1f1e70bc423b24090600bc4f47",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/pr-quality-scoring.md",
+          "sha256": "679a5314595943c035ad4a8dbfa0952eaaa9facec449e156e911325a2c0e2fec",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/pr-split-strategy.md",
+          "sha256": "7b4b536c905b9706ee0616d2cf60c5face578447b054b36fd3a6368cedda2ff9",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/pr-workflow-patterns.md",
+          "sha256": "784bc2d790f9ebab1e41add7fcc623019cf7df19067a7577848c9a20248155ef",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/predictive-quality-gate.md",
+          "sha256": "7c163cdcc5ea1233306c98c065d2319765ed447af4dbc76499df504a5f75259f",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/risk-assessment.md",
+          "sha256": "dce0644093582d7ac6bd931304ed911a5be32ec7635d564115f41641ce47ba4f",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/security-analysis.md",
+          "sha256": "ca7d17582644e3ab84dc5abb3b25c487ea5c84f153f003d1b8cf82ec10e14fe2",
+          "owner": "guardian"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/guardian/references/squash-optimization.md",
+          "sha256": "58a2d6ade09b3978098e62ce67ad80904f4204901e20dc5215eb1cf87164b207",
+          "owner": "guardian"
         }
       ]
     },
@@ -523,7 +4236,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -535,6 +4248,141 @@
             {
               "source": "harvest/SKILL.md",
               "target": "skills/engineering-workflow-automation/harvest/SKILL.md"
+            },
+            {
+              "source": "harvest/reference/autorun-schema.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/caching-strategy.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/caching-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/changelog-best-practices.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/changelog-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/client-report-templates.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/client-report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/dora-metrics.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/dora-metrics.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/engineering-metrics-pitfalls.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/engineering-metrics-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/error-handling.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/error-handling.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/estimation-anti-patterns.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/estimation-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/gh-commands.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/gh-commands.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/okr-linkage.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/okr-linkage.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/outbound-handoffs.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/outbound-handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/pdf-export-guide.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/pdf-export-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/pr-stats-analysis.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/pr-stats-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/report-templates.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/reporting-anti-patterns.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/reporting-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/retrospective-voice.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/retrospective-voice.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/reference/work-hours.md",
+              "target": "skills/engineering-workflow-automation/harvest/reference/work-hours.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/samples/client-report-2026-01-31.html",
+              "target": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.html",
+              "type": "file"
+            },
+            {
+              "source": "harvest/samples/client-report-2026-01-31.md",
+              "target": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/samples/pr-summary-2026-01-31.md",
+              "target": "skills/engineering-workflow-automation/harvest/samples/pr-summary-2026-01-31.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/samples/release-notes-v0.2.0.md",
+              "target": "skills/engineering-workflow-automation/harvest/samples/release-notes-v0.2.0.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/samples/work-report-simota-2026-01-31.md",
+              "target": "skills/engineering-workflow-automation/harvest/samples/work-report-simota-2026-01-31.md",
+              "type": "file"
+            },
+            {
+              "source": "harvest/scripts/generate-report.js",
+              "target": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
+              "type": "file"
+            },
+            {
+              "source": "harvest/scripts/html-to-pdf.sh",
+              "target": "skills/engineering-workflow-automation/harvest/scripts/html-to-pdf.sh",
+              "type": "file"
+            },
+            {
+              "source": "harvest/scripts/puppeteer-pdf.js",
+              "target": "skills/engineering-workflow-automation/harvest/scripts/puppeteer-pdf.js",
+              "type": "file"
+            },
+            {
+              "source": "harvest/styles/harvest-style.css",
+              "target": "skills/engineering-workflow-automation/harvest/styles/harvest-style.css",
+              "type": "file"
+            },
+            {
+              "source": "harvest/templates/client-report.html",
+              "target": "skills/engineering-workflow-automation/harvest/templates/client-report.html",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -546,13 +4394,325 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/engineering-workflow-automation/harvest",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/caching-strategy.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/caching-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/changelog-best-practices.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/changelog-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/client-report-templates.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/client-report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/dora-metrics.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/dora-metrics.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/engineering-metrics-pitfalls.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/engineering-metrics-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/error-handling.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/error-handling.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/estimation-anti-patterns.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/estimation-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/gh-commands.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/gh-commands.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/okr-linkage.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/okr-linkage.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/outbound-handoffs.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/outbound-handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/pdf-export-guide.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/pdf-export-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/pr-stats-analysis.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/pr-stats-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/report-templates.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/reporting-anti-patterns.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/reporting-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/retrospective-voice.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/retrospective-voice.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/references/work-hours.md",
+              "target": "skills/engineering-workflow-automation/harvest/references/work-hours.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/engineering-workflow-automation/harvest/SKILL.md",
-          "owner": "harvest",
-          "sha256": "8d8c7edf2bfcb0cfeb76515cff6a766144d3e60fa43a7b329f8af3814ef4b987"
+          "sha256": "8d8c7edf2bfcb0cfeb76515cff6a766144d3e60fa43a7b329f8af3814ef4b987",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/autorun-schema.md",
+          "sha256": "d83acbd4fca1d86c806cb0cb906f70f518cfbd1a4fef3947f81c6be9b6a56a34",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/caching-strategy.md",
+          "sha256": "0f17e7582c4e55a6df8f7160110850a407f9ec89740836e7aa853c6d45d4b12d",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/changelog-best-practices.md",
+          "sha256": "b48dc8cff4c667feccc86821b190afc2e2acd6c3c36407b15a64245f925d3ed9",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/client-report-templates.md",
+          "sha256": "b708f02c81cfac9c4304d41dd31e0b6c291c008849f10e358ba9d9ae9f9daaa9",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/dora-metrics.md",
+          "sha256": "e719b3a1cfeae9f741aea91287882768772ff3447eb50ad4e7c4b6cac5273912",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/engineering-metrics-pitfalls.md",
+          "sha256": "b8ca45882765180a164eb5796e26ed69091abeae23a2d87799f57bb7c34737fb",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/error-handling.md",
+          "sha256": "81b907dacd8ca7bfe538b5e2b76bc882a7dc7377e8ce940d442b5328c490ad14",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/estimation-anti-patterns.md",
+          "sha256": "66e3b12a06931760a2392d25a05691f06ccafdcda97ed4f9572159757bf5dd79",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/gh-commands.md",
+          "sha256": "93b44998a31dc60fef2cbc5ee99a97e9c9e78a0afa3fdac4018a63200a032b23",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/okr-linkage.md",
+          "sha256": "522b2933ebdff8b422e3bb858182756829b731df8e1ae4e3d0644cf28d80b15a",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/outbound-handoffs.md",
+          "sha256": "d438d3e746009ce907c9e40b9163fa925c8fab6b9c23add706495e1ab6bad0f1",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/pdf-export-guide.md",
+          "sha256": "d21233be228da684d1c3770853a190e3f66428adb02663fbc61680ed3a0caa7c",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/pr-stats-analysis.md",
+          "sha256": "546bd6b2b72c0fdbcf1c404e4986c9c2a674910b97244aee7e0d5f141b46f0b1",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/report-templates.md",
+          "sha256": "cf255fd00a7e40477cb4f231616f76d5e16c8736d77420f1125025f4ab526afe",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/reporting-anti-patterns.md",
+          "sha256": "ad8cab4c346125457c1c444f1771ff4d17b3c702c9e0c2ed673b9386e66ec8b8",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/retrospective-voice.md",
+          "sha256": "004e3565ee28a1806f23f7c624c1e7e4fff6d70226fb318ce30723b1e571241c",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/reference/work-hours.md",
+          "sha256": "e9690b6ba38dc696ad9557f5e3585c52a1f969caf922c7d9850ddc8e87480a70",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/caching-strategy.md",
+          "sha256": "fddd9f344d37f66523c85330d4e0cf1bc3219b508443f5590993a28273daaef6",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/changelog-best-practices.md",
+          "sha256": "573d14e057c4d06356de021c72afd0ea047e00a93f0f8e3a59803627abdf2087",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/client-report-templates.md",
+          "sha256": "5cd6f088da2c03f3ba3a8b67649d877497bb602c0cbb5b502ab7c8059dc04df2",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/dora-metrics.md",
+          "sha256": "862f722b775e46b566a585aa5d4f3ba5e1400ff52445d22f459bb4ee092e86f5",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/engineering-metrics-pitfalls.md",
+          "sha256": "63a602f9ced6ae52e7e9740f09c562be2a4d50a02af8184361bbe4998ebe48e5",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/error-handling.md",
+          "sha256": "3151cb60060c3ac46ca01bc2fa3c507910926bcaa2dc68aa4e8c02d82fe525d0",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/estimation-anti-patterns.md",
+          "sha256": "f44bd9b7494ba7c6e8ae95ca729ce782c09a219651103c7ccde6c6dc4c3db3db",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/gh-commands.md",
+          "sha256": "87573c827a6f09b33275a639e1bca5b777fa98cad1b61df6fdb7f3413e3e87d8",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/okr-linkage.md",
+          "sha256": "b203e135b65dbcbf90aba3d214a451d83e2f1cd918dca9b4a9fa4bd0fba1401d",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/outbound-handoffs.md",
+          "sha256": "ba631eb5d22f9fc742819e49d013ef6a76ddbcdee3ca3283dce704bc447a0453",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/pdf-export-guide.md",
+          "sha256": "690b3e72fe5dd0acc4c9b9c88543312a330053d58de102ef4aadcfba1d01afac",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/pr-stats-analysis.md",
+          "sha256": "13f4b748406887d99c39ebbcf5e52bcd86d8f03a2c554b6f283ba08dc2157b9b",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/report-templates.md",
+          "sha256": "e39bb5af4f822a0df55e8fcbf07077e49c6863abf7e1c88130de8820c5476721",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/reporting-anti-patterns.md",
+          "sha256": "d6541e4648bfa1ae4fc8de2c96f989095e96a47b091a1dc3d0a192f33455c264",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/retrospective-voice.md",
+          "sha256": "ebc4ea9af3e73400feb5b66c6959d32a83efbf6f01c78c9bfb243036808a47ba",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/references/work-hours.md",
+          "sha256": "788b86edd5c8ace8856aed8b1f3a942c4d046643ca7901e3745cdaeb75e4c729",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.html",
+          "sha256": "fb28517f9cc4f7b6ecc3b181e5bc68eb5ae320602568ee49b1d8133f2e6b531f",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/samples/client-report-2026-01-31.md",
+          "sha256": "45de2e7edf69ae4229236ada4000be759b0a00fa4280af168e446a4f71d9c86c",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/samples/pr-summary-2026-01-31.md",
+          "sha256": "a83f7fb1b16bbd4c5f0a7364a8027990e10edd2bb03d69ed5824f2cb9f794018",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/samples/release-notes-v0.2.0.md",
+          "sha256": "93e6538c7800b81add78c8988e57bd530a929dc06a1690cd4060b58394e75612",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/samples/work-report-simota-2026-01-31.md",
+          "sha256": "794fdf8d11736de6d189cb755ae07a702b5f7a7686a202cda31a0b7c6348c6a3",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
+          "sha256": "191cd0266edd13be4084ae45114117842d17427fcca276665e6692192de83f9a",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/scripts/html-to-pdf.sh",
+          "sha256": "337a01144d733b319a6e030476f37052a4b95f864ca6ebbe00b7cd6a1c7566e1",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/scripts/puppeteer-pdf.js",
+          "sha256": "115b6f4b4ba717ca539bf566d81492c7253a32ac5d33d7a63a5ebddf505f4571",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/styles/harvest-style.css",
+          "sha256": "a34870b062bbd7d9cef43f7a1c43c886ece6529bb3368b56348a8d44ff17b695",
+          "owner": "harvest"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/harvest/templates/client-report.html",
+          "sha256": "845cd256464a8834859c6198340d824d0b28a91ff58d2813a80d9e5f9aacd67d",
+          "owner": "harvest"
         }
       ]
     },
@@ -572,7 +4732,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -584,6 +4744,66 @@
             {
               "source": "latch/SKILL.md",
               "target": "skills/engineering-workflow-automation/latch/SKILL.md"
+            },
+            {
+              "source": "latch/reference/claude-md-update-proposer.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/claude-md-update-proposer.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/debugging-guide.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/debugging-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/event-catalog.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/event-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/hook-recipes.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/hook-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/hook-system.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/hook-system.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/loop-automation-context.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/loop-automation-context.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/nexus-integration.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/nexus-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/notification-hook.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/notification-hook.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/security-guard-hook.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/security-guard-hook.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/sessionstart-hook.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/sessionstart-hook.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/skill-quarantine-hook.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/skill-quarantine-hook.md",
+              "type": "file"
+            },
+            {
+              "source": "latch/reference/skill-usage-telemetry.md",
+              "target": "skills/engineering-workflow-automation/latch/reference/skill-usage-telemetry.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -595,13 +4815,130 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/engineering-workflow-automation/latch",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/engineering-workflow-automation/latch/references/debugging-guide.md",
+              "target": "skills/engineering-workflow-automation/latch/references/debugging-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/latch/references/hook-recipes.md",
+              "target": "skills/engineering-workflow-automation/latch/references/hook-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/latch/references/hook-system.md",
+              "target": "skills/engineering-workflow-automation/latch/references/hook-system.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/latch/references/nexus-integration.md",
+              "target": "skills/engineering-workflow-automation/latch/references/nexus-integration.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/engineering-workflow-automation/latch/SKILL.md",
-          "owner": "latch",
-          "sha256": "4899f718e5440ad4e35e5f958cd6915076700d86a9854bf7b7803c1db1003277"
+          "sha256": "4899f718e5440ad4e35e5f958cd6915076700d86a9854bf7b7803c1db1003277",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/claude-md-update-proposer.md",
+          "sha256": "262866e0dbaddb939d651352be45068222333ac973d08aaef59989bca6c6fa9f",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/debugging-guide.md",
+          "sha256": "9a9d03cca7f8f0b8664c2eb1999e70bc2d909e795e0e37bde3d33d98e2a288df",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/event-catalog.md",
+          "sha256": "b693289e7df3cbd30723124cb1a176af350e99d90b415de451672ef6f765f7c6",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/hook-recipes.md",
+          "sha256": "4d515e8e3a57b16e2871dcdbb29899669ffe529a948728700afbcceee5db7f01",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/hook-system.md",
+          "sha256": "8d4a55f1e1f25166f10619d7efdd540405561e70bf04fe07e74cee9170a7c6bf",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/loop-automation-context.md",
+          "sha256": "823bd728dae4664d1169d700d34abe628173ae808a3b99f701c86351783adf0d",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/nexus-integration.md",
+          "sha256": "1cdb73312af748b73261707db9f22ee74d0117631237bfcb6715a04b31075173",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/notification-hook.md",
+          "sha256": "84b11523642403616be3f72eaab094ffd197cce262e78d35e6a7d9ca6d4fa3ea",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/security-guard-hook.md",
+          "sha256": "241fc08195b4b3fd579b52b1a141794d142378d8c32fcdc86a25b88aac3727aa",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/sessionstart-hook.md",
+          "sha256": "f72551fbcd0f470c1b24b148f7c72f985ed945e08f98e6fa2d2d0fb8ba2df3b2",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/skill-quarantine-hook.md",
+          "sha256": "5dacfa797c72f01312df57897774a4fa2cf1d158917ea3e846e4601e16fb7be1",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/reference/skill-usage-telemetry.md",
+          "sha256": "ad9d023a34826640a85e0f66ad63bc0c8dee7c1575ecd329bd549c30f2221e15",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/references/debugging-guide.md",
+          "sha256": "9a9d03cca7f8f0b8664c2eb1999e70bc2d909e795e0e37bde3d33d98e2a288df",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/references/hook-recipes.md",
+          "sha256": "dd88918c21cfb8ed05a0d613bf01b900cf03df29e60bd92ad6cf294cf89b8e47",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/references/hook-system.md",
+          "sha256": "8d4a55f1e1f25166f10619d7efdd540405561e70bf04fe07e74cee9170a7c6bf",
+          "owner": "latch"
+        },
+        {
+          "path": "skills/engineering-workflow-automation/latch/references/nexus-integration.md",
+          "sha256": "1cdb73312af748b73261707db9f22ee74d0117631237bfcb6715a04b31075173",
+          "owner": "latch"
         }
       ]
     },
@@ -621,7 +4958,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -633,6 +4970,76 @@
             {
               "source": "beacon/SKILL.md",
               "target": "skills/devops-sre/beacon/SKILL.md"
+            },
+            {
+              "source": "beacon/reference/alerting-strategy.md",
+              "target": "skills/devops-sre/beacon/reference/alerting-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/autorun-schema.md",
+              "target": "skills/devops-sre/beacon/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/capacity-planning.md",
+              "target": "skills/devops-sre/beacon/reference/capacity-planning.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/dashboard-design.md",
+              "target": "skills/devops-sre/beacon/reference/dashboard-design.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/golden-signals.md",
+              "target": "skills/devops-sre/beacon/reference/golden-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/incident-learning-postmortem.md",
+              "target": "skills/devops-sre/beacon/reference/incident-learning-postmortem.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/llm-observability.md",
+              "target": "skills/devops-sre/beacon/reference/llm-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/logging-design.md",
+              "target": "skills/devops-sre/beacon/reference/logging-design.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/opentelemetry-best-practices.md",
+              "target": "skills/devops-sre/beacon/reference/opentelemetry-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/platform-observability.md",
+              "target": "skills/devops-sre/beacon/reference/platform-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/reliability-review.md",
+              "target": "skills/devops-sre/beacon/reference/reliability-review.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/slo-sli-design.md",
+              "target": "skills/devops-sre/beacon/reference/slo-sli-design.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/toil-automation.md",
+              "target": "skills/devops-sre/beacon/reference/toil-automation.md",
+              "type": "file"
+            },
+            {
+              "source": "beacon/reference/toil-reduction.md",
+              "target": "skills/devops-sre/beacon/reference/toil-reduction.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -644,13 +5051,230 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/devops-sre/beacon",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/devops-sre/beacon/references/alerting-strategy.md",
+              "target": "skills/devops-sre/beacon/references/alerting-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/capacity-planning.md",
+              "target": "skills/devops-sre/beacon/references/capacity-planning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/dashboard-design.md",
+              "target": "skills/devops-sre/beacon/references/dashboard-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/golden-signals.md",
+              "target": "skills/devops-sre/beacon/references/golden-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/incident-learning-postmortem.md",
+              "target": "skills/devops-sre/beacon/references/incident-learning-postmortem.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/llm-observability.md",
+              "target": "skills/devops-sre/beacon/references/llm-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/logging-design.md",
+              "target": "skills/devops-sre/beacon/references/logging-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/opentelemetry-best-practices.md",
+              "target": "skills/devops-sre/beacon/references/opentelemetry-best-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/platform-observability.md",
+              "target": "skills/devops-sre/beacon/references/platform-observability.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/reliability-review.md",
+              "target": "skills/devops-sre/beacon/references/reliability-review.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/slo-sli-design.md",
+              "target": "skills/devops-sre/beacon/references/slo-sli-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/toil-automation.md",
+              "target": "skills/devops-sre/beacon/references/toil-automation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/beacon/references/toil-reduction.md",
+              "target": "skills/devops-sre/beacon/references/toil-reduction.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/devops-sre/beacon/SKILL.md",
-          "owner": "beacon",
-          "sha256": "e1a740d96916fd15117f79c9a105dc0ec5aee6a0a25fec7a43196ba1d3007a76"
+          "sha256": "e1a740d96916fd15117f79c9a105dc0ec5aee6a0a25fec7a43196ba1d3007a76",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/alerting-strategy.md",
+          "sha256": "c87244549571e7d153920981f619d71f9097ab508719d98385db8c6a9fd01987",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/autorun-schema.md",
+          "sha256": "e8e6893650e1742c7f161981d0f2454dc6d797a780af93bbadde4318b6dd287c",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/capacity-planning.md",
+          "sha256": "7665629633808ef8cedb5dda72f3c0d3d28e30ac6dfcd39f1da42644af98d0cd",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/dashboard-design.md",
+          "sha256": "d6d411442573166ec024169fac3ad45ca3db164e165bf83f2c9249cad7aedfbe",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/golden-signals.md",
+          "sha256": "3c719ae91eeaa09d93f03cecd74cb73286d09a5f5bf283b3040fb8531facd96e",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/incident-learning-postmortem.md",
+          "sha256": "246f7d92cc598fb140ea9df73866bf629457d00ee1ad205115ebf01b69409a31",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/llm-observability.md",
+          "sha256": "bc07a535a4d8a7a63b95246632b2bdf6ab9c32177d9cf43bea9c54b53f995d48",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/logging-design.md",
+          "sha256": "59ef9a7f5915bd745d28238d7fe66e6033960d4e7055b3f1a6aac251a18621d0",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/opentelemetry-best-practices.md",
+          "sha256": "088ff70876b2958f7a5c0089ac7eae647175e88414d843a77313f370a355c8bc",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/platform-observability.md",
+          "sha256": "4e29ee67ca2cf58d77031a984bb4a9034b40080297740f22cfaccc7be9f1d77c",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/reliability-review.md",
+          "sha256": "b9b7f2b971bac48e51cbc96c41396f0e113edd223bec11a672aae2b17313b8aa",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/slo-sli-design.md",
+          "sha256": "dc16baee2d779ad864eb10b6d52bee8cdb28afff0d1eb32b7164e5129d8adc3f",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/toil-automation.md",
+          "sha256": "5c4f02476fd3e61887d5df4cd83ccad656329c41ea081f813a7386fa1782e37f",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/reference/toil-reduction.md",
+          "sha256": "0694872b8e1b487a6b6bdc8fa0895f89ca4487e145d5828736dd981213399ff3",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/alerting-strategy.md",
+          "sha256": "b9904d57511fca02b42fba21997e217e3af5b2b471f42971f8def171007c83db",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/capacity-planning.md",
+          "sha256": "7665629633808ef8cedb5dda72f3c0d3d28e30ac6dfcd39f1da42644af98d0cd",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/dashboard-design.md",
+          "sha256": "6ec27eaf4eaa54f3c903bca3f9983f4eb2d0a4825a91003c9da4e18d4a1f2e3f",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/golden-signals.md",
+          "sha256": "3c719ae91eeaa09d93f03cecd74cb73286d09a5f5bf283b3040fb8531facd96e",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/incident-learning-postmortem.md",
+          "sha256": "a5fcaf58c8b27fae736d2a4b2fa2cf382e05d011383c054c0c5d209dbed99fdc",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/llm-observability.md",
+          "sha256": "45d2f5e07cdd4059f4194f7903761d6261f3e7c2ec378581ef42a9f9a3a1bcc0",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/logging-design.md",
+          "sha256": "59ef9a7f5915bd745d28238d7fe66e6033960d4e7055b3f1a6aac251a18621d0",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/opentelemetry-best-practices.md",
+          "sha256": "088ff70876b2958f7a5c0089ac7eae647175e88414d843a77313f370a355c8bc",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/platform-observability.md",
+          "sha256": "4e29ee67ca2cf58d77031a984bb4a9034b40080297740f22cfaccc7be9f1d77c",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/reliability-review.md",
+          "sha256": "b9b7f2b971bac48e51cbc96c41396f0e113edd223bec11a672aae2b17313b8aa",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/slo-sli-design.md",
+          "sha256": "dc16baee2d779ad864eb10b6d52bee8cdb28afff0d1eb32b7164e5129d8adc3f",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/toil-automation.md",
+          "sha256": "5c4f02476fd3e61887d5df4cd83ccad656329c41ea081f813a7386fa1782e37f",
+          "owner": "beacon"
+        },
+        {
+          "path": "skills/devops-sre/beacon/references/toil-reduction.md",
+          "sha256": "0694872b8e1b487a6b6bdc8fa0895f89ca4487e145d5828736dd981213399ff3",
+          "owner": "beacon"
         }
       ]
     },
@@ -670,7 +5294,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -682,6 +5306,46 @@
             {
               "source": "triage/SKILL.md",
               "target": "skills/devops-sre/triage/SKILL.md"
+            },
+            {
+              "source": "triage/reference/autorun-schema.md",
+              "target": "skills/devops-sre/triage/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/collaboration-flows.md",
+              "target": "skills/devops-sre/triage/reference/collaboration-flows.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/escalation-matrix.md",
+              "target": "skills/devops-sre/triage/reference/escalation-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/first-response.md",
+              "target": "skills/devops-sre/triage/reference/first-response.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/incident-communications.md",
+              "target": "skills/devops-sre/triage/reference/incident-communications.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/postmortem-templates.md",
+              "target": "skills/devops-sre/triage/reference/postmortem-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/response-workflow.md",
+              "target": "skills/devops-sre/triage/reference/response-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "triage/reference/runbooks-communication.md",
+              "target": "skills/devops-sre/triage/reference/runbooks-communication.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -693,13 +5357,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/devops-sre/triage",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/devops-sre/triage/references/collaboration-flows.md",
+              "target": "skills/devops-sre/triage/references/collaboration-flows.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/escalation-matrix.md",
+              "target": "skills/devops-sre/triage/references/escalation-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/first-response.md",
+              "target": "skills/devops-sre/triage/references/first-response.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/incident-communications.md",
+              "target": "skills/devops-sre/triage/references/incident-communications.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/postmortem-templates.md",
+              "target": "skills/devops-sre/triage/references/postmortem-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/response-workflow.md",
+              "target": "skills/devops-sre/triage/references/response-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/triage/references/runbooks-communication.md",
+              "target": "skills/devops-sre/triage/references/runbooks-communication.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/devops-sre/triage/SKILL.md",
-          "owner": "triage",
-          "sha256": "23bdbe807afe7312d536ec40c672d2c74c4647f8a79906eb912eff75c4120116"
+          "sha256": "23bdbe807afe7312d536ec40c672d2c74c4647f8a79906eb912eff75c4120116",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/autorun-schema.md",
+          "sha256": "cc2abb908e801bddde1f03ac5c915462adbebd593667de66043ac24e390f1f9c",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/collaboration-flows.md",
+          "sha256": "615ea9e356a49a5e49a26e6ede8847c64f31a401fd9474fa14fe49ede11480b5",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/escalation-matrix.md",
+          "sha256": "3e37bd6f785c21d46a8d76d5cb9e1ee619147cd4f0148e43c16007f74a59d50d",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/first-response.md",
+          "sha256": "e0b7fc760dd0fe636f7b1613b2579b77d3a3d7fdffa161b4c7f80837973f3804",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/incident-communications.md",
+          "sha256": "200a80f16d19dbe7697e2b64f085d8b0dd5cd8262b1b4207f60843dac1e1d16c",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/postmortem-templates.md",
+          "sha256": "443cc3cce6ef2e4ffab79df78cac08326ead0a9b6248d34b2272c908e1791ddf",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/response-workflow.md",
+          "sha256": "940d4a4afba9293b547515e34b6178181972eabc4c40b7251308184f9f748dec",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/reference/runbooks-communication.md",
+          "sha256": "9a24c482b027e3a0ce3a88b76f42d3faae24dd4a1e4c823d202d7b43e6194b05",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/collaboration-flows.md",
+          "sha256": "615ea9e356a49a5e49a26e6ede8847c64f31a401fd9474fa14fe49ede11480b5",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/escalation-matrix.md",
+          "sha256": "3e37bd6f785c21d46a8d76d5cb9e1ee619147cd4f0148e43c16007f74a59d50d",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/first-response.md",
+          "sha256": "2891b394a68dc8bccaa4e6cd9c45eba756bbdcbf18e6d11c5557cc6230a412d9",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/incident-communications.md",
+          "sha256": "200a80f16d19dbe7697e2b64f085d8b0dd5cd8262b1b4207f60843dac1e1d16c",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/postmortem-templates.md",
+          "sha256": "dbc066d54f558cad5c568dc81801b237d0759c0f886e134b7b7aabcfb58bc06c",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/response-workflow.md",
+          "sha256": "08fdfe1309797e10f4e6a37bbbe3e4ce15c2362e086e01fb83934131147d0e63",
+          "owner": "triage"
+        },
+        {
+          "path": "skills/devops-sre/triage/references/runbooks-communication.md",
+          "sha256": "9a24c482b027e3a0ce3a88b76f42d3faae24dd4a1e4c823d202d7b43e6194b05",
+          "owner": "triage"
         }
       ]
     },
@@ -719,7 +5510,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -731,6 +5522,61 @@
             {
               "source": "gear/SKILL.md",
               "target": "skills/devops-sre/gear/SKILL.md"
+            },
+            {
+              "source": "gear/reference/alert-configuration.md",
+              "target": "skills/devops-sre/gear/reference/alert-configuration.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/autorun-schema.md",
+              "target": "skills/devops-sre/gear/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/dependency-management.md",
+              "target": "skills/devops-sre/gear/reference/dependency-management.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/docker-patterns.md",
+              "target": "skills/devops-sre/gear/reference/docker-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/github-actions.md",
+              "target": "skills/devops-sre/gear/reference/github-actions.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/kubernetes-config.md",
+              "target": "skills/devops-sre/gear/reference/kubernetes-config.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/monorepo-guide.md",
+              "target": "skills/devops-sre/gear/reference/monorepo-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/nexus-integration.md",
+              "target": "skills/devops-sre/gear/reference/nexus-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/observability.md",
+              "target": "skills/devops-sre/gear/reference/observability.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/secrets-management.md",
+              "target": "skills/devops-sre/gear/reference/secrets-management.md",
+              "type": "file"
+            },
+            {
+              "source": "gear/reference/troubleshooting.md",
+              "target": "skills/devops-sre/gear/reference/troubleshooting.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -742,13 +5588,185 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/devops-sre/gear",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/devops-sre/gear/references/alert-configuration.md",
+              "target": "skills/devops-sre/gear/references/alert-configuration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/dependency-management.md",
+              "target": "skills/devops-sre/gear/references/dependency-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/docker-patterns.md",
+              "target": "skills/devops-sre/gear/references/docker-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/github-actions.md",
+              "target": "skills/devops-sre/gear/references/github-actions.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/kubernetes-config.md",
+              "target": "skills/devops-sre/gear/references/kubernetes-config.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/monorepo-guide.md",
+              "target": "skills/devops-sre/gear/references/monorepo-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/nexus-integration.md",
+              "target": "skills/devops-sre/gear/references/nexus-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/observability.md",
+              "target": "skills/devops-sre/gear/references/observability.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/secrets-management.md",
+              "target": "skills/devops-sre/gear/references/secrets-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/devops-sre/gear/references/troubleshooting.md",
+              "target": "skills/devops-sre/gear/references/troubleshooting.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/devops-sre/gear/SKILL.md",
-          "owner": "gear",
-          "sha256": "ab6419da527e54f335efea4afd0bb40d639186ab2a8c7d5a0c0f022d9ce74ee5"
+          "sha256": "ab6419da527e54f335efea4afd0bb40d639186ab2a8c7d5a0c0f022d9ce74ee5",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/alert-configuration.md",
+          "sha256": "06e05d4c3ccc8a7226e3b5dfb4bd5699b23c033ce7c618ef754d8fb7a21dad71",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/autorun-schema.md",
+          "sha256": "f243a7e45e2926d1c81afecbd1ea000cb08d8c2fb5ec12f1bc59b51fb4099a17",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/dependency-management.md",
+          "sha256": "eeb6916865f40790a431ea579193d6db4a09ca55bc3d91a2c868bb7e7958f538",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/docker-patterns.md",
+          "sha256": "0c4f932bb12347207ff56e3b5b3d9a3d1add1b6bd34313532de217b01de9df13",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/github-actions.md",
+          "sha256": "16494360513f4f99e6cc8d9e50bf0b465172a6ff1be23e133ec0b9f58f007b95",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/kubernetes-config.md",
+          "sha256": "827e30497226676ec07624eee6ef0b16a5d498ef883d5039216ce7dbf9d17ac6",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/monorepo-guide.md",
+          "sha256": "e6c2a6c380a0957a78d96766a612da28c577dea76b6d849578b8bca767809385",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/nexus-integration.md",
+          "sha256": "327a85507177284aa758d77d85c903d9bb87a000a7a9f153cef35bdd4f42aa7f",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/observability.md",
+          "sha256": "a8cc782c5e7d91111e6e721967579bf5ce99ce4306db637f98128c1110fa3355",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/secrets-management.md",
+          "sha256": "bbd84fc13b0c189b1eb010c886137e6f31f2efcfdd13886d9322a1b5f74dab86",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/reference/troubleshooting.md",
+          "sha256": "43e2b7cd8ca34bae0da27477d7cffcb2cf522979af1fb1cd6e35428ab654d975",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/alert-configuration.md",
+          "sha256": "06e05d4c3ccc8a7226e3b5dfb4bd5699b23c033ce7c618ef754d8fb7a21dad71",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/dependency-management.md",
+          "sha256": "e56aea3ac38837147d45651585c78197790264f2716e9ca2065b17e2ff28220e",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/docker-patterns.md",
+          "sha256": "cb3c6d4a9dfa8fb63527da0a861ba8b440c9b084f7f09c6ae29e6df185a18767",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/github-actions.md",
+          "sha256": "be972e0ec2d62e2de30b3a81d19c0ee63606c56c5b7bc1c942a16c78d2310194",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/kubernetes-config.md",
+          "sha256": "827e30497226676ec07624eee6ef0b16a5d498ef883d5039216ce7dbf9d17ac6",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/monorepo-guide.md",
+          "sha256": "e6c2a6c380a0957a78d96766a612da28c577dea76b6d849578b8bca767809385",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/nexus-integration.md",
+          "sha256": "9ff4ddf0609912c9918ae7c328bde1eb25d6cc846487c55460bdb2f87eaa098c",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/observability.md",
+          "sha256": "ae3184f41b14b30e5226614545321a409472fc54968404cbabe241b0faab5542",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/secrets-management.md",
+          "sha256": "bbd84fc13b0c189b1eb010c886137e6f31f2efcfdd13886d9322a1b5f74dab86",
+          "owner": "gear"
+        },
+        {
+          "path": "skills/devops-sre/gear/references/troubleshooting.md",
+          "sha256": "43e2b7cd8ca34bae0da27477d7cffcb2cf522979af1fb1cd6e35428ab654d975",
+          "owner": "gear"
         }
       ]
     },
@@ -768,7 +5786,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -780,6 +5798,76 @@
             {
               "source": "ledger/SKILL.md",
               "target": "skills/finance-investing/ledger/SKILL.md"
+            },
+            {
+              "source": "ledger/reference/ai-gpu-cost.md",
+              "target": "skills/finance-investing/ledger/reference/ai-gpu-cost.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/autorun-schema.md",
+              "target": "skills/finance-investing/ledger/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/cloud-pricing-models.md",
+              "target": "skills/finance-investing/ledger/reference/cloud-pricing-models.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/cost-anomaly-detection.md",
+              "target": "skills/finance-investing/ledger/reference/cost-anomaly-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/cost-governance.md",
+              "target": "skills/finance-investing/ledger/reference/cost-governance.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/cost-tagging-strategy.md",
+              "target": "skills/finance-investing/ledger/reference/cost-tagging-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/cost-visibility.md",
+              "target": "skills/finance-investing/ledger/reference/cost-visibility.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/finops-framework.md",
+              "target": "skills/finance-investing/ledger/reference/finops-framework.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/greenops-sustainability.md",
+              "target": "skills/finance-investing/ledger/reference/greenops-sustainability.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/handoff-formats.md",
+              "target": "skills/finance-investing/ledger/reference/handoff-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/iac-cost-estimation.md",
+              "target": "skills/finance-investing/ledger/reference/iac-cost-estimation.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/optimization-strategies.md",
+              "target": "skills/finance-investing/ledger/reference/optimization-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/reserved-savings-plans.md",
+              "target": "skills/finance-investing/ledger/reference/reserved-savings-plans.md",
+              "type": "file"
+            },
+            {
+              "source": "ledger/reference/unit-economics.md",
+              "target": "skills/finance-investing/ledger/reference/unit-economics.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -791,13 +5879,200 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/finance-investing/ledger",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/finance-investing/ledger/references/ai-gpu-cost.md",
+              "target": "skills/finance-investing/ledger/references/ai-gpu-cost.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/cloud-pricing-models.md",
+              "target": "skills/finance-investing/ledger/references/cloud-pricing-models.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/cost-anomaly-detection.md",
+              "target": "skills/finance-investing/ledger/references/cost-anomaly-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/cost-governance.md",
+              "target": "skills/finance-investing/ledger/references/cost-governance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/cost-tagging-strategy.md",
+              "target": "skills/finance-investing/ledger/references/cost-tagging-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/cost-visibility.md",
+              "target": "skills/finance-investing/ledger/references/cost-visibility.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/handoff-formats.md",
+              "target": "skills/finance-investing/ledger/references/handoff-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/iac-cost-estimation.md",
+              "target": "skills/finance-investing/ledger/references/iac-cost-estimation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/optimization-strategies.md",
+              "target": "skills/finance-investing/ledger/references/optimization-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/ledger/references/reserved-savings-plans.md",
+              "target": "skills/finance-investing/ledger/references/reserved-savings-plans.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/finance-investing/ledger/SKILL.md",
-          "owner": "ledger",
-          "sha256": "341d43ad5014be4f209e455276edd6563a6004a0457e3ca8c54b2b46062b97d2"
+          "sha256": "341d43ad5014be4f209e455276edd6563a6004a0457e3ca8c54b2b46062b97d2",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/ai-gpu-cost.md",
+          "sha256": "f22a9d1f1c0c43dc711b0b754143fa45174a381d86a76e21eddfc595155860ee",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/autorun-schema.md",
+          "sha256": "eb337d8981125fad8c12289dac182136c7199d5b2dd448bc44d86246dc2d398a",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/cloud-pricing-models.md",
+          "sha256": "0cacbd01c8f68bfa54fe35dd0a0208654bcea02a76f423bdd63440accada9522",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/cost-anomaly-detection.md",
+          "sha256": "e611ec0631076f31e3c0a6577c3cbcac6f541cac0ce7977df5c6177a0e546ffa",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/cost-governance.md",
+          "sha256": "a78a8ab46e8c7caf897b6bd8a7d85bddf3a8faaa29246af7df9dc4412a317dc3",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/cost-tagging-strategy.md",
+          "sha256": "a49a6d41fa35d3b83b8d11873a02eb50a113c6515185ab44f9743bb72d160d87",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/cost-visibility.md",
+          "sha256": "789dff308027ed7edc503af455d74bcc5bee9948028d3e2719b6deb9d52f854b",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/finops-framework.md",
+          "sha256": "38131924470088fc9bf3c19ed1455fc5e0258df1414b77f822a01d1b020ddfbd",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/greenops-sustainability.md",
+          "sha256": "30fc518f3501d087738c6b4faecf09cbac5f3501b669d8840ec9160fde938ad8",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/handoff-formats.md",
+          "sha256": "68f8da7971fd9f745670d709366d0947b5e18b9b4a197e289c66a7260f4a9e47",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/iac-cost-estimation.md",
+          "sha256": "9b86a9dac2a2483725bba5e62fbc3a7fa798821ec02be1ff8c80d1537be5e265",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/optimization-strategies.md",
+          "sha256": "082e7accf6d20bdbab21dab0a4ca89aa692da459b743a8a280662496cfbbfc45",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/reserved-savings-plans.md",
+          "sha256": "0b6e1671b9ab8b591eae083e57d7789690610bcd53017bdd34970a10a2159394",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/reference/unit-economics.md",
+          "sha256": "1e70e4f1ea193f81ef9896cd486f37b93b83aa57f1e7475626897038d830f0cd",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/ai-gpu-cost.md",
+          "sha256": "f22a9d1f1c0c43dc711b0b754143fa45174a381d86a76e21eddfc595155860ee",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/cloud-pricing-models.md",
+          "sha256": "7e4f4b95e793d53c80a9866829bb7d5a4cbaf58ccb690797bb178af1cc2dfe89",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/cost-anomaly-detection.md",
+          "sha256": "340e623681f21c7279feeb1eca267e5ae57f124c318acaf96d78e57fe2a5e272",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/cost-governance.md",
+          "sha256": "1e200074adde526d5670d56bc6bea403faf4cde342b109462cffee02bc4a45a6",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/cost-tagging-strategy.md",
+          "sha256": "8b999eab5669335a64af1fb708a96c70fc6a5e5a3656f6761ef0bd93f8cb8421",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/cost-visibility.md",
+          "sha256": "dc69a432ccf4d8d38ff592960367650c172492e79bcd02a4371fdb6f20cfe5d5",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/handoff-formats.md",
+          "sha256": "f23e90b459ddca05960c33735ed47633ac223a8104931cf7adf44c47d2f5db4c",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/iac-cost-estimation.md",
+          "sha256": "2aefbccf62467a89d49d535c4a1bb0e5acab7688f7cb9bd6c071ad9020694fa7",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/optimization-strategies.md",
+          "sha256": "d04ed5a57451456ba4fa2135d9e4d8a2fca5c866fb550ecebbab8ceb4fec19d5",
+          "owner": "ledger"
+        },
+        {
+          "path": "skills/finance-investing/ledger/references/reserved-savings-plans.md",
+          "sha256": "a6264c964bbdcf4810503ec70258acea8297f3bb7060502981a5b60f0e780c2f",
+          "owner": "ledger"
         }
       ]
     },
@@ -817,7 +6092,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -829,6 +6104,96 @@
             {
               "source": "helm/SKILL.md",
               "target": "skills/finance-investing/helm/SKILL.md"
+            },
+            {
+              "source": "helm/reference/autorun-schema.md",
+              "target": "skills/finance-investing/helm/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/blue-ocean-strategy.md",
+              "target": "skills/finance-investing/helm/reference/blue-ocean-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/business-model-canvas.md",
+              "target": "skills/finance-investing/helm/reference/business-model-canvas.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/cognitive-biases.md",
+              "target": "skills/finance-investing/helm/reference/cognitive-biases.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/data-inputs.md",
+              "target": "skills/finance-investing/helm/reference/data-inputs.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/disruption-detection.md",
+              "target": "skills/finance-investing/helm/reference/disruption-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/financial-modeling-pitfalls.md",
+              "target": "skills/finance-investing/helm/reference/financial-modeling-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/frameworks.md",
+              "target": "skills/finance-investing/helm/reference/frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/jobs-to-be-done.md",
+              "target": "skills/finance-investing/helm/reference/jobs-to-be-done.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/market-sizing-strategy.md",
+              "target": "skills/finance-investing/helm/reference/market-sizing-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/output-templates.md",
+              "target": "skills/finance-investing/helm/reference/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/scenario-planning-pitfalls.md",
+              "target": "skills/finance-investing/helm/reference/scenario-planning-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/simulation-patterns.md",
+              "target": "skills/finance-investing/helm/reference/simulation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/strategic-anti-patterns.md",
+              "target": "skills/finance-investing/helm/reference/strategic-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/strategic-calibration.md",
+              "target": "skills/finance-investing/helm/reference/strategic-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/strategy-monitoring.md",
+              "target": "skills/finance-investing/helm/reference/strategy-monitoring.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/wardley-mapping.md",
+              "target": "skills/finance-investing/helm/reference/wardley-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "helm/reference/wargaming-simulation.md",
+              "target": "skills/finance-investing/helm/reference/wargaming-simulation.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -840,13 +6205,280 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/finance-investing/helm",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/finance-investing/helm/references/blue-ocean-strategy.md",
+              "target": "skills/finance-investing/helm/references/blue-ocean-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/cognitive-biases.md",
+              "target": "skills/finance-investing/helm/references/cognitive-biases.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/data-inputs.md",
+              "target": "skills/finance-investing/helm/references/data-inputs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/disruption-detection.md",
+              "target": "skills/finance-investing/helm/references/disruption-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/financial-modeling-pitfalls.md",
+              "target": "skills/finance-investing/helm/references/financial-modeling-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/frameworks.md",
+              "target": "skills/finance-investing/helm/references/frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/jobs-to-be-done.md",
+              "target": "skills/finance-investing/helm/references/jobs-to-be-done.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/market-sizing-strategy.md",
+              "target": "skills/finance-investing/helm/references/market-sizing-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/output-templates.md",
+              "target": "skills/finance-investing/helm/references/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/scenario-planning-pitfalls.md",
+              "target": "skills/finance-investing/helm/references/scenario-planning-pitfalls.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/simulation-patterns.md",
+              "target": "skills/finance-investing/helm/references/simulation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/strategic-anti-patterns.md",
+              "target": "skills/finance-investing/helm/references/strategic-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/strategic-calibration.md",
+              "target": "skills/finance-investing/helm/references/strategic-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/strategy-monitoring.md",
+              "target": "skills/finance-investing/helm/references/strategy-monitoring.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/wardley-mapping.md",
+              "target": "skills/finance-investing/helm/references/wardley-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/finance-investing/helm/references/wargaming-simulation.md",
+              "target": "skills/finance-investing/helm/references/wargaming-simulation.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/finance-investing/helm/SKILL.md",
-          "owner": "helm",
-          "sha256": "ea82fb0d9a4c705cde015814acd99bc9f63655228175ae594d7ab81128e2e1ba"
+          "sha256": "ea82fb0d9a4c705cde015814acd99bc9f63655228175ae594d7ab81128e2e1ba",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/autorun-schema.md",
+          "sha256": "c487c3df119fe0ba53eae11b5eec04236f3f5cd7a84c23892d06c118511e31cf",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/blue-ocean-strategy.md",
+          "sha256": "e45a38796fc07e4b0ab19e11b525b7130d6f46eb7e8aaa401f4ae4a44a0494b7",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/business-model-canvas.md",
+          "sha256": "fa057050d391f3382b339d3183c21e1b65a8587be8bf8306b44addc1e1f88ec0",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/cognitive-biases.md",
+          "sha256": "35fe03ea65289a52ad6e44ad7c357a1d02b0b6ca176eabbf8c79e81cb8508748",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/data-inputs.md",
+          "sha256": "d5bb5f7ff95bc90cb2c3d31618a5e593bcc3d9b736553e42c1c3ee9e743f0f43",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/disruption-detection.md",
+          "sha256": "e4c510d3c59066844150e9f774a2a8981e5c7813be0deee0595c68a7471daeea",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/financial-modeling-pitfalls.md",
+          "sha256": "d0bdbca68c49789eff60a1d50ad16eebd3e383ea45f049604999b2ab434c4692",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/frameworks.md",
+          "sha256": "01cc3501b40f319a3393ae4a6dd121b520251fa925ad9a9d015034e6a45654cc",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/jobs-to-be-done.md",
+          "sha256": "a3b18a8526a195b9653bf813b048d4c261035b7d719a4197adc0325e9b1120f4",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/market-sizing-strategy.md",
+          "sha256": "f81aeed3109aaff8bdcecd6cd1463102b1d0a40c21d97013013db38af23f2384",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/output-templates.md",
+          "sha256": "4f66b80d2ca5eeee8599e54acfb7336f74dc7e930690b5071bbd52dc841ef59a",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/scenario-planning-pitfalls.md",
+          "sha256": "25b35bee24aed6b15b39014d66e85c48832418435c40d0ba3782b57038a95d56",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/simulation-patterns.md",
+          "sha256": "01e95031d34fa530c7999e6b20792f9f59a76da5395ab6d44ca944eb8684a76f",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/strategic-anti-patterns.md",
+          "sha256": "f57f800db5b6727454ddffcfd7b6db8e269c72890737d59b3a63d182e79b4fb1",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/strategic-calibration.md",
+          "sha256": "df0ddf86c6f5cc296f4326219bcf1ee95ffdfe775ae0282a68f5076ba784b322",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/strategy-monitoring.md",
+          "sha256": "3e069201680893386fa6b80fbc8580b7884f6b1890f3fa8f04fdef65e955bb89",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/wardley-mapping.md",
+          "sha256": "ebf6c4f0aa26b2a3ad371a20ed696016df78dda34eb59a9643209dd64b86f6ff",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/reference/wargaming-simulation.md",
+          "sha256": "d139aeb7ce01d780f8ca5dc530fb1ff80b7dddcf8b7f75ba78f86a72cb4d3f4c",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/blue-ocean-strategy.md",
+          "sha256": "309367b4990ef111f8d669b9a7bb14afca9e8e62fdd1d99194cbfcb2083fa55b",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/cognitive-biases.md",
+          "sha256": "eeeb6655b9bba92e5e5d02c8e631dfd8bc504f8efba10217ac9f7c8bbdc1ad66",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/data-inputs.md",
+          "sha256": "14e16ae1f0a25396e6e3a7ca09abefe18ef5073ecbcb81c37b92f1cff32e7eea",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/disruption-detection.md",
+          "sha256": "778b0db5d5674a26543ac59d98866c3b27d083ddd3c8789aba15e61a0ccac1d3",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/financial-modeling-pitfalls.md",
+          "sha256": "dbe01c68c759a49a5a03ba2552bfeb615bc717a5414f2602b5be441e6b3f4f4d",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/frameworks.md",
+          "sha256": "16d624158a974e66f1375e46e675593262a6347534428987d1fef39141c52b5f",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/jobs-to-be-done.md",
+          "sha256": "8d10c4c5175a4946a3b305581d714ec325e62596adbd3b02e0c364531c51c1f0",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/market-sizing-strategy.md",
+          "sha256": "5c6a3778907eeed8c21ef6c064bf44733d7d8015c44486db35ab5e4d9c4c7bc5",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/output-templates.md",
+          "sha256": "f413c589902112c6c1800f27b91099afc97fdc06221c012bc233f6434e27b0d1",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/scenario-planning-pitfalls.md",
+          "sha256": "d795922d4b977c41f46b2b43c6355bbf2d41ab42c8afb9f0173735104a1fc8d3",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/simulation-patterns.md",
+          "sha256": "01e95031d34fa530c7999e6b20792f9f59a76da5395ab6d44ca944eb8684a76f",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/strategic-anti-patterns.md",
+          "sha256": "e75ea3db50ac7c21cb098ad58de1479e427e0eea771090e071349832ace93338",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/strategic-calibration.md",
+          "sha256": "bbc959bcbb5c1bddb94111aeeebc7331ae242cc5cbbc7a02e64c92b1514c9cbd",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/strategy-monitoring.md",
+          "sha256": "3e069201680893386fa6b80fbc8580b7884f6b1890f3fa8f04fdef65e955bb89",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/wardley-mapping.md",
+          "sha256": "e2f841cc38a7a9c6ff723e766c55fd1dcaf30c23ad19642a2da95158789fb614",
+          "owner": "helm"
+        },
+        {
+          "path": "skills/finance-investing/helm/references/wargaming-simulation.md",
+          "sha256": "b1c0118efd840bdf0e0a7a89e26a528ba2c516b0700f6c1d800619cfc61672de",
+          "owner": "helm"
         }
       ]
     },
@@ -882,6 +6514,56 @@
             {
               "source": "levy/SKILL.md",
               "target": "skills/finance-investing/levy/SKILL.md"
+            },
+            {
+              "source": "levy/references/bookkeeping-patterns.md",
+              "target": "skills/finance-investing/levy/references/bookkeeping-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/deduction-catalog.md",
+              "target": "skills/finance-investing/levy/references/deduction-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/disclaimer-templates.md",
+              "target": "skills/finance-investing/levy/references/disclaimer-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/e-tax-screen-guide.md",
+              "target": "skills/finance-investing/levy/references/e-tax-screen-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/filing-guide.md",
+              "target": "skills/finance-investing/levy/references/filing-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/filing-requirements.md",
+              "target": "skills/finance-investing/levy/references/filing-requirements.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/income-classification.md",
+              "target": "skills/finance-investing/levy/references/income-classification.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/interaction-triggers.md",
+              "target": "skills/finance-investing/levy/references/interaction-triggers.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/salary-plus-side-business.md",
+              "target": "skills/finance-investing/levy/references/salary-plus-side-business.md",
+              "type": "file"
+            },
+            {
+              "source": "levy/references/tax-calculation.md",
+              "target": "skills/finance-investing/levy/references/tax-calculation.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -898,8 +6580,58 @@
       "managed_files": [
         {
           "path": "skills/finance-investing/levy/SKILL.md",
-          "owner": "levy",
-          "sha256": "5c819e57a2d68dd72b12aba1a81a2df57e37753350e500553d71a88a993414ab"
+          "sha256": "5c819e57a2d68dd72b12aba1a81a2df57e37753350e500553d71a88a993414ab",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/bookkeeping-patterns.md",
+          "sha256": "8e18ee2914cdd622c5f10dd75cc417859187436475328d4231254bb5b0aeb892",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/deduction-catalog.md",
+          "sha256": "ab7589acc6505eb1ce6758955955c85e961e2a8a7bea38d6088d59023eb60a07",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/disclaimer-templates.md",
+          "sha256": "ac286c3438563699c1d3c62ba5a7e0e45c3a1469f95f36c60f421531c7c2b90b",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/e-tax-screen-guide.md",
+          "sha256": "b8d55dcba9a65362224d6e9713d642b2308a0f9dbf375f19c37fe32929a4c7a1",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/filing-guide.md",
+          "sha256": "1a0a2f661aa13ac91f5c31cba02090c5034a4b7e67d0be9b4f26bd7e075b15f6",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/filing-requirements.md",
+          "sha256": "29e8f73f51628194e8ea613a90a15fc04d10c2e1f0a4dd629eca437de8021553",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/income-classification.md",
+          "sha256": "f933a68039e47dda738f3adb34427c2ef286b3a060b4e44756c70ff2c5b08d90",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/interaction-triggers.md",
+          "sha256": "68f9c605a4f7328358e6556c4ae3003e324cc5dd5aac1313653bb0b16ab25431",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/salary-plus-side-business.md",
+          "sha256": "dd4c43ee00ddd858eca5b7182e80ce25ac3608727516f4067b63ed5b00af70fa",
+          "owner": "levy"
+        },
+        {
+          "path": "skills/finance-investing/levy/references/tax-calculation.md",
+          "sha256": "5d4518ea72f6f3a8bb91f196579ac43ff2b46f41133bf4cc47eda722ed638ea5",
+          "owner": "levy"
         }
       ]
     },
@@ -919,7 +6651,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -931,6 +6663,81 @@
             {
               "source": "growth/SKILL.md",
               "target": "skills/growth-operations-xiaohongshu/growth/SKILL.md"
+            },
+            {
+              "source": "growth/reference/autorun-schema.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/channel-lifecycle-planning.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/channel-lifecycle-planning.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/code-standards.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/code-standards.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/content-architecture.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/content-architecture.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/core-web-vitals-deep.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals-deep.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/core-web-vitals.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/cro-patterns.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/cro-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/geo-optimization.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/geo-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/json-ld-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/json-ld-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/keyword-research.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/keyword-research.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/ogp-social-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/ogp-social-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/ogp-twitter-card-guide.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/ogp-twitter-card-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/seo-audit.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/seo-audit.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/seo-checklist.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/seo-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "growth/reference/seo-detailed-checklist.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/reference/seo-detailed-checklist.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -942,13 +6749,185 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/growth-operations-xiaohongshu/growth",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/code-standards.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/code-standards.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/core-web-vitals.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/core-web-vitals.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/cro-patterns.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/cro-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/json-ld-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/json-ld-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/ogp-social-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/ogp-social-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/ogp-twitter-card-guide.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/ogp-twitter-card-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/seo-checklist.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/seo-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/growth/references/seo-detailed-checklist.md",
+              "target": "skills/growth-operations-xiaohongshu/growth/references/seo-detailed-checklist.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/growth-operations-xiaohongshu/growth/SKILL.md",
-          "owner": "growth",
-          "sha256": "779e10ed0aa0a71b7d204ce8c413e412900c6ce2fcf890cc1b5f497c037025e1"
+          "sha256": "779e10ed0aa0a71b7d204ce8c413e412900c6ce2fcf890cc1b5f497c037025e1",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/autorun-schema.md",
+          "sha256": "01447de2dd800a7014e22525378365a156ba502295f44db10b963c52ee0697f0",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/channel-lifecycle-planning.md",
+          "sha256": "14b801aa25f8c2dd91a5d616e7698af9b7ce2d27d0641bcfe87e5dac840f167f",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/code-standards.md",
+          "sha256": "4d72e7e8b6d98a1f95a3b8eb17201f5aaf20b17c184f79552877a7f9c47e35be",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/content-architecture.md",
+          "sha256": "9c8bb882173d94e6a240712a919d8802970d25cd57316b6447f317bfb9b1d714",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals-deep.md",
+          "sha256": "f0e41111b9182d299dda289ab2babb1fdec79ae0808562176279754e0c2767d4",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/core-web-vitals.md",
+          "sha256": "eb4e4a042791a1178ed0ada231a777c7f71318ea80ac1fca4e77961d6032a5d8",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/cro-patterns.md",
+          "sha256": "2076fd3732922594c70e5afd1cf2996a05bd0b76228dc1e2524cf207a846bced",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/geo-optimization.md",
+          "sha256": "d0ac3a7c8b198a882d48939fc8525a2d7026097c7ba5575f09ca22f22db73596",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/json-ld-templates.md",
+          "sha256": "0eaeddc8d7b42835ef60055ba7ec1afb1ea21e33a3a9ecee4cdf495d7c26eae1",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/keyword-research.md",
+          "sha256": "453d443b1a96dbe9b9b0174385c3cf85ebac8e251bf888cd311906a0fe2504be",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/ogp-social-templates.md",
+          "sha256": "10908dfce3a53cc62b9fe3ee1cf1ef7e3ab78835127f39683f9cc8cee5285ddc",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/ogp-twitter-card-guide.md",
+          "sha256": "18b20d87e8786ae798f00e9c469c6caee0f991a14725106b4e378a76fa56b792",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-audit.md",
+          "sha256": "bbb07e14ac84a71a0d5e73411c85515cb66bd5808376156b1be9d94913f01dfa",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-checklist.md",
+          "sha256": "f289925a0f4c86be5bac35be78e73d80fef0d789767a7b31b9ce410528d00855",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/reference/seo-detailed-checklist.md",
+          "sha256": "d465229cecc42e4c2028c6537ad1d3dbd430e24c8812846d9f719cbd87841027",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/code-standards.md",
+          "sha256": "4d72e7e8b6d98a1f95a3b8eb17201f5aaf20b17c184f79552877a7f9c47e35be",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/core-web-vitals.md",
+          "sha256": "47ff9e2ae0f4a83d603f35938233cf144d5d3c0d2de673a77c471c86c19f4f1d",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/cro-patterns.md",
+          "sha256": "f22e1bc07b166dfb6d0ac48ad4466a4e9149cea166cbedaffd0b976849a6c01b",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/json-ld-templates.md",
+          "sha256": "1c288ce091c88403d8a8f85fd0435259e21c7ffe1ea134fdb8fcc881ef428ff1",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/ogp-social-templates.md",
+          "sha256": "ccde06215c9da3f170401a5bacc8eb2cd9ad7fbe9bda2b84814835bb1eb36dc9",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/ogp-twitter-card-guide.md",
+          "sha256": "c6f11146033094dd63c10ea3d5d1ab9ea10c9b6b9f79e0cb0a3e76706511e39b",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/seo-checklist.md",
+          "sha256": "b8c6651307099a8ff38847638c1584f1e990b1d2fce78eaf016456d58674b74f",
+          "owner": "growth"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/growth/references/seo-detailed-checklist.md",
+          "sha256": "d465229cecc42e4c2028c6537ad1d3dbd430e24c8812846d9f719cbd87841027",
+          "owner": "growth"
         }
       ]
     },
@@ -968,7 +6947,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -980,6 +6959,106 @@
             {
               "source": "compete/SKILL.md",
               "target": "skills/growth-operations-xiaohongshu/compete/SKILL.md"
+            },
+            {
+              "source": "compete/reference/ai-powered-ci-platforms.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/ai-powered-ci-platforms.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/analysis-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/analysis-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/autorun-schema.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/battle-card.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/battle-card.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/benchmarks-thresholds.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/benchmarks-thresholds.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/brand-equity.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/brand-equity.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/ci-anti-patterns-biases.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/ci-anti-patterns-biases.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/competitive-moats-category-design.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/competitive-moats-category-design.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/competitive-wargaming.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/competitive-wargaming.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/deep-osint-signals.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/deep-osint-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/ecosystem-mapping.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/ecosystem-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/intelligence-calibration.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/intelligence-gathering.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-gathering.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/market-sizing.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/market-sizing.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/moat-7-powers.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/moat-7-powers.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/modern-win-loss-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/modern-win-loss-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/multi-engine-mode.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/multi-engine-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/playbooks.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/playbooks.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/tri-engine-compete.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/tri-engine-compete.md",
+              "type": "file"
+            },
+            {
+              "source": "compete/reference/winloss-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/reference/winloss-analysis.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -991,13 +7070,280 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/growth-operations-xiaohongshu/compete",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/ai-powered-ci-platforms.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/ai-powered-ci-platforms.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/analysis-templates.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/analysis-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/battle-card.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/battle-card.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/ci-anti-patterns-biases.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/ci-anti-patterns-biases.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/competitive-moats-category-design.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/competitive-moats-category-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/competitive-wargaming.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/competitive-wargaming.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/deep-osint-signals.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/deep-osint-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/ecosystem-mapping.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/ecosystem-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/intelligence-calibration.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/intelligence-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/intelligence-gathering.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/intelligence-gathering.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/market-sizing.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/market-sizing.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/moat-7-powers.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/moat-7-powers.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/modern-win-loss-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/modern-win-loss-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/playbooks.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/playbooks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/compete/references/winloss-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/compete/references/winloss-analysis.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/growth-operations-xiaohongshu/compete/SKILL.md",
-          "owner": "compete",
-          "sha256": "11bc68f52ad02f5df7a0a66d5a67217c126e8b04aeb159883727d11390ceccff"
+          "sha256": "11bc68f52ad02f5df7a0a66d5a67217c126e8b04aeb159883727d11390ceccff",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/ai-powered-ci-platforms.md",
+          "sha256": "664ffde4a600ef95c2b2ccf857ab6cee5e1555c4ca9b87444d703b4ead4fbcdf",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/analysis-templates.md",
+          "sha256": "759c0fc4f902ad9b0c547ae753aac1ea97be5bf60e65c27929005e1cf282e140",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/autorun-schema.md",
+          "sha256": "cfa754f4febdd25290287f1c08684154b63fe04f720c82caf444f5f8d6a0dcef",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/battle-card.md",
+          "sha256": "6ea4eae5037e371ae23c40ce513d96cdac6021b4ae9476e09ea49363400e115e",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/benchmarks-thresholds.md",
+          "sha256": "3d6daa93c546b15409a621a472cf13cd228f34d5ea5e0f5beafd78adb5d6d88a",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/brand-equity.md",
+          "sha256": "5efd2e4d547a8f2b1fd43aef02638ea23fc5a9d4fff9b94045bb83b5aa94872a",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/ci-anti-patterns-biases.md",
+          "sha256": "eaaa6a648df6197e1d8e85eeae44ca728f97cbe94fac92e55a57e2c0ca2b2d99",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/competitive-moats-category-design.md",
+          "sha256": "550eda32e9305377863200d1d96ce088f6d3f6a17a24dfd70cb481d89180b6aa",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/competitive-wargaming.md",
+          "sha256": "9ea9de3ff4f09f6b5f97335fef61c6e0e5f9ca05e11bcd513a829c2117f48001",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/deep-osint-signals.md",
+          "sha256": "0238d36d837ef71c832b67b868a3ab8245bb6f7ed90086ba38db303b7aed7b99",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/ecosystem-mapping.md",
+          "sha256": "2d69978150bfd32f7dc04f30da8bf618f8cac96c672778175c71274ea510720b",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-calibration.md",
+          "sha256": "373b0fcf6ecbbf454c2dd1df9808d72f93272eb5a8fe0e05ec99bf159d2fcee5",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/intelligence-gathering.md",
+          "sha256": "d6eb3324e73585c9a75dd3d985056597356803d0d687ebef1a22ce4005abe549",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/market-sizing.md",
+          "sha256": "65374e083419fad5f714274213f6e0d2a8d7dfe7eb0fb7c14598b367f619d321",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/moat-7-powers.md",
+          "sha256": "4e0d9d4c4f060d894298e5fe361fb142ccbf4fbd82a115548683a18587454613",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/modern-win-loss-analysis.md",
+          "sha256": "8cf21c8a433886ebf8dc4d63e4f6d455f9c4d82d01b883fa00293fcf51c7ac31",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/multi-engine-mode.md",
+          "sha256": "f61a7583962438340b1e1dbc76ea60760ed789602c16d9dcb5db4508e4775d01",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/playbooks.md",
+          "sha256": "4eb5a793e14c05008d0c036a3d791d5726ba66cacac22e517d06704faa4b22ed",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/tri-engine-compete.md",
+          "sha256": "a85dc2c30845bc3daa4914205a46bdec4b59a96f763e90736c8dccb40daf8954",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/reference/winloss-analysis.md",
+          "sha256": "a9e9e29ca3c386d0cd8bd77e09fc79c25ff63fc4878bbfbbc9e40fd6c41d073c",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/ai-powered-ci-platforms.md",
+          "sha256": "664ffde4a600ef95c2b2ccf857ab6cee5e1555c4ca9b87444d703b4ead4fbcdf",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/analysis-templates.md",
+          "sha256": "1680884183e88cf74b6bcf65efbb9f2f1dae54fa5ab2d1357bd84eb5664289e1",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/battle-card.md",
+          "sha256": "93828d9c761bf2b6ae127c54073a315c652852c6f7c2b807a9600441bb42b5e7",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/ci-anti-patterns-biases.md",
+          "sha256": "eaaa6a648df6197e1d8e85eeae44ca728f97cbe94fac92e55a57e2c0ca2b2d99",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/competitive-moats-category-design.md",
+          "sha256": "550eda32e9305377863200d1d96ce088f6d3f6a17a24dfd70cb481d89180b6aa",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/competitive-wargaming.md",
+          "sha256": "9ea9de3ff4f09f6b5f97335fef61c6e0e5f9ca05e11bcd513a829c2117f48001",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/deep-osint-signals.md",
+          "sha256": "0238d36d837ef71c832b67b868a3ab8245bb6f7ed90086ba38db303b7aed7b99",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/ecosystem-mapping.md",
+          "sha256": "2d69978150bfd32f7dc04f30da8bf618f8cac96c672778175c71274ea510720b",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/intelligence-calibration.md",
+          "sha256": "373b0fcf6ecbbf454c2dd1df9808d72f93272eb5a8fe0e05ec99bf159d2fcee5",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/intelligence-gathering.md",
+          "sha256": "d6eb3324e73585c9a75dd3d985056597356803d0d687ebef1a22ce4005abe549",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/market-sizing.md",
+          "sha256": "65374e083419fad5f714274213f6e0d2a8d7dfe7eb0fb7c14598b367f619d321",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/moat-7-powers.md",
+          "sha256": "8ae12b0763ce589df3704814423e7aa1279672142585a366b9dce6a9765573f1",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/modern-win-loss-analysis.md",
+          "sha256": "8cf21c8a433886ebf8dc4d63e4f6d455f9c4d82d01b883fa00293fcf51c7ac31",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/playbooks.md",
+          "sha256": "dd46804e13b98def7c4ff64dd8deea40f25871479f55fd64f168785062c7dbc0",
+          "owner": "compete"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/compete/references/winloss-analysis.md",
+          "sha256": "1b917a3f0703f31424cb65e3ea77c168a726d5e5bcf9720ccfd215e617130eca",
+          "owner": "compete"
         }
       ]
     },
@@ -1017,7 +7363,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1029,6 +7375,86 @@
             {
               "source": "pulse/SKILL.md",
               "target": "skills/growth-operations-xiaohongshu/pulse/SKILL.md"
+            },
+            {
+              "source": "pulse/reference/activation-design.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/activation-design.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/alerts-anomaly-detection.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/alerts-anomaly-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/attribution-modeling.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/attribution-modeling.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/autorun-schema.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/code-standards.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/code-standards.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/dashboard-spec.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/dashboard-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/data-quality.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/data-quality.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/event-schema.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/event-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/funnel-cohort-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/funnel-cohort-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/metrics-frameworks.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/metrics-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/north-star-deep-dive.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/north-star-deep-dive.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/platform-integration.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/platform-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/privacy-consent.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/privacy-consent.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/product-qualified-leads.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/product-qualified-leads.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/retention-curve-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/retention-curve-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "pulse/reference/revenue-analytics.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/reference/revenue-analytics.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1040,13 +7466,240 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/growth-operations-xiaohongshu/pulse",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/activation-design.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/activation-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/alerts-anomaly-detection.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/alerts-anomaly-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/code-standards.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/code-standards.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/dashboard-spec.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/dashboard-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/data-quality.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/data-quality.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/event-schema.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/event-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/funnel-cohort-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/funnel-cohort-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/metrics-frameworks.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/metrics-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/north-star-deep-dive.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/north-star-deep-dive.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/platform-integration.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/platform-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/privacy-consent.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/privacy-consent.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/retention-curve-analysis.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/retention-curve-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/pulse/references/revenue-analytics.md",
+              "target": "skills/growth-operations-xiaohongshu/pulse/references/revenue-analytics.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/growth-operations-xiaohongshu/pulse/SKILL.md",
-          "owner": "pulse",
-          "sha256": "ba3a7bc644aaf6058534ab9ee2810cdcc63d136933baa3081ea2d2826c673df5"
+          "sha256": "ba3a7bc644aaf6058534ab9ee2810cdcc63d136933baa3081ea2d2826c673df5",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/activation-design.md",
+          "sha256": "15ff654bbc9a70c7e450d0b1d9fd41d9da8828257b8e587dac6858e5d4cc1d22",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/alerts-anomaly-detection.md",
+          "sha256": "e94f11832bfd208f029cd1d87abffe21aa2a3b91c2783b05cd99219b5233d24a",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/attribution-modeling.md",
+          "sha256": "cd49a0138e67352dcd3371e9c54cb86624b23143a30ada1618216ae99540b6d0",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/autorun-schema.md",
+          "sha256": "edd7dd9e755f00efd900bbdfc63c5e845627486a63d50cc5f5aa9ad4178f4cb2",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/code-standards.md",
+          "sha256": "abc0ec96c64b368430a2403a8f699fa233171c9ab10b79b74f6f9c6331dfa59f",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/dashboard-spec.md",
+          "sha256": "ff2ce161a4a590a863dd26b60376ce5a12827507aebba2bd919053ce6b5edc7c",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/data-quality.md",
+          "sha256": "d1169e9aeaafc13cd2f801df74da6d16818b401ec0a59114db064d9904e42c65",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/event-schema.md",
+          "sha256": "e1c8d1135f341e33d95dd87f0389738a994109f442fbdc2abb383dd5fe8a5693",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/funnel-cohort-analysis.md",
+          "sha256": "6378d082bbc37f2f7a0732a9f2067733c676b8998529653acb5682c547faf0cc",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/metrics-frameworks.md",
+          "sha256": "81b4355573bb07c34be315224d08c4f1c5e496b3b68ebc596ab29199c7c173c9",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/north-star-deep-dive.md",
+          "sha256": "7d33b6ca8aa475f7481644e1d706c074b36f75a11256be5343520e6a35505541",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/platform-integration.md",
+          "sha256": "a4f602f021b7beb2e45a7add92bffe44cae4d75468720e3fd3db4f8576bb7b81",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/privacy-consent.md",
+          "sha256": "53a186b84da2fae9393bc271cb849750f88af71c377d31013d82ea9c6830284e",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/product-qualified-leads.md",
+          "sha256": "6b666ce0c39168866e60721100326108ffd6f7fc935c623b2c124d8045f10303",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/retention-curve-analysis.md",
+          "sha256": "f39ecd0a866f80a8d4402451d2b15754e533d4274734beea50ba63b876a9c509",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/reference/revenue-analytics.md",
+          "sha256": "d048c20e9ab65f7d50b9f33cdbf606c1c569025c10b6f039c416efb76594819f",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/activation-design.md",
+          "sha256": "02fba46af0b94295babe699a8bdcc686bff6038aa21ffa088a9363368ef42fed",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/alerts-anomaly-detection.md",
+          "sha256": "fbd4badd5b7307cba81455264aa7c9f2c046b43f83a50442753377d51cd14c22",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/code-standards.md",
+          "sha256": "abc0ec96c64b368430a2403a8f699fa233171c9ab10b79b74f6f9c6331dfa59f",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/dashboard-spec.md",
+          "sha256": "ff2ce161a4a590a863dd26b60376ce5a12827507aebba2bd919053ce6b5edc7c",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/data-quality.md",
+          "sha256": "2ce93339397f4afba2ac39532c95409904b5194188f0d00781ab13a4c8816eca",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/event-schema.md",
+          "sha256": "6b453d0bbe036156977b7c229b4c5103464c6fe55ed1dfa3cc9fa4c0f70d9fe6",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/funnel-cohort-analysis.md",
+          "sha256": "e0861386182d0d2fc1631796677e09040f822a7eb6067ad542de0dbb4c6ec4b2",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/metrics-frameworks.md",
+          "sha256": "81b4355573bb07c34be315224d08c4f1c5e496b3b68ebc596ab29199c7c173c9",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/north-star-deep-dive.md",
+          "sha256": "2198adbc4ee5a1964f6f163fb5e39f75cfcafc52d3f01848ec832728828c5d7c",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/platform-integration.md",
+          "sha256": "ff4559655f5a407839743d48755dbbac1a2631b1f311ab781b6f01c627921926",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/privacy-consent.md",
+          "sha256": "65c2e83c26fe094286cc9b7f45d53956c16a6454d2ae216396962e488b5d586a",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/retention-curve-analysis.md",
+          "sha256": "5d8a4548cbb6bdaf661b5390e84915fe6091c75c2a21f1c95efa82fd3990ca46",
+          "owner": "pulse"
+        },
+        {
+          "path": "skills/growth-operations-xiaohongshu/pulse/references/revenue-analytics.md",
+          "sha256": "3f0c34562054589d6bc248ef4bf65e34f8d39d686b54c7a943663953e8a0fa99",
+          "owner": "pulse"
         }
       ]
     },
@@ -1066,7 +7719,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1078,6 +7731,86 @@
             {
               "source": "morph/SKILL.md",
               "target": "skills/office-white-collar/morph/SKILL.md"
+            },
+            {
+              "source": "morph/reference/accessibility-guide.md",
+              "target": "skills/office-white-collar/morph/reference/accessibility-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/advanced-features.md",
+              "target": "skills/office-white-collar/morph/reference/advanced-features.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/autorun-schema.md",
+              "target": "skills/office-white-collar/morph/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/batch-conversion-pipeline.md",
+              "target": "skills/office-white-collar/morph/reference/batch-conversion-pipeline.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/conversion-calibration.md",
+              "target": "skills/office-white-collar/morph/reference/conversion-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/conversion-matrix.md",
+              "target": "skills/office-white-collar/morph/reference/conversion-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/conversion-pipeline-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/reference/conversion-pipeline-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/conversion-workflow.md",
+              "target": "skills/office-white-collar/morph/reference/conversion-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/css-print-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/reference/css-print-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/epub-generation.md",
+              "target": "skills/office-white-collar/morph/reference/epub-generation.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/format-conversion-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/reference/format-conversion-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/japanese-typography.md",
+              "target": "skills/office-white-collar/morph/reference/japanese-typography.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/latex-typesetting.md",
+              "target": "skills/office-white-collar/morph/reference/latex-typesetting.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/pandoc-recipes.md",
+              "target": "skills/office-white-collar/morph/reference/pandoc-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/pdf-accessibility-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/reference/pdf-accessibility-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "morph/reference/template-library.md",
+              "target": "skills/office-white-collar/morph/reference/template-library.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1089,13 +7822,260 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/office-white-collar/morph",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/office-white-collar/morph/README.md",
+              "target": "skills/office-white-collar/morph/README.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/reference/quality-assurance.md",
+              "target": "skills/office-white-collar/morph/reference/quality-assurance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/accessibility-guide.md",
+              "target": "skills/office-white-collar/morph/references/accessibility-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/advanced-features.md",
+              "target": "skills/office-white-collar/morph/references/advanced-features.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/conversion-calibration.md",
+              "target": "skills/office-white-collar/morph/references/conversion-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/conversion-matrix.md",
+              "target": "skills/office-white-collar/morph/references/conversion-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/conversion-pipeline-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/references/conversion-pipeline-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/conversion-workflow.md",
+              "target": "skills/office-white-collar/morph/references/conversion-workflow.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/css-print-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/references/css-print-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/format-conversion-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/references/format-conversion-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/japanese-typography.md",
+              "target": "skills/office-white-collar/morph/references/japanese-typography.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/pandoc-recipes.md",
+              "target": "skills/office-white-collar/morph/references/pandoc-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/pdf-accessibility-anti-patterns.md",
+              "target": "skills/office-white-collar/morph/references/pdf-accessibility-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/quality-assurance.md",
+              "target": "skills/office-white-collar/morph/references/quality-assurance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/morph/references/template-library.md",
+              "target": "skills/office-white-collar/morph/references/template-library.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
+          "path": "skills/office-white-collar/morph/README.md",
+          "sha256": "0d79677be87485d42e013ee159066693eac3aa708ec2aafc998ae2fcb136fb2c",
+          "owner": "morph"
+        },
+        {
           "path": "skills/office-white-collar/morph/SKILL.md",
-          "owner": "morph",
-          "sha256": "860dcb6731d95b887979e1d4616e63c8eca19cc7f4ca0415c59d5d98ed76ed7c"
+          "sha256": "860dcb6731d95b887979e1d4616e63c8eca19cc7f4ca0415c59d5d98ed76ed7c",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/accessibility-guide.md",
+          "sha256": "5f358f9e7cc3f76c7e3989080c936dd6404bc4508d22229b1ce7ebb74361ebf7",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/advanced-features.md",
+          "sha256": "5720149200da00f5031d3e0ed79ea814c702c187e7b5d31eb3efc3755c9f0595",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/autorun-schema.md",
+          "sha256": "99a731e452ec4304db40fa9891664f45f63a7b75c7ec56ec59c5bb3668593add",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/batch-conversion-pipeline.md",
+          "sha256": "4458f4f9efbbb75752f5eefe108265d7753f596890e69e1a0f636e20c67c3f59",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/conversion-calibration.md",
+          "sha256": "8a49f5565c0853cd3c0ca88a618fff64100f206899786f132dc10ca3cb488a06",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/conversion-matrix.md",
+          "sha256": "2a5933a59185850a25c8ce8886f65f9709d607135f072aac407c25f9cdb5f9d5",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/conversion-pipeline-anti-patterns.md",
+          "sha256": "7d227f25fecfc73a09738d24f9568b9bb170d229ce317fc4651fee96aeb63cb3",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/conversion-workflow.md",
+          "sha256": "2c22c78e97259bdaaa2bf64738eee4d115b3ff754ef4e1b05af0956f2c1a39a3",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/css-print-anti-patterns.md",
+          "sha256": "ab50746fd02fd9cf1a9dfa06ffd3c9fb0923477f001edcac5850808fb19f91f2",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/epub-generation.md",
+          "sha256": "4046a15b1572c0e27773459c06bb508048e3378236f14f16444130f60c8221f2",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/format-conversion-anti-patterns.md",
+          "sha256": "2626022e962120d2fddd7a0114c583e0c0398bc916193e60db260e5a9fea3d09",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/japanese-typography.md",
+          "sha256": "9adfc518285f527bcf1b4b62cb4ce8b748d1158cc38fe43f2171f4cf462ca712",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/latex-typesetting.md",
+          "sha256": "b8601e924bfc1ffb5b3f6b4a4af2b924fd5ad26f274470e82ad744e4fd0a60fb",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/pandoc-recipes.md",
+          "sha256": "b4c98d7657814d7c7d4e3070aa9408101ea9748d37ecc452e220d5b824b49c0f",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/pdf-accessibility-anti-patterns.md",
+          "sha256": "b5760d58b758d9a853270c80d7b01c3033ea75b0dbaebf8927485d45438b8f52",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/quality-assurance.md",
+          "sha256": "70b6185f9dd9580079d068c26c91dce154f32351bf33038b2d2a4a7d10d3f388",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/reference/template-library.md",
+          "sha256": "fadadb9d8f0e287a018dbc156874da6619b8add658ac7fe79a25a8e0c4a64360",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/accessibility-guide.md",
+          "sha256": "5f358f9e7cc3f76c7e3989080c936dd6404bc4508d22229b1ce7ebb74361ebf7",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/advanced-features.md",
+          "sha256": "5720149200da00f5031d3e0ed79ea814c702c187e7b5d31eb3efc3755c9f0595",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/conversion-calibration.md",
+          "sha256": "26c1997be5b44d5fde8d55b1d9ff4b323409481f751a123488f3bbf47f5e3fab",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/conversion-matrix.md",
+          "sha256": "123ee032d3098b5ef0467ec5f334a193f2972bef7d4f9ba5f3099e9d0679de3f",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/conversion-pipeline-anti-patterns.md",
+          "sha256": "7d227f25fecfc73a09738d24f9568b9bb170d229ce317fc4651fee96aeb63cb3",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/conversion-workflow.md",
+          "sha256": "2c22c78e97259bdaaa2bf64738eee4d115b3ff754ef4e1b05af0956f2c1a39a3",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/css-print-anti-patterns.md",
+          "sha256": "ab50746fd02fd9cf1a9dfa06ffd3c9fb0923477f001edcac5850808fb19f91f2",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/format-conversion-anti-patterns.md",
+          "sha256": "2626022e962120d2fddd7a0114c583e0c0398bc916193e60db260e5a9fea3d09",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/japanese-typography.md",
+          "sha256": "9adfc518285f527bcf1b4b62cb4ce8b748d1158cc38fe43f2171f4cf462ca712",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/pandoc-recipes.md",
+          "sha256": "eecdd70431c1ebcc351e3bf6d0157dca5e9878f47ce9529ce40fdbe353cddd40",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/pdf-accessibility-anti-patterns.md",
+          "sha256": "b5760d58b758d9a853270c80d7b01c3033ea75b0dbaebf8927485d45438b8f52",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/quality-assurance.md",
+          "sha256": "32806129fe895806b2ddb1bada72e2d7124809126d0257439dfe2a590a5f21f8",
+          "owner": "morph"
+        },
+        {
+          "path": "skills/office-white-collar/morph/references/template-library.md",
+          "sha256": "fadadb9d8f0e287a018dbc156874da6619b8add658ac7fe79a25a8e0c4a64360",
+          "owner": "morph"
         }
       ]
     },
@@ -1115,7 +8095,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1127,6 +8107,41 @@
             {
               "source": "stage/SKILL.md",
               "target": "skills/office-white-collar/stage/SKILL.md"
+            },
+            {
+              "source": "stage/reference/autorun-schema.md",
+              "target": "skills/office-white-collar/stage/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/examples.md",
+              "target": "skills/office-white-collar/stage/reference/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/handoffs.md",
+              "target": "skills/office-white-collar/stage/reference/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/narrative-arc-design.md",
+              "target": "skills/office-white-collar/stage/reference/narrative-arc-design.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/patterns.md",
+              "target": "skills/office-white-collar/stage/reference/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/rehearsal-delivery.md",
+              "target": "skills/office-white-collar/stage/reference/rehearsal-delivery.md",
+              "type": "file"
+            },
+            {
+              "source": "stage/reference/slide-visual-design.md",
+              "target": "skills/office-white-collar/stage/reference/slide-visual-design.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1138,13 +8153,95 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/office-white-collar/stage",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/office-white-collar/stage/references/examples.md",
+              "target": "skills/office-white-collar/stage/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/stage/references/handoffs.md",
+              "target": "skills/office-white-collar/stage/references/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/office-white-collar/stage/references/patterns.md",
+              "target": "skills/office-white-collar/stage/references/patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/office-white-collar/stage/SKILL.md",
-          "owner": "stage",
-          "sha256": "b447bd9c82f16482f0bb756805eb57592d36f577d94c61b270470cf306f4746a"
+          "sha256": "b447bd9c82f16482f0bb756805eb57592d36f577d94c61b270470cf306f4746a",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/autorun-schema.md",
+          "sha256": "71075451ce0248c50268ad349c3a9f7c58348d93ffcf843f7e6db4e8f0526ec5",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/examples.md",
+          "sha256": "97fd389513af91de5f8243bb214ab478d0b8033e408814422c02f5ff6c923b44",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/handoffs.md",
+          "sha256": "92dba8c08263ca9dc817b9b20d193867e003aa2f4f3c7f002f4fb23f848ce67e",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/narrative-arc-design.md",
+          "sha256": "2d103632f1624efacc5a326037e977e805ab9fd89dd720aee73799a43f63dfb9",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/patterns.md",
+          "sha256": "72958df67905a1152a2baa7e5cb2c0579eaae160adc756a0db4c589d7f9fc735",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/rehearsal-delivery.md",
+          "sha256": "6b16fd2c5fd0805a6f0cd818105dbfccb04cb3a0684d2e81260cafbe4ce91b42",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/reference/slide-visual-design.md",
+          "sha256": "9c6b3fb2e20d28c1242fff8c974cfdd67f7e62e9267ab4aec0f005e99b53ee76",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/references/examples.md",
+          "sha256": "c3cde26f3db606c11f27ab7720f0bda68ad1d0ff3c7742799334d8c3eb4e1508",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/references/handoffs.md",
+          "sha256": "be92271134b47bea3f319749d3e27e975477583f18b3edcff4e27400f7f0b958",
+          "owner": "stage"
+        },
+        {
+          "path": "skills/office-white-collar/stage/references/patterns.md",
+          "sha256": "cf08ec074dcfd198d2602256e3ca63423c3c47e421be89273776145fdda5ebbd",
+          "owner": "stage"
         }
       ]
     },
@@ -1180,6 +8277,46 @@
             {
               "source": "prism/SKILL.md",
               "target": "skills/office-white-collar/prism/SKILL.md"
+            },
+            {
+              "source": "prism/references/content-quality-anti-patterns.md",
+              "target": "skills/office-white-collar/prism/references/content-quality-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/format-audience-anti-patterns.md",
+              "target": "skills/office-white-collar/prism/references/format-audience-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/prompt-catalog.md",
+              "target": "skills/office-white-collar/prism/references/prompt-catalog.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/prompt-effectiveness.md",
+              "target": "skills/office-white-collar/prism/references/prompt-effectiveness.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/quality-evaluation.md",
+              "target": "skills/office-white-collar/prism/references/quality-evaluation.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/source-curation-anti-patterns.md",
+              "target": "skills/office-white-collar/prism/references/source-curation-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/source-preparation.md",
+              "target": "skills/office-white-collar/prism/references/source-preparation.md",
+              "type": "file"
+            },
+            {
+              "source": "prism/references/steering-prompt-anti-patterns.md",
+              "target": "skills/office-white-collar/prism/references/steering-prompt-anti-patterns.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1196,8 +8333,48 @@
       "managed_files": [
         {
           "path": "skills/office-white-collar/prism/SKILL.md",
-          "owner": "prism",
-          "sha256": "ae3ca9e2b7c62d7975075297fe51e82fc8f4e22d47fb049a5f77a1871e587532"
+          "sha256": "ae3ca9e2b7c62d7975075297fe51e82fc8f4e22d47fb049a5f77a1871e587532",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/content-quality-anti-patterns.md",
+          "sha256": "f27418d7091ca26b3f09dbfdf567b6ff68b53affa65dbe9a1ca3fd1c36569353",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/format-audience-anti-patterns.md",
+          "sha256": "060fd8af39c103f1d8d8beeda477f4b9b3c7937a3e0c8cde33aba55fc57ca55b",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/prompt-catalog.md",
+          "sha256": "123cdcd18122570576d0454ada208b1f0d2f4176fb0c96d10c1c591a8c8565d5",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/prompt-effectiveness.md",
+          "sha256": "511cc2aa30e0721fbc5dd0aee3399a7e680f070323b5a7abda5cd76841b7e916",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/quality-evaluation.md",
+          "sha256": "ee9c27259664641b733ee1dcb4423695255ed0bff0f7503d1dc7024904324d87",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/source-curation-anti-patterns.md",
+          "sha256": "05c16d9a9ab24e9af877d48cbdda6794616d31fa28e21378561e6e0d271ea3d9",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/source-preparation.md",
+          "sha256": "e57cc733e4b336287d390b7127e2aad585f76768e7f378c40afa2eb4d63bad56",
+          "owner": "prism"
+        },
+        {
+          "path": "skills/office-white-collar/prism/references/steering-prompt-anti-patterns.md",
+          "sha256": "4e2a014b292b2d127f7312eb335266423a0f9d5e58ab220de9c60c0cd11f2f8d",
+          "owner": "prism"
         }
       ]
     },
@@ -1217,7 +8394,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1229,6 +8406,36 @@
             {
               "source": "lore/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/lore/SKILL.md"
+            },
+            {
+              "source": "lore/reference/autorun-schema.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "lore/reference/decay-detection.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/decay-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "lore/reference/knowledge-synthesis.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/knowledge-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "lore/reference/official-pattern-taxonomy.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/official-pattern-taxonomy.md",
+              "type": "file"
+            },
+            {
+              "source": "lore/reference/pattern-taxonomy.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/pattern-taxonomy.md",
+              "type": "file"
+            },
+            {
+              "source": "lore/reference/propagation-protocol.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/reference/propagation-protocol.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1240,13 +8447,110 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/knowledge-and-pm-integrations/lore",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/knowledge-and-pm-integrations/lore/references/decay-detection.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/references/decay-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lore/references/knowledge-synthesis.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/references/knowledge-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lore/references/official-pattern-taxonomy.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/references/official-pattern-taxonomy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lore/references/pattern-taxonomy.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/references/pattern-taxonomy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/lore/references/propagation-protocol.md",
+              "target": "skills/knowledge-and-pm-integrations/lore/references/propagation-protocol.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/lore/SKILL.md",
-          "owner": "lore",
-          "sha256": "fb7bd941f0c701b497e0bfa34d9699492650763653d2c233d567d71ebd22e571"
+          "sha256": "fb7bd941f0c701b497e0bfa34d9699492650763653d2c233d567d71ebd22e571",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/autorun-schema.md",
+          "sha256": "b0ec38ed8cab61e016c0d9bbc48991d529f27ecab809d4e060a5ef14902cdaee",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/decay-detection.md",
+          "sha256": "fe533881610e13c4c8e65d71ada1dc06230704da0b1bac4baab2e5b171c7c3f8",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/knowledge-synthesis.md",
+          "sha256": "02642a4b9c379373beed61d42ef57efd1a8d6cd1f41caa66133bec33a210451a",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/official-pattern-taxonomy.md",
+          "sha256": "6c59e02fe83a8a11b1e7009c75dbf89e9f223c6209c2ee9c1946a6947ecf89e1",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/pattern-taxonomy.md",
+          "sha256": "1609f443fd322b1dd408bc061bb23634d1d42b98f3caad355a4b8d9687e94372",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/reference/propagation-protocol.md",
+          "sha256": "418940b2135ca78dcb752731ee9e09070f3f6a20cc939eb9bdeaa152ab12d216",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/references/decay-detection.md",
+          "sha256": "1e618bfe1fcba3d5b091885d9eae7f6eebe5e1ac40a016c95ddd24f800ce4e6d",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/references/knowledge-synthesis.md",
+          "sha256": "de0325a27e06790a0cc75c413445db62b4212ec44396aea0276c4a19878fafb8",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/references/official-pattern-taxonomy.md",
+          "sha256": "d64cea77961b26bbc9b4317b06f1a0e83123716c4b3cf5d7f1273af19eaceced",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/references/pattern-taxonomy.md",
+          "sha256": "1609f443fd322b1dd408bc061bb23634d1d42b98f3caad355a4b8d9687e94372",
+          "owner": "lore"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/lore/references/propagation-protocol.md",
+          "sha256": "82cca7b4d78394129e65e94ec112e56d8aae4dc7714c94d7b74fe03633f0c96e",
+          "owner": "lore"
         }
       ]
     },
@@ -1266,7 +8570,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1278,6 +8582,46 @@
             {
               "source": "tome/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/tome/SKILL.md"
+            },
+            {
+              "source": "tome/reference/autorun-schema.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/coding-kata.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/coding-kata.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/examples.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/handoffs.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/output-templates.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/quickstart-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/quickstart-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "tome/reference/worked-example.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/reference/worked-example.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1289,13 +8633,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/knowledge-and-pm-integrations/tome",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/coding-kata.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/coding-kata.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/examples.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/handoffs.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/output-templates.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/quickstart-guide.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/quickstart-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/tome/references/worked-example.md",
+              "target": "skills/knowledge-and-pm-integrations/tome/references/worked-example.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/tome/SKILL.md",
-          "owner": "tome",
-          "sha256": "b08b6824ec78031e81c480135b50ba7520402353b2ff4dd6b38e013ff756af74"
+          "sha256": "b08b6824ec78031e81c480135b50ba7520402353b2ff4dd6b38e013ff756af74",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/autorun-schema.md",
+          "sha256": "9bb417a202c1a9239ab24e01f2fdebdd601ecc48af5450b054997018f9cfb7af",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/coding-kata.md",
+          "sha256": "a3f55261362daf3afa1e974fbb4d2ce438f60f81dcf7055e6347fcde74713db9",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/examples.md",
+          "sha256": "4d1c8d0a86646dff4f889c5c80daff261bc5f04c34a1d7ed06c6dd3f4f740eb3",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/handoffs.md",
+          "sha256": "769a063b83074c93b3fd65705dfc70f4895083f9e95d42059d8293742928dcd1",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/output-templates.md",
+          "sha256": "7f80ea109c86774963e36d09909d63d756d24ff67e75eb862b2469a9cf32fb0c",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/patterns.md",
+          "sha256": "4cddb3f6a9f1c14e17c85c9edec164d933746e7d6095a9eca221c510c2748eeb",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/quickstart-guide.md",
+          "sha256": "86031aa86c6bab606f03e7722fe4b1d1e9794c302955fbadc2e15665b291134e",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/reference/worked-example.md",
+          "sha256": "6fb1e4dfad15f54e7cdf99cde71a485094a177f67b8f7d9a6b32eeb99d16250b",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/coding-kata.md",
+          "sha256": "3b890fa0aeca88e748869343ee6f23c2e161ec45ab35849f6e5f6cd32e31e078",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/examples.md",
+          "sha256": "4d1c8d0a86646dff4f889c5c80daff261bc5f04c34a1d7ed06c6dd3f4f740eb3",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/handoffs.md",
+          "sha256": "015a6d45a06807b8528cf53b02d315ed5c685db982c9e182e55fb3a603c278ef",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/output-templates.md",
+          "sha256": "06364bcb55f94e1368adab6f16829bed10a764b6bee64b8f6c8e82a78076c19c",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/patterns.md",
+          "sha256": "ec207149c0189b376254eed2db13303a033478bb43830b543b3ab3f64fc9ad83",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/quickstart-guide.md",
+          "sha256": "6dcd9afec54693d7b4dd6d63a4d1383cdf23728df6a9bc3fdb2e4ebf1fd7d3ae",
+          "owner": "tome"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/tome/references/worked-example.md",
+          "sha256": "6fb1e4dfad15f54e7cdf99cde71a485094a177f67b8f7d9a6b32eeb99d16250b",
+          "owner": "tome"
         }
       ]
     },
@@ -1315,7 +8786,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1327,6 +8798,81 @@
             {
               "source": "grove/SKILL.md",
               "target": "skills/knowledge-and-pm-integrations/grove/SKILL.md"
+            },
+            {
+              "source": "grove/reference/anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/audit-commands.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/audit-commands.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/autorun-schema.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/codebase-organization-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/codebase-organization-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/cultural-dna.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/cultural-dna.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/directory-templates.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/directory-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/docs-structure.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/docs-structure.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/documentation-architecture-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/documentation-architecture-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/migration-strategies.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/migration-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/monorepo-health.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-health.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/monorepo-strategy-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-strategy-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/monorepo-structure.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-structure.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/project-scaffolding-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/project-scaffolding-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/scripts-organization.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/scripts-organization.md",
+              "type": "file"
+            },
+            {
+              "source": "grove/reference/tests-layout.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/reference/tests-layout.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1338,13 +8884,245 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/knowledge-and-pm-integrations/grove",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/audit-commands.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/audit-commands.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/codebase-organization-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/codebase-organization-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/cultural-dna.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/cultural-dna.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/directory-templates.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/directory-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/docs-structure.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/docs-structure.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/documentation-architecture-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/documentation-architecture-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/migration-strategies.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/migration-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/monorepo-health.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/monorepo-health.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/monorepo-strategy-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/monorepo-strategy-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/monorepo-structure.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/monorepo-structure.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/project-scaffolding-anti-patterns.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/project-scaffolding-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/scripts-organization.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/scripts-organization.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/knowledge-and-pm-integrations/grove/references/tests-layout.md",
+              "target": "skills/knowledge-and-pm-integrations/grove/references/tests-layout.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/knowledge-and-pm-integrations/grove/SKILL.md",
-          "owner": "grove",
-          "sha256": "47dc3ecced05082f8bfb20e8459b11f426b0edf5d3c26d5c288ce1a85986d310"
+          "sha256": "47dc3ecced05082f8bfb20e8459b11f426b0edf5d3c26d5c288ce1a85986d310",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/anti-patterns.md",
+          "sha256": "4d46f9c90c808d4233476a4526686f39c77b01898c2d62df22813a93bf028cd9",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/audit-commands.md",
+          "sha256": "03380fab0c21af0aeb9b4b847d269dd5d64e491a52a513482c68d02e429cb651",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/autorun-schema.md",
+          "sha256": "45a2508eaee83a58aad15220078ed4424222564e1e1eeb0be015066a3d46105f",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/codebase-organization-anti-patterns.md",
+          "sha256": "d96adae82df6c3fc2efd35691cc87af80fdb9695d77323b92195b2cea2b3482e",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/cultural-dna.md",
+          "sha256": "c7b2cef346d20dfd728a27feebb9f211883a98037174d4619eb034ad44bff65c",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/directory-templates.md",
+          "sha256": "90f4e6ac02510f1ba1b5a39db708da929aa3b358fe1136c0bee2129223ca61a5",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/docs-structure.md",
+          "sha256": "742a0f9b981009770d0e6230539ba3e4f0d205fd0732ba32f129c411cb93f758",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/documentation-architecture-anti-patterns.md",
+          "sha256": "6082c6a09cc1c03a9e377df7c4ce8a0a32e4f54ee2bb9edb6329f7a0f6576f37",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/migration-strategies.md",
+          "sha256": "8daf1ee9abf25cf87adb249e5864d1c3983bbca40c1f76d6b48f35d27f6e4dbe",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-health.md",
+          "sha256": "d2094b0c54b7bc21ac5d12f6f226dc680edda36790d803b9e9999d2952f08c42",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-strategy-anti-patterns.md",
+          "sha256": "854ad2d506d583d609ac656e559fbef4d5b19089fb646eeab951bd279dfcb47d",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/monorepo-structure.md",
+          "sha256": "99ec8fd0cce93788284f90c57103106c603554a6404961feb99b59080617b7c4",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/project-scaffolding-anti-patterns.md",
+          "sha256": "666e2ae9f6cc2deef76cf604acc8631d511e5d0b9404a5f2f0bcfe9efd646b40",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/scripts-organization.md",
+          "sha256": "3f0c7e6a46c7c41c9c2eec4229d6744afe700b2dcff3ead213e928716c3e87d6",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/reference/tests-layout.md",
+          "sha256": "25acdf2e3015007bb956f03110909af1fd4cc8e72c273ab892e71b194014c104",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/anti-patterns.md",
+          "sha256": "4d46f9c90c808d4233476a4526686f39c77b01898c2d62df22813a93bf028cd9",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/audit-commands.md",
+          "sha256": "03380fab0c21af0aeb9b4b847d269dd5d64e491a52a513482c68d02e429cb651",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/codebase-organization-anti-patterns.md",
+          "sha256": "d96adae82df6c3fc2efd35691cc87af80fdb9695d77323b92195b2cea2b3482e",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/cultural-dna.md",
+          "sha256": "c7b2cef346d20dfd728a27feebb9f211883a98037174d4619eb034ad44bff65c",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/directory-templates.md",
+          "sha256": "90f4e6ac02510f1ba1b5a39db708da929aa3b358fe1136c0bee2129223ca61a5",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/docs-structure.md",
+          "sha256": "742a0f9b981009770d0e6230539ba3e4f0d205fd0732ba32f129c411cb93f758",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/documentation-architecture-anti-patterns.md",
+          "sha256": "6082c6a09cc1c03a9e377df7c4ce8a0a32e4f54ee2bb9edb6329f7a0f6576f37",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/migration-strategies.md",
+          "sha256": "8daf1ee9abf25cf87adb249e5864d1c3983bbca40c1f76d6b48f35d27f6e4dbe",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-health.md",
+          "sha256": "d2094b0c54b7bc21ac5d12f6f226dc680edda36790d803b9e9999d2952f08c42",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-strategy-anti-patterns.md",
+          "sha256": "e6f6f5586164255df373114dd2a15b1fc464f020f327063e916a011faa08219f",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/monorepo-structure.md",
+          "sha256": "99ec8fd0cce93788284f90c57103106c603554a6404961feb99b59080617b7c4",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/project-scaffolding-anti-patterns.md",
+          "sha256": "666e2ae9f6cc2deef76cf604acc8631d511e5d0b9404a5f2f0bcfe9efd646b40",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/scripts-organization.md",
+          "sha256": "3f0c7e6a46c7c41c9c2eec4229d6744afe700b2dcff3ead213e928716c3e87d6",
+          "owner": "grove"
+        },
+        {
+          "path": "skills/knowledge-and-pm-integrations/grove/references/tests-layout.md",
+          "sha256": "25acdf2e3015007bb956f03110909af1fd4cc8e72c273ab892e71b194014c104",
+          "owner": "grove"
         }
       ]
     },
@@ -1364,7 +9142,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1376,6 +9154,56 @@
             {
               "source": "crest/SKILL.md",
               "target": "skills/operations-general/crest/SKILL.md"
+            },
+            {
+              "source": "crest/reference/ai-era-strategy.md",
+              "target": "skills/operations-general/crest/reference/ai-era-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/amplification-playbook.md",
+              "target": "skills/operations-general/crest/reference/amplification-playbook.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/anti-patterns.md",
+              "target": "skills/operations-general/crest/reference/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/autorun-schema.md",
+              "target": "skills/operations-general/crest/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/channel-templates.md",
+              "target": "skills/operations-general/crest/reference/channel-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/metrics-guide.md",
+              "target": "skills/operations-general/crest/reference/metrics-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/multi-platform-bio.md",
+              "target": "skills/operations-general/crest/reference/multi-platform-bio.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/portfolio-architecture.md",
+              "target": "skills/operations-general/crest/reference/portfolio-architecture.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/positioning-frameworks.md",
+              "target": "skills/operations-general/crest/reference/positioning-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "crest/reference/topic-dna.md",
+              "target": "skills/operations-general/crest/reference/topic-dna.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1387,13 +9215,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/operations-general/crest",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/operations-general/crest/references/ai-era-strategy.md",
+              "target": "skills/operations-general/crest/references/ai-era-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/crest/references/amplification-playbook.md",
+              "target": "skills/operations-general/crest/references/amplification-playbook.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/crest/references/anti-patterns.md",
+              "target": "skills/operations-general/crest/references/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/crest/references/channel-templates.md",
+              "target": "skills/operations-general/crest/references/channel-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/crest/references/metrics-guide.md",
+              "target": "skills/operations-general/crest/references/metrics-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/crest/references/positioning-frameworks.md",
+              "target": "skills/operations-general/crest/references/positioning-frameworks.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/operations-general/crest/SKILL.md",
-          "owner": "crest",
-          "sha256": "2f47a7d387886315e8b842918350daec5bf35392bf3538a81f6dfc7a18ac9acb"
+          "sha256": "2f47a7d387886315e8b842918350daec5bf35392bf3538a81f6dfc7a18ac9acb",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/ai-era-strategy.md",
+          "sha256": "1b7beb87b603f0cb4ebd251dfd0dc21c3f907497a1c338d15e52542d6b773e4d",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/amplification-playbook.md",
+          "sha256": "7504ccf5137fc1ff1e16925ea5127296fc98fa1c5d30efe6fe14769e0ec94028",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/anti-patterns.md",
+          "sha256": "ba1bf1841044d6afeccafe83b86fdff8862881355061e4b47e8efb15f71fc90b",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/autorun-schema.md",
+          "sha256": "18d4b7ba82071ba7478e3a6caaf48c7aaccb4876b9c400b1356e54a85dfa13e3",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/channel-templates.md",
+          "sha256": "631840abf73d272d20b24e092c67dd6c647e92374bc2487ec2c21a7563541aeb",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/metrics-guide.md",
+          "sha256": "5e3b5339ea46d6605b4e9465855c3d55afd0ef27bc767a304c15ae4f4c1b5a27",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/multi-platform-bio.md",
+          "sha256": "ca9570a1c3509a7106589ba66deb096f0e48d9eb6a2d9c12e154ae6e42ed76a3",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/portfolio-architecture.md",
+          "sha256": "7641cfe1c0806712d6f87d81ab57f4a8f510259e85b79290db80e0629f3afef1",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/positioning-frameworks.md",
+          "sha256": "2432e5ad601d4e3433a51c406d35ffb50200fa81eae861217ab6d77176d0c9e0",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/reference/topic-dna.md",
+          "sha256": "640958ea77b1d5ac97c510b6567ef074e3cb23026a13f947f2c7e75380f8780a",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/ai-era-strategy.md",
+          "sha256": "3296a34a34da3f6398ad9cde87177e10db485505abbe90a20485b728f5882a38",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/amplification-playbook.md",
+          "sha256": "ffb4e043f3e8e550b28346447cef5e73be144945c834a24ad29a0f00f939dc54",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/anti-patterns.md",
+          "sha256": "ba1bf1841044d6afeccafe83b86fdff8862881355061e4b47e8efb15f71fc90b",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/channel-templates.md",
+          "sha256": "0ee51bd446eb5840f509c40775138e8f208864acb5fc42f57b927115fd33a79b",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/metrics-guide.md",
+          "sha256": "d10c13d8e0f5ac393e4682efcc17ed92652d0705da618d8b7dfe0bb551db263e",
+          "owner": "crest"
+        },
+        {
+          "path": "skills/operations-general/crest/references/positioning-frameworks.md",
+          "sha256": "2432e5ad601d4e3433a51c406d35ffb50200fa81eae861217ab6d77176d0c9e0",
+          "owner": "crest"
         }
       ]
     },
@@ -1413,7 +9368,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1425,6 +9380,71 @@
             {
               "source": "hearth/SKILL.md",
               "target": "skills/operations-general/hearth/SKILL.md"
+            },
+            {
+              "source": "hearth/reference/autorun-schema.md",
+              "target": "skills/operations-general/hearth/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/dotfile-management.md",
+              "target": "skills/operations-general/hearth/reference/dotfile-management.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/dotfile-security-anti-patterns.md",
+              "target": "skills/operations-general/hearth/reference/dotfile-security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/editor-configs.md",
+              "target": "skills/operations-general/hearth/reference/editor-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/editor-terminal-anti-patterns.md",
+              "target": "skills/operations-general/hearth/reference/editor-terminal-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/environment-workflow-anti-patterns.md",
+              "target": "skills/operations-general/hearth/reference/environment-workflow-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/git-personal-config.md",
+              "target": "skills/operations-general/hearth/reference/git-personal-config.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/shell-config-anti-patterns.md",
+              "target": "skills/operations-general/hearth/reference/shell-config-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/shell-configs.md",
+              "target": "skills/operations-general/hearth/reference/shell-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/shellfn-functions-env.md",
+              "target": "skills/operations-general/hearth/reference/shellfn-functions-env.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/terminal-configs.md",
+              "target": "skills/operations-general/hearth/reference/terminal-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/tmux-starship.md",
+              "target": "skills/operations-general/hearth/reference/tmux-starship.md",
+              "type": "file"
+            },
+            {
+              "source": "hearth/reference/vscode-editor-config.md",
+              "target": "skills/operations-general/hearth/reference/vscode-editor-config.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1436,13 +9456,215 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/operations-general/hearth",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/operations-general/hearth/references/dotfile-management.md",
+              "target": "skills/operations-general/hearth/references/dotfile-management.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/dotfile-security-anti-patterns.md",
+              "target": "skills/operations-general/hearth/references/dotfile-security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/editor-configs.md",
+              "target": "skills/operations-general/hearth/references/editor-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/editor-terminal-anti-patterns.md",
+              "target": "skills/operations-general/hearth/references/editor-terminal-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/environment-workflow-anti-patterns.md",
+              "target": "skills/operations-general/hearth/references/environment-workflow-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/git-personal-config.md",
+              "target": "skills/operations-general/hearth/references/git-personal-config.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/shell-config-anti-patterns.md",
+              "target": "skills/operations-general/hearth/references/shell-config-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/shell-configs.md",
+              "target": "skills/operations-general/hearth/references/shell-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/shellfn-functions-env.md",
+              "target": "skills/operations-general/hearth/references/shellfn-functions-env.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/terminal-configs.md",
+              "target": "skills/operations-general/hearth/references/terminal-configs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/tmux-starship.md",
+              "target": "skills/operations-general/hearth/references/tmux-starship.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/operations-general/hearth/references/vscode-editor-config.md",
+              "target": "skills/operations-general/hearth/references/vscode-editor-config.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/operations-general/hearth/SKILL.md",
-          "owner": "hearth",
-          "sha256": "e654afdb9b4e522eac6205306269ff6ced61108bcc64ea79cecd5f0abbfda1fc"
+          "sha256": "e654afdb9b4e522eac6205306269ff6ced61108bcc64ea79cecd5f0abbfda1fc",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/autorun-schema.md",
+          "sha256": "c05bda9ac954a2b4ba6775d8ba3261f36134bffa6b394ace0a26bfc7c1720065",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/dotfile-management.md",
+          "sha256": "c15d2e8477b89b5d27d647a548e3bd8c331bd4975ae614e9fc43ac6ac0926f2b",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/dotfile-security-anti-patterns.md",
+          "sha256": "8999997cfdba876186e72ac1b9f6570fbecc8f0730cc677fa6f94994801b4b9d",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/editor-configs.md",
+          "sha256": "be9d0f2496e0bb18f965cc1267839a061d3220b6112e840259e7e30edefb1fee",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/editor-terminal-anti-patterns.md",
+          "sha256": "1431bc45a673cb3f2322df69fd18e58b835342dc437e0d9bd2b47e4dad5e56fc",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/environment-workflow-anti-patterns.md",
+          "sha256": "cc139ed47b7a3b3512383b3dad3429ee41b5e372357a42025340f25b02ee55e4",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/git-personal-config.md",
+          "sha256": "7f65f0a4f3dd8c323e77c6fca2bd053098879e2dcca572f3ccd1e33d754a28c3",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/shell-config-anti-patterns.md",
+          "sha256": "1818a2bef5ef53fb843009a00576fdf2bd98d8b7ac9debdaeedb4e0b13c348f8",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/shell-configs.md",
+          "sha256": "4b9eb653dab93a0dc383d0e055c9bca90527ba2c5d3c5678b026e29a6a59b1b4",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/shellfn-functions-env.md",
+          "sha256": "93f4cee0aba51c8aa77ff16b51886e63dc76e23198b02db4e8fe9568433dd96a",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/terminal-configs.md",
+          "sha256": "88052e6ccb8ac472177e55ecbdbfdfbb2f08123c775b6f45d9c79b3088e1e514",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/tmux-starship.md",
+          "sha256": "c515e54f5acf711c62b1778ddae99e198fb47ee4a9b6ff06a0b7d3177fc336c9",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/reference/vscode-editor-config.md",
+          "sha256": "6e5d6636175d38e1c6bfe02ec658a12ca668664db7689f29cbbf7b7f96cb961a",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/dotfile-management.md",
+          "sha256": "c15d2e8477b89b5d27d647a548e3bd8c331bd4975ae614e9fc43ac6ac0926f2b",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/dotfile-security-anti-patterns.md",
+          "sha256": "8999997cfdba876186e72ac1b9f6570fbecc8f0730cc677fa6f94994801b4b9d",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/editor-configs.md",
+          "sha256": "be9d0f2496e0bb18f965cc1267839a061d3220b6112e840259e7e30edefb1fee",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/editor-terminal-anti-patterns.md",
+          "sha256": "1431bc45a673cb3f2322df69fd18e58b835342dc437e0d9bd2b47e4dad5e56fc",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/environment-workflow-anti-patterns.md",
+          "sha256": "cc139ed47b7a3b3512383b3dad3429ee41b5e372357a42025340f25b02ee55e4",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/git-personal-config.md",
+          "sha256": "7f65f0a4f3dd8c323e77c6fca2bd053098879e2dcca572f3ccd1e33d754a28c3",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/shell-config-anti-patterns.md",
+          "sha256": "1818a2bef5ef53fb843009a00576fdf2bd98d8b7ac9debdaeedb4e0b13c348f8",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/shell-configs.md",
+          "sha256": "ddfee3c5f5bd0b4d68c63d7ed10f51c320178754ba608a3681cd17e7e3c598e9",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/shellfn-functions-env.md",
+          "sha256": "93f4cee0aba51c8aa77ff16b51886e63dc76e23198b02db4e8fe9568433dd96a",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/terminal-configs.md",
+          "sha256": "88052e6ccb8ac472177e55ecbdbfdfbb2f08123c775b6f45d9c79b3088e1e514",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/tmux-starship.md",
+          "sha256": "c515e54f5acf711c62b1778ddae99e198fb47ee4a9b6ff06a0b7d3177fc336c9",
+          "owner": "hearth"
+        },
+        {
+          "path": "skills/operations-general/hearth/references/vscode-editor-config.md",
+          "sha256": "49d747ee359944115b8ece125730a643898feace93cf37b3326b50bb9ab595d7",
+          "owner": "hearth"
         }
       ]
     },
@@ -1515,7 +9737,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1527,6 +9749,51 @@
             {
               "source": "voice/SKILL.md",
               "target": "skills/product-design/voice/SKILL.md"
+            },
+            {
+              "source": "voice/reference/autorun-schema.md",
+              "target": "skills/product-design/voice/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/csat-ces-measurement.md",
+              "target": "skills/product-design/voice/reference/csat-ces-measurement.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/csat-ces-surveys.md",
+              "target": "skills/product-design/voice/reference/csat-ces-surveys.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/exit-survey.md",
+              "target": "skills/product-design/voice/reference/exit-survey.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/feedback-widget-analysis.md",
+              "target": "skills/product-design/voice/reference/feedback-widget-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/kano-model.md",
+              "target": "skills/product-design/voice/reference/kano-model.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/multi-channel-synthesis.md",
+              "target": "skills/product-design/voice/reference/multi-channel-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/nps-survey.md",
+              "target": "skills/product-design/voice/reference/nps-survey.md",
+              "type": "file"
+            },
+            {
+              "source": "voice/reference/thematic-coding.md",
+              "target": "skills/product-design/voice/reference/thematic-coding.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1538,13 +9805,155 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/product-design/voice",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/product-design/voice/references/csat-ces-measurement.md",
+              "target": "skills/product-design/voice/references/csat-ces-measurement.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/csat-ces-surveys.md",
+              "target": "skills/product-design/voice/references/csat-ces-surveys.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/exit-survey.md",
+              "target": "skills/product-design/voice/references/exit-survey.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/feedback-widget-analysis.md",
+              "target": "skills/product-design/voice/references/feedback-widget-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/kano-model.md",
+              "target": "skills/product-design/voice/references/kano-model.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/multi-channel-synthesis.md",
+              "target": "skills/product-design/voice/references/multi-channel-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/nps-survey.md",
+              "target": "skills/product-design/voice/references/nps-survey.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/voice/references/thematic-coding.md",
+              "target": "skills/product-design/voice/references/thematic-coding.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/product-design/voice/SKILL.md",
-          "owner": "voice",
-          "sha256": "901dab76e7da3111593d9fca1c6f32102806825a8028fc21819fd4ea52e4f22a"
+          "sha256": "901dab76e7da3111593d9fca1c6f32102806825a8028fc21819fd4ea52e4f22a",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/autorun-schema.md",
+          "sha256": "5f76137183fc0caafdf4f4cf852583ff044a9f27a7c2db93c143840636efc04c",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/csat-ces-measurement.md",
+          "sha256": "ca22d8c2903e954da1cf5b198e218744cc52d14f02aa485f94967dc1d4002e95",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/csat-ces-surveys.md",
+          "sha256": "55079c91e36fb3b5c5b0a239e187463d69d03aa5fc1bbda6472756dc460aa01d",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/exit-survey.md",
+          "sha256": "0077542505641a32eea803b369ea4ac587d2cf9b60001363b349e6c35d3012ca",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/feedback-widget-analysis.md",
+          "sha256": "9d5863c6f418ad00798cdcacc612998c1ab8e45b30c644aa6897e2e1784129a9",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/kano-model.md",
+          "sha256": "a8425e76ac8dda04797e0fbe184f2ef51de3a308fac4f49cf9b5d2f9b89bf124",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/multi-channel-synthesis.md",
+          "sha256": "16c5ced6b4c7d5df4f298a315b8539364817c174466334499b081b6cab5cd5dc",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/nps-survey.md",
+          "sha256": "b81736d258178bf7588079f160d39663d2521d78d3a6ffcccc34e803a9ff8e65",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/reference/thematic-coding.md",
+          "sha256": "bd21e0fe4876d1b77c8b2863be7a0b2cc8655f8bc7e32025b148c76936a66e84",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/csat-ces-measurement.md",
+          "sha256": "a2e04fb842fabc61b48df1cce0070e8ddb2fae4e4b2c10ff5195c770296fd020",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/csat-ces-surveys.md",
+          "sha256": "55079c91e36fb3b5c5b0a239e187463d69d03aa5fc1bbda6472756dc460aa01d",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/exit-survey.md",
+          "sha256": "04cb85d26e8627df6dad34a5e102c778f1ab1f5a5e299afcd83d3ffe4842f963",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/feedback-widget-analysis.md",
+          "sha256": "5df3420cd65eabe1210988e79c898a416d04dcec65660d7a659aeaf4e6b6c5bb",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/kano-model.md",
+          "sha256": "4789bdf5b36d0b8c4f727d1bb8a069634569b0c72e190fe5f8cbacf961900784",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/multi-channel-synthesis.md",
+          "sha256": "46215c8657a474fb722d89d5106e049bd1b907f3c4219b3e6c6eeabeb633d102",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/nps-survey.md",
+          "sha256": "f3cb924ea027b5d12f641fe22d01ca21918f9257a52cf6b4ea2b910c6e325ee1",
+          "owner": "voice"
+        },
+        {
+          "path": "skills/product-design/voice/references/thematic-coding.md",
+          "sha256": "2ea663bc62ed340a472f0c80af3cb56be3f269416d7b27d6d63b3eb49746b6ce",
+          "owner": "voice"
         }
       ]
     },
@@ -1564,7 +9973,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1576,6 +9985,46 @@
             {
               "source": "trace/SKILL.md",
               "target": "skills/product-design/trace/SKILL.md"
+            },
+            {
+              "source": "trace/reference/autorun-schema.md",
+              "target": "skills/product-design/trace/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/frustration-signals.md",
+              "target": "skills/product-design/trace/reference/frustration-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/funnel-dropoff.md",
+              "target": "skills/product-design/trace/reference/funnel-dropoff.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/heatmap-synthesis.md",
+              "target": "skills/product-design/trace/reference/heatmap-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/persona-integration.md",
+              "target": "skills/product-design/trace/reference/persona-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/rageclick-detection.md",
+              "target": "skills/product-design/trace/reference/rageclick-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/report-templates.md",
+              "target": "skills/product-design/trace/reference/report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "trace/reference/session-analysis.md",
+              "target": "skills/product-design/trace/reference/session-analysis.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1587,13 +10036,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/product-design/trace",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/product-design/trace/references/frustration-signals.md",
+              "target": "skills/product-design/trace/references/frustration-signals.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/funnel-dropoff.md",
+              "target": "skills/product-design/trace/references/funnel-dropoff.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/heatmap-synthesis.md",
+              "target": "skills/product-design/trace/references/heatmap-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/persona-integration.md",
+              "target": "skills/product-design/trace/references/persona-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/rageclick-detection.md",
+              "target": "skills/product-design/trace/references/rageclick-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/report-templates.md",
+              "target": "skills/product-design/trace/references/report-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/product-design/trace/references/session-analysis.md",
+              "target": "skills/product-design/trace/references/session-analysis.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/product-design/trace/SKILL.md",
-          "owner": "trace",
-          "sha256": "a9c94a690a83d85385623d96eed0a74ea52ab20a4313a4f3c89e968f6a4d3a23"
+          "sha256": "a9c94a690a83d85385623d96eed0a74ea52ab20a4313a4f3c89e968f6a4d3a23",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/autorun-schema.md",
+          "sha256": "29a53b3ab41687c3b78d6a36c082d2ecb387492a66fd6cf381c1404f260ac291",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/frustration-signals.md",
+          "sha256": "dc21de6d309bf0dfcdafb3f8220e0c3b34ca81dafff60303c0aa94181bf16d66",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/funnel-dropoff.md",
+          "sha256": "f78b53103f1a2b0c58ec0bca7d724857dd76e237420f604ef932a364015e0cc5",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/heatmap-synthesis.md",
+          "sha256": "76ef391d45b72f36a91977631abf574299825a4f3c07b81a47e7b41a86702c81",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/persona-integration.md",
+          "sha256": "47de43bdb1e623902107bc6e23a2196d375ac432bf3df9d0c43daf00ceb559db",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/rageclick-detection.md",
+          "sha256": "6e69be43dd1789e52d578f51cc7628801aacc36ee6029e616b4b54c71e9599b5",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/report-templates.md",
+          "sha256": "7bd748757fea5f0f072d05d930783fce698329786bab53f9a80f6a2e6af62d7f",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/reference/session-analysis.md",
+          "sha256": "571a2af802afb6c2622face98101c90bdcb5c038a6f37dcab000e9f03ff758b3",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/frustration-signals.md",
+          "sha256": "569f5a06ccd522b1b8d092efb5e1713b49bb3f6e4429c4404f8f19af71abfa02",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/funnel-dropoff.md",
+          "sha256": "28271a5bd6d26340b79f3344a03c6083c6c689bc89ef9d3e79dbbe33feb3f59d",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/heatmap-synthesis.md",
+          "sha256": "76ef391d45b72f36a91977631abf574299825a4f3c07b81a47e7b41a86702c81",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/persona-integration.md",
+          "sha256": "cd9e73776455e8487c2ae5c7cc08ab961b8f2452e0ae0cfc2afd71f3839100e1",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/rageclick-detection.md",
+          "sha256": "6e69be43dd1789e52d578f51cc7628801aacc36ee6029e616b4b54c71e9599b5",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/report-templates.md",
+          "sha256": "b94fe278cee70c53c37d261c2be500db6bcdb405b04acf81d05a83b8e1970f93",
+          "owner": "trace"
+        },
+        {
+          "path": "skills/product-design/trace/references/session-analysis.md",
+          "sha256": "eda5c41884e50fb234cd96e77f97ed8904455fed96c1e5a1a5c10b2c035d09b9",
+          "owner": "trace"
         }
       ]
     },
@@ -1629,6 +10205,66 @@
             {
               "source": "researcher/SKILL.md",
               "target": "skills/product-design/researcher/SKILL.md"
+            },
+            {
+              "source": "researcher/references/ai-assisted-research.md",
+              "target": "skills/product-design/researcher/references/ai-assisted-research.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/analysis-and-synthesis.md",
+              "target": "skills/product-design/researcher/references/analysis-and-synthesis.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/bias-checklist.md",
+              "target": "skills/product-design/researcher/references/bias-checklist.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/cards-ia-validation.md",
+              "target": "skills/product-design/researcher/references/cards-ia-validation.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/continuous-discovery-mixed-methods.md",
+              "target": "skills/product-design/researcher/references/continuous-discovery-mixed-methods.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/diary-longitudinal-study.md",
+              "target": "skills/product-design/researcher/references/diary-longitudinal-study.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/interview-guide.md",
+              "target": "skills/product-design/researcher/references/interview-guide.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/participant-screening.md",
+              "target": "skills/product-design/researcher/references/participant-screening.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/research-anti-patterns-impact.md",
+              "target": "skills/product-design/researcher/references/research-anti-patterns-impact.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/research-calibration.md",
+              "target": "skills/product-design/researcher/references/research-calibration.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/research-ops-democratization.md",
+              "target": "skills/product-design/researcher/references/research-ops-democratization.md",
+              "type": "file"
+            },
+            {
+              "source": "researcher/references/survey-quantitative-design.md",
+              "target": "skills/product-design/researcher/references/survey-quantitative-design.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1645,8 +10281,68 @@
       "managed_files": [
         {
           "path": "skills/product-design/researcher/SKILL.md",
-          "owner": "researcher",
-          "sha256": "d32fb51129858c00d7748d78d77ed6fd53543f98af28b2666ce404d9b6a57565"
+          "sha256": "d32fb51129858c00d7748d78d77ed6fd53543f98af28b2666ce404d9b6a57565",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/ai-assisted-research.md",
+          "sha256": "ebc3d32d103e3a88ce4ef8c8aafda83776c63e299e61b59fbbcae7b5cc7974e1",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/analysis-and-synthesis.md",
+          "sha256": "425278cb0fc9d51493d9196614af4b0523d36525a495e3f467641cf3f8f375ef",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/bias-checklist.md",
+          "sha256": "5dc65152173d10f86870cdb2074446b8a013a381e390d8600ec6a1d5facb5ca7",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/cards-ia-validation.md",
+          "sha256": "9f246676095d6dc29ba01942bd88edcc8e1b6d422f594b29eee9700e60b01a59",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/continuous-discovery-mixed-methods.md",
+          "sha256": "5a7c51509f2f6f6bfa188512d04620b31aefecacc23f1981c89bd2afed538bb8",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/diary-longitudinal-study.md",
+          "sha256": "f6dbc90efecab4b9651bfbe9c471eb5ce03e752995d27d630e60a2dd1c03a67e",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/interview-guide.md",
+          "sha256": "ec227246f55f8441c6e6fba041170d7ad45dd91611d8e7a78169b5102808387e",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/participant-screening.md",
+          "sha256": "748e2be9afc328b3eb295a00f1ef75a0110b2edd5776afa2f169506b49185a55",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/research-anti-patterns-impact.md",
+          "sha256": "7de2c12505ee03da04fb54cf64e68cd4c8b7fb4af6ba37fb637dcf570bab877e",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/research-calibration.md",
+          "sha256": "d61d090708b3f0be602b772cd1d255fb05dbef51913fd59a494758855e308191",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/research-ops-democratization.md",
+          "sha256": "ddae48654e2b94fc3592effdf0a0fd2d70b8d208283d80987e989a7a88ebaf3c",
+          "owner": "researcher"
+        },
+        {
+          "path": "skills/product-design/researcher/references/survey-quantitative-design.md",
+          "sha256": "ca2db3e98d3b09b8c55e706aec6b337a68ec6ab9d97caa00d4b68206044d5910",
+          "owner": "researcher"
         }
       ]
     },
@@ -1666,7 +10362,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1678,6 +10374,46 @@
             {
               "source": "breach/SKILL.md",
               "target": "skills/security-and-reliability/breach/SKILL.md"
+            },
+            {
+              "source": "breach/reference/ai-red-teaming.md",
+              "target": "skills/security-and-reliability/breach/reference/ai-red-teaming.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/attack-playbooks.md",
+              "target": "skills/security-and-reliability/breach/reference/attack-playbooks.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/autorun-schema.md",
+              "target": "skills/security-and-reliability/breach/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/handoffs.md",
+              "target": "skills/security-and-reliability/breach/reference/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/phishing-campaign-design.md",
+              "target": "skills/security-and-reliability/breach/reference/phishing-campaign-design.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/social-engineering-design.md",
+              "target": "skills/security-and-reliability/breach/reference/social-engineering-design.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/supply-chain-attack-design.md",
+              "target": "skills/security-and-reliability/breach/reference/supply-chain-attack-design.md",
+              "type": "file"
+            },
+            {
+              "source": "breach/reference/threat-modeling.md",
+              "target": "skills/security-and-reliability/breach/reference/threat-modeling.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1689,13 +10425,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/security-and-reliability/breach",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/security-and-reliability/breach/references/ai-red-teaming.md",
+              "target": "skills/security-and-reliability/breach/references/ai-red-teaming.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/attack-playbooks.md",
+              "target": "skills/security-and-reliability/breach/references/attack-playbooks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/handoffs.md",
+              "target": "skills/security-and-reliability/breach/references/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/phishing-campaign-design.md",
+              "target": "skills/security-and-reliability/breach/references/phishing-campaign-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/social-engineering-design.md",
+              "target": "skills/security-and-reliability/breach/references/social-engineering-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/supply-chain-attack-design.md",
+              "target": "skills/security-and-reliability/breach/references/supply-chain-attack-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/breach/references/threat-modeling.md",
+              "target": "skills/security-and-reliability/breach/references/threat-modeling.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/security-and-reliability/breach/SKILL.md",
-          "owner": "breach",
-          "sha256": "01e0081d3f8ff15cf74b884cadfefe581ed2808baca3898600005752565e1975"
+          "sha256": "01e0081d3f8ff15cf74b884cadfefe581ed2808baca3898600005752565e1975",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/ai-red-teaming.md",
+          "sha256": "ef11a8074dac433a739667f4dee61be8d991de4486c476e93520960e58ec15d2",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/attack-playbooks.md",
+          "sha256": "43eb4f18315fc92c96379ab09315f67117a2652d4555f27cfa51bd0b663baeb2",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/autorun-schema.md",
+          "sha256": "79d22d39ecf82192fad335429995ad936ee8c400577b760d2c55122295c842cd",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/handoffs.md",
+          "sha256": "a6babeceb2ce7ed53b6bf14902e64832641b07b1c06a4c3291726775c923be4e",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/phishing-campaign-design.md",
+          "sha256": "21ef3a342859193ffe3b642e43661519e907cab489199707af25db95777a829a",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/social-engineering-design.md",
+          "sha256": "c4a0ecacf7df6218c52688340a416d0134efd2a036fc2f9d2c9b071f43389e13",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/supply-chain-attack-design.md",
+          "sha256": "f4424ba01e7316d57f143f7ab701b99a0b728372128ec97ff652cc51676c1014",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/reference/threat-modeling.md",
+          "sha256": "f1d28cab4863216bffdf8bcf9845d0851b15cb4c6f2bcb920b4729d7a0c6c5c2",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/ai-red-teaming.md",
+          "sha256": "7cf54ba9215f1601244f3c85de85226cb723788bde2c0b0e464251c4ad3e5932",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/attack-playbooks.md",
+          "sha256": "693a185e5a3f23d0d422c539a0730bed80be04628e87e0aa6fe857faa6925a79",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/handoffs.md",
+          "sha256": "a6babeceb2ce7ed53b6bf14902e64832641b07b1c06a4c3291726775c923be4e",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/phishing-campaign-design.md",
+          "sha256": "d7bd7caa1aa514910720da572ff7f5b002a24443a9a89eb27c29495447c2ec6c",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/social-engineering-design.md",
+          "sha256": "31937a11bbaa5852ee1ca6b7402c14210a122bb580d4f91d361566fb8d92a37e",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/supply-chain-attack-design.md",
+          "sha256": "56dc91b3e11cef086f552c67449ab6748666c3ed463146b1119dc8a6273022cb",
+          "owner": "breach"
+        },
+        {
+          "path": "skills/security-and-reliability/breach/references/threat-modeling.md",
+          "sha256": "25e1ac61752fd32dc1618cbe130a0c78e539fb80dbbee0e26b1a8b50906908b6",
+          "owner": "breach"
         }
       ]
     },
@@ -1715,7 +10578,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1727,6 +10590,41 @@
             {
               "source": "cloak/SKILL.md",
               "target": "skills/security-and-reliability/cloak/SKILL.md"
+            },
+            {
+              "source": "cloak/reference/appi-japan.md",
+              "target": "skills/security-and-reliability/cloak/reference/appi-japan.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/autorun-schema.md",
+              "target": "skills/security-and-reliability/cloak/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/ccpa-cpra.md",
+              "target": "skills/security-and-reliability/cloak/reference/ccpa-cpra.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/implementation-patterns.md",
+              "target": "skills/security-and-reliability/cloak/reference/implementation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/pii-detection.md",
+              "target": "skills/security-and-reliability/cloak/reference/pii-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/privacy-regulations.md",
+              "target": "skills/security-and-reliability/cloak/reference/privacy-regulations.md",
+              "type": "file"
+            },
+            {
+              "source": "cloak/reference/pseudonymization-techniques.md",
+              "target": "skills/security-and-reliability/cloak/reference/pseudonymization-techniques.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1738,13 +10636,125 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/security-and-reliability/cloak",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/security-and-reliability/cloak/references/appi-japan.md",
+              "target": "skills/security-and-reliability/cloak/references/appi-japan.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/cloak/references/ccpa-cpra.md",
+              "target": "skills/security-and-reliability/cloak/references/ccpa-cpra.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/cloak/references/implementation-patterns.md",
+              "target": "skills/security-and-reliability/cloak/references/implementation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/cloak/references/pii-detection.md",
+              "target": "skills/security-and-reliability/cloak/references/pii-detection.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/cloak/references/privacy-regulations.md",
+              "target": "skills/security-and-reliability/cloak/references/privacy-regulations.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/security-and-reliability/cloak/references/pseudonymization-techniques.md",
+              "target": "skills/security-and-reliability/cloak/references/pseudonymization-techniques.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/security-and-reliability/cloak/SKILL.md",
-          "owner": "cloak",
-          "sha256": "7c3a0e49e6f2d75569ec96e994625040d3dc98f27a654b2776fd5d8e8ebc7e2b"
+          "sha256": "7c3a0e49e6f2d75569ec96e994625040d3dc98f27a654b2776fd5d8e8ebc7e2b",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/appi-japan.md",
+          "sha256": "4b2a4217408db800a7fb858164894d408261e133341fc2dcc2295a2a649416c3",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/autorun-schema.md",
+          "sha256": "23bae450067424fb08ceba6dabd4044e328fddfff869c51f128f51d3bbe39bf0",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/ccpa-cpra.md",
+          "sha256": "7dc021467da2f3b8c7de42e2ad3874ad78c67d5474872117d5c925ad46560c38",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/implementation-patterns.md",
+          "sha256": "f042c8e2f3194092d6d806e315b1261532e57a819c226a9a0fb6c4cbdaccbe50",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/pii-detection.md",
+          "sha256": "7ffd07c4e449e42ddee2bdcc71180dbb06cb09470f2376fe531e9deeb67d9b9c",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/privacy-regulations.md",
+          "sha256": "c199706d20f704225a6f237f8314ee32ac7a293cd080346a40d00bfa7c8d6f11",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/reference/pseudonymization-techniques.md",
+          "sha256": "5035b5d3621594e3d29fce6e3a798d6471c6427c22dd806e04e8b852f706190f",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/appi-japan.md",
+          "sha256": "8203a4786bcbaa04383dc0c15eee3fcdc6526c6dbe74e511e5415622e2ae8fd4",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/ccpa-cpra.md",
+          "sha256": "6f09a18cba90aed9a1863611a1de325c6cd4d44e52b298b6a354652e59f9fe6d",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/implementation-patterns.md",
+          "sha256": "f042c8e2f3194092d6d806e315b1261532e57a819c226a9a0fb6c4cbdaccbe50",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/pii-detection.md",
+          "sha256": "7ffd07c4e449e42ddee2bdcc71180dbb06cb09470f2376fe531e9deeb67d9b9c",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/privacy-regulations.md",
+          "sha256": "56df63f29f0cf03c6587425876236c38c9a38a1419cbe1d4e96c9d9c2443f0fe",
+          "owner": "cloak"
+        },
+        {
+          "path": "skills/security-and-reliability/cloak/references/pseudonymization-techniques.md",
+          "sha256": "e01604bd465d0f3c380cb50fefc98781f08ac3e3d6dae9cab6db6cdfc05c627a",
+          "owner": "cloak"
         }
       ]
     },
@@ -1780,6 +10790,51 @@
             {
               "source": "comply/SKILL.md",
               "target": "skills/security-and-reliability/comply/SKILL.md"
+            },
+            {
+              "source": "comply/references/audit-readiness.md",
+              "target": "skills/security-and-reliability/comply/references/audit-readiness.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/audit-trail-design.md",
+              "target": "skills/security-and-reliability/comply/references/audit-trail-design.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/compliance-reporting.md",
+              "target": "skills/security-and-reliability/comply/references/compliance-reporting.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/control-mapping.md",
+              "target": "skills/security-and-reliability/comply/references/control-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/gdpr-eu-ai-act.md",
+              "target": "skills/security-and-reliability/comply/references/gdpr-eu-ai-act.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/handoff-formats.md",
+              "target": "skills/security-and-reliability/comply/references/handoff-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/policy-as-code.md",
+              "target": "skills/security-and-reliability/comply/references/policy-as-code.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/regulatory-frameworks.md",
+              "target": "skills/security-and-reliability/comply/references/regulatory-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "comply/references/vendor-risk-assessment.md",
+              "target": "skills/security-and-reliability/comply/references/vendor-risk-assessment.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1796,8 +10851,53 @@
       "managed_files": [
         {
           "path": "skills/security-and-reliability/comply/SKILL.md",
-          "owner": "comply",
-          "sha256": "3e588304796dac5afc5df08915376e5b91bc80542d42259422b360e2d2e0187c"
+          "sha256": "3e588304796dac5afc5df08915376e5b91bc80542d42259422b360e2d2e0187c",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/audit-readiness.md",
+          "sha256": "75dbbfc38155dcde4d0ae2eb6138974862a4ed2db081c96e27d2931c8bd2ff35",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/audit-trail-design.md",
+          "sha256": "bc753bf1d34eb6a299b828317e7b0791451ec3490bd66dce70fe99ca2421bb9e",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/compliance-reporting.md",
+          "sha256": "4c27c878ddc9f2d782ec0783790efd30d14d51d939a16d5cc6e72a176c4232b1",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/control-mapping.md",
+          "sha256": "dfd01e78a018b6765c9c730b68d060e8ff70e083a690a0fd8c082e054bb4f734",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/gdpr-eu-ai-act.md",
+          "sha256": "74090e7f865a786108620dd088c334d4db84d107e0ffb02375afcdb05dc3e6d7",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/handoff-formats.md",
+          "sha256": "a95a3c2abd18878597f9589bc345698da2165f09615dd48e5074e73464b39ca0",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/policy-as-code.md",
+          "sha256": "e568ec3d8e019f4c58482b40525970c632765e0bab21be30f9b6920f9e6bc7f7",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/regulatory-frameworks.md",
+          "sha256": "c9abf9a6b49be4edbedc773f26d0d6894c64dd1d44aaed3563d9901df7d9884a",
+          "owner": "comply"
+        },
+        {
+          "path": "skills/security-and-reliability/comply/references/vendor-risk-assessment.md",
+          "sha256": "5a85d060f62eaa8f95cd8efade27a042669292f544f571780ac0a18f50093659",
+          "owner": "comply"
         }
       ]
     },
@@ -1817,7 +10917,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1829,6 +10929,56 @@
             {
               "source": "sketch/SKILL.md",
               "target": "skills/multimodal-media/sketch/SKILL.md"
+            },
+            {
+              "source": "sketch/reference/api-integration.md",
+              "target": "skills/multimodal-media/sketch/reference/api-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/autorun-schema.md",
+              "target": "skills/multimodal-media/sketch/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/batch-generation.md",
+              "target": "skills/multimodal-media/sketch/reference/batch-generation.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/cinematic-prompting.md",
+              "target": "skills/multimodal-media/sketch/reference/cinematic-prompting.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/content-policy-guardrails.md",
+              "target": "skills/multimodal-media/sketch/reference/content-policy-guardrails.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/examples.md",
+              "target": "skills/multimodal-media/sketch/reference/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/prompt-patterns.md",
+              "target": "skills/multimodal-media/sketch/reference/prompt-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/provenance-disclosure.md",
+              "target": "skills/multimodal-media/sketch/reference/provenance-disclosure.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/style-transfer.md",
+              "target": "skills/multimodal-media/sketch/reference/style-transfer.md",
+              "type": "file"
+            },
+            {
+              "source": "sketch/reference/upscale-postprocess.md",
+              "target": "skills/multimodal-media/sketch/reference/upscale-postprocess.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1840,13 +10990,140 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/multimodal-media/sketch",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/multimodal-media/sketch/references/api-integration.md",
+              "target": "skills/multimodal-media/sketch/references/api-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/multimodal-media/sketch/references/batch-generation.md",
+              "target": "skills/multimodal-media/sketch/references/batch-generation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/multimodal-media/sketch/references/examples.md",
+              "target": "skills/multimodal-media/sketch/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/multimodal-media/sketch/references/prompt-patterns.md",
+              "target": "skills/multimodal-media/sketch/references/prompt-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/multimodal-media/sketch/references/style-transfer.md",
+              "target": "skills/multimodal-media/sketch/references/style-transfer.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/multimodal-media/sketch/references/upscale-postprocess.md",
+              "target": "skills/multimodal-media/sketch/references/upscale-postprocess.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/multimodal-media/sketch/SKILL.md",
-          "owner": "sketch",
-          "sha256": "b59f59e44e4ad6c71413defa13f02d9729a1d8a962e96ff00799718f677c6de1"
+          "sha256": "b59f59e44e4ad6c71413defa13f02d9729a1d8a962e96ff00799718f677c6de1",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/api-integration.md",
+          "sha256": "8713811d4c8bc1e9ee435d5f90ca84a20c24e293014d81b3da7d7fd4eeb78e09",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/autorun-schema.md",
+          "sha256": "255307a890f963fad3b7d52df39d68a6b0b47a67cd9e5e554654aa3a3ec51021",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/batch-generation.md",
+          "sha256": "b1db674e0739fe4e524341d24ccc4bf8203a93b5e7c2afc10cbd77df6089f9fb",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/cinematic-prompting.md",
+          "sha256": "80f9cb323151001c69f6ed3ae62e6e84b86809db39b234af86bf095066e8fc0e",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/content-policy-guardrails.md",
+          "sha256": "255b61e671d51e84dc4797f40f1364b64316c69e458e3a3973c694404223242d",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/examples.md",
+          "sha256": "d15f3593d12810f5a02af39802594c63a97b6eaf7d890bacf45e580588c09187",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/prompt-patterns.md",
+          "sha256": "7ff9ceaa1ccaeef20a2ab7745b09d95824ce01d143837d12513b44bf86724ae1",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/provenance-disclosure.md",
+          "sha256": "92977e8c8165865996d7f8cc06c1d8dd2e027e061a67a18e847093f1b4547a49",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/style-transfer.md",
+          "sha256": "7ff76434a976ef5c1bce865453d11b576ca4a03e9127406cdeee72fee165ed0b",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/reference/upscale-postprocess.md",
+          "sha256": "d92271ecef11f6e27c754bf65702fd2f833631af6030a39435e37382c998a3b6",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/api-integration.md",
+          "sha256": "8225b0f7aefd21c751d832b8564033f27c01544166abee06548946123ab15e95",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/batch-generation.md",
+          "sha256": "7792fe1905e37b7b12b0cf448288b650f6c7054e155396d21e172ea38c498ab2",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/examples.md",
+          "sha256": "d15f3593d12810f5a02af39802594c63a97b6eaf7d890bacf45e580588c09187",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/prompt-patterns.md",
+          "sha256": "7ff9ceaa1ccaeef20a2ab7745b09d95824ce01d143837d12513b44bf86724ae1",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/style-transfer.md",
+          "sha256": "7ff76434a976ef5c1bce865453d11b576ca4a03e9127406cdeee72fee165ed0b",
+          "owner": "sketch"
+        },
+        {
+          "path": "skills/multimodal-media/sketch/references/upscale-postprocess.md",
+          "sha256": "bfc8f3ce48aa1a2a549e74cc9f086793af04d70ab1e4430284d184239d4e652c",
+          "owner": "sketch"
         }
       ]
     },
@@ -1882,6 +11159,36 @@
             {
               "source": "clay/SKILL.md",
               "target": "skills/multimodal-media/clay/SKILL.md"
+            },
+            {
+              "source": "clay/references/anti-patterns.md",
+              "target": "skills/multimodal-media/clay/references/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "clay/references/api-integration.md",
+              "target": "skills/multimodal-media/clay/references/api-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "clay/references/code-patterns.md",
+              "target": "skills/multimodal-media/clay/references/code-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "clay/references/game-pipeline.md",
+              "target": "skills/multimodal-media/clay/references/game-pipeline.md",
+              "type": "file"
+            },
+            {
+              "source": "clay/references/prompt-engineering.md",
+              "target": "skills/multimodal-media/clay/references/prompt-engineering.md",
+              "type": "file"
+            },
+            {
+              "source": "clay/references/quality-validation.md",
+              "target": "skills/multimodal-media/clay/references/quality-validation.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1898,8 +11205,38 @@
       "managed_files": [
         {
           "path": "skills/multimodal-media/clay/SKILL.md",
-          "owner": "clay",
-          "sha256": "1bf8f74ab113d8bb812adbb14dd4d91ec2e10664d700a0be576097cc68adc0d3"
+          "sha256": "1bf8f74ab113d8bb812adbb14dd4d91ec2e10664d700a0be576097cc68adc0d3",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/anti-patterns.md",
+          "sha256": "f2f9e3abc3513d56660e7d9dc828b8cf01979c024dd8ac9551b96d338278ddb6",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/api-integration.md",
+          "sha256": "5f20f97a4685c2ab39bd65955181c82488b0d52118444084e52bb5c8408236c7",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/code-patterns.md",
+          "sha256": "d186d879d7299259f90f3aac8de3ecde546099a48ef37b4e0fa4cf074caa786a",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/game-pipeline.md",
+          "sha256": "361efa5e7c21af22798b49000bbdb934224a4a3c3b3b76d3ccf4db9778215d67",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/prompt-engineering.md",
+          "sha256": "d1d366e7801d952bce99242b76c66deaf18b9bb96b79651d9a94c9b64b6daec6",
+          "owner": "clay"
+        },
+        {
+          "path": "skills/multimodal-media/clay/references/quality-validation.md",
+          "sha256": "eea16c21254ed88df9b4c57d293b50388307f20eb736b5415ac017470fbf05cd",
+          "owner": "clay"
         }
       ]
     },
@@ -1935,6 +11272,41 @@
             {
               "source": "tone/SKILL.md",
               "target": "skills/multimodal-media/tone/SKILL.md"
+            },
+            {
+              "source": "tone/references/anti-patterns.md",
+              "target": "skills/multimodal-media/tone/references/anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/api-integration.md",
+              "target": "skills/multimodal-media/tone/references/api-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/format-optimization.md",
+              "target": "skills/multimodal-media/tone/references/format-optimization.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/game-audio-practices.md",
+              "target": "skills/multimodal-media/tone/references/game-audio-practices.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/middleware-integration.md",
+              "target": "skills/multimodal-media/tone/references/middleware-integration.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/model-setup.md",
+              "target": "skills/multimodal-media/tone/references/model-setup.md",
+              "type": "file"
+            },
+            {
+              "source": "tone/references/suno-prompt-guide.md",
+              "target": "skills/multimodal-media/tone/references/suno-prompt-guide.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1951,8 +11323,43 @@
       "managed_files": [
         {
           "path": "skills/multimodal-media/tone/SKILL.md",
-          "owner": "tone",
-          "sha256": "7606feb663d1be1e32e0718d609940f7648c328eef0a1afb90e57024f110941d"
+          "sha256": "7606feb663d1be1e32e0718d609940f7648c328eef0a1afb90e57024f110941d",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/anti-patterns.md",
+          "sha256": "f6f1336aa69afcb9ee562e8de2369d6e8ecd70450aa655de5a0322c2c51fe0f8",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/api-integration.md",
+          "sha256": "76d8e1476ba3a620cb85b5c9a079d79c6138dd20a3647622d134f0b3c44e3f84",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/format-optimization.md",
+          "sha256": "f7f8548ff1e0e8e295581df7c00f73123d5b9404092e9df64be47ff52006b4db",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/game-audio-practices.md",
+          "sha256": "4e9169a9e190000a70a4f37953d35912056d4a88b677ae97f4d0bdc9191b8808",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/middleware-integration.md",
+          "sha256": "181cbc40ee7114d6179c51393bbbc9df76ed84992a959a7775f3559c6f9a8347",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/model-setup.md",
+          "sha256": "8afcf6bbb3b1d75e089e3ccd06e5fdb54c439395955a8eede81a64264f8f002c",
+          "owner": "tone"
+        },
+        {
+          "path": "skills/multimodal-media/tone/references/suno-prompt-guide.md",
+          "sha256": "ddf0f87f49d3d2aca04a43931fa80450d60e8ab81afca617345e696a841c32a2",
+          "owner": "tone"
         }
       ]
     },
@@ -1972,7 +11379,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -1984,6 +11391,91 @@
             {
               "source": "scaffold/SKILL.md",
               "target": "skills/deployment-platforms/scaffold/SKILL.md"
+            },
+            {
+              "source": "scaffold/reference/autorun-schema.md",
+              "target": "skills/deployment-platforms/scaffold/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/aws-specialist.md",
+              "target": "skills/deployment-platforms/scaffold/reference/aws-specialist.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/cdk-scaffolding.md",
+              "target": "skills/deployment-platforms/scaffold/reference/cdk-scaffolding.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/cloud-infrastructure-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/reference/cloud-infrastructure-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/cost-estimation.md",
+              "target": "skills/deployment-platforms/scaffold/reference/cost-estimation.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/cost-finops-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/reference/cost-finops-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/docker-compose-templates.md",
+              "target": "skills/deployment-platforms/scaffold/reference/docker-compose-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/docker-environment-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/reference/docker-environment-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/gcp-specialist.md",
+              "target": "skills/deployment-platforms/scaffold/reference/gcp-specialist.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/helm-chart-authoring.md",
+              "target": "skills/deployment-platforms/scaffold/reference/helm-chart-authoring.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/k8s-manifest-scaffolding.md",
+              "target": "skills/deployment-platforms/scaffold/reference/k8s-manifest-scaffolding.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/multicloud-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/reference/multicloud-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/security-and-cost.md",
+              "target": "skills/deployment-platforms/scaffold/reference/security-and-cost.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/terraform-compliance.md",
+              "target": "skills/deployment-platforms/scaffold/reference/terraform-compliance.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/terraform-iac-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/reference/terraform-iac-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/terraform-modules.md",
+              "target": "skills/deployment-platforms/scaffold/reference/terraform-modules.md",
+              "type": "file"
+            },
+            {
+              "source": "scaffold/reference/terraform-operations.md",
+              "target": "skills/deployment-platforms/scaffold/reference/terraform-operations.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -1995,13 +11487,275 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/deployment-platforms/scaffold",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/deployment-platforms/scaffold/references/aws-specialist.md",
+              "target": "skills/deployment-platforms/scaffold/references/aws-specialist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/cdk-scaffolding.md",
+              "target": "skills/deployment-platforms/scaffold/references/cdk-scaffolding.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/cloud-infrastructure-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/references/cloud-infrastructure-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/cost-estimation.md",
+              "target": "skills/deployment-platforms/scaffold/references/cost-estimation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/cost-finops-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/references/cost-finops-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/docker-compose-templates.md",
+              "target": "skills/deployment-platforms/scaffold/references/docker-compose-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/docker-environment-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/references/docker-environment-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/gcp-specialist.md",
+              "target": "skills/deployment-platforms/scaffold/references/gcp-specialist.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/helm-chart-authoring.md",
+              "target": "skills/deployment-platforms/scaffold/references/helm-chart-authoring.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/k8s-manifest-scaffolding.md",
+              "target": "skills/deployment-platforms/scaffold/references/k8s-manifest-scaffolding.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/multicloud-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/references/multicloud-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/security-and-cost.md",
+              "target": "skills/deployment-platforms/scaffold/references/security-and-cost.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/terraform-compliance.md",
+              "target": "skills/deployment-platforms/scaffold/references/terraform-compliance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/terraform-iac-anti-patterns.md",
+              "target": "skills/deployment-platforms/scaffold/references/terraform-iac-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/terraform-modules.md",
+              "target": "skills/deployment-platforms/scaffold/references/terraform-modules.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/scaffold/references/terraform-operations.md",
+              "target": "skills/deployment-platforms/scaffold/references/terraform-operations.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/deployment-platforms/scaffold/SKILL.md",
-          "owner": "scaffold",
-          "sha256": "23d47d528279c7530347c07d87774c4ef6b83d419d06e7751b149eb641a52852"
+          "sha256": "23d47d528279c7530347c07d87774c4ef6b83d419d06e7751b149eb641a52852",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/autorun-schema.md",
+          "sha256": "d7619b88d5754e282e1f44f7ac56804e45477c770ce49b7debd840353204e6cd",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/aws-specialist.md",
+          "sha256": "c35effae9eb71d4e3b13eb19c751185d464ea887cf2b671fdea6686101b4a7ec",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/cdk-scaffolding.md",
+          "sha256": "bc6a3b79ca4816f6659ec7e42a0eb9c72a12ac27731f5617beefd1002b1718f6",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/cloud-infrastructure-anti-patterns.md",
+          "sha256": "ff21c098ea9835fc13b1ef03ab71d1de99a13019c8695675c42bfdaa3421d12a",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/cost-estimation.md",
+          "sha256": "1f74500c466bc39533645f6a98065e324f7d496699cc48fb3abaa85ccee051c2",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/cost-finops-anti-patterns.md",
+          "sha256": "6d92c6b12dfa9739840ac52a79b6f119e400a8049bc294187302c8e54082daf0",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/docker-compose-templates.md",
+          "sha256": "eb9deb20685c70a201dd5cc46af941fa522ac7e4fdff5c900e8d8e5d67275aea",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/docker-environment-anti-patterns.md",
+          "sha256": "ef5dc2668359ac017495f726f2bc1c9ce070004330923ac97fe924ae437f650e",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/gcp-specialist.md",
+          "sha256": "2bd6daa557c20175c3da5d4316cc8a4dfc0fc80b7b3ff49da7afbee45dde4bdd",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/helm-chart-authoring.md",
+          "sha256": "d1e1dcbed4d4f1f2a25ec2b3ef0a4a142bb902c2d7f492a0413963ceb9163146",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/k8s-manifest-scaffolding.md",
+          "sha256": "dd4627decb99df15c772d6c9c50df4e78a78b1059e379cee6d8bda388abf5772",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/multicloud-patterns.md",
+          "sha256": "f4d5d248e57dc14493eb5177e1f525761128ce24d882b19f4c40a82217d16e8b",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/security-and-cost.md",
+          "sha256": "7e5dc97a78bc83eae5d00454a799f5ffdfc6d1ab6c0a3dd6601fd6af3eaee4e4",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/terraform-compliance.md",
+          "sha256": "89bbaf1692beed73a746444b509569d78ef9cf53589e43cdb40cedb6e35faf56",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/terraform-iac-anti-patterns.md",
+          "sha256": "93233524b6052412121871794c1e0d30f80aad6265ef2bd229a08664dfb15f6f",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/terraform-modules.md",
+          "sha256": "0e5bde71cab18c95d6d66931226172c2d6db2c3f40ab0b42f084ffff60fdd765",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/reference/terraform-operations.md",
+          "sha256": "290332e085b2539ca1190297b35d0ddf09ede5400d2cca951efae4007a3487e3",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/aws-specialist.md",
+          "sha256": "c35effae9eb71d4e3b13eb19c751185d464ea887cf2b671fdea6686101b4a7ec",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/cdk-scaffolding.md",
+          "sha256": "bc6a3b79ca4816f6659ec7e42a0eb9c72a12ac27731f5617beefd1002b1718f6",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/cloud-infrastructure-anti-patterns.md",
+          "sha256": "ff21c098ea9835fc13b1ef03ab71d1de99a13019c8695675c42bfdaa3421d12a",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/cost-estimation.md",
+          "sha256": "1f74500c466bc39533645f6a98065e324f7d496699cc48fb3abaa85ccee051c2",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/cost-finops-anti-patterns.md",
+          "sha256": "6d92c6b12dfa9739840ac52a79b6f119e400a8049bc294187302c8e54082daf0",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/docker-compose-templates.md",
+          "sha256": "eb9deb20685c70a201dd5cc46af941fa522ac7e4fdff5c900e8d8e5d67275aea",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/docker-environment-anti-patterns.md",
+          "sha256": "ef5dc2668359ac017495f726f2bc1c9ce070004330923ac97fe924ae437f650e",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/gcp-specialist.md",
+          "sha256": "2bd6daa557c20175c3da5d4316cc8a4dfc0fc80b7b3ff49da7afbee45dde4bdd",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/helm-chart-authoring.md",
+          "sha256": "d1e1dcbed4d4f1f2a25ec2b3ef0a4a142bb902c2d7f492a0413963ceb9163146",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/k8s-manifest-scaffolding.md",
+          "sha256": "ee6b0ad863803aaba45f49ee68c0fff87cd49ab3dc2125d1efbf5d24ddc9e1e0",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/multicloud-patterns.md",
+          "sha256": "f4d5d248e57dc14493eb5177e1f525761128ce24d882b19f4c40a82217d16e8b",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/security-and-cost.md",
+          "sha256": "7e5dc97a78bc83eae5d00454a799f5ffdfc6d1ab6c0a3dd6601fd6af3eaee4e4",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/terraform-compliance.md",
+          "sha256": "89bbaf1692beed73a746444b509569d78ef9cf53589e43cdb40cedb6e35faf56",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/terraform-iac-anti-patterns.md",
+          "sha256": "3d794f576bcc5d9caabd463226e72971c9bb1475453cc1aa61c6ce4858793452",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/terraform-modules.md",
+          "sha256": "f84055b3c20a9774c47d5704c899e1bbd4bd35bb2229e06bb0a6ee7611304fa9",
+          "owner": "scaffold"
+        },
+        {
+          "path": "skills/deployment-platforms/scaffold/references/terraform-operations.md",
+          "sha256": "290332e085b2539ca1190297b35d0ddf09ede5400d2cca951efae4007a3487e3",
+          "owner": "scaffold"
         }
       ]
     },
@@ -2021,7 +11775,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2033,6 +11787,76 @@
             {
               "source": "pipe/SKILL.md",
               "target": "skills/deployment-platforms/pipe/SKILL.md"
+            },
+            {
+              "source": "pipe/reference/advanced-patterns.md",
+              "target": "skills/deployment-platforms/pipe/reference/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/automation-recipes.md",
+              "target": "skills/deployment-platforms/pipe/reference/automation-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/autorun-schema.md",
+              "target": "skills/deployment-platforms/pipe/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/cache-strategy.md",
+              "target": "skills/deployment-platforms/pipe/reference/cache-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/gha-secrets.md",
+              "target": "skills/deployment-platforms/pipe/reference/gha-secrets.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/matrix-strategy.md",
+              "target": "skills/deployment-platforms/pipe/reference/matrix-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/performance-and-caching.md",
+              "target": "skills/deployment-platforms/pipe/reference/performance-and-caching.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/performance-cost-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/reference/performance-cost-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/reusable-and-composite.md",
+              "target": "skills/deployment-platforms/pipe/reference/reusable-and-composite.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/reusable-maintenance-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/reference/reusable-maintenance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/security-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/reference/security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/security-hardening.md",
+              "target": "skills/deployment-platforms/pipe/reference/security-hardening.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/triggers-and-events.md",
+              "target": "skills/deployment-platforms/pipe/reference/triggers-and-events.md",
+              "type": "file"
+            },
+            {
+              "source": "pipe/reference/workflow-design-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/reference/workflow-design-anti-patterns.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2044,13 +11868,230 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/deployment-platforms/pipe",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/deployment-platforms/pipe/references/advanced-patterns.md",
+              "target": "skills/deployment-platforms/pipe/references/advanced-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/automation-recipes.md",
+              "target": "skills/deployment-platforms/pipe/references/automation-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/cache-strategy.md",
+              "target": "skills/deployment-platforms/pipe/references/cache-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/gha-secrets.md",
+              "target": "skills/deployment-platforms/pipe/references/gha-secrets.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/matrix-strategy.md",
+              "target": "skills/deployment-platforms/pipe/references/matrix-strategy.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/performance-and-caching.md",
+              "target": "skills/deployment-platforms/pipe/references/performance-and-caching.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/performance-cost-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/references/performance-cost-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/reusable-and-composite.md",
+              "target": "skills/deployment-platforms/pipe/references/reusable-and-composite.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/reusable-maintenance-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/references/reusable-maintenance-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/security-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/references/security-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/security-hardening.md",
+              "target": "skills/deployment-platforms/pipe/references/security-hardening.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/triggers-and-events.md",
+              "target": "skills/deployment-platforms/pipe/references/triggers-and-events.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/pipe/references/workflow-design-anti-patterns.md",
+              "target": "skills/deployment-platforms/pipe/references/workflow-design-anti-patterns.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/deployment-platforms/pipe/SKILL.md",
-          "owner": "pipe",
-          "sha256": "559b95dd83f242f04ef351418563630d7c3f5df7f718cc9b8971e96707fe014b"
+          "sha256": "559b95dd83f242f04ef351418563630d7c3f5df7f718cc9b8971e96707fe014b",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/advanced-patterns.md",
+          "sha256": "e27fe4077509496b895fb9d0176cec4bce825167c4cc413dd520eb642b15724f",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/automation-recipes.md",
+          "sha256": "a7dddfc21a89c8323bd4ad0df4864d59162bb8648df959a11f386ea13bf03a15",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/autorun-schema.md",
+          "sha256": "3d9848f4d1176e74c66f79f9d80800dc0317248492a804ff2c1bce1ad0b3cbd8",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/cache-strategy.md",
+          "sha256": "a189440a7cb40c48b4c3d39d55609f601df408bebb15701a0b18de58f18727fb",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/gha-secrets.md",
+          "sha256": "a1e223abe3e94eb57f4c8adf53d3845bb0d86c4eee4386adfd20f64ff359f9c6",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/matrix-strategy.md",
+          "sha256": "545e3159c963fdfa2b35ac212054a0e364a3067c3df356452846c68c5dea3acc",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/performance-and-caching.md",
+          "sha256": "9cb6a9165d1fc4c94ba8c7195e052800963a46089af45cecc33183177f5160a1",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/performance-cost-anti-patterns.md",
+          "sha256": "09b4601ad70346f4f7a332c2af926374921e82d645c847ce31efc32d048ab265",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/reusable-and-composite.md",
+          "sha256": "b66d5770fb59c7aff8c1084772d222d0d3025ec302ba5b5270fd6c20efb0dcc3",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/reusable-maintenance-anti-patterns.md",
+          "sha256": "36d67af7cf566cee2daf382a3b64e08bf5835ad802c97972efdfe246fea1e6cf",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/security-anti-patterns.md",
+          "sha256": "0d574ca53d997ab2add7b35d2053d2b54f330ed26ed2ace98142cd305e65e4b0",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/security-hardening.md",
+          "sha256": "10bd284d4e5a4779a3e513a7d96caff594fb8a91a538b311fdc14ff2a4ccf2b9",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/triggers-and-events.md",
+          "sha256": "ae4e974b1f9633fc18ac2626f704142270537b41e21f633202ddef7db2d904bf",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/reference/workflow-design-anti-patterns.md",
+          "sha256": "8f6993aea1b9842f9674b8eed7bb3eac867f22727998a5ab9566bac91391960c",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/advanced-patterns.md",
+          "sha256": "e27fe4077509496b895fb9d0176cec4bce825167c4cc413dd520eb642b15724f",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/automation-recipes.md",
+          "sha256": "a7dddfc21a89c8323bd4ad0df4864d59162bb8648df959a11f386ea13bf03a15",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/cache-strategy.md",
+          "sha256": "a189440a7cb40c48b4c3d39d55609f601df408bebb15701a0b18de58f18727fb",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/gha-secrets.md",
+          "sha256": "a1e223abe3e94eb57f4c8adf53d3845bb0d86c4eee4386adfd20f64ff359f9c6",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/matrix-strategy.md",
+          "sha256": "545e3159c963fdfa2b35ac212054a0e364a3067c3df356452846c68c5dea3acc",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/performance-and-caching.md",
+          "sha256": "79c39c810cd639f51627c1af7b0bf024c84d2c5a4881945177e7c700c0110463",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/performance-cost-anti-patterns.md",
+          "sha256": "09b4601ad70346f4f7a332c2af926374921e82d645c847ce31efc32d048ab265",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/reusable-and-composite.md",
+          "sha256": "b66d5770fb59c7aff8c1084772d222d0d3025ec302ba5b5270fd6c20efb0dcc3",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/reusable-maintenance-anti-patterns.md",
+          "sha256": "36d67af7cf566cee2daf382a3b64e08bf5835ad802c97972efdfe246fea1e6cf",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/security-anti-patterns.md",
+          "sha256": "0d574ca53d997ab2add7b35d2053d2b54f330ed26ed2ace98142cd305e65e4b0",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/security-hardening.md",
+          "sha256": "1c0f5927a45f9d215fc06b539a3d6b1546c7c7cc5dd0fabc77bcbe986ac6fb70",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/triggers-and-events.md",
+          "sha256": "153e486a1c9a74d95be63fb0fd41516bb1f8b36cadbc614f8cb10d42c386c5cc",
+          "owner": "pipe"
+        },
+        {
+          "path": "skills/deployment-platforms/pipe/references/workflow-design-anti-patterns.md",
+          "sha256": "8f6993aea1b9842f9674b8eed7bb3eac867f22727998a5ab9566bac91391960c",
+          "owner": "pipe"
         }
       ]
     },
@@ -2070,7 +12111,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2082,6 +12123,41 @@
             {
               "source": "shard/SKILL.md",
               "target": "skills/deployment-platforms/shard/SKILL.md"
+            },
+            {
+              "source": "shard/reference/autorun-schema.md",
+              "target": "skills/deployment-platforms/shard/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/examples.md",
+              "target": "skills/deployment-platforms/shard/reference/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/handoffs.md",
+              "target": "skills/deployment-platforms/shard/reference/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/patterns.md",
+              "target": "skills/deployment-platforms/shard/reference/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/tenant-migration.md",
+              "target": "skills/deployment-platforms/shard/reference/tenant-migration.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/tenant-provisioning.md",
+              "target": "skills/deployment-platforms/shard/reference/tenant-provisioning.md",
+              "type": "file"
+            },
+            {
+              "source": "shard/reference/tenant-quota-throttling.md",
+              "target": "skills/deployment-platforms/shard/reference/tenant-quota-throttling.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2093,13 +12169,125 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/deployment-platforms/shard",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/deployment-platforms/shard/references/examples.md",
+              "target": "skills/deployment-platforms/shard/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/shard/references/handoffs.md",
+              "target": "skills/deployment-platforms/shard/references/handoffs.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/shard/references/patterns.md",
+              "target": "skills/deployment-platforms/shard/references/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/shard/references/tenant-migration.md",
+              "target": "skills/deployment-platforms/shard/references/tenant-migration.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/shard/references/tenant-provisioning.md",
+              "target": "skills/deployment-platforms/shard/references/tenant-provisioning.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/deployment-platforms/shard/references/tenant-quota-throttling.md",
+              "target": "skills/deployment-platforms/shard/references/tenant-quota-throttling.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/deployment-platforms/shard/SKILL.md",
-          "owner": "shard",
-          "sha256": "6b913b113ca8562aeafad557959931a92fe32d7871c43c90ec7e64780c0dc626"
+          "sha256": "6b913b113ca8562aeafad557959931a92fe32d7871c43c90ec7e64780c0dc626",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/autorun-schema.md",
+          "sha256": "1fa33b77a6a98b3394f932318b1a96164e786a68129c0b3a716ed4c1fbb924e0",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/examples.md",
+          "sha256": "ebc16d08af440a75b5dd1099abdc9899ad4ee78abf5148bbb76239f9f85b3f13",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/handoffs.md",
+          "sha256": "6aacae154e386f9b0fb9d3b5fecc9415b542affa0942bc8806fe19579c9708c8",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/patterns.md",
+          "sha256": "f66520e8096ebfd7e9ba1deaf9b1822fae4e9c5f57a40accb9b7999de5a1e236",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/tenant-migration.md",
+          "sha256": "bd6e85c7b83934fd799d7da210d6d97ad4a9dede07e4965ac7bc41ffa6c0fd71",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/tenant-provisioning.md",
+          "sha256": "1d156ae88789b6de7c575a3b2c4bdc57887082026770d7fcc9ebde07573b6a49",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/reference/tenant-quota-throttling.md",
+          "sha256": "d46892547d31f2e38ccb550027545dccb5e38b3d22d5e49ae41c8734c11ddfbb",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/examples.md",
+          "sha256": "ebc16d08af440a75b5dd1099abdc9899ad4ee78abf5148bbb76239f9f85b3f13",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/handoffs.md",
+          "sha256": "6aacae154e386f9b0fb9d3b5fecc9415b542affa0942bc8806fe19579c9708c8",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/patterns.md",
+          "sha256": "d18970fa50576b7f4c74234ab8640ba16aa145497916f750f66de0dcc0082703",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/tenant-migration.md",
+          "sha256": "bd6e85c7b83934fd799d7da210d6d97ad4a9dede07e4965ac7bc41ffa6c0fd71",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/tenant-provisioning.md",
+          "sha256": "358bb41b89bbce97d3934a310aca8f55ac67d37220fa338e20e6048e43a4f5e3",
+          "owner": "shard"
+        },
+        {
+          "path": "skills/deployment-platforms/shard/references/tenant-quota-throttling.md",
+          "sha256": "d46892547d31f2e38ccb550027545dccb5e38b3d22d5e49ae41c8734c11ddfbb",
+          "owner": "shard"
         }
       ]
     },
@@ -2119,7 +12307,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2131,6 +12319,71 @@
             {
               "source": "cast/SKILL.md",
               "target": "skills/openclaw-memory-and-safety/cast/SKILL.md"
+            },
+            {
+              "source": "cast/reference/archetype-mapping.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/archetype-mapping.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/autorun-schema.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/collaboration-formats.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/collaboration-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/distribution-adapters.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/distribution-adapters.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/evolution-engine.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/evolution-engine.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/generation-workflows.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/generation-workflows.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/persona-bias-audit.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/persona-bias-audit.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/persona-governance.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/persona-governance.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/persona-model.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/persona-model.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/persona-validation.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/persona-validation.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/registry-spec.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/registry-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/segmentation-methods.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/segmentation-methods.md",
+              "type": "file"
+            },
+            {
+              "source": "cast/reference/speak-engine.md",
+              "target": "skills/openclaw-memory-and-safety/cast/reference/speak-engine.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2142,13 +12395,185 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/openclaw-memory-and-safety/cast",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/collaboration-formats.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/collaboration-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/distribution-adapters.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/distribution-adapters.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/evolution-engine.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/evolution-engine.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/generation-workflows.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/generation-workflows.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/persona-governance.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/persona-governance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/persona-model.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/persona-model.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/persona-validation.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/persona-validation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/registry-spec.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/registry-spec.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/cast/references/speak-engine.md",
+              "target": "skills/openclaw-memory-and-safety/cast/references/speak-engine.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/openclaw-memory-and-safety/cast/SKILL.md",
-          "owner": "cast",
-          "sha256": "614ffa2160bab1085b7fa7bdb449843a15b74144a9b3fc223808a158ad742f86"
+          "sha256": "614ffa2160bab1085b7fa7bdb449843a15b74144a9b3fc223808a158ad742f86",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/archetype-mapping.md",
+          "sha256": "f5502b48af8701f056d46b9dc216119d65aa979f2fcd37f31efd23d159b60c6b",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/autorun-schema.md",
+          "sha256": "b62c6c9c3940f92ec23f4e65728bda4f917396c2e0181f877e3a27a786072e85",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/collaboration-formats.md",
+          "sha256": "5a4ef3d3e750bfeccdbb90428f3c004bdcf484886f2b4f23faaf09b985653e92",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/distribution-adapters.md",
+          "sha256": "bbe33387fc19bed54b7abbc751df98c82e983966e7447c1f55d0703e7c2a92b1",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/evolution-engine.md",
+          "sha256": "a8e929b1a06671462f2cce1b860465c4aac11604cc0215f5a31e6812ff2c9fc3",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/generation-workflows.md",
+          "sha256": "d3110f88d180630d8b3de5a073045d25320548c0136babc847328fae45d1c066",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/persona-bias-audit.md",
+          "sha256": "cce0daee811a891f7ac1601bba8062b9c49950b137b987e03437ee23a026f2ce",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/persona-governance.md",
+          "sha256": "ecbf1b9afcffacf3d47ebad087653c8952f65975e8c33940b33a17808bf6bb0d",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/persona-model.md",
+          "sha256": "6979b9829f9e894f4df76bf980d97d36233a200cabdc44a8d4e2ec7e49378243",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/persona-validation.md",
+          "sha256": "248de474423baffe97a5490af109e981f4d665f1c513dac990853503b2fc1215",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/registry-spec.md",
+          "sha256": "aef70d93cb00b82183e30a79e6a51b0a8c26d665d0f2f000bac10e7cc304b609",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/segmentation-methods.md",
+          "sha256": "38c3877733a4a8da2a52c4a4a5c48792f2bee96498129d753519f4a29b83b245",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/reference/speak-engine.md",
+          "sha256": "a44a43f4895cfbb32df31d0561ab92006350a2c04a3232713d39c6c659146a21",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/collaboration-formats.md",
+          "sha256": "c0bbcbef6a6147a286a216a5727f6d903b0bc14623a4b86ef63df44841d59c4b",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/distribution-adapters.md",
+          "sha256": "c24abf4d75e38ff64e15c53c3443ac0958fb3b120a7cfc287838ff3a4d8aeeb6",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/evolution-engine.md",
+          "sha256": "12780a6fb073669e6f8a8b4d02b072c71b8d13961c6b929a3cbfd36093322a5c",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/generation-workflows.md",
+          "sha256": "a2d0fbdd2361494ce467ec3a4a2b3cbba0a75cf35e036639315c80fd4eba5b92",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/persona-governance.md",
+          "sha256": "9e3241dc08ef1f5b19b38ba46973a00d00522067ad77dc9bdeedf08eb52d87d2",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/persona-model.md",
+          "sha256": "6979b9829f9e894f4df76bf980d97d36233a200cabdc44a8d4e2ec7e49378243",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/persona-validation.md",
+          "sha256": "6a018d4dc90a6a18a36d3fbbe7b602cc749b58c2fe82bc880c6d3fca6ca01b43",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/registry-spec.md",
+          "sha256": "aef70d93cb00b82183e30a79e6a51b0a8c26d665d0f2f000bac10e7cc304b609",
+          "owner": "cast"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/cast/references/speak-engine.md",
+          "sha256": "f937c2ba6492d6d594d142c95b3da031e1b0572904b8e0d33d8341dfcd0d1467",
+          "owner": "cast"
         }
       ]
     },
@@ -2168,7 +12593,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2180,6 +12605,51 @@
             {
               "source": "omen/SKILL.md",
               "target": "skills/openclaw-memory-and-safety/omen/SKILL.md"
+            },
+            {
+              "source": "omen/reference/autorun-schema.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/bowtie-diagram.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/bowtie-diagram.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/failure-frameworks.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/failure-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/fault-tree-analysis.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/fault-tree-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/fix-prompt-generation.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/fix-prompt-generation.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/hazop-methodology.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/hazop-methodology.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/output-templates.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/scoring-methodology.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/scoring-methodology.md",
+              "type": "file"
+            },
+            {
+              "source": "omen/reference/tri-engine-failure.md",
+              "target": "skills/openclaw-memory-and-safety/omen/reference/tri-engine-failure.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2191,13 +12661,135 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/openclaw-memory-and-safety/omen",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/bowtie-diagram.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/bowtie-diagram.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/failure-frameworks.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/failure-frameworks.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/fault-tree-analysis.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/fault-tree-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/hazop-methodology.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/hazop-methodology.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/output-templates.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/output-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/openclaw-memory-and-safety/omen/references/scoring-methodology.md",
+              "target": "skills/openclaw-memory-and-safety/omen/references/scoring-methodology.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/openclaw-memory-and-safety/omen/SKILL.md",
-          "owner": "omen",
-          "sha256": "06b17ff5138e3ff89a07fa56b630e76cf4d72520ec371123b4744eb6b3ddbd8e"
+          "sha256": "06b17ff5138e3ff89a07fa56b630e76cf4d72520ec371123b4744eb6b3ddbd8e",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/autorun-schema.md",
+          "sha256": "3268c0e83d7969969edfc299271acf1a6207b1777a34728490297e0cdf2685cd",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/bowtie-diagram.md",
+          "sha256": "e762ef59ebc8cfb7d72db4580284648b035e890b32bfd510b61579140ebb8f90",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/failure-frameworks.md",
+          "sha256": "7fcc90c62fd1769465abd28ff0b73d9452c3b68571b8f8835f102db4c2e6b4dd",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/fault-tree-analysis.md",
+          "sha256": "b8da68f5981aef68a621da90acfafb8a6d1de5d5b23ffb2017f337a9f9b8b306",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/fix-prompt-generation.md",
+          "sha256": "e9a781e028f50a0899db0187d3d20b8ceb19277817e90b1d34b0ac1e87c227a9",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/hazop-methodology.md",
+          "sha256": "08cd42ecb60b219c237546471dadc6e26d54020200169ba33d20dd3fa756cba2",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/output-templates.md",
+          "sha256": "ba4eea3ad1914cedae8e297247bebfe34d25232681418bb12956bd7c1328d527",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/scoring-methodology.md",
+          "sha256": "b9013546e15a43acfda2abfd25e5955f1e77aada657816f93ad03747f91536ce",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/reference/tri-engine-failure.md",
+          "sha256": "5a7fd5d0cafb5194b0b1aa8a12bd84aa75e002356ee3c6141ca153f3007daebc",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/bowtie-diagram.md",
+          "sha256": "e762ef59ebc8cfb7d72db4580284648b035e890b32bfd510b61579140ebb8f90",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/failure-frameworks.md",
+          "sha256": "7fcc90c62fd1769465abd28ff0b73d9452c3b68571b8f8835f102db4c2e6b4dd",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/fault-tree-analysis.md",
+          "sha256": "ffeff141caa1fcd0aa4ba1e990269fc0bbf822753f2d18502a379eaf9bdf67c5",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/hazop-methodology.md",
+          "sha256": "c5e22d174ed1adbdf6301b7942a3c90543677dda646b090a726228ea7a366929",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/output-templates.md",
+          "sha256": "a38fdd8399fbf60e0ad12a83b15983b9bcaddc8d43f130f02ceeeed48f3cb1e6",
+          "owner": "omen"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/omen/references/scoring-methodology.md",
+          "sha256": "b9013546e15a43acfda2abfd25e5955f1e77aada657816f93ad03747f91536ce",
+          "owner": "omen"
         }
       ]
     },
@@ -2233,6 +12825,46 @@
             {
               "source": "warden/SKILL.md",
               "target": "skills/openclaw-memory-and-safety/warden/SKILL.md"
+            },
+            {
+              "source": "warden/references/agency-user-control.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/agency-user-control.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/design-litmus-check.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/design-litmus-check.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/examples.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/examples.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/experience-emotional-quality.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/experience-emotional-quality.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/identity-brand-voice.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/identity-brand-voice.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/patterns.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/ux-agent-matrix.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/ux-agent-matrix.md",
+              "type": "file"
+            },
+            {
+              "source": "warden/references/vaire-framework.md",
+              "target": "skills/openclaw-memory-and-safety/warden/references/vaire-framework.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2249,8 +12881,48 @@
       "managed_files": [
         {
           "path": "skills/openclaw-memory-and-safety/warden/SKILL.md",
-          "owner": "warden",
-          "sha256": "3f09ad867923ccac18df034a7290cf1fb08f198dde7caed3086f8a848abf522d"
+          "sha256": "3f09ad867923ccac18df034a7290cf1fb08f198dde7caed3086f8a848abf522d",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/agency-user-control.md",
+          "sha256": "2cf59c27d116daf5cc3d6536c677fb8eac3fe01d180468bd426cfb7d2ab48036",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/design-litmus-check.md",
+          "sha256": "fdfc020be40f9d6bd7f9cb33d7fea6bdbaf01e7c12d23726935c29b123024de6",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/examples.md",
+          "sha256": "6def01030a42648825c27d301afd070d53aea63e886124eb0113e23efdd8bfa7",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/experience-emotional-quality.md",
+          "sha256": "a26748dbd4fe55940287d8302913ff10df9641743bce66a10e7eac420627e01e",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/identity-brand-voice.md",
+          "sha256": "ffe0a09e3487f5aa48922a83807fd18f71bff4e703aebcd8582c82e02a1adc5f",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/patterns.md",
+          "sha256": "332b973790db8e95c4882109feeaf24208ae181358c0bf56be5e3f7f1582ee4b",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/ux-agent-matrix.md",
+          "sha256": "5ddd0b9d17888f2e8a889881970e89c3addf05fd55141afc58c5f94e11da6dbe",
+          "owner": "warden"
+        },
+        {
+          "path": "skills/openclaw-memory-and-safety/warden/references/vaire-framework.md",
+          "sha256": "98316b24ed441a16f2415bf2cd693d6e232589d492310b2b6d7790daaef8c5fb",
+          "owner": "warden"
         }
       ]
     },
@@ -2270,7 +12942,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2282,6 +12954,71 @@
             {
               "source": "lens/SKILL.md",
               "target": "skills/task-understanding-decomposition/lens/SKILL.md"
+            },
+            {
+              "source": "lens/reference/autorun-schema.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/change-hotspot.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/change-hotspot.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/code-evolution.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/code-evolution.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/complexity-assessment.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/complexity-assessment.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/comprehension-research.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/comprehension-research.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/dependency-graph.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/dependency-graph.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/investigation-budget.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/investigation-budget.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/investigation-patterns.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/investigation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/lens-framework.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/lens-framework.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/output-formats.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/output-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/qa-mode.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/qa-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/recipes-detail.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/recipes-detail.md",
+              "type": "file"
+            },
+            {
+              "source": "lens/reference/search-strategies.md",
+              "target": "skills/task-understanding-decomposition/lens/reference/search-strategies.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2293,13 +13030,155 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/task-understanding-decomposition/lens",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/complexity-assessment.md",
+              "target": "skills/task-understanding-decomposition/lens/references/complexity-assessment.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/investigation-budget.md",
+              "target": "skills/task-understanding-decomposition/lens/references/investigation-budget.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/investigation-patterns.md",
+              "target": "skills/task-understanding-decomposition/lens/references/investigation-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/lens-framework.md",
+              "target": "skills/task-understanding-decomposition/lens/references/lens-framework.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/output-formats.md",
+              "target": "skills/task-understanding-decomposition/lens/references/output-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/lens/references/search-strategies.md",
+              "target": "skills/task-understanding-decomposition/lens/references/search-strategies.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/task-understanding-decomposition/lens/SKILL.md",
-          "owner": "lens",
-          "sha256": "8bf3f52555332d54743f8d111484027a2892b7b75fd9b125ba54183f7856f141"
+          "sha256": "8bf3f52555332d54743f8d111484027a2892b7b75fd9b125ba54183f7856f141",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/autorun-schema.md",
+          "sha256": "7dbbb3c389c8fd6c56238be7d8753ef1b92cf3508a49d8034d03972d1375a5b6",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/change-hotspot.md",
+          "sha256": "77085a0cfe0a59e41a5c2e299c3b76d9ab1f46f3af18b4d3adb932552fee848c",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/code-evolution.md",
+          "sha256": "8fc2b526586c7ea00c9a4cc1e1bd05427f47f31b1f932d584c3535bdf63c2e63",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/complexity-assessment.md",
+          "sha256": "17e19dfbe2a74348966e6518fa8b6d3ed2141501c1172f4999b6fff6bc83c007",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/comprehension-research.md",
+          "sha256": "94849ff62bc2565c425e138f33f655e095f7d870ff4643bd1f4982fdbb63a364",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/dependency-graph.md",
+          "sha256": "cda609319bccf7edf53b1950067de6e3c881816130a8df8bb334edf03c84296d",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/investigation-budget.md",
+          "sha256": "3fa91bed32c95183fc6fbb669979e798e84e14388d23d5a7676a4716ca47e795",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/investigation-patterns.md",
+          "sha256": "7ee68d290d0f1efbcb19e744d7b29bb0a9361c88d290253711be3c4f4cc96e3f",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/lens-framework.md",
+          "sha256": "27b7a02a9955636188c40536a634c7ab7409f5cc3355290d46bc04f61153d93c",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/output-formats.md",
+          "sha256": "153201cf45d452aabf76b8d75d2c886f4a0c357bf00e840c52666e783596842a",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/qa-mode.md",
+          "sha256": "0716b252da41b90274794dd977845822e4df853e88528c9f9b6aeab188381a23",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/recipes-detail.md",
+          "sha256": "bba8cc4863ac87405b65bf0e20399c3bf516d0a88a424173ff307d17cb757c52",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/reference/search-strategies.md",
+          "sha256": "ce289ab80470b8f7ffc63300c1df9460c1d2894736355edbfa12f74ee7ac48ca",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/complexity-assessment.md",
+          "sha256": "17e19dfbe2a74348966e6518fa8b6d3ed2141501c1172f4999b6fff6bc83c007",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/investigation-budget.md",
+          "sha256": "3fa91bed32c95183fc6fbb669979e798e84e14388d23d5a7676a4716ca47e795",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/investigation-patterns.md",
+          "sha256": "7ee68d290d0f1efbcb19e744d7b29bb0a9361c88d290253711be3c4f4cc96e3f",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/lens-framework.md",
+          "sha256": "27b7a02a9955636188c40536a634c7ab7409f5cc3355290d46bc04f61153d93c",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/output-formats.md",
+          "sha256": "153201cf45d452aabf76b8d75d2c886f4a0c357bf00e840c52666e783596842a",
+          "owner": "lens"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/lens/references/search-strategies.md",
+          "sha256": "ce289ab80470b8f7ffc63300c1df9460c1d2894736355edbfa12f74ee7ac48ca",
+          "owner": "lens"
         }
       ]
     },
@@ -2319,7 +13198,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2331,6 +13210,116 @@
             {
               "source": "scout/SKILL.md",
               "target": "skills/task-understanding-decomposition/scout/SKILL.md"
+            },
+            {
+              "source": "scout/reference/5whys-rca.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/5whys-rca.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/advanced-reproduction-triage.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/advanced-reproduction-triage.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/bug-patterns.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/bug-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/debug-strategies.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/debug-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/debugging-anti-patterns.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/debugging-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/fishbone-6m.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/fishbone-6m.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/fix-prompt-generation.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/fix-prompt-generation.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/flake-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/flake-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/frontend-debugging.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/frontend-debugging.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/git-bisect.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/git-bisect.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/handoff-formats.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/handoff-formats.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/memory-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/memory-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/modern-rca-methodology.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/modern-rca-methodology.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/multi-engine-mode.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/multi-engine-mode.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/observability-debugging.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/observability-debugging.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/output-format.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/output-format.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/perf-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/perf-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/reproduction-templates.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/reproduction-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/timeline-reconstruction.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/timeline-reconstruction.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/tri-engine-investigate.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/tri-engine-investigate.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/vague-report-handling.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/vague-report-handling.md",
+              "type": "file"
+            },
+            {
+              "source": "scout/reference/video-bug-analysis.md",
+              "target": "skills/task-understanding-decomposition/scout/reference/video-bug-analysis.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2342,13 +13331,280 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/task-understanding-decomposition/scout",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/advanced-reproduction-triage.md",
+              "target": "skills/task-understanding-decomposition/scout/references/advanced-reproduction-triage.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/bug-patterns.md",
+              "target": "skills/task-understanding-decomposition/scout/references/bug-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/debug-strategies.md",
+              "target": "skills/task-understanding-decomposition/scout/references/debug-strategies.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/debugging-anti-patterns.md",
+              "target": "skills/task-understanding-decomposition/scout/references/debugging-anti-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/flake-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/references/flake-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/frontend-debugging.md",
+              "target": "skills/task-understanding-decomposition/scout/references/frontend-debugging.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/git-bisect.md",
+              "target": "skills/task-understanding-decomposition/scout/references/git-bisect.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/memory-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/references/memory-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/modern-rca-methodology.md",
+              "target": "skills/task-understanding-decomposition/scout/references/modern-rca-methodology.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/observability-debugging.md",
+              "target": "skills/task-understanding-decomposition/scout/references/observability-debugging.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/output-format.md",
+              "target": "skills/task-understanding-decomposition/scout/references/output-format.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/perf-investigation.md",
+              "target": "skills/task-understanding-decomposition/scout/references/perf-investigation.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/reproduction-templates.md",
+              "target": "skills/task-understanding-decomposition/scout/references/reproduction-templates.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/scout/references/vague-report-handling.md",
+              "target": "skills/task-understanding-decomposition/scout/references/vague-report-handling.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/task-understanding-decomposition/scout/SKILL.md",
-          "owner": "scout",
-          "sha256": "ab6593544ac8fb1c5c9e910ede6b014910cbe9413afb5f798726ccac41affba5"
+          "sha256": "ab6593544ac8fb1c5c9e910ede6b014910cbe9413afb5f798726ccac41affba5",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/5whys-rca.md",
+          "sha256": "aa4373b9ccf2d5b9d3ddca99733a485bf106c735b4b8fdfa258f2b81cd577108",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/advanced-reproduction-triage.md",
+          "sha256": "9dca5a5cd5e2296cfae9ce623483065b5fce529e8cd678a9beb1f750e7453d31",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/bug-patterns.md",
+          "sha256": "d94ac563d2af6082c916128e4251d36e8ab2f3d875e9092c2e82e99c3d67e0e7",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/debug-strategies.md",
+          "sha256": "c1a2795aa747af39512fa1d7b3f8d7508ee71b6414df13420bcdbbdfa9df7fbc",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/debugging-anti-patterns.md",
+          "sha256": "66a99a7faefa5cb21bb6de3c1e94035111f719b2d9d0b5ca2d4eade008a8c508",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/fishbone-6m.md",
+          "sha256": "f76741f6150a73d3af98e047a83189ba20a0c6b511f75150d7137a5a80c9398d",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/fix-prompt-generation.md",
+          "sha256": "c2920d441acba66e82aea275144501e3f176d404eb91f67c64e6e6658c816880",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/flake-investigation.md",
+          "sha256": "c57ac42c36d2efb20e010557e9e5d60b88eb776d90ea57fef9b33b8d68392f70",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/frontend-debugging.md",
+          "sha256": "b472a4faf0ddfc0c0061ad41b9e395bd7c76ca29d85d56d16ca2128718e8dca9",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/git-bisect.md",
+          "sha256": "e92edb30fed1d19a11be9505dc069a2abe0c7c43fc7e261bdb86ee73be7e5dcb",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/handoff-formats.md",
+          "sha256": "7cad34c97af695a54a0ee7a880cd211373e35ff8562d8e8b4125af3d3d2c0ec3",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/memory-investigation.md",
+          "sha256": "c69f6af7b8fb4380547343f444121615e592eb02381ae73aa632340b7af1ccf7",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/modern-rca-methodology.md",
+          "sha256": "33695ccbb68a0cd77856da4a79fdf62f72e269e6fbec643da4e158d81983ec6a",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/multi-engine-mode.md",
+          "sha256": "3fcb54febbf045477db25339d3e708d920088eb94fdeb42efcb944436be2a5d0",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/observability-debugging.md",
+          "sha256": "e3e317930643b7ed019ba340302d857787e4ccfe93425a0f25dea6d8d020d341",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/output-format.md",
+          "sha256": "3e8fdaa5fb6763ea19d79e5ae587196a573a51a9e3052f4380676831e4ecbddf",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/perf-investigation.md",
+          "sha256": "aec6d34717683f9baa223af691b68c44b117da9a59db228c686be20642520f29",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/reproduction-templates.md",
+          "sha256": "f41c831bf18d6a8de9f2838a2d446865041097c49ac20455836bfc345efa84ce",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/timeline-reconstruction.md",
+          "sha256": "a1e4a1a2d3e06ff8a66ea45ea5f93bf4a1e45682e5d20a38d28b901fd519c764",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/tri-engine-investigate.md",
+          "sha256": "f810c492c50ee5e2f151f9704a614e6d9ea3ae7e6468ccc78f34c5b9ba4517c6",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/vague-report-handling.md",
+          "sha256": "9152b515afb3257d03863671043dc87501061794148bfb2bbc1b1f20afd3320a",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/reference/video-bug-analysis.md",
+          "sha256": "ef63483b5e572921c520a6ebc286a5846f58f55e19ca0338fed25abf49ed63d1",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/advanced-reproduction-triage.md",
+          "sha256": "9dca5a5cd5e2296cfae9ce623483065b5fce529e8cd678a9beb1f750e7453d31",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/bug-patterns.md",
+          "sha256": "d94ac563d2af6082c916128e4251d36e8ab2f3d875e9092c2e82e99c3d67e0e7",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/debug-strategies.md",
+          "sha256": "c1a2795aa747af39512fa1d7b3f8d7508ee71b6414df13420bcdbbdfa9df7fbc",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/debugging-anti-patterns.md",
+          "sha256": "66a99a7faefa5cb21bb6de3c1e94035111f719b2d9d0b5ca2d4eade008a8c508",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/flake-investigation.md",
+          "sha256": "9a4b742188de3008a1ca1b8b007b40022242dd41ba5d406d334d495ae70e0e3e",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/frontend-debugging.md",
+          "sha256": "7efc8637e8c28001e4067b87784bfdc15196dd907b73cde6a24b7b65911f2346",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/git-bisect.md",
+          "sha256": "e92edb30fed1d19a11be9505dc069a2abe0c7c43fc7e261bdb86ee73be7e5dcb",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/memory-investigation.md",
+          "sha256": "dc9ecc3a548aaeb2096ba6ff12cfbbc6608b57650886b56e916eecc51f1c77dd",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/modern-rca-methodology.md",
+          "sha256": "7a0e0b30a2565f5a7be7504ad18b11270007fb44ee335b404d9671a00fd8314f",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/observability-debugging.md",
+          "sha256": "e3e317930643b7ed019ba340302d857787e4ccfe93425a0f25dea6d8d020d341",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/output-format.md",
+          "sha256": "47e76a689ff370a246e6043da8787d2c6b5228abc82108f3cb42fd866e315418",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/perf-investigation.md",
+          "sha256": "670b2fafaa46e6db7e2ad110ac0adfd61803d90e8db1687893087a23a9a5344d",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/reproduction-templates.md",
+          "sha256": "f41c831bf18d6a8de9f2838a2d446865041097c49ac20455836bfc345efa84ce",
+          "owner": "scout"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/scout/references/vague-report-handling.md",
+          "sha256": "9152b515afb3257d03863671043dc87501061794148bfb2bbc1b1f20afd3320a",
+          "owner": "scout"
         }
       ]
     },
@@ -2368,7 +13624,7 @@
         "last_synced_commit": "2a3b975720432cd2e6fdaf132261f0e9ef75ed70",
         "sync_mode": "monitor"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -2380,6 +13636,51 @@
             {
               "source": "ripple/SKILL.md",
               "target": "skills/task-understanding-decomposition/ripple/SKILL.md"
+            },
+            {
+              "source": "ripple/reference/analysis-techniques.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/analysis-techniques.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/autorun-schema.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/autorun-schema.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/blast-radius-quant.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/blast-radius-quant.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/canary-scope-design.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/canary-scope-design.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/cascade-analysis.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/cascade-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/consistency-report-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/consistency-report-template.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/impact-report-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/impact-report-template.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/ripple-analysis-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/ripple-analysis-template.md",
+              "type": "file"
+            },
+            {
+              "source": "ripple/reference/rollback-plan-design.md",
+              "target": "skills/task-understanding-decomposition/ripple/reference/rollback-plan-design.md",
+              "type": "file"
             }
           ],
           "tracking": {
@@ -2391,13 +13692,155 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/task-understanding-decomposition/ripple",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/analysis-techniques.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/analysis-techniques.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/blast-radius-quant.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/blast-radius-quant.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/canary-scope-design.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/canary-scope-design.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/cascade-analysis.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/cascade-analysis.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/consistency-report-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/consistency-report-template.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/impact-report-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/impact-report-template.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/ripple-analysis-template.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/ripple-analysis-template.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/task-understanding-decomposition/ripple/references/rollback-plan-design.md",
+              "target": "skills/task-understanding-decomposition/ripple/references/rollback-plan-design.md",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/task-understanding-decomposition/ripple/SKILL.md",
-          "owner": "ripple",
-          "sha256": "83f2fe5a02e0bfbe5c8e72e9c99a53098720f6504a4177da787e8b2d8c10d2d4"
+          "sha256": "83f2fe5a02e0bfbe5c8e72e9c99a53098720f6504a4177da787e8b2d8c10d2d4",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/analysis-techniques.md",
+          "sha256": "dcf66ede92e5eb93bc3d665fb558c4749377fdb12fbf28b85328f26788e866aa",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/autorun-schema.md",
+          "sha256": "9ea173f7b6c9ade56f16a978ce9de344e448f0cc46b879fce5ef760dab4f1108",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/blast-radius-quant.md",
+          "sha256": "a22c3ae344dfa4edae85de3a726ce580067b57a5f0f8187c15a4a203f40ee064",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/canary-scope-design.md",
+          "sha256": "8c222d0cde16b1d756f73fbd301e53089413254261376fafd08cd15cb946884b",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/cascade-analysis.md",
+          "sha256": "daa3b0818650ae670a2af1d11639d904e76ed89bd04dff60a6a440ad76e0fc96",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/consistency-report-template.md",
+          "sha256": "b5cde4b9b55658778b1ba0ddcdc08864b2e68a071c8f55beeeaf6a945ff191df",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/impact-report-template.md",
+          "sha256": "8868550b96bd444aaeeb10cf87c09214e50bb0bee262cb0da7ef103110822e46",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/ripple-analysis-template.md",
+          "sha256": "afefa162b1d1f3b28e2d223ec543d1b93fa697f369381d09f811162b352bd573",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/reference/rollback-plan-design.md",
+          "sha256": "9aa8e5a7ec30158b4e8268cb17534d421d3952a27fcadf558fb539353f1511e7",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/analysis-techniques.md",
+          "sha256": "dcf66ede92e5eb93bc3d665fb558c4749377fdb12fbf28b85328f26788e866aa",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/blast-radius-quant.md",
+          "sha256": "77c4a93df7a9806f4dff4adca66ff1716bb13b46744e3edbfd2b0bf8ce61c902",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/canary-scope-design.md",
+          "sha256": "8c222d0cde16b1d756f73fbd301e53089413254261376fafd08cd15cb946884b",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/cascade-analysis.md",
+          "sha256": "56f4755eb3dec9b06bb11c218bbe73419e9d4ddba2d45de192f2ef593606c06e",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/consistency-report-template.md",
+          "sha256": "b5cde4b9b55658778b1ba0ddcdc08864b2e68a071c8f55beeeaf6a945ff191df",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/impact-report-template.md",
+          "sha256": "8868550b96bd444aaeeb10cf87c09214e50bb0bee262cb0da7ef103110822e46",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/ripple-analysis-template.md",
+          "sha256": "afefa162b1d1f3b28e2d223ec543d1b93fa697f369381d09f811162b352bd573",
+          "owner": "ripple"
+        },
+        {
+          "path": "skills/task-understanding-decomposition/ripple/references/rollback-plan-design.md",
+          "sha256": "9aa8e5a7ec30158b4e8268cb17534d421d3952a27fcadf558fb539353f1511e7",
+          "owner": "ripple"
         }
       ]
     }

--- a/docs/sources/wshobson-agents-2026-04.skills.json
+++ b/docs/sources/wshobson-agents-2026-04.skills.json
@@ -73,7 +73,8 @@
         {
           "path": "skills/engineering-workflow-automation/billing-automation/SKILL.md",
           "owner": "billing-automation",
-          "sha256": "f197cebea2d295528dbaf5c7c6fb0830c4d72e95f527c325a638a88a49c66188"
+          "sha256": "f197cebea2d295528dbaf5c7c6fb0830c4d72e95f527c325a638a88a49c66188",
+          "mode": "100644"
         }
       ]
     },

--- a/docs/sources/xiaolai-nlpm-2026-06.skills.json
+++ b/docs/sources/xiaolai-nlpm-2026-06.skills.json
@@ -54,7 +54,7 @@
         "last_synced_at": "2026-08-18",
         "last_synced_commit": "d4ca2d45618334dc86c79a09ab1b2bbe2c47e1d7"
       },
-      "kind": "mirror",
+      "kind": "overlay",
       "sync_mode": "monitor",
       "origins": [
         {
@@ -77,13 +77,90 @@
             "last_checked_at": "2026-08-18",
             "last_synced_at": "2026-08-18"
           }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/nlpm-audit",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/nlpm-audit/references/audit-rules.md",
+              "target": "skills/ai-workflow/nlpm-audit/references/audit-rules.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nlpm-audit/references/ci-and-maintenance.md",
+              "target": "skills/ai-workflow/nlpm-audit/references/ci-and-maintenance.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nlpm-audit/references/command-recipes.md",
+              "target": "skills/ai-workflow/nlpm-audit/references/command-recipes.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nlpm-audit/references/scoring-rubric.md",
+              "target": "skills/ai-workflow/nlpm-audit/references/scoring-rubric.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nlpm-audit/references/security-patterns.md",
+              "target": "skills/ai-workflow/nlpm-audit/references/security-patterns.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/ai-workflow/nlpm-audit/scripts/nl_artifact_check.py",
+              "target": "skills/ai-workflow/nlpm-audit/scripts/nl_artifact_check.py",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20"
+          }
         }
       ],
       "managed_files": [
         {
           "path": "skills/ai-workflow/nlpm-audit/SKILL.md",
-          "owner": "nlpm-audit",
-          "sha256": "a604f3831f0a6821ce47c490f291ccbccf2e07befe9e6b85fcbf55ee55f1d844"
+          "sha256": "a604f3831f0a6821ce47c490f291ccbccf2e07befe9e6b85fcbf55ee55f1d844",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/references/audit-rules.md",
+          "sha256": "617e7027a19862ff1fd1774022c242dff1f280e91eba24cc90c86029deded1fb",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/references/ci-and-maintenance.md",
+          "sha256": "1db27fcc9c7d97296b7796f4ad0a28865c9a1cb2f378078997538e8d91f15f4d",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/references/command-recipes.md",
+          "sha256": "51aeba20f8747cbd4b47ae60059d4325c0c30eafc962ea06427fd8c54083de0e",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/references/scoring-rubric.md",
+          "sha256": "c0d1012434b5a70b3fc8a52e2decc37b563c1809afdde7b5a0a51a6ce4080b1a",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/references/security-patterns.md",
+          "sha256": "e2b5eca8c8c767e868990261241b6dffb718b86c67495b39cdb3b69949c08cc7",
+          "owner": "nlpm-audit"
+        },
+        {
+          "path": "skills/ai-workflow/nlpm-audit/scripts/nl_artifact_check.py",
+          "sha256": "0600d88a50b1430008894961f7833f2cc6332b14fbf5180c4a83bf8f3d54ec92",
+          "owner": "nlpm-audit"
         }
       ]
     }

--- a/docs/sources/xiaolai-nlpm-2026-06.skills.json
+++ b/docs/sources/xiaolai-nlpm-2026-06.skills.json
@@ -130,37 +130,44 @@
         {
           "path": "skills/ai-workflow/nlpm-audit/SKILL.md",
           "sha256": "a604f3831f0a6821ce47c490f291ccbccf2e07befe9e6b85fcbf55ee55f1d844",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/references/audit-rules.md",
           "sha256": "617e7027a19862ff1fd1774022c242dff1f280e91eba24cc90c86029deded1fb",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/references/ci-and-maintenance.md",
           "sha256": "1db27fcc9c7d97296b7796f4ad0a28865c9a1cb2f378078997538e8d91f15f4d",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/references/command-recipes.md",
           "sha256": "51aeba20f8747cbd4b47ae60059d4325c0c30eafc962ea06427fd8c54083de0e",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/references/scoring-rubric.md",
           "sha256": "c0d1012434b5a70b3fc8a52e2decc37b563c1809afdde7b5a0a51a6ce4080b1a",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/references/security-patterns.md",
           "sha256": "e2b5eca8c8c767e868990261241b6dffb718b86c67495b39cdb3b69949c08cc7",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         },
         {
           "path": "skills/ai-workflow/nlpm-audit/scripts/nl_artifact_check.py",
           "sha256": "0600d88a50b1430008894961f7833f2cc6332b14fbf5180c4a83bf8f3d54ec92",
-          "owner": "nlpm-audit"
+          "owner": "nlpm-audit",
+          "mode": "100644"
         }
       ]
     }

--- a/docs/upstream-sync-runbook.md
+++ b/docs/upstream-sync-runbook.md
@@ -14,82 +14,156 @@ Use this for routine maintenance when upstream repositories may have changed:
 python scripts/sync_all_upstream_skills.py --apply --run-pipeline
 ```
 
-This command refreshes:
+This command checks every active external canonical skill artifact set and
+refreshes only the sources whose provenance policy permits automatic
+replacement:
 
-- `addyosmani/agent-skills` through its bundle-aware importer
-- every other external skill listed in `docs/sources/*.skills.json`
+- every active external canonical skill in `*.skills.json` is checked
+- only stable-release or immutable-commit sources approved for `replace`
 - generated repository views, OpenClaw export, tag index, catalog, quality lint, and tests
 
-To also install the refreshed skills into local Codex:
+Managed bundles in `*.bundle.json` are intentionally outside this command.
+They must be checked with their bundle-specific release, package-integrity,
+inventory, and installer validation.
+
+Repository refresh and client installation are separate transactions. After
+the sync and full pipeline pass, use the governed installer explicitly:
 
 ```bash
-python scripts/sync_all_upstream_skills.py --apply --run-pipeline --sync-codex-root ~/.codex/skills
+node bin/install-skills.js install --target codex
 ```
 
 ## Check Everything Without Writing
 
 ```bash
-python scripts/sync_all_upstream_skills.py
+python scripts/sync_upstream.py --check-only \
+  --report-json /tmp/upstream-report.json
 ```
+
+Exit status `0` means `complete`, `2` means `degraded` (manual monitor review
+or rollback review is required), and `1` means `failed`. A failed or incomplete
+network scan must never be reported as “all up to date”.
 
 ## Sync One Source
 
-For non-addyosmani sources, use exact provenance-backed sync:
+For any provenance-backed canonical source, use exact source filtering:
 
 ```bash
 python scripts/sync_upstream.py --check-only --source github:obra/superpowers
 python scripts/sync_upstream.py --apply --source github:obra/superpowers
 ```
 
-For `addyosmani/agent-skills`, use its dedicated importer because it also preserves commands, personas, hooks, docs, and references:
-
-```bash
-python scripts/sync_addyosmani_agent_skills.py --apply --run-pipeline
-```
+Default-branch sources such as `addyosmani/agent-skills` and
+`simota/agent-skills` remain monitor-only. Review their commit range and
+artifact inventory explicitly; the all-source command does not bypass that
+policy through a legacy importer.
 
 ## What Makes A Skill Auto-Upgradeable
 
-An external skill is auto-upgradeable when its source mapping contains:
+Provenance v2 is authoritative. An external artifact set is auto-upgradeable
+only when it has an approved stable channel and complete immutable checkpoints:
 
 ```json
 {
   "repo_skill": "skills/<category>/<skill>/SKILL.md",
-  "upstream": {
+  "kind": "mirror",
+  "sync_mode": "replace",
+  "origins": [{
     "repo": "owner/repo",
-    "path": "path/in/upstream/SKILL.md",
-    "ref": "main"
-  }
+    "sync_mode": "replace",
+    "artifacts": [{
+      "source": "path/in/upstream",
+      "target": "skills/<category>/<skill>",
+      "type": "directory"
+    }],
+    "tracking": {
+      "channel": "latest_release",
+      "ref": "v1.2.3",
+      "resolved_commit": "<full commit>",
+      "path_commit": "<full commit>",
+      "content_sha256": "<sha256>"
+    }
+  }]
 }
 ```
 
-The generic sync reads those exact paths from `docs/sources/*.skills.json`, fetches upstream content, keeps local enriched frontmatter, replaces the body, updates timestamps, and syncs same-directory auxiliary files when available.
+`default_branch`, canary, movable aliases, and composite dependencies are
+monitor-only. A fixed ref is auto-replaceable only when the ref itself is the
+full immutable commit.
+
+The generic sync materializes every declared file or directory artifact as
+binary bytes, preserves repository frontmatter on the canonical `SKILL.md`,
+and applies the complete set through a staged transaction. It may replace or
+prune only files owned by the selected origin whose current digest still
+matches `managed_files`. Files owned by local curation or another origin are
+protected.
+
+Before adopting historical sidecars, classify their ownership:
+
+```bash
+python scripts/reconcile_artifact_inventory.py \
+  --output /tmp/artifact-inventory.json
+python scripts/reconcile_artifact_inventory.py \
+  --write --output /tmp/artifact-inventory-write.json
+```
+
+Only an exact blob match at the locked commit becomes an external artifact.
+Everything else must be an explicit local overlay or remain blocked for review.
+
+The machine report always satisfies:
+
+```text
+total = equal + changed + monitor_review + unavailable + rollback + expected_skipped
+```
 
 ## Handling Noisy Or Retired Upstreams
 
 Do not treat every upstream fetch failure as a repository regression.
 
 - ClawHub SSL EOF, TLS handshake timeouts, and transient `IncompleteRead` errors are external noise. Retry briefly, record source health, and avoid marking the run as fully fresh if discovery was partial.
-- Old GitHub raw-path `404` responses usually mean the provenance path is stale. First repair the exact upstream path from `source_url` or the GitHub API.
+- Old GitHub path `404` responses usually mean the provenance path moved or was archived. Exact blob/tree move candidates may be reported, but the synchronizer never guesses or applies a rename automatically.
 - If the upstream skill has genuinely disappeared but the local skill remains valuable, keep the local version and mark the mapping as archived or local-only instead of repeatedly failing future sync runs.
 - License gaps are not noise. Missing or unknown license metadata must be fixed, or the skill must become an original in-house rewrite before copying any upstream text.
 
-Example archived mapping:
+Example archived v2 origin:
 
 ```json
 {
+  "kind": "snapshot",
+  "sync_mode": "archived",
   "upstream": {
     "sync_mode": "archived",
     "archived_at": "2026-06-29"
-  }
+  },
+  "origins": [{
+    "repo": "owner/repo",
+    "sync_mode": "archived",
+    "tracking": {
+      "channel": "fixed_ref",
+      "ref": "<immutable-commit>",
+      "resolved_commit": "<immutable-commit>"
+    }
+  }]
 }
 ```
 
-Example local-only mapping:
+Example local-only v2 snapshot:
 
 ```json
 {
+  "kind": "snapshot",
+  "sync_mode": "local-only",
   "upstream": {
     "sync_mode": "local-only"
-  }
+  },
+  "origins": [{
+    "repo": "owner/repo",
+    "sync_mode": "local-only",
+    "tracking": {
+      "channel": "fixed_ref",
+      "ref": "<immutable-commit>",
+      "resolved_commit": "<immutable-commit>"
+    }
+  }]
 }
 ```

--- a/openclaw-skills/using-agent-skills/upstream-bundle/.claude/commands/webperf.md
+++ b/openclaw-skills/using-agent-skills/upstream-bundle/.claude/commands/webperf.md
@@ -1,0 +1,32 @@
+---
+description: Run a web performance audit via the web-performance-auditor persona
+---
+
+`/webperf` targets web applications specifically. Do not use it for utility libraries, CLIs, or server-only code with no browser-facing output.
+
+## Determine the mode
+
+**Deep mode** — activate when any of these is available:
+- A Lighthouse JSON report file (e.g. `npx lighthouse <url> --output json --output-path ./report.json`, or `npx -p chrome-devtools-mcp chrome-devtools lighthouse_audit --output-format=json` from the Chrome DevTools MCP CLI)
+- A PageSpeed Insights JSON response (includes Lighthouse + CrUX)
+- A CrUX API response (requires `CRUX_API_KEY` or `GOOGLE_API_KEY`)
+- A DevTools performance trace
+- A live URL plus the `chrome-devtools` MCP server configured in the harness (the agent can capture metrics directly via `lighthouse_audit` and `performance_*` tools)
+- The Chrome DevTools MCP CLI invoked locally (via `npx -p chrome-devtools-mcp chrome-devtools <tool>` or after `npm i -g chrome-devtools-mcp`) — the user runs commands like `chrome-devtools lighthouse_audit --output-format=json` and passes the JSON output to the agent
+
+**Quick mode** — default when none of the above are available. The agent scans source code for structural anti-patterns and labels every finding as `potential impact`.
+
+## Run the audit
+
+Spawn the `web-performance-auditor` subagent. Pass it explicitly:
+
+- The files, components, or diff under review
+- Any artifact paths (Lighthouse JSON, PSI JSON, CrUX response, trace) or pasted JSON content
+- The target URL or page name when known
+- A note on which mode you expect (Quick or Deep), so the agent surfaces missing inputs if Deep was intended
+
+The subagent returns a scorecard (only populated with sourced values), a ranked list of findings, positive observations, and proactive recommendations.
+
+## Output
+
+Return the full audit report to the user. No synthesis or merge step is needed — this is a single-persona command.

--- a/scripts/artifact_set_sync.py
+++ b/scripts/artifact_set_sync.py
@@ -1,0 +1,2827 @@
+#!/usr/bin/env python3
+"""Prune-safe, transactional synchronization of one canonical skill artifact set.
+
+This module deliberately has no network or mapping-file responsibilities.  A
+caller resolves an upstream ref, downloads and expands its complete file
+inventory, then passes the bytes here.  The returned metadata can be committed
+to provenance only after the filesystem transaction succeeds.
+
+Ownership is fail-closed:
+
+* an existing file may be replaced or removed only when its current digest
+  matches the corresponding ``managed_files`` checkpoint;
+* files outside the old managed manifest are copied through unchanged and are
+  never silently adopted, overwritten, or removed;
+* a user-modified managed file blocks the transaction when the requested
+  artifact set would overwrite or remove it.
+
+The complete skill directory is built beside the destination and validated
+before a rename-based switch.  A temporary backup allows failures after either
+rename to restore the original directory.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import stat
+import tempfile
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Any, Iterator, Self
+
+try:  # POSIX advisory locks are released automatically when a process exits.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows is not used by repository CI.
+    fcntl = None  # type: ignore[assignment]
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+class ArtifactSetSyncError(RuntimeError):
+    """Base class for artifact-set planning and application failures."""
+
+
+class ArtifactValidationError(ArtifactSetSyncError):
+    """The entry, manifest, payload, or filesystem shape is unsafe."""
+
+
+class OwnershipConflictError(ArtifactSetSyncError):
+    """The requested change lacks safe overwrite or deletion authority."""
+
+    def __init__(
+        self,
+        *,
+        user_modified: Sequence[str] = (),
+        unowned_conflicts: Sequence[str] = (),
+    ) -> None:
+        self.user_modified = tuple(user_modified)
+        self.unowned_conflicts = tuple(unowned_conflicts)
+        details: list[str] = []
+        if self.user_modified:
+            details.append("user_modified=" + ", ".join(self.user_modified))
+        if self.unowned_conflicts:
+            details.append(
+                "unowned_conflicts=" + ", ".join(self.unowned_conflicts)
+            )
+        super().__init__(
+            "artifact-set ownership conflict"
+            + (": " + "; ".join(details) if details else "")
+        )
+
+
+class ConcurrentModificationError(ArtifactSetSyncError):
+    """The canonical directory changed after its plan was constructed."""
+
+    def __init__(self, paths: Sequence[str]) -> None:
+        self.paths = tuple(paths)
+        super().__init__(
+            "canonical skill changed after planning: " + ", ".join(self.paths)
+        )
+
+
+class ArtifactApplyError(ArtifactSetSyncError):
+    """The transaction failed; ``rollback_succeeded`` reports recovery state."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        rollback_succeeded: bool,
+        cause: Exception,
+        recovery_path: Path | None = None,
+    ) -> None:
+        self.rollback_succeeded = rollback_succeeded
+        self.cause = cause
+        self.recovery_path = recovery_path
+        suffix = "rollback succeeded" if rollback_succeeded else "rollback failed"
+        recovery = (
+            f"; recovery_path={recovery_path}"
+            if recovery_path is not None
+            else ""
+        )
+        super().__init__(f"{message} ({suffix}{recovery}): {cause}")
+
+
+class ArtifactLockError(ArtifactSetSyncError):
+    """Another conforming transaction currently owns this canonical skill."""
+
+    def __init__(self, lock_path: Path) -> None:
+        self.lock_path = lock_path
+        super().__init__(
+            f"artifact-set transaction is already active: {lock_path}"
+        )
+
+
+class ArtifactRecoveryError(ArtifactSetSyncError):
+    """A durable transaction journal cannot be recovered without authority."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        recovery_paths: Sequence[Path] = (),
+    ) -> None:
+        self.recovery_paths = tuple(recovery_paths)
+        suffix = (
+            "; recovery_paths="
+            + ", ".join(str(path) for path in self.recovery_paths)
+            if self.recovery_paths
+            else ""
+        )
+        super().__init__(message + suffix)
+
+
+@dataclass(frozen=True)
+class ArtifactPayload:
+    """One expanded upstream file.
+
+    ``type`` accepts ``file`` and ``binary``.  Both become provenance
+    ``type: file`` entries because binary safety comes from byte-wise hashing,
+    not from a separate mapping type.
+    """
+
+    source: str
+    target: str
+    type: str
+    data: bytes
+
+
+@dataclass(frozen=True)
+class Drift:
+    """A discrepancy between the old ownership checkpoint and local disk."""
+
+    path: str
+    kind: str
+    expected_sha256: str | None
+    actual_sha256: str | None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "path": self.path,
+            "kind": self.kind,
+            "expected_sha256": self.expected_sha256,
+            "actual_sha256": self.actual_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class SyncPlan:
+    """A validated filesystem plan with immutable byte payloads."""
+
+    repo_root: Path
+    skill_root: str
+    repo_skill: str
+    owner: str
+    payloads: tuple[ArtifactPayload, ...]
+    artifacts: tuple[Mapping[str, str], ...]
+    managed_files: tuple[Mapping[str, str], ...]
+    checkpoint: Mapping[str, Any]
+    content_sha256: str
+    changed: tuple[str, ...]
+    pruned: tuple[str, ...]
+    preserved: tuple[str, ...]
+    drift: tuple[Drift, ...]
+    user_modified: tuple[str, ...]
+    unowned_conflicts: tuple[str, ...]
+    owned_targets: tuple[str, ...]
+    protected_targets: tuple[str, ...]
+    baseline_inventory: Mapping[str, str]
+    baseline_root_identity: tuple[int, int] | None
+
+    @property
+    def blocked(self) -> bool:
+        return bool(self.user_modified or self.unowned_conflicts)
+
+    @property
+    def has_filesystem_changes(self) -> bool:
+        return bool(self.changed or self.pruned)
+
+    def metadata_patch(self) -> dict[str, Any]:
+        """Return JSON-ready provenance fields without mutating an entry."""
+        return {
+            "artifacts": [dict(item) for item in self.artifacts],
+            "managed_files": [dict(item) for item in self.managed_files],
+            "tracking": deepcopy(dict(self.checkpoint)),
+            "content_sha256": self.content_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """The plan outcome and JSON-ready provenance metadata."""
+
+    artifacts: tuple[Mapping[str, str], ...]
+    managed_files: tuple[Mapping[str, str], ...]
+    checkpoint: Mapping[str, Any]
+    content_sha256: str
+    changed: tuple[str, ...]
+    pruned: tuple[str, ...]
+    preserved: tuple[str, ...]
+    drift: tuple[Drift, ...]
+    applied: bool
+    dry_run: bool
+
+    @property
+    def has_filesystem_changes(self) -> bool:
+        return bool(self.changed or self.pruned)
+
+    def metadata_patch(self) -> dict[str, Any]:
+        """Return JSON-ready origin/entry fields for the mapping caller."""
+        return {
+            "artifacts": [dict(item) for item in self.artifacts],
+            "managed_files": [dict(item) for item in self.managed_files],
+            "tracking": deepcopy(dict(self.checkpoint)),
+            "content_sha256": self.content_sha256,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self.metadata_patch(),
+            "changed": list(self.changed),
+            "pruned": list(self.pruned),
+            "preserved": list(self.preserved),
+            "drift": [item.to_dict() for item in self.drift],
+            "applied": self.applied,
+            "dry_run": self.dry_run,
+        }
+
+
+FaultInjector = Callable[[str], None]
+
+
+def skill_lock_identity(
+    repo_root: str | os.PathLike[str],
+    skill_root: str,
+) -> str:
+    """Return the stable cross-process identity for one canonical skill root."""
+    try:
+        root = Path(repo_root).resolve(strict=True)
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise ArtifactValidationError(
+            f"repository root does not exist or cannot be resolved: {repo_root}"
+        ) from exc
+    if not root.is_dir():
+        raise ArtifactValidationError(f"repository root is not a directory: {root}")
+    if not _safe_relative_posix(skill_root):
+        raise ArtifactValidationError(
+            f"skill_root is not canonical relative POSIX: {skill_root!r}"
+        )
+    return hashlib.sha256(
+        f"{root}\0{skill_root}".encode("utf-8", errors="surrogateescape")
+    ).hexdigest()
+
+
+def skill_lock_path(
+    repo_root: str | os.PathLike[str],
+    skill_root: str,
+) -> Path:
+    """Return the private advisory-lock path shared by engine and ingest."""
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    digest = skill_lock_identity(repo_root, skill_root)
+    return (
+        Path(tempfile.gettempdir())
+        / f"high-value-skills-artifact-locks-{uid}"
+        / f"{digest}.lock"
+    )
+
+
+def skill_transaction_journal_path(
+    repo_root: str | os.PathLike[str],
+    skill_root: str,
+) -> Path:
+    """Return the stable durable-journal path protected by the skill lock."""
+    return skill_lock_path(repo_root, skill_root).with_suffix(".journal.json")
+
+
+def _ensure_private_lock_root(path: Path) -> None:
+    try:
+        path.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ArtifactValidationError(
+            f"artifact lock root is not a private directory: {path}"
+        )
+    if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+        raise ArtifactValidationError(
+            f"artifact lock root is owned by another user: {path}"
+        )
+    if metadata.st_mode & 0o077:
+        try:
+            path.chmod(0o700)
+        except OSError as exc:
+            raise ArtifactValidationError(
+                f"artifact lock root is not private: {path}"
+            ) from exc
+
+
+class _SkillLock:
+    """Process-crash-safe advisory lock for one canonical skill."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._fd: int | None = None
+
+    def acquire(self, timeout: float) -> None:
+        if fcntl is None:  # pragma: no cover - see guarded import above
+            raise ArtifactValidationError(
+                "artifact transactions require POSIX advisory file locks"
+            )
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout < 0
+        ):
+            raise ArtifactValidationError(
+                "lock_timeout must be a finite non-negative number"
+            )
+        _ensure_private_lock_root(self.path.parent)
+        flags = os.O_CREAT | os.O_RDWR
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(self.path, flags, 0o600)
+        except OSError as exc:
+            raise ArtifactValidationError(
+                f"cannot open artifact lock file safely: {self.path}"
+            ) from exc
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ArtifactValidationError(
+                    f"artifact lock path is not a regular file: {self.path}"
+                )
+            if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+                raise ArtifactValidationError(
+                    f"artifact lock file is owned by another user: {self.path}"
+                )
+            deadline = time.monotonic() + timeout
+            while True:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError as exc:
+                    if time.monotonic() >= deadline:
+                        raise ArtifactLockError(self.path) from exc
+                    time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+            os.ftruncate(descriptor, 0)
+            os.write(
+                descriptor,
+                f"pid={os.getpid()}\n".encode("ascii"),
+            )
+            os.fsync(descriptor)
+            self._fd = descriptor
+        except Exception:
+            os.close(descriptor)
+            raise
+
+    def release(self) -> None:
+        descriptor = self._fd
+        if descriptor is None:
+            return
+        self._fd = None
+        try:
+            # Keep the inode stable so waiters can never split across an
+            # unlink/recreate race.  Empty stale files carry no lock: flock is
+            # released by close, including after process termination.
+            os.ftruncate(descriptor, 0)
+            os.fsync(descriptor)
+            if fcntl is not None:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+@contextmanager
+def skill_advisory_lock(
+    repo_root: str | os.PathLike[str],
+    skill_root: str,
+    *,
+    timeout: float = 0.0,
+    recover_pending: bool = True,
+) -> Iterator[_SkillLock]:
+    """Acquire the exact skill lock used by artifact transactions.
+
+    Callers that also own a provenance mapping lock must acquire that mapping
+    lock first, then enter this context, establishing the global
+    ``mapping -> skill`` lock order.  Read-only callers may set
+    ``recover_pending=False``; they still serialize on the same lock, but fail
+    closed without mutating repository state when a journal is present.
+    """
+    resolved_root = Path(repo_root).resolve(strict=True)
+    lock = _SkillLock(skill_lock_path(resolved_root, skill_root))
+    lock.acquire(timeout)
+    try:
+        journal_path = lock.path.with_suffix(".journal.json")
+        if recover_pending:
+            _recover_pending_transaction(
+                resolved_root,
+                skill_root,
+                journal_path,
+            )
+        elif os.path.lexists(journal_path):
+            raise ArtifactRecoveryError(
+                "read-only skill lock found a pending artifact transaction",
+                recovery_paths=(journal_path,),
+            )
+        yield lock
+    finally:
+        lock.release()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_relative_posix(value: object) -> bool:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or value.startswith("/")
+        or "\\" in value
+        or re.match(r"^[A-Za-z]:/", value)
+    ):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    path = PurePosixPath(value)
+    return not path.is_absolute() and path.as_posix() == value
+
+
+def _inside(path: str, root: str) -> bool:
+    candidate = PurePosixPath(path)
+    boundary = PurePosixPath(root)
+    return candidate != boundary and boundary in candidate.parents
+
+
+def _entry_owner(entry: Mapping[str, Any], skill_root: str) -> str:
+    for key in ("normalized_slug", "video_name", "name"):
+        value = entry.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return PurePosixPath(skill_root).name
+
+
+def _coerce_payload(value: ArtifactPayload | Mapping[str, Any]) -> ArtifactPayload:
+    if isinstance(value, ArtifactPayload):
+        payload = value
+    elif isinstance(value, Mapping):
+        data = value.get("data")
+        if data is None and "bytes" in value:
+            data = value["bytes"]
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise ArtifactValidationError(
+                "each upstream artifact must contain bytes in 'data' or 'bytes'"
+            )
+        payload = ArtifactPayload(
+            source=value.get("source"),  # type: ignore[arg-type]
+            target=value.get("target"),  # type: ignore[arg-type]
+            type=value.get("type", "file"),  # type: ignore[arg-type]
+            data=bytes(data),
+        )
+    else:
+        raise ArtifactValidationError(
+            "upstream artifacts must be ArtifactPayload or mapping objects"
+        )
+
+    if not _safe_relative_posix(payload.source):
+        raise ArtifactValidationError(
+            f"artifact source is not canonical relative POSIX: {payload.source!r}"
+        )
+    if not _safe_relative_posix(payload.target):
+        raise ArtifactValidationError(
+            f"artifact target is not canonical relative POSIX: {payload.target!r}"
+        )
+    if payload.type not in {"file", "binary"}:
+        detail = (
+            " (directory payloads must be expanded first)"
+            if payload.type == "directory"
+            else ""
+        )
+        raise ArtifactValidationError(
+            f"unsupported artifact type {payload.type!r}{detail}"
+        )
+    if not isinstance(payload.data, bytes):
+        payload = ArtifactPayload(
+            payload.source, payload.target, payload.type, bytes(payload.data)
+        )
+    return payload
+
+
+def _assert_no_symlink_ancestors(repo_root: Path, path: Path) -> None:
+    try:
+        relative = path.relative_to(repo_root)
+    except ValueError as exc:
+        raise ArtifactValidationError(
+            f"path escapes repository root: {path}"
+        ) from exc
+
+    current = repo_root
+    for component in relative.parts:
+        current = current / component
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(mode):
+            raise ArtifactValidationError(
+                f"symlink or symlink parent is not allowed: {current}"
+            )
+
+
+def _inventory(repo_root: Path, skill_path: Path, skill_root: str) -> dict[str, str]:
+    if not skill_path.exists():
+        return {}
+    try:
+        root_mode = skill_path.lstat().st_mode
+    except FileNotFoundError:
+        return {}
+    if stat.S_ISLNK(root_mode):
+        raise ArtifactValidationError(f"skill root is a symlink: {skill_path}")
+    if not stat.S_ISDIR(root_mode):
+        raise ArtifactValidationError(
+            f"skill root must be a directory: {skill_path}"
+        )
+
+    inventory: dict[str, str] = {}
+    for current, dirs, files in os.walk(skill_path, followlinks=False):
+        current_path = Path(current)
+        for name in tuple(dirs):
+            candidate = current_path / name
+            mode = candidate.lstat().st_mode
+            if stat.S_ISLNK(mode):
+                raise ArtifactValidationError(
+                    f"symlink inside canonical skill is not allowed: {candidate}"
+                )
+            if not stat.S_ISDIR(mode):
+                raise ArtifactValidationError(
+                    f"non-directory entry in directory list: {candidate}"
+                )
+        for name in files:
+            candidate = current_path / name
+            mode = candidate.lstat().st_mode
+            if stat.S_ISLNK(mode):
+                raise ArtifactValidationError(
+                    f"symlink inside canonical skill is not allowed: {candidate}"
+                )
+            if not stat.S_ISREG(mode):
+                raise ArtifactValidationError(
+                    f"special file inside canonical skill is not allowed: {candidate}"
+                )
+            suffix = candidate.relative_to(skill_path).as_posix()
+            target = f"{skill_root}/{suffix}"
+            inventory[target] = _sha256_file(candidate)
+    return dict(sorted(inventory.items()))
+
+
+def _directory_identity(path: Path) -> tuple[int, int] | None:
+    """Return the directory inode identity without following a symlink."""
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ArtifactValidationError(
+            f"canonical skill root is not a regular directory: {path}"
+        )
+    return metadata.st_dev, metadata.st_ino
+
+
+def _validate_managed_manifest(
+    entry: Mapping[str, Any],
+    *,
+    owner: str,
+    skill_root: str,
+) -> dict[str, Mapping[str, str]]:
+    raw = entry.get("managed_files")
+    if not isinstance(raw, list):
+        raise ArtifactValidationError("entry.managed_files must be an array")
+    managed: dict[str, Mapping[str, str]] = {}
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise ArtifactValidationError(
+                f"managed_files[{index}] must be an object"
+            )
+        path = item.get("path")
+        digest = item.get("sha256")
+        declared_owner = item.get("owner")
+        if not _safe_relative_posix(path) or not _inside(str(path), skill_root):
+            raise ArtifactValidationError(
+                f"managed_files[{index}].path is outside the skill root: {path!r}"
+            )
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            raise ArtifactValidationError(
+                f"managed_files[{index}].sha256 is not SHA-256"
+            )
+        if declared_owner != owner:
+            raise ArtifactValidationError(
+                f"managed_files[{index}] owner {declared_owner!r} "
+                f"does not match entry owner {owner!r}"
+            )
+        if path in managed:
+            raise ArtifactValidationError(f"duplicate managed path: {path}")
+        managed[str(path)] = MappingProxyType(
+            {
+                "path": str(path),
+                "sha256": digest.lower(),
+                "owner": owner,
+            }
+        )
+    return managed
+
+
+def _validate_scope_target(
+    value: object,
+    *,
+    label: str,
+    skill_root: str,
+    allow_root: bool = False,
+) -> str:
+    canonical = _safe_relative_posix(value)
+    contained = _inside(str(value), skill_root)
+    if not canonical or not (
+        contained or (allow_root and str(value) == skill_root)
+    ):
+        raise ArtifactValidationError(
+            f"{label} is outside the canonical skill root: {value!r}"
+        )
+    return str(value)
+
+
+def _targets_from_origin(
+    entry: Mapping[str, Any],
+    *,
+    origin_index: int,
+    managed_paths: set[str],
+    skill_root: str,
+) -> set[str]:
+    origins = entry.get("origins")
+    if not isinstance(origins, list):
+        raise ArtifactValidationError(
+            "origin_index requires entry.origins to be an array"
+        )
+    if (
+        isinstance(origin_index, bool)
+        or not isinstance(origin_index, int)
+        or origin_index < 0
+        or origin_index >= len(origins)
+    ):
+        raise ArtifactValidationError(f"origin_index is out of range: {origin_index}")
+    origin = origins[origin_index]
+    if not isinstance(origin, Mapping):
+        raise ArtifactValidationError(
+            f"entry.origins[{origin_index}] must be an object"
+        )
+    artifacts = origin.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ArtifactValidationError(
+            f"entry.origins[{origin_index}].artifacts must be an array"
+        )
+
+    owned: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            raise ArtifactValidationError(
+                f"entry.origins[{origin_index}].artifacts[{index}] "
+                "must be an object"
+            )
+        artifact_type = artifact.get("type", "file")
+        target = _validate_scope_target(
+            artifact.get("target"),
+            label=f"entry.origins[{origin_index}].artifacts[{index}].target",
+            skill_root=skill_root,
+            allow_root=artifact_type == "directory",
+        )
+        if artifact_type == "file":
+            if target in managed_paths:
+                owned.add(target)
+        elif artifact_type == "directory":
+            boundary = PurePosixPath(target)
+            owned.update(
+                path
+                for path in managed_paths
+                if PurePosixPath(path) == boundary
+                or boundary in PurePosixPath(path).parents
+            )
+        else:
+            raise ArtifactValidationError(
+                f"entry.origins[{origin_index}].artifacts[{index}].type "
+                f"is unsupported: {artifact_type!r}"
+            )
+    return owned
+
+
+def _origin_claims_target(
+    entry: Mapping[str, Any],
+    *,
+    origin_index: int,
+    target: str,
+    skill_root: str,
+) -> bool:
+    """Whether one origin's declared scope covers a desired target.
+
+    Unlike ``_targets_from_origin``, this predicate is deliberately independent
+    of the old managed manifest.  It therefore protects brand-new payloads from
+    a directory claim held by another origin.
+    """
+    origins = entry.get("origins")
+    if not isinstance(origins, list) or not (0 <= origin_index < len(origins)):
+        raise ArtifactValidationError(f"origin_index is out of range: {origin_index}")
+    origin = origins[origin_index]
+    if not isinstance(origin, Mapping):
+        raise ArtifactValidationError(
+            f"entry.origins[{origin_index}] must be an object"
+        )
+    artifacts = origin.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ArtifactValidationError(
+            f"entry.origins[{origin_index}].artifacts must be an array"
+        )
+    requested = PurePosixPath(target)
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, Mapping):
+            raise ArtifactValidationError(
+                f"entry.origins[{origin_index}].artifacts[{index}] "
+                "must be an object"
+            )
+        artifact_type = artifact.get("type", "file")
+        declared = _validate_scope_target(
+            artifact.get("target"),
+            label=f"entry.origins[{origin_index}].artifacts[{index}].target",
+            skill_root=skill_root,
+            allow_root=artifact_type == "directory",
+        )
+        boundary = PurePosixPath(declared)
+        if artifact_type == "file" and requested == boundary:
+            return True
+        if artifact_type == "directory" and (
+            requested == boundary or boundary in requested.parents
+        ):
+            return True
+        if artifact_type not in {"file", "directory"}:
+            raise ArtifactValidationError(
+                f"entry.origins[{origin_index}].artifacts[{index}].type "
+                f"is unsupported: {artifact_type!r}"
+            )
+    return False
+
+
+def _changed_inventory_paths(
+    before: Mapping[str, str], after: Mapping[str, str]
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            path
+            for path in set(before) | set(after)
+            if before.get(path) != after.get(path)
+        )
+    )
+
+
+def plan_artifact_set_sync(
+    repo_root: str | os.PathLike[str],
+    entry: Mapping[str, Any],
+    upstream_artifacts: Iterable[ArtifactPayload | Mapping[str, Any]],
+    checkpoint: Mapping[str, Any],
+    *,
+    origin_index: int | None = None,
+    owned_targets: Iterable[str] | None = None,
+    protected_targets: Iterable[str] = (),
+) -> SyncPlan:
+    """Build a complete, read-only synchronization plan.
+
+    Planning performs only reads.  Ownership conflicts are recorded on the
+    plan so reporting callers can present all affected paths at once; applying
+    a blocked plan raises :class:`OwnershipConflictError`.
+    """
+    root_input = Path(repo_root)
+    try:
+        root = root_input.resolve(strict=True)
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise ArtifactValidationError(
+            f"repository root does not exist or cannot be resolved: {repo_root}"
+        ) from exc
+    if not root.is_dir():
+        raise ArtifactValidationError(f"repository root is not a directory: {root}")
+    if not isinstance(entry, Mapping):
+        raise ArtifactValidationError("entry must be a mapping")
+    if not isinstance(checkpoint, Mapping):
+        raise ArtifactValidationError("checkpoint must be a mapping")
+
+    repo_skill = entry.get("repo_skill")
+    if not _safe_relative_posix(repo_skill):
+        raise ArtifactValidationError(
+            f"entry.repo_skill is not canonical relative POSIX: {repo_skill!r}"
+        )
+    repo_skill = str(repo_skill)
+    skill_root = PurePosixPath(repo_skill).parent.as_posix()
+    if skill_root == "." or not _safe_relative_posix(skill_root):
+        raise ArtifactValidationError(
+            f"entry.repo_skill has no safe canonical skill root: {repo_skill!r}"
+        )
+    owner = _entry_owner(entry, skill_root)
+    if not owner:
+        raise ArtifactValidationError("entry has no usable ownership identity")
+
+    payloads = tuple(_coerce_payload(value) for value in upstream_artifacts)
+    if not payloads:
+        raise ArtifactValidationError("complete upstream artifact set is empty")
+    targets: set[str] = set()
+    for payload in payloads:
+        if not _inside(payload.target, skill_root):
+            raise ArtifactValidationError(
+                f"artifact target is outside {skill_root}: {payload.target}"
+            )
+        if payload.target in targets:
+            raise ArtifactValidationError(
+                f"duplicate upstream artifact target: {payload.target}"
+            )
+        targets.add(payload.target)
+    if repo_skill not in targets:
+        raise ArtifactValidationError(
+            f"complete artifact set does not contain repo_skill: {repo_skill}"
+        )
+
+    # Deterministic output is important for mapping idempotence.
+    payloads = tuple(sorted(payloads, key=lambda item: (item.target, item.source)))
+    target_by_path = {item.target: item for item in payloads}
+    old_managed_records = _validate_managed_manifest(
+        entry, owner=owner, skill_root=skill_root
+    )
+    old_managed_paths = set(old_managed_records)
+    if origin_index is not None and owned_targets is not None:
+        raise ArtifactValidationError(
+            "origin_index and owned_targets are mutually exclusive"
+        )
+    if origin_index is not None:
+        selected_owned = _targets_from_origin(
+            entry,
+            origin_index=origin_index,
+            managed_paths=old_managed_paths,
+            skill_root=skill_root,
+        )
+        origins = entry.get("origins")
+        if not isinstance(origins, list):  # defensive; helper already checked
+            raise ArtifactValidationError(
+                "origin_index requires entry.origins to be an array"
+            )
+        other_origin_owned: set[str] = set()
+        other_origin_payload_claims: set[str] = set()
+        for other_index in range(len(origins)):
+            if other_index == origin_index:
+                continue
+            other_origin_owned.update(
+                _targets_from_origin(
+                    entry,
+                    origin_index=other_index,
+                    managed_paths=old_managed_paths,
+                    skill_root=skill_root,
+                )
+            )
+            other_origin_payload_claims.update(
+                target
+                for target in targets
+                if _origin_claims_target(
+                    entry,
+                    origin_index=other_index,
+                    target=target,
+                    skill_root=skill_root,
+                )
+            )
+        unclaimed_payloads = sorted(
+            target
+            for target in targets
+            if not _origin_claims_target(
+                entry,
+                origin_index=origin_index,
+                target=target,
+                skill_root=skill_root,
+            )
+        )
+        if unclaimed_payloads:
+            raise ArtifactValidationError(
+                "selected origin does not claim payload target(s): "
+                + ", ".join(unclaimed_payloads)
+            )
+        # Ambiguous broad-directory claims are resolved conservatively: an
+        # explicit or directory claim from any non-selected origin protects the
+        # file.  The provenance validator may separately reject the overlap,
+        # but the transaction engine must never turn it into deletion authority.
+        selected_owned.difference_update(other_origin_owned)
+    elif owned_targets is not None:
+        selected_owned = {
+            _validate_scope_target(
+                value,
+                label="owned_targets item",
+                skill_root=skill_root,
+            )
+            for value in owned_targets
+        }
+        unknown_owned = selected_owned - old_managed_paths
+        if unknown_owned:
+            raise ArtifactValidationError(
+                "owned_targets lack managed-file checkpoints: "
+                + ", ".join(sorted(unknown_owned))
+            )
+    else:
+        origins = entry.get("origins")
+        if entry.get("kind") != "mirror" or not (
+            isinstance(origins, list) and len(origins) == 1
+        ):
+            raise ArtifactValidationError(
+                "implicit ownership is allowed only for a single-origin "
+                "mirror; pass origin_index or owned_targets explicitly"
+            )
+        # A validated single-origin mirror owns its complete managed inventory.
+        # Overlay, composite, bundle, and ambiguous multi-origin entries must
+        # always select an origin scope explicitly.
+        selected_owned = set(old_managed_paths)
+
+    explicit_protected = {
+        _validate_scope_target(
+            value,
+            label="protected_targets item",
+            skill_root=skill_root,
+        )
+        for value in protected_targets
+    }
+    overlap = selected_owned & explicit_protected
+    if overlap:
+        raise ArtifactValidationError(
+            "targets cannot be both owned and protected: "
+            + ", ".join(sorted(overlap))
+        )
+    protected = (old_managed_paths - selected_owned) | explicit_protected
+    if origin_index is not None:
+        protected |= other_origin_payload_claims
+    old_managed = {
+        path: record["sha256"] for path, record in old_managed_records.items()
+    }
+
+    skill_path = root.joinpath(*PurePosixPath(skill_root).parts)
+    _assert_no_symlink_ancestors(root, skill_path)
+    for payload in payloads:
+        _assert_no_symlink_ancestors(
+            root, root.joinpath(*PurePosixPath(payload.target).parts)
+        )
+    baseline = _inventory(root, skill_path, skill_root)
+    baseline_root_identity = _directory_identity(skill_path)
+
+    drift: list[Drift] = []
+    user_modified: set[str] = set()
+    unowned_conflicts: set[str] = set()
+    changed: set[str] = set()
+    pruned: set[str] = set()
+
+    for target, payload in target_by_path.items():
+        new_digest = _sha256_bytes(payload.data)
+        current_digest = baseline.get(target)
+        expected_digest = old_managed.get(target)
+        if target in protected:
+            unowned_conflicts.add(target)
+            continue
+        if current_digest is None:
+            changed.add(target)
+            if expected_digest is not None:
+                drift.append(Drift(target, "missing", expected_digest, None))
+            continue
+        if expected_digest is None:
+            # Even identical bytes are not ownership authority: silently
+            # adopting an unowned file would permit deleting it on a later run.
+            unowned_conflicts.add(target)
+            continue
+        if current_digest != expected_digest:
+            drift.append(
+                Drift(target, "hash_mismatch", expected_digest, current_digest)
+            )
+            if current_digest != new_digest:
+                user_modified.add(target)
+        if current_digest != new_digest:
+            changed.add(target)
+
+    for path in selected_owned:
+        if path in target_by_path:
+            continue
+        expected_digest = old_managed[path]
+        current_digest = baseline.get(path)
+        if current_digest is None:
+            drift.append(Drift(path, "missing", expected_digest, None))
+        elif current_digest != expected_digest:
+            drift.append(
+                Drift(path, "hash_mismatch", expected_digest, current_digest)
+            )
+            user_modified.add(path)
+        else:
+            pruned.add(path)
+
+    preserved = tuple(
+        sorted(set(baseline) - changed - pruned - unowned_conflicts)
+    )
+    artifacts: tuple[Mapping[str, str], ...] = tuple(
+        MappingProxyType(
+            {
+                "source": payload.source,
+                "target": payload.target,
+                "type": "file",
+            }
+        )
+        for payload in payloads
+    )
+    next_managed: dict[str, Mapping[str, str]] = {
+        path: record
+        for path, record in old_managed_records.items()
+        if path not in selected_owned
+    }
+    for payload in payloads:
+        next_managed[payload.target] = MappingProxyType(
+            {
+                "path": payload.target,
+                "sha256": _sha256_bytes(payload.data),
+                "owner": owner,
+            }
+        )
+    managed_files: tuple[Mapping[str, str], ...] = tuple(
+        next_managed[path] for path in sorted(next_managed)
+    )
+    content_sha256 = next(
+        item["sha256"]
+        for item in managed_files
+        if item["path"] == repo_skill
+    )
+    new_checkpoint = deepcopy(dict(checkpoint))
+    new_checkpoint["content_sha256"] = content_sha256
+
+    return SyncPlan(
+        repo_root=root,
+        skill_root=skill_root,
+        repo_skill=repo_skill,
+        owner=owner,
+        payloads=payloads,
+        artifacts=artifacts,
+        managed_files=managed_files,
+        checkpoint=MappingProxyType(new_checkpoint),
+        content_sha256=content_sha256,
+        changed=tuple(sorted(changed)),
+        pruned=tuple(sorted(pruned)),
+        preserved=preserved,
+        drift=tuple(sorted(drift, key=lambda item: (item.path, item.kind))),
+        user_modified=tuple(sorted(user_modified)),
+        unowned_conflicts=tuple(sorted(unowned_conflicts)),
+        owned_targets=tuple(sorted(selected_owned)),
+        protected_targets=tuple(sorted(protected)),
+        baseline_inventory=MappingProxyType(baseline),
+        baseline_root_identity=baseline_root_identity,
+    )
+
+
+def _result_from_plan(
+    plan: SyncPlan, *, applied: bool, dry_run: bool
+) -> SyncResult:
+    return SyncResult(
+        artifacts=plan.artifacts,
+        managed_files=plan.managed_files,
+        checkpoint=plan.checkpoint,
+        content_sha256=plan.content_sha256,
+        changed=plan.changed,
+        pruned=plan.pruned,
+        preserved=plan.preserved,
+        drift=plan.drift,
+        applied=applied,
+        dry_run=dry_run,
+    )
+
+
+def _invoke_fault(fault_injector: FaultInjector | None, event: str) -> None:
+    if fault_injector is not None:
+        fault_injector(event)
+
+
+def _remove_empty_parents(path: Path, boundary: Path) -> None:
+    current = path
+    while current != boundary:
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
+def _validate_staged_tree(plan: SyncPlan, stage_skill: Path) -> None:
+    inventory = _inventory(plan.repo_root, stage_skill, plan.skill_root)
+    desired = {
+        payload.target: _sha256_bytes(payload.data)
+        for payload in plan.payloads
+    }
+    for path, digest in desired.items():
+        if inventory.get(path) != digest:
+            raise ArtifactValidationError(
+                f"staged artifact digest mismatch: {path}"
+            )
+    for path in plan.pruned:
+        if path in inventory:
+            raise ArtifactValidationError(
+                f"pruned artifact remains in staged tree: {path}"
+            )
+    for path in plan.preserved:
+        if inventory.get(path) != plan.baseline_inventory.get(path):
+            raise ArtifactValidationError(
+                f"preserved artifact changed in staged tree: {path}"
+            )
+
+
+def _build_stage(plan: SyncPlan, stage_skill: Path) -> None:
+    skill_path = plan.repo_root.joinpath(*PurePosixPath(plan.skill_root).parts)
+    if skill_path.exists():
+        # Copy links as links; staged inventory then rejects them.  This avoids
+        # following a link that appeared in the source after planning.
+        shutil.copytree(skill_path, stage_skill, symlinks=True)
+    else:
+        stage_skill.mkdir()
+
+    # Validate the copy before opening any destination.  In particular, never
+    # let a symlink introduced between planning and copy redirect a stage write
+    # outside the transaction directory.
+    _inventory(plan.repo_root, stage_skill, plan.skill_root)
+
+    for path in plan.pruned:
+        relative = PurePosixPath(path).relative_to(PurePosixPath(plan.skill_root))
+        candidate = stage_skill.joinpath(*relative.parts)
+        if candidate.exists():
+            if candidate.is_symlink() or not candidate.is_file():
+                raise ArtifactValidationError(
+                    f"managed prune target is not a regular file: {path}"
+                )
+            candidate.unlink()
+            _remove_empty_parents(candidate.parent, stage_skill)
+
+    for payload in plan.payloads:
+        relative = PurePosixPath(payload.target).relative_to(
+            PurePosixPath(plan.skill_root)
+        )
+        candidate = stage_skill.joinpath(*relative.parts)
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        if candidate.exists() and (
+            candidate.is_symlink() or not candidate.is_file()
+        ):
+            raise ArtifactValidationError(
+                f"artifact target is not a regular file: {payload.target}"
+            )
+        with candidate.open("wb") as handle:
+            handle.write(payload.data)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    _validate_staged_tree(plan, stage_skill)
+
+
+def _cleanup_tree(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        if path.is_symlink() or path.is_file():
+            path.unlink(missing_ok=True)
+        elif path.exists():
+            shutil.rmtree(path)
+    except FileNotFoundError:
+        return
+
+
+def _current_inventory(plan: SyncPlan) -> dict[str, str]:
+    skill_path = plan.repo_root.joinpath(*PurePosixPath(plan.skill_root).parts)
+    _assert_no_symlink_ancestors(plan.repo_root, skill_path)
+    return _inventory(plan.repo_root, skill_path, plan.skill_root)
+
+
+def _path_lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _expected_installed_inventory(plan: SyncPlan) -> dict[str, str]:
+    expected = dict(plan.baseline_inventory)
+    for path in plan.pruned:
+        expected.pop(path, None)
+    for payload in plan.payloads:
+        expected[payload.target] = _sha256_bytes(payload.data)
+    return dict(sorted(expected.items()))
+
+
+JOURNAL_VERSION = 1
+JOURNAL_STATES = {
+    "staged",
+    "old_moved",
+    "new_installed",
+    "prepared",
+    "rolling_back",
+    "committing_new",
+}
+MAX_JOURNAL_BYTES = 16 * 1024 * 1024
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise ArtifactValidationError(f"not a directory for fsync: {path}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _replace_tree_and_fsync(source: Path, destination: Path) -> None:
+    os.replace(source, destination)
+    for parent in {source.parent, destination.parent}:
+        _fsync_directory(parent)
+
+
+def _fsync_tree(path: Path) -> None:
+    """Durably flush every regular file and directory in one staged tree."""
+    if not path.exists():
+        return
+    directories: list[Path] = []
+    for current, dirs, files in os.walk(path, followlinks=False):
+        current_path = Path(current)
+        directories.append(current_path)
+        for name in dirs:
+            candidate = current_path / name
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise ArtifactValidationError(
+                    f"unsafe directory in staged tree: {candidate}"
+                )
+        for name in files:
+            candidate = current_path / name
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise ArtifactValidationError(
+                    f"unsafe file in staged tree: {candidate}"
+                )
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(candidate, flags)
+            try:
+                opened = os.fstat(descriptor)
+                if (
+                    opened.st_dev != metadata.st_dev
+                    or opened.st_ino != metadata.st_ino
+                ):
+                    raise ArtifactValidationError(
+                        f"staged file changed while opening: {candidate}"
+                    )
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    for directory in reversed(directories):
+        _fsync_directory(directory)
+
+
+def _owned_regular_metadata(path: Path) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ArtifactRecoveryError(f"cannot inspect durable path {path}: {exc}") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ArtifactRecoveryError(
+            f"durable path is not a regular non-symlink file: {path}"
+        )
+    if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+        raise ArtifactRecoveryError(
+            f"durable path is owned by another user: {path}"
+        )
+    return metadata
+
+
+def _owned_directory_metadata(path: Path) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ArtifactRecoveryError(f"cannot inspect durable directory {path}: {exc}") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise ArtifactRecoveryError(
+            f"durable path is not a non-symlink directory: {path}"
+        )
+    if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+        raise ArtifactRecoveryError(
+            f"durable directory is owned by another user: {path}"
+        )
+    return metadata
+
+
+def _journal_existing_identity(path: Path) -> tuple[int, int] | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    _owned_regular_metadata(path)
+    return metadata.st_dev, metadata.st_ino
+
+
+def _computed_journal_integrity(payload: Mapping[str, Any]) -> str:
+    unsigned = {
+        key: deepcopy(value)
+        for key, value in payload.items()
+        if key != "journal_sha256"
+    }
+    return hashlib.sha256(
+        json.dumps(
+            unsigned,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _journal_integrity_is_valid(payload: Mapping[str, Any]) -> bool:
+    recorded = payload.get("journal_sha256")
+    return bool(
+        isinstance(recorded, str)
+        and SHA256_RE.fullmatch(recorded)
+        and recorded.lower() == _computed_journal_integrity(payload)
+    )
+
+
+def _write_journal(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically persist and directory-fsync a private transaction journal."""
+    _ensure_private_lock_root(path.parent)
+    before_identity = _journal_existing_identity(path)
+    if before_identity is not None:
+        existing = _read_journal(path)
+        if existing is None or not _journal_integrity_is_valid(existing):
+            raise ArtifactRecoveryError(
+                f"existing transaction journal failed integrity validation: {path}",
+                recovery_paths=(path,),
+            )
+        immutable_fields = (
+            "version",
+            "transaction_id",
+            "repo_root",
+            "skill_root",
+            "repo_skill",
+            "stage_container",
+            "backup_container",
+            "baseline_inventory",
+            "new_inventory",
+            "baseline_root_identity",
+            "new_root_identity",
+            "stage_container_identity",
+            "backup_container_identity",
+            "original_existed",
+        )
+        if any(existing.get(field) != payload.get(field) for field in immutable_fields):
+            raise ArtifactRecoveryError(
+                f"existing transaction journal immutable fields changed: {path}",
+                recovery_paths=(path,),
+            )
+        existing_authority = existing.get("authority")
+        next_authority = payload.get("authority")
+        if existing_authority is not None and existing_authority != next_authority:
+            raise ArtifactRecoveryError(
+                f"existing transaction journal authority changed: {path}",
+                recovery_paths=(path,),
+            )
+    serialized_payload = {
+        key: deepcopy(value)
+        for key, value in payload.items()
+        if key != "journal_sha256"
+    }
+    serialized_payload["journal_sha256"] = _computed_journal_integrity(
+        serialized_payload
+    )
+    content = (
+        json.dumps(
+            serialized_payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+    if len(content) > MAX_JOURNAL_BYTES:
+        raise ArtifactValidationError("artifact transaction journal is too large")
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(temporary, flags, 0o600)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError(f"short journal write: {temporary}")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        if _journal_existing_identity(path) != before_identity:
+            raise ArtifactRecoveryError(
+                f"transaction journal changed concurrently: {path}",
+                recovery_paths=(path,),
+            )
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _read_journal(path: Path) -> dict[str, Any] | None:
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        return None
+    _owned_regular_metadata(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or opened.st_size > MAX_JOURNAL_BYTES
+        ):
+            raise ArtifactRecoveryError(
+                f"transaction journal changed or is oversized: {path}",
+                recovery_paths=(path,),
+            )
+        chunks: list[bytes] = []
+        remaining = MAX_JOURNAL_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        after = os.fstat(descriptor)
+        if (
+            after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+        ):
+            raise ArtifactRecoveryError(
+                f"transaction journal changed while reading: {path}",
+                recovery_paths=(path,),
+            )
+    finally:
+        os.close(descriptor)
+    raw = b"".join(chunks)
+    if len(raw) > MAX_JOURNAL_BYTES:
+        raise ArtifactRecoveryError(
+            f"transaction journal is oversized: {path}",
+            recovery_paths=(path,),
+        )
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ArtifactRecoveryError(
+            f"transaction journal is invalid JSON: {path}: {exc}",
+            recovery_paths=(path,),
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ArtifactRecoveryError(
+            f"transaction journal root is not an object: {path}",
+            recovery_paths=(path,),
+        )
+    return payload
+
+
+def _remove_journal(path: Path) -> None:
+    try:
+        _owned_regular_metadata(path)
+    except ArtifactRecoveryError:
+        if not os.path.lexists(path):
+            return
+        raise
+    path.unlink()
+    _fsync_directory(path.parent)
+
+
+def _relative_to_repo(repo_root: Path, path: Path) -> str:
+    try:
+        relative = path.relative_to(repo_root).as_posix()
+    except ValueError as exc:
+        raise ArtifactValidationError(
+            f"transaction path escapes repository root: {path}"
+        ) from exc
+    if not _safe_relative_posix(relative):
+        raise ArtifactValidationError(
+            f"transaction path is not canonical relative POSIX: {relative!r}"
+        )
+    return relative
+
+
+def _journal_inventory(value: object, *, skill_root: str, label: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ArtifactRecoveryError(f"journal {label} must be an object")
+    result: dict[str, str] = {}
+    for path, digest in value.items():
+        if (
+            not _safe_relative_posix(path)
+            or not _inside(str(path), skill_root)
+            or not isinstance(digest, str)
+            or not SHA256_RE.fullmatch(digest)
+        ):
+            raise ArtifactRecoveryError(
+                f"journal {label} contains an unsafe path or digest: {path!r}"
+            )
+        result[str(path)] = digest.lower()
+    return dict(sorted(result.items()))
+
+
+def _journal_identity(
+    value: object,
+    *,
+    label: str,
+    nullable: bool,
+) -> tuple[int, int] | None:
+    if value is None and nullable:
+        return None
+    if (
+        not isinstance(value, list)
+        or len(value) != 2
+        or any(
+            isinstance(item, bool) or not isinstance(item, int) or item < 0
+            for item in value
+        )
+    ):
+        raise ArtifactRecoveryError(
+            f"journal {label} must be a device/inode pair"
+        )
+    return int(value[0]), int(value[1])
+
+
+def _journal_repo_path(
+    repo_root: Path,
+    value: object,
+    *,
+    label: str,
+    expected_parent: PurePosixPath | None = None,
+    prefix: str | None = None,
+) -> Path:
+    if not _safe_relative_posix(value):
+        raise ArtifactRecoveryError(
+            f"journal {label} is not canonical relative POSIX: {value!r}"
+        )
+    relative = PurePosixPath(str(value))
+    if expected_parent is not None and relative.parent != expected_parent:
+        raise ArtifactRecoveryError(
+            f"journal {label} has an unexpected parent: {value!r}"
+        )
+    if prefix is not None and not relative.name.startswith(prefix):
+        raise ArtifactRecoveryError(
+            f"journal {label} has an unexpected name: {value!r}"
+        )
+    path = repo_root.joinpath(*relative.parts)
+    try:
+        _assert_no_symlink_ancestors(repo_root, path)
+    except ArtifactValidationError as exc:
+        raise ArtifactRecoveryError(
+            f"journal {label} traverses an unsafe path: {path}"
+        ) from exc
+    return path
+
+
+def _secure_mapping_digest(repo_root: Path, relative: str) -> str:
+    path = _journal_repo_path(repo_root, relative, label="authority.mapping_path")
+    before = _owned_regular_metadata(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if opened.st_dev != before.st_dev or opened.st_ino != before.st_ino:
+            raise ArtifactRecoveryError(f"mapping changed while opening: {path}")
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: os.read(descriptor, 1024 * 1024), b""):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        if (
+            after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+        ):
+            raise ArtifactRecoveryError(f"mapping changed while reading: {path}")
+        return digest.hexdigest()
+    finally:
+        os.close(descriptor)
+
+
+def _validate_journal(
+    payload: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    skill_root: str,
+    journal_path: Path,
+) -> dict[str, Any]:
+    if not _journal_integrity_is_valid(payload):
+        raise ArtifactRecoveryError(
+            "transaction journal integrity hash mismatch",
+            recovery_paths=(journal_path,),
+        )
+    if payload.get("version") != JOURNAL_VERSION:
+        raise ArtifactRecoveryError(
+            f"unsupported transaction journal version: {payload.get('version')!r}",
+            recovery_paths=(journal_path,),
+        )
+    if payload.get("repo_root") != str(repo_root) or payload.get("skill_root") != skill_root:
+        raise ArtifactRecoveryError(
+            "transaction journal identity does not match the acquired skill lock",
+            recovery_paths=(journal_path,),
+        )
+    state = payload.get("state")
+    if state not in JOURNAL_STATES:
+        raise ArtifactRecoveryError(
+            f"transaction journal has invalid state: {state!r}",
+            recovery_paths=(journal_path,),
+        )
+    repo_skill = payload.get("repo_skill")
+    if (
+        not _safe_relative_posix(repo_skill)
+        or PurePosixPath(str(repo_skill)).parent.as_posix() != skill_root
+    ):
+        raise ArtifactRecoveryError(
+            f"transaction journal has invalid repo_skill: {repo_skill!r}",
+            recovery_paths=(journal_path,),
+        )
+    skill_parent = PurePosixPath(skill_root).parent
+    skill_name = PurePosixPath(skill_root).name
+    stage_container = _journal_repo_path(
+        repo_root,
+        payload.get("stage_container"),
+        label="stage_container",
+        expected_parent=skill_parent,
+        prefix=f".{skill_name}.artifact-stage-",
+    )
+    backup_container = _journal_repo_path(
+        repo_root,
+        payload.get("backup_container"),
+        label="backup_container",
+        expected_parent=skill_parent,
+        prefix=f".{skill_name}.artifact-backup-",
+    )
+    for container in (stage_container, backup_container):
+        if os.path.lexists(container):
+            _owned_directory_metadata(container)
+    stage_container_identity = _journal_identity(
+        payload.get("stage_container_identity"),
+        label="stage_container_identity",
+        nullable=False,
+    )
+    backup_container_identity = _journal_identity(
+        payload.get("backup_container_identity"),
+        label="backup_container_identity",
+        nullable=False,
+    )
+    for container, expected_identity in (
+        (stage_container, stage_container_identity),
+        (backup_container, backup_container_identity),
+    ):
+        if os.path.lexists(container):
+            metadata = _owned_directory_metadata(container)
+            if (metadata.st_dev, metadata.st_ino) != expected_identity:
+                raise ArtifactRecoveryError(
+                    f"durable transaction container inode changed: {container}",
+                    recovery_paths=(journal_path, container),
+                )
+    baseline = _journal_inventory(
+        payload.get("baseline_inventory"),
+        skill_root=skill_root,
+        label="baseline_inventory",
+    )
+    installed = _journal_inventory(
+        payload.get("new_inventory"),
+        skill_root=skill_root,
+        label="new_inventory",
+    )
+    if str(repo_skill) not in installed:
+        raise ArtifactRecoveryError(
+            "transaction journal new inventory omits repo_skill",
+            recovery_paths=(journal_path,),
+        )
+    baseline_root_identity = _journal_identity(
+        payload.get("baseline_root_identity"),
+        label="baseline_root_identity",
+        nullable=True,
+    )
+    new_root_identity = _journal_identity(
+        payload.get("new_root_identity"),
+        label="new_root_identity",
+        nullable=False,
+    )
+    transaction_id = payload.get("transaction_id")
+    if not isinstance(transaction_id, str) or not re.fullmatch(
+        r"[0-9a-f]{32}",
+        transaction_id,
+    ):
+        raise ArtifactRecoveryError(
+            "journal transaction_id is invalid",
+            recovery_paths=(journal_path,),
+        )
+    authority = payload.get("authority")
+    if authority is not None:
+        if not isinstance(authority, dict):
+            raise ArtifactRecoveryError("journal authority must be null or an object")
+        mapping_path = authority.get("mapping_path")
+        before_hash = authority.get("before_sha256")
+        after_hash = authority.get("after_sha256")
+        if (
+            not _safe_relative_posix(mapping_path)
+            or not isinstance(before_hash, str)
+            or not SHA256_RE.fullmatch(before_hash)
+            or not isinstance(after_hash, str)
+            or not SHA256_RE.fullmatch(after_hash)
+            or before_hash.lower() == after_hash.lower()
+        ):
+            raise ArtifactRecoveryError(
+                "journal authority is malformed",
+                recovery_paths=(journal_path,),
+            )
+        _journal_repo_path(
+            repo_root,
+            mapping_path,
+            label="authority.mapping_path",
+        )
+        authority = {
+            "mapping_path": str(mapping_path),
+            "before_sha256": before_hash.lower(),
+            "after_sha256": after_hash.lower(),
+        }
+    explicit_commit = payload.get("explicit_commit", False)
+    if not isinstance(explicit_commit, bool):
+        raise ArtifactRecoveryError("journal explicit_commit must be boolean")
+    original_existed = payload.get("original_existed")
+    if not isinstance(original_existed, bool):
+        raise ArtifactRecoveryError("journal original_existed must be boolean")
+    return {
+        **dict(payload),
+        "baseline_inventory": baseline,
+        "new_inventory": installed,
+        "stage_container_path": stage_container,
+        "backup_container_path": backup_container,
+        "skill_path": repo_root.joinpath(*PurePosixPath(skill_root).parts),
+        "authority": authority,
+        "explicit_commit": explicit_commit,
+        "original_existed": original_existed,
+        "baseline_root_identity": baseline_root_identity,
+        "new_root_identity": new_root_identity,
+        "stage_container_identity": stage_container_identity,
+        "backup_container_identity": backup_container_identity,
+    }
+
+
+def _tree_inventory_kind(
+    *,
+    repo_root: Path,
+    candidate: Path,
+    skill_root: str,
+    baseline: Mapping[str, str],
+    installed: Mapping[str, str],
+    baseline_identity: tuple[int, int] | None,
+    new_identity: tuple[int, int],
+) -> str:
+    if not os.path.lexists(candidate):
+        return "missing"
+    metadata = _owned_directory_metadata(candidate)
+    identity = (metadata.st_dev, metadata.st_ino)
+    inventory = _inventory(repo_root, candidate, skill_root)
+    if _directory_identity(candidate) != identity:
+        return "other"
+    if inventory == dict(baseline) and identity == baseline_identity:
+        return "baseline"
+    if inventory == dict(installed) and identity == new_identity:
+        return "new"
+    return "other"
+
+
+def _journal_recovery_paths(journal: Mapping[str, Any], journal_path: Path) -> tuple[Path, ...]:
+    return tuple(
+        path
+        for path in (
+            journal_path,
+            journal["skill_path"],
+            journal["stage_container_path"],
+            journal["backup_container_path"],
+        )
+        if os.path.lexists(path)
+    )
+
+
+def _validate_recovery_container(
+    path: Path,
+    *,
+    allowed_names: set[str],
+    journal_path: Path,
+    expected_identity: tuple[int, int],
+) -> None:
+    if not os.path.lexists(path):
+        return
+    _owned_directory_metadata(path)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = -1
+    try:
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != expected_identity:
+            raise ArtifactRecoveryError(
+                f"recovery container inode changed: {path}",
+                recovery_paths=(journal_path, path),
+            )
+        names = {entry.name for entry in os.scandir(descriptor)}
+    except OSError as exc:
+        raise ArtifactRecoveryError(
+            f"cannot inspect recovery container {path}: {exc}",
+            recovery_paths=(journal_path, path),
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    unexpected = names - allowed_names
+    if unexpected:
+        raise ArtifactRecoveryError(
+            f"recovery container has unexpected entries: {path}: "
+            + ", ".join(sorted(unexpected)),
+            recovery_paths=(journal_path, path),
+        )
+
+
+def _recover_pending_transaction(
+    repo_root: Path,
+    skill_root: str,
+    journal_path: Path,
+) -> None:
+    raw = _read_journal(journal_path)
+    if raw is None:
+        return
+    journal = _validate_journal(
+        raw,
+        repo_root=repo_root,
+        skill_root=skill_root,
+        journal_path=journal_path,
+    )
+    skill_path: Path = journal["skill_path"]
+    stage_container: Path = journal["stage_container_path"]
+    backup_container: Path = journal["backup_container_path"]
+    stage_skill = stage_container / "new"
+    backup_skill = backup_container / "previous"
+    baseline = journal["baseline_inventory"]
+    installed = journal["new_inventory"]
+    _validate_recovery_container(
+        stage_container,
+        allowed_names={"new", "recovery-new"},
+        journal_path=journal_path,
+        expected_identity=journal["stage_container_identity"],
+    )
+    _validate_recovery_container(
+        backup_container,
+        allowed_names={"previous"},
+        journal_path=journal_path,
+        expected_identity=journal["backup_container_identity"],
+    )
+
+    canonical_kind = _tree_inventory_kind(
+        repo_root=repo_root,
+        candidate=skill_path,
+        skill_root=skill_root,
+        baseline=baseline,
+        installed=installed,
+        baseline_identity=journal["baseline_root_identity"],
+        new_identity=journal["new_root_identity"],
+    )
+    stage_kind = _tree_inventory_kind(
+        repo_root=repo_root,
+        candidate=stage_skill,
+        skill_root=skill_root,
+        baseline=baseline,
+        installed=installed,
+        baseline_identity=journal["baseline_root_identity"],
+        new_identity=journal["new_root_identity"],
+    )
+    backup_kind = _tree_inventory_kind(
+        repo_root=repo_root,
+        candidate=backup_skill,
+        skill_root=skill_root,
+        baseline=baseline,
+        installed=installed,
+        baseline_identity=journal["baseline_root_identity"],
+        new_identity=journal["new_root_identity"],
+    )
+    if "other" in {canonical_kind, stage_kind, backup_kind}:
+        raise ArtifactRecoveryError(
+            "durable artifact transaction contains unrecognized concurrent data",
+            recovery_paths=_journal_recovery_paths(journal, journal_path),
+        )
+
+    keep_new = bool(journal["explicit_commit"])
+    authority = journal["authority"]
+    if not keep_new and authority is not None:
+        try:
+            current_mapping_hash = _secure_mapping_digest(
+                repo_root,
+                authority["mapping_path"],
+            )
+        except ArtifactRecoveryError as exc:
+            raise ArtifactRecoveryError(
+                f"cannot resolve mapping authority during recovery: {exc}",
+                recovery_paths=_journal_recovery_paths(journal, journal_path),
+            ) from exc
+        if current_mapping_hash == authority["before_sha256"]:
+            keep_new = False
+        elif current_mapping_hash == authority["after_sha256"]:
+            keep_new = True
+        else:
+            raise ArtifactRecoveryError(
+                "mapping authority hash matches neither before nor after state",
+                recovery_paths=_journal_recovery_paths(journal, journal_path),
+            )
+
+    if keep_new:
+        if canonical_kind != "new":
+            raise ArtifactRecoveryError(
+                "mapping committed new authority but canonical new tree is unavailable",
+                recovery_paths=_journal_recovery_paths(journal, journal_path),
+            )
+    elif not journal["original_existed"]:
+        if canonical_kind == "new":
+            quarantine = stage_container / "recovery-new"
+            if os.path.lexists(quarantine):
+                raise ArtifactRecoveryError(
+                    f"recovery quarantine already exists: {quarantine}",
+                    recovery_paths=_journal_recovery_paths(journal, journal_path),
+                )
+            _replace_tree_and_fsync(skill_path, quarantine)
+            canonical_kind = "missing"
+        if canonical_kind != "missing":
+            raise ArtifactRecoveryError(
+                "cannot restore originally absent canonical skill safely",
+                recovery_paths=_journal_recovery_paths(journal, journal_path),
+            )
+    else:
+        if canonical_kind == "baseline":
+            pass
+        elif canonical_kind in {"new", "missing"} and backup_kind == "baseline":
+            if canonical_kind == "new":
+                quarantine = stage_container / "recovery-new"
+                if os.path.lexists(quarantine):
+                    raise ArtifactRecoveryError(
+                        f"recovery quarantine already exists: {quarantine}",
+                        recovery_paths=_journal_recovery_paths(journal, journal_path),
+                    )
+                _replace_tree_and_fsync(skill_path, quarantine)
+            _replace_tree_and_fsync(backup_skill, skill_path)
+            canonical_kind = "baseline"
+        else:
+            raise ArtifactRecoveryError(
+                "cannot restore baseline tree from durable transaction",
+                recovery_paths=_journal_recovery_paths(journal, journal_path),
+            )
+
+    final_kind = _tree_inventory_kind(
+        repo_root=repo_root,
+        candidate=skill_path,
+        skill_root=skill_root,
+        baseline=baseline,
+        installed=installed,
+        baseline_identity=journal["baseline_root_identity"],
+        new_identity=journal["new_root_identity"],
+    )
+    expected_final_kind = (
+        "new"
+        if keep_new
+        else "baseline"
+        if journal["original_existed"]
+        else "missing"
+    )
+    if final_kind != expected_final_kind:
+        raise ArtifactRecoveryError(
+            "canonical tree changed during durable recovery",
+            recovery_paths=_journal_recovery_paths(journal, journal_path),
+        )
+    _validate_recovery_container(
+        stage_container,
+        allowed_names={"new", "recovery-new"},
+        journal_path=journal_path,
+        expected_identity=journal["stage_container_identity"],
+    )
+    _validate_recovery_container(
+        backup_container,
+        allowed_names={"previous"},
+        journal_path=journal_path,
+        expected_identity=journal["backup_container_identity"],
+    )
+    _cleanup_tree(stage_container)
+    _cleanup_tree(backup_container)
+    _fsync_directory(skill_path.parent)
+    _remove_journal(journal_path)
+
+
+class ArtifactTransaction:
+    """A prepared filesystem switch awaiting mapping finalization.
+
+    Use this as a context manager around the caller's atomic mapping write::
+
+        with prepare_artifact_set_sync(plan) as transaction:
+            atomic_write_mapping(transaction.result.metadata_patch())
+            transaction.commit()
+
+    Leaving the context without ``commit()``, including because the mapping
+    writer raised, restores the old canonical directory.
+    """
+
+    def __init__(
+        self,
+        *,
+        plan: SyncPlan,
+        result: SyncResult,
+        skill_path: Path,
+        stage_container: Path | None,
+        backup_container: Path | None,
+        stage_skill: Path | None,
+        backup_skill: Path | None,
+        original_existed: bool,
+        lock: _SkillLock,
+        state: str,
+        journal_path: Path | None = None,
+        journal_payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.plan = plan
+        self.result = result
+        self._skill_path = skill_path
+        self._stage_container = stage_container
+        self._backup_container = backup_container
+        self._stage_skill = stage_skill
+        self._backup_skill = backup_skill
+        self._original_existed = original_existed
+        self._lock = lock
+        self._old_moved = False
+        self._new_installed = False
+        self._recovery_path: Path | None = None
+        self._state = state
+        self._journal_path = journal_path
+        self._journal_payload = (
+            deepcopy(journal_payload)
+            if journal_payload is not None
+            else None
+        )
+        self._authority = (
+            deepcopy(self._journal_payload.get("authority"))
+            if self._journal_payload is not None
+            else None
+        )
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def active(self) -> bool:
+        return self._state in {"preparing", "prepared"}
+
+    @property
+    def recovery_path(self) -> Path | None:
+        """Preserved concurrent content or an unrestored backup, if any."""
+        return self._recovery_path
+
+    @property
+    def lock_path(self) -> Path:
+        return self._lock.path
+
+    @property
+    def journal_path(self) -> Path | None:
+        return self._journal_path
+
+    def _persist_journal(
+        self,
+        *,
+        state: str | None = None,
+        explicit_commit: bool | None = None,
+    ) -> None:
+        if self._journal_path is None or self._journal_payload is None:
+            return
+        if state is not None:
+            if state not in JOURNAL_STATES:
+                raise ArtifactValidationError(
+                    f"invalid journal state transition: {state!r}"
+                )
+            self._journal_payload["state"] = state
+        if explicit_commit is not None:
+            self._journal_payload["explicit_commit"] = explicit_commit
+        _write_journal(self._journal_path, self._journal_payload)
+
+    def bind_authority(
+        self,
+        mapping_path: str | os.PathLike[str],
+        before_sha256: str,
+        after_sha256: str,
+    ) -> None:
+        """Durably bind crash recovery to one atomic mapping replacement.
+
+        Call this after prepare returns and before replacing ``mapping_path``.
+        The current mapping must still match ``before_sha256``.
+        """
+        if self._state != "prepared":
+            raise ArtifactValidationError(
+                f"transaction cannot bind authority from state {self._state!r}"
+            )
+        if (
+            not isinstance(before_sha256, str)
+            or not SHA256_RE.fullmatch(before_sha256)
+            or not isinstance(after_sha256, str)
+            or not SHA256_RE.fullmatch(after_sha256)
+            or before_sha256.lower() == after_sha256.lower()
+        ):
+            raise ArtifactValidationError(
+                "authority hashes must be distinct SHA-256 values"
+            )
+        candidate = Path(mapping_path)
+        if candidate.is_absolute():
+            lexical_root = next(
+                (
+                    ancestor
+                    for ancestor in (candidate, *candidate.parents)
+                    if ancestor.exists()
+                    and ancestor.resolve(strict=True) == self.plan.repo_root
+                ),
+                None,
+            )
+            if lexical_root is None:
+                raise ArtifactValidationError(
+                    f"authority mapping escapes repository root: {candidate}"
+                )
+            try:
+                relative = candidate.relative_to(lexical_root).as_posix()
+            except ValueError as exc:  # pragma: no cover - guarded above
+                raise ArtifactValidationError(
+                    f"authority mapping escapes repository root: {candidate}"
+                ) from exc
+            current = lexical_root
+            for component in PurePosixPath(relative).parts:
+                current = current / component
+                try:
+                    metadata = current.lstat()
+                except OSError as exc:
+                    raise ArtifactValidationError(
+                        f"cannot inspect authority mapping path: {current}"
+                    ) from exc
+                if stat.S_ISLNK(metadata.st_mode):
+                    raise ArtifactRecoveryError(
+                        f"authority mapping traverses an unsafe path: {current}"
+                    )
+        else:
+            relative = candidate.as_posix()
+        if not _safe_relative_posix(relative):
+            raise ArtifactValidationError(
+                f"authority mapping is not canonical relative POSIX: {relative!r}"
+            )
+        current = _secure_mapping_digest(self.plan.repo_root, relative)
+        if current != before_sha256.lower():
+            raise ConcurrentModificationError((relative,))
+        authority = {
+            "mapping_path": relative,
+            "before_sha256": before_sha256.lower(),
+            "after_sha256": after_sha256.lower(),
+        }
+        if self._journal_payload is not None:
+            existing = self._journal_payload.get("authority")
+            if existing is not None and existing != authority:
+                raise ArtifactValidationError(
+                    "transaction authority is already bound differently"
+                )
+            self._journal_payload["authority"] = authority
+            self._persist_journal()
+        self._authority = authority
+
+    def commit(self) -> SyncResult:
+        """Finalize the filesystem side after the mapping write succeeds."""
+        if self._state != "prepared":
+            raise ArtifactValidationError(
+                f"transaction cannot commit from state {self._state!r}"
+            )
+        authority = self._authority
+        if isinstance(authority, dict):
+            current_mapping_hash = _secure_mapping_digest(
+                self.plan.repo_root,
+                authority["mapping_path"],
+            )
+            if current_mapping_hash != authority["after_sha256"]:
+                raise ArtifactRecoveryError(
+                    "cannot commit artifact transaction before its bound "
+                    "mapping reaches the after hash",
+                    recovery_paths=tuple(
+                        path
+                        for path in (
+                            self._journal_path,
+                            self._skill_path,
+                            self._backup_container,
+                        )
+                        if path is not None and os.path.lexists(path)
+                    ),
+                )
+        self._persist_journal(
+            state="committing_new",
+            explicit_commit=authority is None,
+        )
+        self._state = "committing"
+        failure: Exception | None = None
+        try:
+            _cleanup_tree(self._stage_container)
+            self._stage_container = None
+            _cleanup_tree(self._backup_container)
+            self._backup_container = None
+            _fsync_directory(self._skill_path.parent)
+            if self._journal_path is not None:
+                _remove_journal(self._journal_path)
+                self._journal_path = None
+                self._journal_payload = None
+        except Exception as cause:  # noqa: BLE001  # pragma: no cover
+            failure = cause
+        try:
+            self._lock.release()
+        except Exception as cause:  # noqa: BLE001  # pragma: no cover
+            failure = (
+                cause
+                if failure is None
+                else RuntimeError(f"{failure}; lock release failed: {cause}")
+            )
+        if failure is not None:
+            # The caller's mapping and the live directory already describe the
+            # new state.  A partially removed backup is not safe rollback
+            # material, so report cleanup failure without attempting restore.
+            self._state = "commit_cleanup_failed"
+            raise ArtifactApplyError(
+                "failed to finalize artifact-set transaction",
+                rollback_succeeded=False,
+                cause=failure,
+                recovery_path=self._backup_container,
+            ) from failure
+        self._state = "committed"
+        return self.result
+
+    def _tree_is_installed_payload(self, candidate: Path) -> bool:
+        if not self._new_installed or not _path_lexists(candidate):
+            return False
+        try:
+            current = _inventory(
+                self.plan.repo_root,
+                candidate,
+                self.plan.skill_root,
+            )
+        except ArtifactValidationError:
+            return False
+        return current == _expected_installed_inventory(self.plan)
+
+    def _preserve_path(self, source: Path) -> None:
+        if not _path_lexists(source):
+            return
+        if self._backup_container is None:
+            raise RuntimeError(
+                f"cannot preserve concurrent occupant at {source}: "
+                "transaction has no recovery container"
+            )
+        self._recovery_path = self._backup_container
+        for index in range(1, 1000):
+            destination = (
+                self._backup_container / f"concurrent-occupant-{index}"
+            )
+            if _path_lexists(destination):
+                continue
+            _replace_tree_and_fsync(source, destination)
+            return
+        raise RuntimeError(
+            f"cannot allocate recovery name under {self._backup_container}"
+        )
+
+    def _preserve_concurrent_occupant(self) -> None:
+        self._preserve_path(self._skill_path)
+
+    def _quarantine_live_tree_for_rollback(self) -> None:
+        if not _path_lexists(self._skill_path):
+            return
+        if self._stage_container is None:
+            raise RuntimeError(
+                f"cannot isolate rollback candidate at {self._skill_path}: "
+                "transaction has no staging container"
+            )
+        for index in range(1, 1000):
+            candidate = (
+                self._stage_container / f"live-rollback-candidate-{index}"
+            )
+            if _path_lexists(candidate):
+                continue
+            # Move first, inspect second.  No unrelated process can replace the
+            # captured inode between classification and cleanup.
+            _replace_tree_and_fsync(self._skill_path, candidate)
+            if self._tree_is_installed_payload(candidate):
+                self._new_installed = False
+            else:
+                self._new_installed = False
+                self._preserve_path(candidate)
+            return
+        raise RuntimeError(
+            f"cannot allocate rollback quarantine under {self._stage_container}"
+        )
+
+    def _restore_old_tree(self) -> None:
+        if not self._old_moved:
+            return
+        if self._backup_skill is None or not _path_lexists(self._backup_skill):
+            raise RuntimeError(
+                f"canonical backup is missing: {self._backup_skill}"
+            )
+        # A conforming transaction cannot enter while our lock is held, but an
+        # unrelated process may still create the canonical path.  Preserve such
+        # occupants, then retry the atomic restore a bounded number of times.
+        last_error: OSError | None = None
+        for _attempt in range(8):
+            if _path_lexists(self._skill_path):
+                self._preserve_concurrent_occupant()
+            try:
+                _replace_tree_and_fsync(self._backup_skill, self._skill_path)
+                self._old_moved = False
+                return
+            except OSError as exc:
+                last_error = exc
+                if not _path_lexists(self._skill_path):
+                    break
+        raise RuntimeError(
+            f"failed to restore canonical backup {self._backup_skill} "
+            f"to {self._skill_path}: {last_error}"
+        ) from last_error
+
+    def rollback(self) -> None:
+        """Restore the pre-transaction canonical directory and clean temps."""
+        if self._state == "rolled_back":
+            return
+        if self._state == "committed":
+            raise ArtifactValidationError("committed transaction cannot roll back")
+        if self._state not in {"preparing", "prepared"}:
+            raise ArtifactValidationError(
+                f"transaction cannot roll back from state {self._state!r}"
+            )
+        if isinstance(self._authority, dict):
+            try:
+                mapping_hash = _secure_mapping_digest(
+                    self.plan.repo_root,
+                    self._authority["mapping_path"],
+                )
+            except ArtifactRecoveryError as exc:
+                self._state = "recovery_required"
+                self._lock.release()
+                raise ArtifactRecoveryError(
+                    f"cannot resolve bound authority while rolling back: {exc}",
+                    recovery_paths=tuple(
+                        path
+                        for path in (
+                            self._journal_path,
+                            self._skill_path,
+                            self._backup_container,
+                        )
+                        if path is not None and os.path.lexists(path)
+                    ),
+                ) from exc
+            if mapping_hash == self._authority["after_sha256"]:
+                self.commit()
+                return
+            if mapping_hash != self._authority["before_sha256"]:
+                self._state = "recovery_required"
+                self._lock.release()
+                raise ArtifactRecoveryError(
+                    "bound mapping matches neither before nor after hash "
+                    "during rollback",
+                    recovery_paths=tuple(
+                        path
+                        for path in (
+                            self._journal_path,
+                            self._skill_path,
+                            self._backup_container,
+                        )
+                        if path is not None and os.path.lexists(path)
+                    ),
+                )
+        rollback_errors: list[Exception] = []
+        try:
+            self._persist_journal(state="rolling_back", explicit_commit=False)
+        except Exception as journal_error:  # noqa: BLE001
+            rollback_errors.append(journal_error)
+        try:
+            if self._old_moved or self._new_installed:
+                if _path_lexists(self._skill_path):
+                    self._quarantine_live_tree_for_rollback()
+                if self._old_moved:
+                    self._restore_old_tree()
+        except Exception as rollback_error:  # noqa: BLE001  # pragma: no cover
+            rollback_errors.append(rollback_error)
+        finally:
+            try:
+                _cleanup_tree(self._stage_container)
+            except Exception as cleanup_error:  # noqa: BLE001  # pragma: no cover
+                rollback_errors.append(cleanup_error)
+            self._stage_container = None
+            # Never remove a container that may hold the only old canonical
+            # tree or a concurrent occupant.  A surfaced recovery_path is an
+            # intentional durable quarantine, not disposable staging.
+            if not self._old_moved and self._recovery_path is None:
+                try:
+                    _cleanup_tree(self._backup_container)
+                    self._backup_container = None
+                except Exception as cleanup_error:  # noqa: BLE001  # pragma: no cover
+                    rollback_errors.append(cleanup_error)
+            elif self._backup_container is not None:
+                self._recovery_path = self._backup_container
+            if not rollback_errors and not self._old_moved:
+                try:
+                    _fsync_directory(self._skill_path.parent)
+                    if self._journal_path is not None:
+                        _remove_journal(self._journal_path)
+                        self._journal_path = None
+                        self._journal_payload = None
+                except Exception as journal_error:  # noqa: BLE001
+                    rollback_errors.append(journal_error)
+            try:
+                self._lock.release()
+            except Exception as lock_error:  # noqa: BLE001  # pragma: no cover
+                rollback_errors.append(lock_error)
+
+        if rollback_errors:
+            self._state = "rollback_failed"
+            cause = RuntimeError(
+                "; ".join(str(error) for error in rollback_errors)
+            )
+            raise ArtifactApplyError(
+                "failed to roll back artifact-set transaction",
+                rollback_succeeded=False,
+                cause=cause,
+                recovery_path=self._recovery_path,
+            ) from cause
+        self._state = "rolled_back"
+
+    def __enter__(self) -> Self:
+        if self._state != "prepared":
+            raise ArtifactValidationError(
+                f"transaction cannot enter from state {self._state!r}"
+            )
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self._state == "prepared":
+            self.rollback()
+        return False
+
+
+def _validate_plan_for_apply(plan: SyncPlan) -> None:
+    if not isinstance(plan, SyncPlan):
+        raise ArtifactValidationError("plan must be a SyncPlan")
+    if plan.blocked:
+        raise OwnershipConflictError(
+            user_modified=plan.user_modified,
+            unowned_conflicts=plan.unowned_conflicts,
+        )
+    current = _current_inventory(plan)
+    changed_since_plan = _changed_inventory_paths(plan.baseline_inventory, current)
+    skill_path = plan.repo_root.joinpath(*PurePosixPath(plan.skill_root).parts)
+    if _directory_identity(skill_path) != plan.baseline_root_identity:
+        changed_since_plan = tuple(
+            sorted(set(changed_since_plan) | {f"{plan.skill_root}/<root-inode>"})
+        )
+    if changed_since_plan:
+        raise ConcurrentModificationError(changed_since_plan)
+
+
+def prepare_artifact_set_sync(
+    plan: SyncPlan,
+    *,
+    fault_injector: FaultInjector | None = None,
+    lock_timeout: float = 0.0,
+) -> ArtifactTransaction:
+    """Install the new tree while retaining rollback state for mapping commit.
+
+    Fault-injection events are ``after_stage_built``, ``after_backup_rename``,
+    ``after_install_rename``, and ``after_live_validation``.
+    """
+    if not isinstance(plan, SyncPlan):
+        raise ArtifactValidationError("plan must be a SyncPlan")
+    lock = _SkillLock(skill_lock_path(plan.repo_root, plan.skill_root))
+    lock.acquire(lock_timeout)
+    stage_container: Path | None = None
+    backup_container: Path | None = None
+    stage_skill: Path | None = None
+    backup_skill: Path | None = None
+    transaction: ArtifactTransaction | None = None
+
+    try:
+        _recover_pending_transaction(
+            plan.repo_root,
+            plan.skill_root,
+            lock.path.with_suffix(".journal.json"),
+        )
+        _validate_plan_for_apply(plan)
+        skill_path = plan.repo_root.joinpath(
+            *PurePosixPath(plan.skill_root).parts
+        )
+        if not plan.has_filesystem_changes:
+            return ArtifactTransaction(
+                plan=plan,
+                result=_result_from_plan(plan, applied=False, dry_run=False),
+                skill_path=skill_path,
+                stage_container=None,
+                backup_container=None,
+                stage_skill=None,
+                backup_skill=None,
+                original_existed=skill_path.exists(),
+                lock=lock,
+                state="prepared",
+            )
+
+        skill_parent = skill_path.parent
+        _assert_no_symlink_ancestors(plan.repo_root, skill_parent)
+        skill_parent.mkdir(parents=True, exist_ok=True)
+        stage_container = Path(
+            tempfile.mkdtemp(
+                prefix=f".{skill_path.name}.artifact-stage-",
+                dir=skill_parent,
+            )
+        )
+        backup_container = Path(
+            tempfile.mkdtemp(
+                prefix=f".{skill_path.name}.artifact-backup-",
+                dir=skill_parent,
+            )
+        )
+        stage_skill = stage_container / "new"
+        backup_skill = backup_container / "previous"
+        original_existed = _path_lexists(skill_path)
+        stage_container_metadata = stage_container.lstat()
+        backup_container_metadata = backup_container.lstat()
+        journal_path = lock.path.with_suffix(".journal.json")
+        journal_payload = {
+            "version": JOURNAL_VERSION,
+            "transaction_id": uuid.uuid4().hex,
+            "repo_root": str(plan.repo_root),
+            "skill_root": plan.skill_root,
+            "repo_skill": plan.repo_skill,
+            "stage_container": _relative_to_repo(
+                plan.repo_root,
+                stage_container,
+            ),
+            "backup_container": _relative_to_repo(
+                plan.repo_root,
+                backup_container,
+            ),
+            "baseline_inventory": dict(plan.baseline_inventory),
+            "new_inventory": _expected_installed_inventory(plan),
+            "baseline_root_identity": (
+                list(plan.baseline_root_identity)
+                if plan.baseline_root_identity is not None
+                else None
+            ),
+            "new_root_identity": None,
+            "stage_container_identity": list(
+                (stage_container_metadata.st_dev, stage_container_metadata.st_ino)
+            ),
+            "backup_container_identity": list(
+                (backup_container_metadata.st_dev, backup_container_metadata.st_ino)
+            ),
+            "original_existed": original_existed,
+            "state": "staged",
+            "authority": None,
+            "explicit_commit": False,
+        }
+        transaction = ArtifactTransaction(
+            plan=plan,
+            result=_result_from_plan(plan, applied=True, dry_run=False),
+            skill_path=skill_path,
+            stage_container=stage_container,
+            backup_container=backup_container,
+            stage_skill=stage_skill,
+            backup_skill=backup_skill,
+            original_existed=original_existed,
+            lock=lock,
+            state="preparing",
+            journal_path=journal_path,
+            journal_payload=journal_payload,
+        )
+        _build_stage(plan, stage_skill)
+        new_root_identity = _directory_identity(stage_skill)
+        if new_root_identity is None:
+            raise ArtifactValidationError("staged skill root disappeared")
+        transaction._journal_payload["new_root_identity"] = list(
+            new_root_identity
+        )
+        _fsync_tree(stage_skill)
+        _fsync_directory(stage_container)
+        _fsync_directory(backup_container)
+        _fsync_directory(skill_parent)
+        transaction._persist_journal(state="staged", explicit_commit=False)
+        _invoke_fault(fault_injector, "after_stage_built")
+
+        # Recheck the entire directory immediately before the first rename.
+        pre_rename_identity = _directory_identity(skill_path)
+        current = _current_inventory(plan)
+        changed_since_plan = _changed_inventory_paths(
+            plan.baseline_inventory, current
+        )
+        if pre_rename_identity != plan.baseline_root_identity:
+            changed_since_plan = tuple(
+                sorted(
+                    set(changed_since_plan)
+                    | {f"{plan.skill_root}/<root-inode>"}
+                )
+            )
+        if changed_since_plan:
+            raise ConcurrentModificationError(changed_since_plan)
+
+        if transaction._original_existed:
+            _replace_tree_and_fsync(skill_path, backup_skill)
+            transaction._old_moved = True
+            transaction._persist_journal(state="old_moved")
+            moved_identity = _directory_identity(backup_skill)
+            moved_inventory = _inventory(
+                plan.repo_root,
+                backup_skill,
+                plan.skill_root,
+            )
+            moved_changes = _changed_inventory_paths(
+                plan.baseline_inventory,
+                moved_inventory,
+            )
+            if moved_identity != pre_rename_identity:
+                moved_changes = tuple(
+                    sorted(
+                        set(moved_changes)
+                        | {f"{plan.skill_root}/<root-inode>"}
+                    )
+                )
+            if moved_changes:
+                raise ConcurrentModificationError(moved_changes)
+        _invoke_fault(fault_injector, "after_backup_rename")
+
+        _replace_tree_and_fsync(stage_skill, skill_path)
+        transaction._new_installed = True
+        transaction._persist_journal(state="new_installed")
+        _invoke_fault(fault_injector, "after_install_rename")
+
+        _validate_staged_tree(plan, skill_path)
+        _invoke_fault(fault_injector, "after_live_validation")
+        transaction._persist_journal(state="prepared")
+        transaction._state = "prepared"
+        return transaction
+    except Exception as cause:
+        try:
+            if transaction is not None:
+                transaction.rollback()
+            else:
+                cleanup_errors: list[Exception] = []
+                try:
+                    _cleanup_tree(stage_container)
+                    _cleanup_tree(backup_container)
+                except Exception as cleanup_error:  # noqa: BLE001
+                    cleanup_errors.append(cleanup_error)
+                try:
+                    lock.release()
+                except Exception as lock_error:  # noqa: BLE001
+                    cleanup_errors.append(lock_error)
+                if cleanup_errors:
+                    raise ArtifactApplyError(
+                        "failed to clean an unprepared artifact transaction",
+                        rollback_succeeded=False,
+                        cause=RuntimeError(
+                            "; ".join(str(error) for error in cleanup_errors)
+                        ),
+                        recovery_path=backup_container,
+                    )
+        except ArtifactApplyError as rollback_error:
+            raise ArtifactApplyError(
+                "artifact-set transaction failed",
+                rollback_succeeded=False,
+                cause=RuntimeError(f"{cause}; {rollback_error}"),
+                recovery_path=rollback_error.recovery_path,
+            ) from cause
+
+        if isinstance(
+            cause,
+            (
+                ArtifactValidationError,
+                ArtifactRecoveryError,
+                ConcurrentModificationError,
+                OwnershipConflictError,
+            ),
+        ):
+            raise
+        raise ArtifactApplyError(
+            "artifact-set transaction failed",
+            rollback_succeeded=True,
+            cause=cause,
+            recovery_path=(
+                transaction.recovery_path
+                if transaction is not None
+                else None
+            ),
+        ) from cause
+
+
+def apply_artifact_set_sync(
+    plan: SyncPlan,
+    *,
+    dry_run: bool = False,
+    fault_injector: FaultInjector | None = None,
+    lock_timeout: float = 0.0,
+) -> SyncResult:
+    """Apply and immediately finalize a plan.
+
+    Callers that also update provenance should instead use
+    :func:`prepare_artifact_set_sync` so a mapping-write failure can roll back
+    the canonical directory.
+    """
+    if dry_run:
+        _validate_plan_for_apply(plan)
+        return _result_from_plan(plan, applied=False, dry_run=True)
+    transaction = prepare_artifact_set_sync(
+        plan,
+        fault_injector=fault_injector,
+        lock_timeout=lock_timeout,
+    )
+    return transaction.commit()
+
+
+def sync_artifact_set(
+    repo_root: str | os.PathLike[str],
+    entry: Mapping[str, Any],
+    upstream_artifacts: Iterable[ArtifactPayload | Mapping[str, Any]],
+    checkpoint: Mapping[str, Any],
+    *,
+    dry_run: bool = False,
+    fault_injector: FaultInjector | None = None,
+    lock_timeout: float = 0.0,
+    origin_index: int | None = None,
+    owned_targets: Iterable[str] | None = None,
+    protected_targets: Iterable[str] = (),
+) -> SyncResult:
+    """Plan and apply one complete artifact set."""
+    plan = plan_artifact_set_sync(
+        repo_root,
+        entry,
+        upstream_artifacts,
+        checkpoint,
+        origin_index=origin_index,
+        owned_targets=owned_targets,
+        protected_targets=protected_targets,
+    )
+    return apply_artifact_set_sync(
+        plan,
+        dry_run=dry_run,
+        fault_injector=fault_injector,
+        lock_timeout=lock_timeout,
+    )
+
+
+__all__ = [
+    "ArtifactApplyError",
+    "ArtifactLockError",
+    "ArtifactPayload",
+    "ArtifactRecoveryError",
+    "ArtifactSetSyncError",
+    "ArtifactTransaction",
+    "ArtifactValidationError",
+    "ConcurrentModificationError",
+    "Drift",
+    "OwnershipConflictError",
+    "SyncPlan",
+    "SyncResult",
+    "apply_artifact_set_sync",
+    "plan_artifact_set_sync",
+    "prepare_artifact_set_sync",
+    "skill_advisory_lock",
+    "skill_lock_identity",
+    "skill_lock_path",
+    "skill_transaction_journal_path",
+    "sync_artifact_set",
+]

--- a/scripts/artifact_set_sync.py
+++ b/scripts/artifact_set_sync.py
@@ -45,6 +45,7 @@ except ImportError:  # pragma: no cover - Windows is not used by repository CI.
     fcntl = None  # type: ignore[assignment]
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+GIT_FILE_MODES = frozenset({"100644", "100755"})
 
 
 class ArtifactSetSyncError(RuntimeError):
@@ -154,6 +155,7 @@ class ArtifactPayload:
     target: str
     type: str
     data: bytes
+    mode: str
 
 
 @dataclass(frozen=True)
@@ -164,14 +166,20 @@ class Drift:
     kind: str
     expected_sha256: str | None
     actual_sha256: str | None
+    expected_mode: str | None = None
+    actual_mode: str | None = None
 
     def to_dict(self) -> dict[str, str | None]:
-        return {
+        result: dict[str, str | None] = {
             "path": self.path,
             "kind": self.kind,
             "expected_sha256": self.expected_sha256,
             "actual_sha256": self.actual_sha256,
         }
+        if self.expected_mode is not None or self.actual_mode is not None:
+            result["expected_mode"] = self.expected_mode
+            result["actual_mode"] = self.actual_mode
+        return result
 
 
 @dataclass(frozen=True)
@@ -196,6 +204,7 @@ class SyncPlan:
     owned_targets: tuple[str, ...]
     protected_targets: tuple[str, ...]
     baseline_inventory: Mapping[str, str]
+    baseline_modes: Mapping[str, str]
     baseline_root_identity: tuple[int, int] | None
 
     @property
@@ -445,14 +454,6 @@ def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _safe_relative_posix(value: object) -> bool:
     if (
         not isinstance(value, str)
@@ -500,6 +501,7 @@ def _coerce_payload(value: ArtifactPayload | Mapping[str, Any]) -> ArtifactPaylo
             target=value.get("target"),  # type: ignore[arg-type]
             type=value.get("type", "file"),  # type: ignore[arg-type]
             data=bytes(data),
+            mode=value.get("mode"),  # type: ignore[arg-type]
         )
     else:
         raise ArtifactValidationError(
@@ -523,9 +525,17 @@ def _coerce_payload(value: ArtifactPayload | Mapping[str, Any]) -> ArtifactPaylo
         raise ArtifactValidationError(
             f"unsupported artifact type {payload.type!r}{detail}"
         )
+    if payload.mode not in GIT_FILE_MODES:
+        raise ArtifactValidationError(
+            f"artifact mode must be 100644 or 100755: {payload.mode!r}"
+        )
     if not isinstance(payload.data, bytes):
         payload = ArtifactPayload(
-            payload.source, payload.target, payload.type, bytes(payload.data)
+            payload.source,
+            payload.target,
+            payload.type,
+            bytes(payload.data),
+            payload.mode,
         )
     return payload
 
@@ -551,13 +561,83 @@ def _assert_no_symlink_ancestors(repo_root: Path, path: Path) -> None:
             )
 
 
-def _inventory(repo_root: Path, skill_path: Path, skill_root: str) -> dict[str, str]:
+def _git_mode(metadata: os.stat_result) -> str:
+    return "100755" if stat.S_IMODE(metadata.st_mode) & 0o111 else "100644"
+
+
+def _file_digest_and_mode(path: Path) -> tuple[str, str]:
+    """Read content and executable mode from one pinned regular-file inode."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ArtifactValidationError(
+            f"cannot open canonical artifact safely: {path}"
+        ) from exc
+    try:
+        opened = os.fstat(descriptor)
+        try:
+            named_before = path.lstat()
+        except OSError as exc:
+            raise ArtifactValidationError(
+                f"canonical artifact changed while opening: {path}"
+            ) from exc
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or stat.S_ISLNK(named_before.st_mode)
+            or not stat.S_ISREG(named_before.st_mode)
+            or (opened.st_dev, opened.st_ino)
+            != (named_before.st_dev, named_before.st_ino)
+        ):
+            raise ArtifactValidationError(
+                f"canonical artifact is not a pinned regular file: {path}"
+            )
+
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: os.read(descriptor, 1024 * 1024), b""):
+            digest.update(chunk)
+
+        after = os.fstat(descriptor)
+        try:
+            named_after = path.lstat()
+        except OSError as exc:
+            raise ArtifactValidationError(
+                f"canonical artifact changed while reading: {path}"
+            ) from exc
+        stable_fields = (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        if any(
+            getattr(opened, field) != getattr(after, field)
+            for field in stable_fields
+        ) or any(
+            getattr(after, field) != getattr(named_after, field)
+            for field in stable_fields
+        ):
+            raise ArtifactValidationError(
+                f"canonical artifact changed while reading: {path}"
+            )
+        return digest.hexdigest(), _git_mode(after)
+    finally:
+        os.close(descriptor)
+
+
+def _inventory_with_modes(
+    repo_root: Path,
+    skill_path: Path,
+    skill_root: str,
+) -> tuple[dict[str, str], dict[str, str]]:
     if not skill_path.exists():
-        return {}
+        return {}, {}
     try:
         root_mode = skill_path.lstat().st_mode
     except FileNotFoundError:
-        return {}
+        return {}, {}
     if stat.S_ISLNK(root_mode):
         raise ArtifactValidationError(f"skill root is a symlink: {skill_path}")
     if not stat.S_ISDIR(root_mode):
@@ -566,6 +646,7 @@ def _inventory(repo_root: Path, skill_path: Path, skill_root: str) -> dict[str, 
         )
 
     inventory: dict[str, str] = {}
+    modes: dict[str, str] = {}
     for current, dirs, files in os.walk(skill_path, followlinks=False):
         current_path = Path(current)
         for name in tuple(dirs):
@@ -592,8 +673,28 @@ def _inventory(repo_root: Path, skill_path: Path, skill_root: str) -> dict[str, 
                 )
             suffix = candidate.relative_to(skill_path).as_posix()
             target = f"{skill_root}/{suffix}"
-            inventory[target] = _sha256_file(candidate)
-    return dict(sorted(inventory.items()))
+            digest, git_mode = _file_digest_and_mode(candidate)
+            inventory[target] = digest
+            modes[target] = git_mode
+    return dict(sorted(inventory.items())), dict(sorted(modes.items()))
+
+
+def _inventory(repo_root: Path, skill_path: Path, skill_root: str) -> dict[str, str]:
+    return _inventory_with_modes(repo_root, skill_path, skill_root)[0]
+
+
+def _state_inventory(
+    inventory: Mapping[str, str],
+    modes: Mapping[str, str],
+) -> dict[str, str]:
+    if set(inventory) != set(modes):
+        raise ArtifactValidationError("artifact inventory modes are incomplete")
+    return {
+        path: hashlib.sha256(
+            f"{modes[path]}\0{inventory[path]}".encode("ascii")
+        ).hexdigest()
+        for path in sorted(inventory)
+    }
 
 
 def _directory_identity(path: Path) -> tuple[int, int] | None:
@@ -627,6 +728,7 @@ def _validate_managed_manifest(
         path = item.get("path")
         digest = item.get("sha256")
         declared_owner = item.get("owner")
+        mode = item.get("mode")
         if not _safe_relative_posix(path) or not _inside(str(path), skill_root):
             raise ArtifactValidationError(
                 f"managed_files[{index}].path is outside the skill root: {path!r}"
@@ -640,6 +742,10 @@ def _validate_managed_manifest(
                 f"managed_files[{index}] owner {declared_owner!r} "
                 f"does not match entry owner {owner!r}"
             )
+        if mode not in GIT_FILE_MODES:
+            raise ArtifactValidationError(
+                f"managed_files[{index}].mode must be 100644 or 100755"
+            )
         if path in managed:
             raise ArtifactValidationError(f"duplicate managed path: {path}")
         managed[str(path)] = MappingProxyType(
@@ -647,6 +753,7 @@ def _validate_managed_manifest(
                 "path": str(path),
                 "sha256": digest.lower(),
                 "owner": owner,
+                "mode": str(mode),
             }
         )
     return managed
@@ -979,6 +1086,9 @@ def plan_artifact_set_sync(
     old_managed = {
         path: record["sha256"] for path, record in old_managed_records.items()
     }
+    old_managed_modes = {
+        path: record["mode"] for path, record in old_managed_records.items()
+    }
 
     skill_path = root.joinpath(*PurePosixPath(skill_root).parts)
     _assert_no_symlink_ancestors(root, skill_path)
@@ -986,7 +1096,9 @@ def plan_artifact_set_sync(
         _assert_no_symlink_ancestors(
             root, root.joinpath(*PurePosixPath(payload.target).parts)
         )
-    baseline = _inventory(root, skill_path, skill_root)
+    baseline, baseline_modes = _inventory_with_modes(
+        root, skill_path, skill_root
+    )
     baseline_root_identity = _directory_identity(skill_path)
 
     drift: list[Drift] = []
@@ -998,7 +1110,9 @@ def plan_artifact_set_sync(
     for target, payload in target_by_path.items():
         new_digest = _sha256_bytes(payload.data)
         current_digest = baseline.get(target)
+        current_mode = baseline_modes.get(target)
         expected_digest = old_managed.get(target)
+        expected_mode = old_managed_modes.get(target)
         if target in protected:
             unowned_conflicts.add(target)
             continue
@@ -1018,7 +1132,22 @@ def plan_artifact_set_sync(
             )
             if current_digest != new_digest:
                 user_modified.add(target)
-        if current_digest != new_digest:
+        if current_mode != expected_mode:
+            drift.append(
+                Drift(
+                    target,
+                    "mode_mismatch",
+                    expected_digest,
+                    current_digest,
+                    expected_mode,
+                    current_mode,
+                )
+            )
+            # For a retained target, executable mode is managed metadata and
+            # the reviewed payload explicitly declares its desired value.
+            # Content drift remains ownership-protected above; mode-only drift
+            # may therefore be repaired without treating bytes as modified.
+        if current_digest != new_digest or current_mode != payload.mode:
             changed.add(target)
 
     for path in selected_owned:
@@ -1026,11 +1155,24 @@ def plan_artifact_set_sync(
             continue
         expected_digest = old_managed[path]
         current_digest = baseline.get(path)
+        expected_mode = old_managed_modes[path]
+        current_mode = baseline_modes.get(path)
         if current_digest is None:
             drift.append(Drift(path, "missing", expected_digest, None))
-        elif current_digest != expected_digest:
+        elif current_digest != expected_digest or current_mode != expected_mode:
             drift.append(
-                Drift(path, "hash_mismatch", expected_digest, current_digest)
+                Drift(
+                    path,
+                    (
+                        "hash_mismatch"
+                        if current_digest != expected_digest
+                        else "mode_mismatch"
+                    ),
+                    expected_digest,
+                    current_digest,
+                    expected_mode,
+                    current_mode,
+                )
             )
             user_modified.add(path)
         else:
@@ -1060,6 +1202,7 @@ def plan_artifact_set_sync(
                 "path": payload.target,
                 "sha256": _sha256_bytes(payload.data),
                 "owner": owner,
+                "mode": payload.mode,
             }
         )
     managed_files: tuple[Mapping[str, str], ...] = tuple(
@@ -1092,6 +1235,7 @@ def plan_artifact_set_sync(
         owned_targets=tuple(sorted(selected_owned)),
         protected_targets=tuple(sorted(protected)),
         baseline_inventory=MappingProxyType(baseline),
+        baseline_modes=MappingProxyType(baseline_modes),
         baseline_root_identity=baseline_root_identity,
     )
 
@@ -1129,15 +1273,18 @@ def _remove_empty_parents(path: Path, boundary: Path) -> None:
 
 
 def _validate_staged_tree(plan: SyncPlan, stage_skill: Path) -> None:
-    inventory = _inventory(plan.repo_root, stage_skill, plan.skill_root)
+    inventory, modes = _inventory_with_modes(
+        plan.repo_root, stage_skill, plan.skill_root
+    )
     desired = {
         payload.target: _sha256_bytes(payload.data)
         for payload in plan.payloads
     }
     for path, digest in desired.items():
-        if inventory.get(path) != digest:
+        payload = next(item for item in plan.payloads if item.target == path)
+        if inventory.get(path) != digest or modes.get(path) != payload.mode:
             raise ArtifactValidationError(
-                f"staged artifact digest mismatch: {path}"
+                f"staged artifact digest or mode mismatch: {path}"
             )
     for path in plan.pruned:
         if path in inventory:
@@ -1145,7 +1292,10 @@ def _validate_staged_tree(plan: SyncPlan, stage_skill: Path) -> None:
                 f"pruned artifact remains in staged tree: {path}"
             )
     for path in plan.preserved:
-        if inventory.get(path) != plan.baseline_inventory.get(path):
+        if (
+            inventory.get(path) != plan.baseline_inventory.get(path)
+            or modes.get(path) != plan.baseline_modes.get(path)
+        ):
             raise ArtifactValidationError(
                 f"preserved artifact changed in staged tree: {path}"
             )
@@ -1191,6 +1341,10 @@ def _build_stage(plan: SyncPlan, stage_skill: Path) -> None:
         with candidate.open("wb") as handle:
             handle.write(payload.data)
             handle.flush()
+            os.fchmod(
+                handle.fileno(),
+                0o755 if payload.mode == "100755" else 0o644,
+            )
             os.fsync(handle.fileno())
 
     _validate_staged_tree(plan, stage_skill)
@@ -1208,10 +1362,14 @@ def _cleanup_tree(path: Path | None) -> None:
         return
 
 
-def _current_inventory(plan: SyncPlan) -> dict[str, str]:
+def _current_inventory_with_modes(
+    plan: SyncPlan,
+) -> tuple[dict[str, str], dict[str, str]]:
     skill_path = plan.repo_root.joinpath(*PurePosixPath(plan.skill_root).parts)
     _assert_no_symlink_ancestors(plan.repo_root, skill_path)
-    return _inventory(plan.repo_root, skill_path, plan.skill_root)
+    return _inventory_with_modes(
+        plan.repo_root, skill_path, plan.skill_root
+    )
 
 
 def _path_lexists(path: Path) -> bool:
@@ -1227,7 +1385,26 @@ def _expected_installed_inventory(plan: SyncPlan) -> dict[str, str]:
     return dict(sorted(expected.items()))
 
 
-JOURNAL_VERSION = 1
+def _expected_installed_modes(plan: SyncPlan) -> dict[str, str]:
+    expected = dict(plan.baseline_modes)
+    for path in plan.pruned:
+        expected.pop(path, None)
+    for payload in plan.payloads:
+        expected[payload.target] = payload.mode
+    return dict(sorted(expected.items()))
+
+
+def _expected_installed_state_inventory(plan: SyncPlan) -> dict[str, str]:
+    return _state_inventory(
+        _expected_installed_inventory(plan),
+        _expected_installed_modes(plan),
+    )
+
+
+# Version 2 binds both bytes and executable mode into journal inventories.
+# Older byte-only journals are intentionally rejected for manual recovery:
+# treating them as authoritative could erase an unreviewed mode change.
+JOURNAL_VERSION = 2
 JOURNAL_STATES = {
     "staged",
     "old_moved",
@@ -1809,12 +1986,15 @@ def _tree_inventory_kind(
         return "missing"
     metadata = _owned_directory_metadata(candidate)
     identity = (metadata.st_dev, metadata.st_ino)
-    inventory = _inventory(repo_root, candidate, skill_root)
+    inventory, modes = _inventory_with_modes(
+        repo_root, candidate, skill_root
+    )
+    state_inventory = _state_inventory(inventory, modes)
     if _directory_identity(candidate) != identity:
         return "other"
-    if inventory == dict(baseline) and identity == baseline_identity:
+    if state_inventory == dict(baseline) and identity == baseline_identity:
         return "baseline"
-    if inventory == dict(installed) and identity == new_identity:
+    if state_inventory == dict(installed) and identity == new_identity:
         return "new"
     return "other"
 
@@ -2290,14 +2470,17 @@ class ArtifactTransaction:
         if not self._new_installed or not _path_lexists(candidate):
             return False
         try:
-            current = _inventory(
+            current, modes = _inventory_with_modes(
                 self.plan.repo_root,
                 candidate,
                 self.plan.skill_root,
             )
         except ArtifactValidationError:
             return False
-        return current == _expected_installed_inventory(self.plan)
+        return _state_inventory(
+            current,
+            modes,
+        ) == _expected_installed_state_inventory(self.plan)
 
     def _preserve_path(self, source: Path) -> None:
         if not _path_lexists(source):
@@ -2505,8 +2688,19 @@ def _validate_plan_for_apply(plan: SyncPlan) -> None:
             user_modified=plan.user_modified,
             unowned_conflicts=plan.unowned_conflicts,
         )
-    current = _current_inventory(plan)
+    current, current_modes = _current_inventory_with_modes(plan)
     changed_since_plan = _changed_inventory_paths(plan.baseline_inventory, current)
+    changed_since_plan = tuple(
+        sorted(
+            set(changed_since_plan)
+            | set(
+                _changed_inventory_paths(
+                    plan.baseline_modes,
+                    current_modes,
+                )
+            )
+        )
+    )
     skill_path = plan.repo_root.joinpath(*PurePosixPath(plan.skill_root).parts)
     if _directory_identity(skill_path) != plan.baseline_root_identity:
         changed_since_plan = tuple(
@@ -2596,8 +2790,11 @@ def prepare_artifact_set_sync(
                 plan.repo_root,
                 backup_container,
             ),
-            "baseline_inventory": dict(plan.baseline_inventory),
-            "new_inventory": _expected_installed_inventory(plan),
+            "baseline_inventory": _state_inventory(
+                plan.baseline_inventory,
+                plan.baseline_modes,
+            ),
+            "new_inventory": _expected_installed_state_inventory(plan),
             "baseline_root_identity": (
                 list(plan.baseline_root_identity)
                 if plan.baseline_root_identity is not None
@@ -2645,9 +2842,20 @@ def prepare_artifact_set_sync(
 
         # Recheck the entire directory immediately before the first rename.
         pre_rename_identity = _directory_identity(skill_path)
-        current = _current_inventory(plan)
+        current, current_modes = _current_inventory_with_modes(plan)
         changed_since_plan = _changed_inventory_paths(
             plan.baseline_inventory, current
+        )
+        changed_since_plan = tuple(
+            sorted(
+                set(changed_since_plan)
+                | set(
+                    _changed_inventory_paths(
+                        plan.baseline_modes,
+                        current_modes,
+                    )
+                )
+            )
         )
         if pre_rename_identity != plan.baseline_root_identity:
             changed_since_plan = tuple(
@@ -2664,7 +2872,7 @@ def prepare_artifact_set_sync(
             transaction._old_moved = True
             transaction._persist_journal(state="old_moved")
             moved_identity = _directory_identity(backup_skill)
-            moved_inventory = _inventory(
+            moved_inventory, moved_modes = _inventory_with_modes(
                 plan.repo_root,
                 backup_skill,
                 plan.skill_root,
@@ -2672,6 +2880,17 @@ def prepare_artifact_set_sync(
             moved_changes = _changed_inventory_paths(
                 plan.baseline_inventory,
                 moved_inventory,
+            )
+            moved_changes = tuple(
+                sorted(
+                    set(moved_changes)
+                    | set(
+                        _changed_inventory_paths(
+                            plan.baseline_modes,
+                            moved_modes,
+                        )
+                    )
+                )
             )
             if moved_identity != pre_rename_identity:
                 moved_changes = tuple(

--- a/scripts/check_upstream_github_updates.py
+++ b/scripts/check_upstream_github_updates.py
@@ -15,6 +15,7 @@ import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
@@ -26,6 +27,47 @@ from sync_upstream import (  # noqa: E402
     load_skills_with_upstream,
     resolve_github_token,
 )
+from provenance_v2 import atomic_write_json  # noqa: E402
+
+
+BUCKETS = (
+    "equal",
+    "changed",
+    "monitor_review",
+    "unavailable",
+    "rollback",
+    "expected_skipped",
+)
+UPDATE_TYPES = {"body_changed", "artifact_changed"}
+REVIEW_TYPES = {"monitor_review", "upstream_rollback"}
+
+
+def expected_skip_result(skill: dict[str, Any]) -> dict[str, Any] | None:
+    """Return policy skips without resolving tokens or touching the network."""
+    reason = skill.get("expected_skip_reason")
+    if not reason and skill.get("kind") == "snapshot":
+        reason = "licensed immutable snapshot; upstream checks are disabled"
+    if not reason and skill.get("sync_mode") in {
+        "manual",
+        "local-only",
+        "archived",
+    }:
+        reason = f"{skill.get('sync_mode')} source is not network checked"
+    if not reason:
+        return None
+    return {
+        "needs_update": False,
+        "needs_review": False,
+        "latest_commit": skill.get("last_synced_commit"),
+        "latest_commit_date": None,
+        "check_error": None,
+        "change_type": "expected_skipped",
+        "skip_reason": str(reason),
+        "changed_files": [],
+        "added_files": [],
+        "removed_files": [],
+        "moved_candidates": {},
+    }
 
 
 def github_latest_path_commit(
@@ -58,43 +100,134 @@ def github_latest_path_commit(
 
 def online_result(skill: dict, token: str | None) -> dict:
     """Return meaningful drift state plus display metadata for one skill."""
+    policy_skip = expected_skip_result(skill)
+    if policy_skip is not None:
+        return policy_skip
     checked = check_upstream_changes(skill, token)
     if checked is None:
         return {
             "needs_update": False,
+            "needs_review": False,
             "latest_commit": None,
             "latest_commit_date": None,
             "check_error": "upstream_content_unavailable",
             "change_type": "unavailable",
+            "changed_files": [],
+            "added_files": [],
+            "removed_files": [],
+            "moved_candidates": {},
         }
 
     change_type = checked.get("changes", "none")
-    latest_commit = None
+    latest_commit = checked.get("current_commit")
     latest_commit_date = None
-    check_error = None
-    try:
-        if skill.get("sync_mode") == "monitor":
-            latest_commit = checked.get("current_commit") or github_commit_sha(
-                skill["repo"],
-                skill.get("ref", "main"),
-                token,
-            )
-        else:
-            latest_commit, latest_commit_date, check_error = github_latest_path_commit(
-                skill["repo"],
-                checked.get("upstream_path") or skill.get("upstream_path") or "",
-                skill.get("ref", "main"),
-                token,
-            )
-    except Exception as exc:
-        check_error = f"commit_metadata: {exc}"
+    check_error = (
+        checked.get("reason")
+        if change_type == "unavailable"
+        else None
+    )
+    if latest_commit is None and change_type != "unavailable":
+        try:
+            if skill.get("sync_mode") == "monitor":
+                latest_commit = github_commit_sha(
+                    skill["repo"],
+                    skill.get("ref", "main"),
+                    token,
+                )
+            else:
+                latest_commit, latest_commit_date, check_error = github_latest_path_commit(
+                    skill["repo"],
+                    checked.get("upstream_path") or skill.get("upstream_path") or "",
+                    skill.get("ref", "main"),
+                    token,
+                )
+        except Exception as exc:
+            check_error = f"commit_metadata: {exc}"
 
     return {
-        "needs_update": change_type == "body_changed",
+        "needs_update": change_type in {"body_changed", "artifact_changed"},
+        "needs_review": change_type in {"monitor_review", "upstream_rollback"},
         "latest_commit": latest_commit,
         "latest_commit_date": latest_commit_date,
         "check_error": check_error,
         "change_type": change_type,
+        "changed_files": checked.get("changed_files", []),
+        "added_files": checked.get("added_files", []),
+        "removed_files": checked.get("removed_files", []),
+        "moved_candidates": checked.get("moved_candidates", {}),
+    }
+
+
+def row_bucket(row: object) -> str:
+    if not isinstance(row, dict):
+        return "unavailable"
+    change_type = row.get("change_type")
+    if row.get("check_error") or change_type == "unavailable":
+        return "unavailable"
+    if change_type == "none":
+        return "equal"
+    if change_type in UPDATE_TYPES:
+        return "changed"
+    if change_type == "monitor_review":
+        return "monitor_review"
+    if change_type == "upstream_rollback":
+        return "rollback"
+    if change_type in {"expected_skipped", "offline"}:
+        return "expected_skipped"
+    return "unavailable"
+
+
+def summarize_states(
+    rows: list[dict],
+    *,
+    online: bool = True,
+) -> tuple[dict[str, int], str]:
+    buckets = {key: 0 for key in BUCKETS}
+    for row in rows:
+        buckets[row_bucket(row)] += 1
+
+    if not rows or buckets["unavailable"]:
+        state = "failed"
+    elif (
+        not online
+        or buckets["monitor_review"]
+        or buckets["rollback"]
+    ):
+        state = "degraded"
+    else:
+        state = "complete"
+    return {"total": len(rows), **buckets}, state
+
+
+def _base_row(skill: dict[str, Any], root: Path, *, online: bool) -> dict[str, Any]:
+    local_path = skill.get("local_path")
+    try:
+        repo_skill = str(Path(local_path).relative_to(root))
+    except (TypeError, ValueError):
+        repo_skill = str(local_path or "")
+    mapping_value = skill.get("mapping_path")
+    return {
+        "mapping": Path(mapping_value).name if mapping_value else None,
+        "video_name": skill.get("name"),
+        "slug": skill.get("name"),
+        "repo_skill": repo_skill,
+        "status": "verified_in_repo",
+        "upstream_repo": skill.get("repo"),
+        "upstream_path": skill.get("upstream_path"),
+        "upstream_ref": skill.get("ref", "main"),
+        "sync_mode": skill.get("sync_mode", "replace"),
+        "last_synced_commit": skill.get("last_synced_commit"),
+        "needs_update": False,
+        "needs_review": False,
+        "latest_commit": None,
+        "latest_commit_date": None,
+        "check_error": None,
+        "change_type": "unavailable" if online else "expected_skipped",
+        "check_mode": "online" if online else "offline",
+        "changed_files": [],
+        "added_files": [],
+        "removed_files": [],
+        "moved_candidates": {},
     }
 
 
@@ -105,48 +238,64 @@ def main() -> int:
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
-    skills = load_skills_with_upstream()
-    token = resolve_github_token() if args.online else None
-    rows = []
+    try:
+        skills = load_skills_with_upstream()
+        load_error = None
+    except Exception as exc:  # a failed inventory can never be reported fresh
+        skills = []
+        load_error = f"mapping_inventory: {type(exc).__name__}: {exc}"
+    token: str | None = None
+    token_resolved = False
+    rows: list[dict[str, Any]] = []
 
     for skill in skills:
-        item = {
-            "mapping": Path(skill.get("mapping_path", "")).name or None,
-            "video_name": skill.get("name"),
-            "slug": skill.get("name"),
-            "repo_skill": str(skill["local_path"].relative_to(root)),
-            "status": "verified_in_repo",
-            "upstream_repo": skill["repo"],
-            "upstream_path": skill.get("upstream_path"),
-            "upstream_ref": skill.get("ref", "main"),
-            "sync_mode": skill.get("sync_mode", "replace"),
-            "last_synced_commit": skill.get("last_synced_commit"),
-            "needs_update": False,
-            "latest_commit": None,
-            "latest_commit_date": None,
-            "check_error": None,
-            "change_type": "offline",
-            "check_mode": "online" if args.online else "offline",
-        }
-
-        if args.online:
-            item.update(online_result(skill, token))
-        elif not skill.get("last_synced_commit"):
-            item["check_error"] = "missing_last_synced_commit"
+        item = _base_row(skill, root, online=args.online)
+        try:
+            policy_skip = expected_skip_result(skill)
+            if policy_skip is not None:
+                item.update(policy_skip)
+            elif args.online:
+                if not token_resolved:
+                    token = resolve_github_token()
+                    token_resolved = True
+                item.update(online_result(skill, token))
+            elif not skill.get("last_synced_commit"):
+                item["check_error"] = "missing_last_synced_commit"
+                item["change_type"] = "unavailable"
+        except Exception as exc:
+            item.update(
+                {
+                    "needs_update": False,
+                    "needs_review": False,
+                    "check_error": (
+                        f"upstream_check: {type(exc).__name__}: {exc}"
+                    ),
+                    "change_type": "unavailable",
+                }
+            )
         rows.append(item)
 
+    summary, state = summarize_states(rows, online=args.online)
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "mode": "online" if args.online else "offline",
+        "state": state,
+        "summary": summary,
         "total_checked": len(rows),
         "needs_update_count": sum(1 for row in rows if row["needs_update"]),
+        "needs_review_count": sum(1 for row in rows if row["needs_review"]),
         "check_error_count": sum(1 for row in rows if row["check_error"]),
+        "inventory_error": load_error,
         "rows": rows,
     }
+    if load_error:
+        payload["state"] = "failed"
 
-    out = root / args.write_json
+    out = Path(args.write_json)
+    if not out.is_absolute():
+        out = root / out
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    atomic_write_json(out, payload)
     try:
         display_path = out.relative_to(root)
     except ValueError:
@@ -155,9 +304,11 @@ def main() -> int:
     print(
         f"Checked rows: {payload['total_checked']}, "
         f"needs_update: {payload['needs_update_count']}, "
-        f"errors: {payload['check_error_count']}"
+        f"needs_review: {payload['needs_review_count']}, "
+        f"errors: {payload['check_error_count']}, "
+        f"state: {payload['state']}"
     )
-    return 0
+    return {"complete": 0, "failed": 1, "degraded": 2}[payload["state"]]
 
 
 if __name__ == "__main__":

--- a/scripts/discover_new_skills.py
+++ b/scripts/discover_new_skills.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from threading import Lock
 from time import sleep
 
+try:
+    from provenance_v2 import atomic_write_json
+except ModuleNotFoundError:  # pragma: no cover - package-style unit import
+    from scripts.provenance_v2 import atomic_write_json
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 WATCHED_REPOS = [
@@ -211,7 +216,17 @@ def finalize_source_health(source_health: dict[str, dict]) -> dict[str, dict]:
         entry = {
             "queries": raw["queries"],
             "results": raw["results"],
-            "errors": raw["errors"],
+            "raw_results": raw["results"],
+            "emitted": 0,
+            "unique_emitted": 0,
+            "errors": sorted(
+                raw["errors"],
+                key=lambda item: (
+                    str(item.get("kind", "")),
+                    str(item.get("status_code", "")),
+                    str(item.get("message", "")),
+                ),
+            ),
             "status": "unknown",
         }
         if raw["queries"] == 0:
@@ -228,7 +243,8 @@ def finalize_source_health(source_health: dict[str, dict]) -> dict[str, dict]:
 
 def flatten_errors(source_health: dict[str, dict]) -> list[dict]:
     errors = []
-    for source_key, entry in source_health.items():
+    for source_key in (SOURCE_GITHUB, SOURCE_SKILLS_SH, SOURCE_CLAWHUB):
+        entry = source_health[source_key]
         for item in entry.get("errors", []):
             error = dict(item)
             error["source"] = source_key
@@ -291,13 +307,27 @@ def github_api_get(url: str, token: str | None, source_health: dict[str, dict]) 
         return None
 
 
-def make_discovery(*, name: str, source: str, url: str, repo_stars: int, description: str) -> dict:
+def make_discovery(
+    *,
+    source_key: str,
+    name: str,
+    source: str,
+    url: str,
+    repo_stars: int,
+    description: str,
+) -> dict:
+    normalized_stars = (
+        repo_stars
+        if type(repo_stars) is int and repo_stars >= 0
+        else 0
+    )
     return {
-        "name": name,
-        "source": source,
-        "url": url,
-        "repo_stars": repo_stars,
-        "description": description,
+        "source_key": source_key,
+        "name": str(name or "").strip(),
+        "source": str(source or "").strip(),
+        "url": str(url or "").strip(),
+        "repo_stars": normalized_stars,
+        "description": str(description or ""),
         "discovered_at": utc_day(),
     }
 
@@ -323,6 +353,7 @@ def discover_from_watched_repos(token: str | None, source_health: dict[str, dict
             if len(parts) >= 2 and parts[-1] == "SKILL.md":
                 discoveries.append(
                     make_discovery(
+                        source_key=SOURCE_GITHUB,
                         name=parts[-2],
                         source=f"GitHub ({repo})",
                         url=f"https://github.com/{repo}/blob/main/{path}",
@@ -354,6 +385,7 @@ def discover_from_github_search(token: str | None, source_health: dict[str, dict
             seen_repos.add(full_name)
             discoveries.append(
                 make_discovery(
+                    source_key=SOURCE_GITHUB,
                     name=f"[repo] {full_name}",
                     source="GitHub Search",
                     url=repo.get("html_url", ""),
@@ -383,6 +415,7 @@ def discover_from_skills_sh(keywords: list[str], source_health: dict[str, dict])
                         seen_ids.add(skill_id)
                         discoveries.append(
                             make_discovery(
+                                source_key=SOURCE_SKILLS_SH,
                                 name=item.get("name", ""),
                                 source=f"skills.sh ({item.get('source', '')})",
                                 url=f"https://skills.sh/{item.get('id', '')}",
@@ -429,6 +462,7 @@ def discover_from_skills_sh(keywords: list[str], source_health: dict[str, dict])
                     installs = 0
             discoveries.append(
                 make_discovery(
+                    source_key=SOURCE_SKILLS_SH,
                     name=match.group(2).strip(),
                     source="skills.sh (scraped)",
                     url=f"https://skills.sh/{skill_id}",
@@ -461,6 +495,7 @@ def discover_from_clawhub(keywords: list[str], source_health: dict[str, dict]) -
                         seen_slugs.add(slug)
                         discoveries.append(
                             make_discovery(
+                                source_key=SOURCE_CLAWHUB,
                                 name=item.get("displayName", slug),
                                 source="ClawHub",
                                 url=f"https://clawhub.com/s/{slug}",
@@ -486,6 +521,7 @@ def discover_from_clawhub(keywords: list[str], source_health: dict[str, dict]) -
             seen_slugs.add(slug)
             discoveries.append(
                 make_discovery(
+                    source_key=SOURCE_CLAWHUB,
                     name=match.group(2).strip(),
                     source="ClawHub (scraped)",
                     url=f"https://clawhub.com/s/{slug}",
@@ -507,16 +543,33 @@ def dedupe_discoveries(
 ) -> list[dict]:
     rejected_names = rejected_names or set()
     rejected_urls = rejected_urls or set()
+    local_keys = {name.strip().casefold() for name in local_names}
+    rejected_keys = {
+        name.strip().casefold() for name in rejected_names
+    }
     seen_names = set()
     unique_discoveries = []
     for item in all_discoveries:
-        name = item["name"]
+        name = str(item.get("name") or "").strip()
         url = item.get("url", "")
-        if name in local_names or name in seen_names:
+        source_key = item.get("source_key")
+        if (
+            not name
+            or source_key not in {
+                SOURCE_GITHUB,
+                SOURCE_SKILLS_SH,
+                SOURCE_CLAWHUB,
+            }
+            or not isinstance(url, str)
+            or not url.startswith("https://")
+        ):
             continue
-        if name in rejected_names or (url and url in rejected_urls):
+        name_key = name.casefold()
+        if name_key in local_keys or name_key in seen_names:
             continue
-        seen_names.add(name)
+        if name_key in rejected_keys or (url and url in rejected_urls):
+            continue
+        seen_names.add(name_key)
         unique_discoveries.append(item)
     unique_discoveries.sort(key=lambda entry: entry.get("repo_stars", 0), reverse=True)
     return unique_discoveries
@@ -529,10 +582,33 @@ def build_discovery_report(
     unique_discoveries: list[dict],
     source_health: dict[str, dict],
 ) -> dict:
+    expected_sources = {SOURCE_GITHUB, SOURCE_SKILLS_SH, SOURCE_CLAWHUB}
+    if set(source_health) != expected_sources:
+        raise ValueError(
+            "source_health must contain github, skills_sh, and clawhub"
+        )
     finalized_health = finalize_source_health(source_health)
+    for item in all_discoveries:
+        source_key = item.get("source_key")
+        if source_key not in expected_sources:
+            raise ValueError("every raw discovery requires a valid source_key")
+        finalized_health[source_key]["emitted"] += 1
+    for item in unique_discoveries:
+        source_key = item.get("source_key")
+        if source_key not in expected_sources:
+            raise ValueError("every emitted discovery requires a valid source_key")
+        finalized_health[source_key]["unique_emitted"] += 1
+    for source_key, health in finalized_health.items():
+        if health["emitted"] > health["raw_results"]:
+            raise ValueError(
+                f"{source_key} emitted count exceeds raw results"
+            )
     return {
         "generated_at": utc_timestamp(),
         "local_skill_count": local_skill_count,
+        "raw_discovered": sum(
+            entry["raw_results"] for entry in finalized_health.values()
+        ),
         "total_discovered": len(all_discoveries),
         "unique_discovered": len(unique_discoveries),
         "discoveries": unique_discoveries,
@@ -606,7 +682,7 @@ def main() -> None:
         source_health=source_health,
     )
 
-    output_path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    atomic_write_json(output_path, report)
     print(f"\nWrote discovery report: {output_path}")
     print(f"Total discovered: {len(all_discoveries)}, Unique/New: {len(unique_discoveries)}")
 

--- a/scripts/durable_file_batch.py
+++ b/scripts/durable_file_batch.py
@@ -1,0 +1,1538 @@
+#!/usr/bin/env python3
+"""Crash-durable coordination for multi-file repository replacements.
+
+The public entrypoint is :func:`durable_batch_lock_and_recover`.  Every writer
+uses one repository-scoped lock and publishes a private, fsync-backed journal
+before its first destination replacement.  A later process classifies the
+whole batch as all-before, all-after, a safe before/after mixture, or an
+unknown third state.  Only the safe mixture is rolled back automatically.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import secrets
+import stat
+import time
+from collections.abc import Callable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - repository CI is POSIX
+    fcntl = None  # type: ignore[assignment]
+
+
+STATE_DIRECTORY = ".hvs-transactions"
+LOCK_FILENAME = "batch.lock"
+PENDING_DIRECTORY = "pending"
+JOURNAL_FILENAME = "journal.json"
+JOURNAL_VERSION = 1
+MAX_JOURNAL_BYTES = 16 * 1024 * 1024
+READ_CHUNK = 1024 * 1024
+
+
+class DurableBatchError(RuntimeError):
+    """A durable batch cannot proceed without risking user-owned bytes."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        recovery_paths: tuple[Path, ...] = (),
+    ) -> None:
+        self.recovery_paths = recovery_paths
+        suffix = (
+            "; recovery=" + ", ".join(str(path) for path in recovery_paths)
+            if recovery_paths
+            else ""
+        )
+        super().__init__(message + suffix)
+
+
+class DurableBatchLockError(DurableBatchError):
+    """The repository-wide durable batch lock is unavailable or unsafe."""
+
+
+class DurableBatchRecoveryError(DurableBatchError):
+    """A pending journal is unsafe, tampered, or contains a third state."""
+
+
+@dataclass(frozen=True)
+class FileFingerprint:
+    exists: bool
+    sha256: str | None
+    mode: int | None
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "exists": self.exists,
+            "sha256": self.sha256,
+            "mode": self.mode,
+        }
+
+
+def _uid() -> int | None:
+    return os.getuid() if hasattr(os, "getuid") else None
+
+
+def _directory_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def _file_read_flags() -> int:
+    return os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+
+
+def _validate_owned_directory(
+    descriptor: int,
+    path: Path,
+    *,
+    private: bool,
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    named = path.lstat()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(named.st_mode)
+        or metadata.st_dev != named.st_dev
+        or metadata.st_ino != named.st_ino
+        or (_uid() is not None and metadata.st_uid != _uid())
+    ):
+        raise DurableBatchError(f"unsafe durable batch directory: {path}")
+    if private and stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise DurableBatchError(
+            f"durable batch directory is not private: {path}"
+        )
+    return metadata
+
+
+def _repository_root(repo_root: Path) -> Path:
+    root = Path(os.path.abspath(repo_root))
+    descriptor = os.open(root, _directory_flags())
+    try:
+        _validate_owned_directory(descriptor, root, private=False)
+    finally:
+        os.close(descriptor)
+    return root
+
+
+def _ensure_state_root(repo_root: Path) -> tuple[Path, int]:
+    state_root = repo_root / STATE_DIRECTORY
+    root_fd = os.open(repo_root, _directory_flags())
+    try:
+        try:
+            os.mkdir(STATE_DIRECTORY, 0o700, dir_fd=root_fd)
+            os.fsync(root_fd)
+        except FileExistsError:
+            pass
+        state_fd = os.open(STATE_DIRECTORY, _directory_flags(), dir_fd=root_fd)
+    finally:
+        os.close(root_fd)
+    try:
+        _validate_owned_directory(state_fd, state_root, private=True)
+    except BaseException:
+        os.close(state_fd)
+        raise
+    return state_root, state_fd
+
+
+def _validate_lock_descriptor(
+    state_fd: int,
+    descriptor: int,
+    lock_path: Path,
+) -> None:
+    metadata = os.fstat(descriptor)
+    named = os.stat(
+        LOCK_FILENAME,
+        dir_fd=state_fd,
+        follow_symlinks=False,
+    )
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(named.st_mode)
+        or metadata.st_dev != named.st_dev
+        or metadata.st_ino != named.st_ino
+        or (_uid() is not None and metadata.st_uid != _uid())
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+    ):
+        raise DurableBatchLockError(
+            f"unsafe durable batch lock: {lock_path}"
+        )
+
+
+def _relative_target(repo_root: Path, target: Path) -> str:
+    candidate = Path(os.path.abspath(target))
+    try:
+        relative = candidate.relative_to(repo_root)
+    except ValueError as exc:
+        raise DurableBatchError(
+            f"durable batch target escapes repository root: {target}"
+        ) from exc
+    value = relative.as_posix()
+    pure = PurePosixPath(value)
+    if (
+        not value
+        or pure == PurePosixPath(".")
+        or pure.is_absolute()
+        or any(part in {"", ".", ".."} for part in pure.parts)
+        or "\\" in value
+    ):
+        raise DurableBatchError(f"unsafe durable batch target: {target}")
+    if pure.parts[0] == STATE_DIRECTORY:
+        raise DurableBatchError(
+            "durable batch targets must not overlap transaction state"
+        )
+    return value
+
+
+def _open_target_parent(
+    repo_root: Path,
+    relative: str,
+    *,
+    allow_missing: bool,
+) -> tuple[int | None, str]:
+    parts = PurePosixPath(relative).parts
+    descriptor = os.open(repo_root, _directory_flags())
+    try:
+        for component in parts[:-1]:
+            try:
+                next_descriptor = os.open(
+                    component,
+                    _directory_flags(),
+                    dir_fd=descriptor,
+                )
+            except FileNotFoundError:
+                if allow_missing:
+                    os.close(descriptor)
+                    return None, parts[-1]
+                raise
+            os.close(descriptor)
+            descriptor = next_descriptor
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise DurableBatchError(
+                    f"target ancestor is not a directory: {relative}"
+                )
+        return descriptor, parts[-1]
+    except BaseException:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+
+
+def _missing_parent_paths(repo_root: Path, relative: str) -> list[str]:
+    """Return parent directories absent before the batch, shallow to deep."""
+    parts = PurePosixPath(relative).parts[:-1]
+    descriptor = os.open(repo_root, _directory_flags())
+    missing: list[str] = []
+    prefix: list[str] = []
+    absent = False
+    try:
+        for component in parts:
+            prefix.append(component)
+            if absent:
+                missing.append(PurePosixPath(*prefix).as_posix())
+                continue
+            try:
+                next_descriptor = os.open(
+                    component,
+                    _directory_flags(),
+                    dir_fd=descriptor,
+                )
+            except FileNotFoundError:
+                absent = True
+                missing.append(PurePosixPath(*prefix).as_posix())
+                continue
+            os.close(descriptor)
+            descriptor = next_descriptor
+            if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+                raise DurableBatchError(
+                    f"target ancestor is not a directory: {relative}"
+                )
+        return missing
+    finally:
+        os.close(descriptor)
+
+
+def _read_all(descriptor: int, *, limit: int | None = None) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = os.read(descriptor, READ_CHUNK)
+        if not chunk:
+            break
+        total += len(chunk)
+        if limit is not None and total > limit:
+            raise DurableBatchRecoveryError("durable journal exceeds size limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _capture_target(
+    repo_root: Path,
+    relative: str,
+    *,
+    include_content: bool,
+    recovery_path: Path | None = None,
+) -> tuple[FileFingerprint, bytes | None]:
+    try:
+        parent_fd, leaf = _open_target_parent(
+            repo_root,
+            relative,
+            allow_missing=True,
+        )
+    except (OSError, DurableBatchError) as exc:
+        if recovery_path is not None:
+            raise DurableBatchRecoveryError(
+                f"cannot safely open durable recovery target: {relative}",
+                recovery_paths=(recovery_path,),
+            ) from exc
+        raise
+    if parent_fd is None:
+        return FileFingerprint(False, None, None), None
+    descriptor = -1
+    try:
+        try:
+            descriptor = os.open(leaf, _file_read_flags(), dir_fd=parent_fd)
+        except FileNotFoundError:
+            return FileFingerprint(False, None, None), None
+        except OSError as exc:
+            if recovery_path is not None:
+                raise DurableBatchRecoveryError(
+                    f"durable recovery target is missing or unsafe: {relative}",
+                    recovery_paths=(recovery_path,),
+                ) from exc
+            raise
+        metadata = os.fstat(descriptor)
+        named = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(named.st_mode)
+            or metadata.st_dev != named.st_dev
+            or metadata.st_ino != named.st_ino
+        ):
+            error_type = (
+                DurableBatchRecoveryError
+                if recovery_path is not None
+                else DurableBatchError
+            )
+            raise error_type(
+                f"durable batch target is not a stable regular file: {relative}",
+                recovery_paths=(recovery_path,) if recovery_path else (),
+            )
+        content = _read_all(descriptor)
+        fingerprint = FileFingerprint(
+            True,
+            hashlib.sha256(content).hexdigest(),
+            stat.S_IMODE(metadata.st_mode),
+        )
+        return fingerprint, content if include_content else None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
+def _fingerprint_from_json(value: object, *, label: str) -> FileFingerprint:
+    if not isinstance(value, dict) or set(value) != {
+        "exists",
+        "sha256",
+        "mode",
+    }:
+        raise DurableBatchRecoveryError(f"invalid {label} fingerprint")
+    exists = value.get("exists")
+    digest = value.get("sha256")
+    mode = value.get("mode")
+    if type(exists) is not bool:
+        raise DurableBatchRecoveryError(f"invalid {label}.exists")
+    if exists:
+        if (
+            not isinstance(digest, str)
+            or not re_full_sha256(digest)
+            or isinstance(mode, bool)
+            or not isinstance(mode, int)
+            or mode < 0
+            or mode > 0o777
+        ):
+            raise DurableBatchRecoveryError(f"invalid {label} file state")
+    elif digest is not None or mode is not None:
+        raise DurableBatchRecoveryError(f"invalid absent {label} state")
+    return FileFingerprint(exists, digest, mode)
+
+
+def re_full_sha256(value: str) -> bool:
+    return len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _write_private_file(
+    directory_fd: int,
+    name: str,
+    content: bytes,
+) -> None:
+    descriptor = os.open(
+        name,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=directory_fd,
+    )
+    try:
+        offset = 0
+        while offset < len(content):
+            offset += os.write(descriptor, content[offset:])
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        named = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(named.st_mode)
+            or metadata.st_dev != named.st_dev
+            or metadata.st_ino != named.st_ino
+        ):
+            raise DurableBatchError(
+                f"private durable batch file changed while writing: {name}"
+            )
+    finally:
+        os.close(descriptor)
+
+
+def _persist_journal(
+    repo_root: Path,
+    state_root: Path,
+    state_fd: int,
+    replacements: Mapping[Path, bytes | None],
+    after_modes: Mapping[Path, int | None] | None,
+) -> dict[str, Any]:
+    transaction_name = f".pending.{secrets.token_hex(16)}"
+    os.mkdir(transaction_name, 0o700, dir_fd=state_fd)
+    os.fsync(state_fd)
+    transaction_path = state_root / transaction_name
+    transaction_fd = os.open(
+        transaction_name,
+        _directory_flags(),
+        dir_fd=state_fd,
+    )
+    published = False
+    try:
+        _validate_owned_directory(
+            transaction_fd,
+            transaction_path,
+            private=True,
+        )
+        entries: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        missing_directories: set[str] = set()
+        for index, (target, desired) in enumerate(
+            sorted(replacements.items(), key=lambda item: str(item[0]))
+        ):
+            relative = _relative_target(repo_root, Path(target))
+            if relative in seen:
+                raise DurableBatchError(
+                    f"duplicate durable batch target: {relative}"
+                )
+            seen.add(relative)
+            missing_directories.update(
+                _missing_parent_paths(repo_root, relative)
+            )
+            before, original = _capture_target(
+                repo_root,
+                relative,
+                include_content=True,
+            )
+            if before.exists and (
+                before.mode is None or before.mode < 0 or before.mode > 0o777
+            ):
+                raise DurableBatchError(
+                    "durable batch refuses target mode with special bits: "
+                    f"{relative}"
+                )
+            requested_mode = (
+                (after_modes or {}).get(Path(target))
+                if after_modes is not None
+                else None
+            )
+            if requested_mode is not None and (
+                isinstance(requested_mode, bool)
+                or not isinstance(requested_mode, int)
+                or requested_mode < 0
+                or requested_mode > 0o777
+            ):
+                raise DurableBatchError(
+                    f"invalid durable after mode for {relative}"
+                )
+            after = FileFingerprint(False, None, None)
+            if desired is not None:
+                after = FileFingerprint(
+                    True,
+                    hashlib.sha256(desired).hexdigest(),
+                    (
+                        requested_mode
+                        if requested_mode is not None
+                        else before.mode
+                        if before.exists
+                        else 0o644
+                    ),
+                )
+            payload_name = None
+            if before.exists:
+                payload_name = f"{index:08d}.before"
+                if original is None:
+                    raise DurableBatchError(
+                        f"missing original bytes for {relative}"
+                    )
+                _write_private_file(transaction_fd, payload_name, original)
+            entries.append(
+                {
+                    "path": relative,
+                    "before": before.as_json(),
+                    "after": after.as_json(),
+                    "before_payload": payload_name,
+                }
+            )
+        payload = {
+            "version": JOURNAL_VERSION,
+            "repository": hashlib.sha256(
+                str(repo_root).encode("utf-8")
+            ).hexdigest(),
+            "entries": entries,
+            "created_directories": sorted(
+                missing_directories,
+                key=lambda value: (
+                    len(PurePosixPath(value).parts),
+                    value,
+                ),
+            ),
+        }
+        payload_bytes = _canonical_json(payload)
+        envelope = {
+            "payload": payload,
+            "checksum": hashlib.sha256(payload_bytes).hexdigest(),
+        }
+        journal_bytes = _canonical_json(envelope) + b"\n"
+        if len(journal_bytes) > MAX_JOURNAL_BYTES:
+            raise DurableBatchError("durable batch journal exceeds size limit")
+        _write_private_file(
+            transaction_fd,
+            f".{JOURNAL_FILENAME}.tmp",
+            journal_bytes,
+        )
+        os.rename(
+            f".{JOURNAL_FILENAME}.tmp",
+            JOURNAL_FILENAME,
+            src_dir_fd=transaction_fd,
+            dst_dir_fd=transaction_fd,
+        )
+        os.fsync(transaction_fd)
+        try:
+            os.rename(
+                transaction_name,
+                PENDING_DIRECTORY,
+                src_dir_fd=state_fd,
+                dst_dir_fd=state_fd,
+            )
+        except FileExistsError as exc:
+            raise DurableBatchRecoveryError(
+                "another durable batch journal is already pending",
+                recovery_paths=(state_root / PENDING_DIRECTORY,),
+            ) from exc
+        os.fsync(state_fd)
+        published = True
+        return payload
+    finally:
+        os.close(transaction_fd)
+        if not published:
+            _remove_unpublished_transaction(
+                state_fd,
+                transaction_name,
+            )
+
+
+def _remove_unpublished_transaction(state_fd: int, name: str) -> None:
+    try:
+        descriptor = os.open(name, _directory_flags(), dir_fd=state_fd)
+    except FileNotFoundError:
+        return
+    try:
+        for child in os.listdir(descriptor):
+            try:
+                os.unlink(child, dir_fd=descriptor)
+            except FileNotFoundError:
+                pass
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.rmdir(name, dir_fd=state_fd)
+        os.fsync(state_fd)
+    except FileNotFoundError:
+        pass
+
+
+def _read_private_file(
+    directory_fd: int,
+    name: str,
+    *,
+    limit: int | None = None,
+) -> bytes:
+    descriptor = os.open(name, _file_read_flags(), dir_fd=directory_fd)
+    try:
+        metadata = os.fstat(descriptor)
+        named = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(named.st_mode)
+            or metadata.st_dev != named.st_dev
+            or metadata.st_ino != named.st_ino
+            or (_uid() is not None and metadata.st_uid != _uid())
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+        ):
+            raise DurableBatchRecoveryError(
+                f"unsafe durable recovery file: {name}"
+            )
+        content = _read_all(descriptor, limit=limit)
+        current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if (
+            current.st_dev != metadata.st_dev
+            or current.st_ino != metadata.st_ino
+        ):
+            raise DurableBatchRecoveryError(
+                f"durable recovery file changed while reading: {name}"
+            )
+        return content
+    finally:
+        os.close(descriptor)
+
+
+def _load_pending(
+    repo_root: Path,
+    state_root: Path,
+    state_fd: int,
+) -> tuple[dict[str, Any], dict[str, bytes], int] | None:
+    try:
+        pending_fd = os.open(
+            PENDING_DIRECTORY,
+            _directory_flags(),
+            dir_fd=state_fd,
+        )
+    except FileNotFoundError:
+        return None
+    pending_path = state_root / PENDING_DIRECTORY
+    try:
+        _validate_owned_directory(pending_fd, pending_path, private=True)
+        try:
+            raw = _read_private_file(
+                pending_fd,
+                JOURNAL_FILENAME,
+                limit=MAX_JOURNAL_BYTES,
+            )
+        except OSError as exc:
+            raise DurableBatchRecoveryError(
+                "durable batch journal is missing or unsafe",
+                recovery_paths=(pending_path,),
+            ) from exc
+        try:
+            envelope = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise DurableBatchRecoveryError(
+                "durable batch journal is not valid UTF-8 JSON",
+                recovery_paths=(pending_path,),
+            ) from exc
+        if (
+            not isinstance(envelope, dict)
+            or set(envelope) != {"payload", "checksum"}
+            or not isinstance(envelope.get("payload"), dict)
+            or not isinstance(envelope.get("checksum"), str)
+        ):
+            raise DurableBatchRecoveryError(
+                "durable batch journal envelope is invalid",
+                recovery_paths=(pending_path,),
+            )
+        payload = envelope["payload"]
+        expected_checksum = hashlib.sha256(_canonical_json(payload)).hexdigest()
+        if envelope["checksum"] != expected_checksum:
+            raise DurableBatchRecoveryError(
+                "durable batch journal checksum mismatch",
+                recovery_paths=(pending_path,),
+            )
+        if (
+            set(payload)
+            != {
+                "version",
+                "repository",
+                "entries",
+                "created_directories",
+            }
+            or payload.get("version") != JOURNAL_VERSION
+            or payload.get("repository")
+            != hashlib.sha256(str(repo_root).encode("utf-8")).hexdigest()
+            or not isinstance(payload.get("entries"), list)
+            or not payload["entries"]
+            or not isinstance(payload.get("created_directories"), list)
+        ):
+            raise DurableBatchRecoveryError(
+                "durable batch journal authority is invalid",
+                recovery_paths=(pending_path,),
+            )
+        originals: dict[str, bytes] = {}
+        seen: set[str] = set()
+        directories: list[str] = []
+        for value in payload["created_directories"]:
+            if (
+                not isinstance(value, str)
+                or _relative_target(repo_root, repo_root / value) != value
+                or value in directories
+                or value == STATE_DIRECTORY
+                or value.startswith(STATE_DIRECTORY + "/")
+            ):
+                raise DurableBatchRecoveryError(
+                    "durable batch created-directory list is invalid",
+                    recovery_paths=(pending_path,),
+                )
+            directories.append(value)
+        if directories != sorted(
+            directories,
+            key=lambda value: (len(PurePosixPath(value).parts), value),
+        ):
+            raise DurableBatchRecoveryError(
+                "durable batch created-directory list is not canonical",
+                recovery_paths=(pending_path,),
+            )
+        expected_children = {JOURNAL_FILENAME}
+        for index, entry in enumerate(payload["entries"]):
+            if not isinstance(entry, dict) or set(entry) != {
+                "path",
+                "before",
+                "after",
+                "before_payload",
+            }:
+                raise DurableBatchRecoveryError(
+                    "durable batch journal entry is invalid",
+                    recovery_paths=(pending_path,),
+                )
+            relative = entry.get("path")
+            if (
+                not isinstance(relative, str)
+                or _relative_target(repo_root, repo_root / relative) != relative
+                or relative in seen
+            ):
+                raise DurableBatchRecoveryError(
+                    "durable batch journal path is invalid or duplicated",
+                    recovery_paths=(pending_path,),
+                )
+            seen.add(relative)
+            before = _fingerprint_from_json(
+                entry.get("before"),
+                label=f"entries[{index}].before",
+            )
+            _fingerprint_from_json(
+                entry.get("after"),
+                label=f"entries[{index}].after",
+            )
+            payload_name = entry.get("before_payload")
+            if before.exists:
+                if (
+                    not isinstance(payload_name, str)
+                    or payload_name != f"{index:08d}.before"
+                ):
+                    raise DurableBatchRecoveryError(
+                        "durable batch original payload name is invalid",
+                        recovery_paths=(pending_path,),
+                    )
+                original = _read_private_file(pending_fd, payload_name)
+                if hashlib.sha256(original).hexdigest() != before.sha256:
+                    raise DurableBatchRecoveryError(
+                        "durable batch original payload hash mismatch",
+                        recovery_paths=(pending_path,),
+                    )
+                originals[relative] = original
+                expected_children.add(payload_name)
+            elif payload_name is not None:
+                raise DurableBatchRecoveryError(
+                    "absent durable batch target unexpectedly has a payload",
+                    recovery_paths=(pending_path,),
+                )
+        if set(os.listdir(pending_fd)) != expected_children:
+            raise DurableBatchRecoveryError(
+                "durable batch pending directory contains unknown files",
+                recovery_paths=(pending_path,),
+            )
+        return payload, originals, pending_fd
+    except BaseException:
+        os.close(pending_fd)
+        raise
+
+
+def _matches(current: FileFingerprint, expected: FileFingerprint) -> bool:
+    return current == expected
+
+
+def _replace_target_with_original(
+    repo_root: Path,
+    relative: str,
+    content: bytes,
+    mode: int,
+) -> None:
+    parent_fd, leaf = _open_target_parent(
+        repo_root,
+        relative,
+        allow_missing=False,
+    )
+    if parent_fd is None:  # pragma: no cover - allow_missing is false
+        raise DurableBatchRecoveryError(
+            f"recovery parent is missing: {relative}"
+        )
+    temporary = f".{leaf}.{secrets.token_hex(16)}.recovery.tmp"
+    descriptor = -1
+    created = False
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_fd,
+        )
+        created = True
+        offset = 0
+        while offset < len(content):
+            offset += os.write(descriptor, content[offset:])
+        os.fchmod(descriptor, mode)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.rename(
+            temporary,
+            leaf,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        created = False
+        os.fsync(parent_fd)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if created:
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+        os.close(parent_fd)
+
+
+def _remove_after_target(repo_root: Path, relative: str) -> None:
+    parent_fd, leaf = _open_target_parent(
+        repo_root,
+        relative,
+        allow_missing=False,
+    )
+    if parent_fd is None:  # pragma: no cover - allow_missing is false
+        raise DurableBatchRecoveryError(
+            f"recovery parent is missing: {relative}"
+        )
+    try:
+        os.unlink(leaf, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+
+def _cleanup_pending(
+    state_root: Path,
+    state_fd: int,
+    pending_fd: int,
+    payload: dict[str, Any],
+) -> None:
+    names = {JOURNAL_FILENAME}
+    for entry in payload["entries"]:
+        if entry.get("before_payload") is not None:
+            names.add(entry["before_payload"])
+    if set(os.listdir(pending_fd)) != names:
+        raise DurableBatchRecoveryError(
+            "durable batch pending directory changed before cleanup",
+            recovery_paths=(state_root / PENDING_DIRECTORY,),
+        )
+    for name in sorted(names):
+        os.unlink(name, dir_fd=pending_fd)
+    os.fsync(pending_fd)
+    os.close(pending_fd)
+    os.rmdir(PENDING_DIRECTORY, dir_fd=state_fd)
+    os.fsync(state_fd)
+
+
+def _cleanup_created_directories(
+    repo_root: Path,
+    payload: dict[str, Any],
+    *,
+    recovery_path: Path,
+) -> None:
+    """Remove only parents that were absent pre-batch and remain empty."""
+    for relative in reversed(payload["created_directories"]):
+        pure = PurePosixPath(relative)
+        parent_relative = (
+            PurePosixPath(*pure.parts[:-1]).as_posix()
+            if len(pure.parts) > 1
+            else None
+        )
+        if parent_relative is None:
+            parent_fd = os.open(repo_root, _directory_flags())
+        else:
+            parent_fd, _unused = _open_target_parent(
+                repo_root,
+                parent_relative + "/sentinel",
+                allow_missing=True,
+            )
+            if parent_fd is None:
+                continue
+        try:
+            try:
+                metadata = os.stat(
+                    pure.name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(
+                metadata.st_mode
+            ):
+                raise DurableBatchRecoveryError(
+                    f"created recovery parent became unsafe: {relative}",
+                    recovery_paths=(recovery_path,),
+                )
+            try:
+                os.rmdir(pure.name, dir_fd=parent_fd)
+            except OSError as exc:
+                raise DurableBatchRecoveryError(
+                    f"created recovery parent is not empty: {relative}",
+                    recovery_paths=(recovery_path,),
+                ) from exc
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+
+def _open_verified_active_parent(
+    repo_root: Path,
+    relative: str,
+    expected_identity: tuple[int, int],
+    *,
+    recovery_path: Path,
+) -> tuple[int, str]:
+    """Reopen the canonical parent path and prove it is still the pinned inode."""
+    try:
+        parent_fd, leaf = _open_target_parent(
+            repo_root,
+            relative,
+            allow_missing=False,
+        )
+    except (OSError, DurableBatchError) as exc:
+        raise DurableBatchRecoveryError(
+            f"cannot reopen active recovery parent: {relative}",
+            recovery_paths=(recovery_path,),
+        ) from exc
+    if parent_fd is None:  # pragma: no cover - allow_missing is false
+        raise DurableBatchRecoveryError(
+            f"active recovery parent is missing: {relative}",
+            recovery_paths=(recovery_path,),
+        )
+    metadata = os.fstat(parent_fd)
+    if (metadata.st_dev, metadata.st_ino) != expected_identity:
+        os.close(parent_fd)
+        raise DurableBatchRecoveryError(
+            f"active recovery parent detached from canonical path: {relative}",
+            recovery_paths=(recovery_path,),
+        )
+    return parent_fd, leaf
+
+
+def _verify_active_parent_identity(
+    repo_root: Path,
+    relative: str,
+    expected_identity: tuple[int, int],
+    *,
+    recovery_path: Path,
+) -> None:
+    parent_fd, _leaf = _open_verified_active_parent(
+        repo_root,
+        relative,
+        expected_identity,
+        recovery_path=recovery_path,
+    )
+    os.close(parent_fd)
+
+
+def _confirm_after_states_durable(
+    repo_root: Path,
+    payload: dict[str, Any],
+    *,
+    recovery_path: Path,
+) -> None:
+    """Revalidate and durably flush every installed after state.
+
+    An atomic rename can become visible before either its file data or parent
+    directory entry is durable.  A process recovering an all-after journal
+    therefore assumes responsibility for both fsync boundaries before it may
+    discard the only rollback authority.
+    """
+    parent_fds: dict[tuple[int, int], int] = {}
+    parent_authorities: dict[tuple[int, int], str] = {}
+    checks: list[
+        tuple[tuple[int, int], str, str, FileFingerprint]
+    ] = []
+    try:
+        # Flush every regular file first.  Parent directory fsyncs happen only
+        # after all file-data boundaries, preserving the required ordering
+        # even when several targets share one parent.
+        for entry in payload["entries"]:
+            relative = entry["path"]
+            after = _fingerprint_from_json(entry["after"], label="after")
+            try:
+                opened_parent_fd, leaf = _open_target_parent(
+                    repo_root,
+                    relative,
+                    allow_missing=False,
+                )
+            except (OSError, DurableBatchError) as exc:
+                raise DurableBatchRecoveryError(
+                    f"cannot open all-after parent durably: {relative}",
+                    recovery_paths=(recovery_path,),
+                ) from exc
+            if opened_parent_fd is None:  # pragma: no cover - missing forbidden
+                raise DurableBatchRecoveryError(
+                    f"all-after parent is missing: {relative}",
+                    recovery_paths=(recovery_path,),
+                )
+            parent_metadata = os.fstat(opened_parent_fd)
+            parent_identity = (
+                parent_metadata.st_dev,
+                parent_metadata.st_ino,
+            )
+            parent_fd = parent_fds.get(parent_identity)
+            if parent_fd is None:
+                parent_fd = opened_parent_fd
+                parent_fds[parent_identity] = parent_fd
+                parent_authorities[parent_identity] = relative
+            else:
+                os.close(opened_parent_fd)
+            descriptor = -1
+            try:
+                if after.exists:
+                    try:
+                        descriptor = os.open(
+                            leaf,
+                            _file_read_flags(),
+                            dir_fd=parent_fd,
+                        )
+                    except OSError as exc:
+                        raise DurableBatchRecoveryError(
+                            f"cannot open all-after file durably: {relative}",
+                            recovery_paths=(recovery_path,),
+                        ) from exc
+                    opened = os.fstat(descriptor)
+                    named = os.stat(
+                        leaf,
+                        dir_fd=parent_fd,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        not stat.S_ISREG(opened.st_mode)
+                        or stat.S_ISLNK(named.st_mode)
+                        or opened.st_dev != named.st_dev
+                        or opened.st_ino != named.st_ino
+                    ):
+                        raise DurableBatchRecoveryError(
+                            "all-after file is not a stable regular file: "
+                            f"{relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+                    content = _read_all(descriptor)
+                    observed = FileFingerprint(
+                        True,
+                        hashlib.sha256(content).hexdigest(),
+                        stat.S_IMODE(opened.st_mode),
+                    )
+                    if observed != after:
+                        raise DurableBatchRecoveryError(
+                            f"all-after file changed before durability: {relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+                    os.fsync(descriptor)
+                    completed = os.fstat(descriptor)
+                    renamed = os.stat(
+                        leaf,
+                        dir_fd=parent_fd,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        completed.st_dev != opened.st_dev
+                        or completed.st_ino != opened.st_ino
+                        or completed.st_mode != opened.st_mode
+                        or completed.st_size != opened.st_size
+                        or completed.st_mtime_ns != opened.st_mtime_ns
+                        or stat.S_ISLNK(renamed.st_mode)
+                        or renamed.st_dev != opened.st_dev
+                        or renamed.st_ino != opened.st_ino
+                    ):
+                        raise DurableBatchRecoveryError(
+                            f"all-after file changed while being flushed: {relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+                    _verify_active_parent_identity(
+                        repo_root,
+                        relative,
+                        parent_identity,
+                        recovery_path=recovery_path,
+                    )
+                else:
+                    try:
+                        os.stat(
+                            leaf,
+                            dir_fd=parent_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        raise DurableBatchRecoveryError(
+                            f"all-after deletion is no longer absent: {relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+                    _verify_active_parent_identity(
+                        repo_root,
+                        relative,
+                        parent_identity,
+                        recovery_path=recovery_path,
+                    )
+                checks.append(
+                    (parent_identity, leaf, relative, after)
+                )
+            except DurableBatchRecoveryError:
+                raise
+            except OSError as exc:
+                raise DurableBatchRecoveryError(
+                    f"cannot confirm all-after file durability: {relative}",
+                    recovery_paths=(recovery_path,),
+                ) from exc
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+
+        for parent_identity, parent_fd in parent_fds.items():
+            os.fsync(parent_fd)
+            _verify_active_parent_identity(
+                repo_root,
+                parent_authorities[parent_identity],
+                parent_identity,
+                recovery_path=recovery_path,
+            )
+
+        # Reopen every active parent from the repository root and use that
+        # descriptor for the final target read.  The earlier pinned dirfd is
+        # insufficient if its directory was renamed out of the canonical tree.
+        for parent_identity, _leaf, relative, after in checks:
+            active_parent_fd, active_leaf = _open_verified_active_parent(
+                repo_root,
+                relative,
+                parent_identity,
+                recovery_path=recovery_path,
+            )
+            try:
+                if after.exists:
+                    descriptor = -1
+                    try:
+                        try:
+                            descriptor = os.open(
+                                active_leaf,
+                                _file_read_flags(),
+                                dir_fd=active_parent_fd,
+                            )
+                        except OSError as exc:
+                            raise DurableBatchRecoveryError(
+                                f"cannot open all-after file durably: {relative}",
+                                recovery_paths=(recovery_path,),
+                            ) from exc
+                        opened = os.fstat(descriptor)
+                        named = os.stat(
+                            active_leaf,
+                            dir_fd=active_parent_fd,
+                            follow_symlinks=False,
+                        )
+                        if (
+                            not stat.S_ISREG(opened.st_mode)
+                            or stat.S_ISLNK(named.st_mode)
+                            or opened.st_dev != named.st_dev
+                            or opened.st_ino != named.st_ino
+                        ):
+                            raise DurableBatchRecoveryError(
+                                "all-after file is not stable after parent flush: "
+                                f"{relative}",
+                                recovery_paths=(recovery_path,),
+                            )
+                        content = _read_all(descriptor)
+                        completed = os.fstat(descriptor)
+                    finally:
+                        if descriptor >= 0:
+                            os.close(descriptor)
+                    observed = FileFingerprint(
+                        True,
+                        hashlib.sha256(content).hexdigest(),
+                        stat.S_IMODE(completed.st_mode),
+                    )
+                    if (
+                        observed != after
+                        or completed.st_dev != opened.st_dev
+                        or completed.st_ino != opened.st_ino
+                        or completed.st_mode != opened.st_mode
+                        or completed.st_size != opened.st_size
+                        or completed.st_mtime_ns != opened.st_mtime_ns
+                    ):
+                        raise DurableBatchRecoveryError(
+                            f"all-after file changed after parent flush: {relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+                else:
+                    try:
+                        os.stat(
+                            active_leaf,
+                            dir_fd=active_parent_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        raise DurableBatchRecoveryError(
+                            f"all-after deletion is no longer absent: {relative}",
+                            recovery_paths=(recovery_path,),
+                        )
+            finally:
+                os.close(active_parent_fd)
+            _verify_active_parent_identity(
+                repo_root,
+                relative,
+                parent_identity,
+                recovery_path=recovery_path,
+            )
+    except DurableBatchRecoveryError:
+        raise
+    except OSError as exc:
+        raise DurableBatchRecoveryError(
+            "cannot confirm all-after durability",
+            recovery_paths=(recovery_path,),
+        ) from exc
+    finally:
+        for parent_fd in parent_fds.values():
+            os.close(parent_fd)
+
+
+def _recover_pending_locked(
+    repo_root: Path,
+    state_root: Path,
+    state_fd: int,
+) -> str:
+    loaded = _load_pending(repo_root, state_root, state_fd)
+    if loaded is None:
+        return "none"
+    payload, originals, pending_fd = loaded
+    pending_path = state_root / PENDING_DIRECTORY
+    try:
+        states: list[str] = []
+        for entry in payload["entries"]:
+            current, _ = _capture_target(
+                repo_root,
+                entry["path"],
+                include_content=False,
+                recovery_path=pending_path,
+            )
+            before = _fingerprint_from_json(
+                entry["before"],
+                label="before",
+            )
+            after = _fingerprint_from_json(
+                entry["after"],
+                label="after",
+            )
+            if _matches(current, before):
+                states.append("before")
+            elif _matches(current, after):
+                states.append("after")
+            else:
+                raise DurableBatchRecoveryError(
+                    "durable batch contains an unknown third-state target: "
+                    f"{entry['path']}",
+                    recovery_paths=(pending_path,),
+                )
+        if all(value == "before" for value in states):
+            _cleanup_created_directories(
+                repo_root,
+                payload,
+                recovery_path=pending_path,
+            )
+            _cleanup_pending(
+                state_root,
+                state_fd,
+                pending_fd,
+                payload,
+            )
+            return "discarded-before"
+        if all(value == "after" for value in states):
+            _confirm_after_states_durable(
+                repo_root,
+                payload,
+                recovery_path=pending_path,
+            )
+            _cleanup_pending(
+                state_root,
+                state_fd,
+                pending_fd,
+                payload,
+            )
+            return "completed-after"
+
+        for entry, current_state in zip(payload["entries"], states, strict=True):
+            if current_state != "after":
+                continue
+            before = _fingerprint_from_json(entry["before"], label="before")
+            if before.exists:
+                original = originals.get(entry["path"])
+                if original is None or before.mode is None:
+                    raise DurableBatchRecoveryError(
+                        f"durable original is unavailable: {entry['path']}",
+                        recovery_paths=(pending_path,),
+                    )
+                _replace_target_with_original(
+                    repo_root,
+                    entry["path"],
+                    original,
+                    before.mode,
+                )
+            else:
+                _remove_after_target(repo_root, entry["path"])
+        for entry in payload["entries"]:
+            current, _ = _capture_target(
+                repo_root,
+                entry["path"],
+                include_content=False,
+                recovery_path=pending_path,
+            )
+            before = _fingerprint_from_json(entry["before"], label="before")
+            if current != before:
+                raise DurableBatchRecoveryError(
+                    f"durable rollback verification failed: {entry['path']}",
+                    recovery_paths=(pending_path,),
+                )
+        _cleanup_created_directories(
+            repo_root,
+            payload,
+            recovery_path=pending_path,
+        )
+        _cleanup_pending(state_root, state_fd, pending_fd, payload)
+        return "rolled-back"
+    except BaseException:
+        try:
+            os.close(pending_fd)
+        except OSError:
+            pass
+        raise
+
+
+class DurableBatchGuard:
+    """A held repository-wide lock with crash recovery already completed."""
+
+    def __init__(self, repo_root: Path, state_root: Path, state_fd: int) -> None:
+        self.repo_root = repo_root
+        self.state_root = state_root
+        self.state_fd = state_fd
+
+    def recover(self) -> str:
+        return _recover_pending_locked(
+            self.repo_root,
+            self.state_root,
+            self.state_fd,
+        )
+
+    def commit_batch(
+        self,
+        replacements: Mapping[Path, bytes | None],
+        apply_batch: Callable[[], None],
+        *,
+        after_modes: Mapping[Path, int | None] | None = None,
+    ) -> None:
+        normalized: dict[Path, bytes | None] = {}
+        for path, content in replacements.items():
+            if content is not None and not isinstance(content, bytes):
+                raise TypeError("durable replacement content must be bytes or None")
+            candidate = (
+                Path(path)
+                if Path(path).is_absolute()
+                else self.repo_root / Path(path)
+            )
+            absolute = self.repo_root / _relative_target(
+                self.repo_root,
+                candidate,
+            )
+            normalized[absolute] = content
+        normalized_modes: dict[Path, int | None] = {}
+        for path, mode in (after_modes or {}).items():
+            candidate = (
+                Path(path)
+                if Path(path).is_absolute()
+                else self.repo_root / Path(path)
+            )
+            absolute = self.repo_root / _relative_target(
+                self.repo_root,
+                candidate,
+            )
+            if absolute not in normalized:
+                raise DurableBatchError(
+                    f"after mode has no replacement target: {path}"
+                )
+            normalized_modes[absolute] = mode
+        if not normalized:
+            apply_batch()
+            return
+        _persist_journal(
+            self.repo_root,
+            self.state_root,
+            self.state_fd,
+            normalized,
+            normalized_modes,
+        )
+        try:
+            apply_batch()
+        except BaseException as cause:
+            try:
+                self.recover()
+            except BaseException as recovery_error:
+                if hasattr(cause, "add_note"):
+                    cause.add_note(
+                        "durable batch recovery failed closed; pending journal "
+                        f"preserved at {self.state_root / PENDING_DIRECTORY}: "
+                        f"{recovery_error}"
+                    )
+                setattr(
+                    cause,
+                    "durable_recovery_paths",
+                    (self.state_root / PENDING_DIRECTORY,),
+                )
+                raise cause from recovery_error
+            raise
+        outcome = self.recover()
+        if outcome != "completed-after":
+            raise DurableBatchRecoveryError(
+                "durable batch callback returned without installing every "
+                f"after state; recovery outcome={outcome}"
+            )
+
+
+@contextmanager
+def durable_batch_lock_and_recover(
+    repo_root: Path,
+    *,
+    timeout: float = 10.0,
+) -> Iterator[DurableBatchGuard]:
+    """Acquire the cross-tool batch lock and recover a prior hard exit."""
+    if fcntl is None:  # pragma: no cover - repository CI is POSIX
+        raise DurableBatchLockError("durable batch locks require POSIX flock")
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not math.isfinite(float(timeout))
+        or timeout < 0
+    ):
+        raise ValueError("durable batch lock timeout must be finite and non-negative")
+    root = _repository_root(Path(repo_root))
+    state_root, state_fd = _ensure_state_root(root)
+    lock_path = state_root / LOCK_FILENAME
+    lock_fd = os.open(
+        LOCK_FILENAME,
+        os.O_CREAT
+        | os.O_RDWR
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=state_fd,
+    )
+    acquired = False
+    try:
+        _validate_lock_descriptor(state_fd, lock_fd, lock_path)
+        deadline = time.monotonic() + float(timeout)
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError as exc:
+                if time.monotonic() >= deadline:
+                    raise DurableBatchLockError(
+                        f"durable batch is already active: {lock_path}"
+                    ) from exc
+                time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+        os.ftruncate(lock_fd, 0)
+        os.write(lock_fd, f"pid={os.getpid()}\n".encode("ascii"))
+        os.fsync(lock_fd)
+        guard = DurableBatchGuard(root, state_root, state_fd)
+        guard.recover()
+        yield guard
+    finally:
+        try:
+            if acquired:
+                os.ftruncate(lock_fd, 0)
+                os.fsync(lock_fd)
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
+            os.close(state_fd)
+
+
+def commit_batch(
+    repo_root: Path,
+    replacements: Mapping[Path, bytes | None],
+    apply_batch: Callable[[], None],
+    *,
+    after_modes: Mapping[Path, int | None] | None = None,
+    timeout: float = 10.0,
+) -> None:
+    """Convenience wrapper for one locked, recoverable file batch."""
+    with durable_batch_lock_and_recover(repo_root, timeout=timeout) as guard:
+        guard.commit_batch(
+            replacements,
+            apply_batch,
+            after_modes=after_modes,
+        )
+
+
+__all__ = [
+    "DurableBatchError",
+    "DurableBatchGuard",
+    "DurableBatchLockError",
+    "DurableBatchRecoveryError",
+    "commit_batch",
+    "durable_batch_lock_and_recover",
+]

--- a/scripts/generate_sync_report.py
+++ b/scripts/generate_sync_report.py
@@ -5,12 +5,33 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 import re
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DISCOVERY_SOURCES = ("github", "skills_sh", "clawhub")
+DISCOVERY_STATUSES = {"healthy", "degraded", "unavailable"}
+UPSTREAM_BUCKETS = (
+    "equal",
+    "changed",
+    "monitor_review",
+    "unavailable",
+    "rollback",
+    "expected_skipped",
+)
+UPSTREAM_CHANGE_TYPES = {
+    "none",
+    "body_changed",
+    "artifact_changed",
+    "monitor_review",
+    "upstream_rollback",
+    "expected_skipped",
+    "offline",
+    "unavailable",
+}
 
 
 def escape_table_cell(value: object) -> str:
@@ -52,45 +73,438 @@ def upstream_update_reason(row: dict) -> str:
     return "new commits available"
 
 
-def main() -> None:
+def _is_count(value: object) -> bool:
+    return type(value) is int and value >= 0
+
+
+def validate_discovery(payload: object) -> str:
+    if not isinstance(payload, dict):
+        raise ValueError("discovery report must be an object")
+    source_health = payload.get("source_health")
+    if (
+        not isinstance(source_health, dict)
+        or set(source_health) != set(DISCOVERY_SOURCES)
+    ):
+        raise ValueError(
+            "discovery source_health must contain exactly "
+            "github, skills_sh, and clawhub"
+        )
+    flattened_errors: list[dict[str, Any]] = []
+    statuses: set[str] = set()
+    for source in DISCOVERY_SOURCES:
+        health = source_health[source]
+        if not isinstance(health, dict):
+            raise ValueError(f"discovery source {source} health must be an object")
+        status = health.get("status")
+        queries = health.get("queries")
+        results = health.get("results")
+        raw_results = health.get("raw_results")
+        emitted = health.get("emitted")
+        unique_emitted = health.get("unique_emitted")
+        errors = health.get("errors")
+        if status not in DISCOVERY_STATUSES:
+            raise ValueError(f"discovery source {source} has invalid status")
+        if any(
+            not _is_count(value)
+            for value in (
+                queries,
+                results,
+                raw_results,
+                emitted,
+                unique_emitted,
+            )
+        ):
+            raise ValueError(
+                f"discovery source {source} counts must be non-negative integers"
+            )
+        if (
+            results != raw_results
+            or raw_results < emitted
+            or emitted < unique_emitted
+        ):
+            raise ValueError(
+                f"discovery source {source} raw/emitted counts are inconsistent"
+            )
+        if queries == 0:
+            raise ValueError(f"discovery source {source} performed zero queries")
+        if not isinstance(errors, list) or any(
+            not isinstance(error, dict) for error in errors
+        ):
+            raise ValueError(f"discovery source {source} errors must be objects")
+        for error in errors:
+            if (
+                not isinstance(error.get("kind"), str)
+                or not error["kind"].strip()
+                or not isinstance(error.get("message"), str)
+            ):
+                raise ValueError(
+                    f"discovery source {source} error fields are invalid"
+                )
+            status_code = error.get("status_code")
+            if status_code is not None and not _is_count(status_code):
+                raise ValueError(
+                    f"discovery source {source} error status_code is invalid"
+                )
+        sorted_errors = sorted(
+            errors,
+            key=lambda item: (
+                str(item.get("kind", "")),
+                str(item.get("status_code", "")),
+                str(item.get("message", "")),
+            ),
+        )
+        if errors != sorted_errors:
+            raise ValueError(
+                f"discovery source {source} errors are not stably sorted"
+            )
+        expected_status = (
+            "healthy"
+            if not errors
+            else ("degraded" if results > 0 else "unavailable")
+        )
+        if status != expected_status:
+            raise ValueError(
+                f"discovery source {source} status {status!r} disagrees with "
+                f"queries/results/errors; expected {expected_status!r}"
+            )
+        statuses.add(status)
+        for error in errors:
+            flattened_errors.append({**error, "source": source})
+
+    discoveries = payload.get("discoveries")
+    if not isinstance(discoveries, list) or any(
+        not isinstance(item, dict) for item in discoveries
+    ):
+        raise ValueError("discovery discoveries must be a list of objects")
+    seen_names: set[str] = set()
+    for index, item in enumerate(discoveries):
+        source_key = item.get("source_key")
+        name = item.get("name")
+        source = item.get("source")
+        url = item.get("url")
+        description = item.get("description")
+        stars = item.get("repo_stars")
+        if source_key not in DISCOVERY_SOURCES:
+            raise ValueError(f"discovery row {index} has invalid source_key")
+        if any(
+            not isinstance(value, str) or not value.strip()
+            for value in (name, source, url)
+        ):
+            raise ValueError(
+                f"discovery row {index} requires name/source/url strings"
+            )
+        if not url.startswith("https://"):
+            raise ValueError(f"discovery row {index} url must use HTTPS")
+        if not isinstance(description, str):
+            raise ValueError(
+                f"discovery row {index} description must be a string"
+            )
+        if not _is_count(stars):
+            raise ValueError(
+                f"discovery row {index} repo_stars must be non-negative"
+            )
+        normalized_name = name.strip().casefold()
+        if normalized_name in seen_names:
+            raise ValueError("discovery rows must have unique names")
+        seen_names.add(normalized_name)
+    for field in (
+        "local_skill_count",
+        "raw_discovered",
+        "total_discovered",
+        "unique_discovered",
+    ):
+        if not _is_count(payload.get(field)):
+            raise ValueError(f"discovery {field} must be a non-negative integer")
+    if payload["unique_discovered"] != len(discoveries):
+        raise ValueError("discovery unique_discovered disagrees with discoveries")
+    if payload["total_discovered"] < payload["unique_discovered"]:
+        raise ValueError("discovery total_discovered is smaller than unique count")
+    if payload["raw_discovered"] != sum(
+        source_health[source]["raw_results"] for source in DISCOVERY_SOURCES
+    ):
+        raise ValueError("discovery raw_discovered violates source conservation")
+    if payload["total_discovered"] != sum(
+        source_health[source]["emitted"] for source in DISCOVERY_SOURCES
+    ):
+        raise ValueError("discovery total_discovered violates source conservation")
+    if payload["unique_discovered"] != sum(
+        source_health[source]["unique_emitted"]
+        for source in DISCOVERY_SOURCES
+    ):
+        raise ValueError("discovery unique count violates source conservation")
+    if payload.get("errors") != flattened_errors:
+        raise ValueError("discovery top-level errors disagree with source errors")
+    if "unavailable" in statuses:
+        return "failed"
+    if "degraded" in statuses:
+        return "degraded"
+    return "complete"
+
+
+def discovery_state(payload: dict, *, exists: bool) -> str:
+    if not exists:
+        return "failed"
+    try:
+        return validate_discovery(payload)
+    except ValueError:
+        return "failed"
+
+
+def upstream_row_bucket(row: object) -> str:
+    if not isinstance(row, dict):
+        raise ValueError("upstream rows must contain objects")
+    change_type = row.get("change_type")
+    if change_type not in UPSTREAM_CHANGE_TYPES:
+        raise ValueError(f"upstream row has invalid change_type {change_type!r}")
+    check_error = row.get("check_error")
+    if check_error is not None and not isinstance(check_error, str):
+        raise ValueError("upstream row check_error must be a string or null")
+    if type(row.get("needs_update")) is not bool:
+        raise ValueError("upstream row needs_update must be boolean")
+    if type(row.get("needs_review")) is not bool:
+        raise ValueError("upstream row needs_review must be boolean")
+    expected_update = change_type in {"body_changed", "artifact_changed"}
+    expected_review = change_type in {"monitor_review", "upstream_rollback"}
+    if row["needs_update"] != expected_update:
+        raise ValueError("upstream row needs_update disagrees with change_type")
+    if row["needs_review"] != expected_review:
+        raise ValueError("upstream row needs_review disagrees with change_type")
+    if check_error or change_type == "unavailable":
+        return "unavailable"
+    return {
+        "none": "equal",
+        "body_changed": "changed",
+        "artifact_changed": "changed",
+        "monitor_review": "monitor_review",
+        "upstream_rollback": "rollback",
+        "expected_skipped": "expected_skipped",
+        "offline": "expected_skipped",
+    }[change_type]
+
+
+def validate_upstream(payload: object) -> str:
+    if not isinstance(payload, dict):
+        raise ValueError("upstream report must be an object")
+    summary = payload.get("summary")
+    rows = payload.get("rows")
+    if not isinstance(summary, dict) or not isinstance(rows, list):
+        raise ValueError("upstream summary and rows are required")
+    mode = payload.get("mode")
+    if mode not in {"online", "offline"}:
+        raise ValueError("upstream mode must be online or offline")
+    recomputed = {key: 0 for key in UPSTREAM_BUCKETS}
+    for row in rows:
+        recomputed[upstream_row_bucket(row)] += 1
+    expected_summary = {"total": len(rows), **recomputed}
+    if set(summary) != set(expected_summary):
+        raise ValueError("upstream summary has missing or unexpected buckets")
+    for key, expected in expected_summary.items():
+        value = summary.get(key)
+        if not _is_count(value) or value != expected:
+            raise ValueError(
+                f"upstream summary {key} disagrees with rows: "
+                f"{value!r} != {expected}"
+            )
+    if not rows or recomputed["unavailable"] or payload.get("inventory_error"):
+        expected_state = "failed"
+    elif (
+        mode == "offline"
+        or recomputed["monitor_review"]
+        or recomputed["rollback"]
+    ):
+        expected_state = "degraded"
+    else:
+        expected_state = "complete"
+    if payload.get("state") != expected_state:
+        raise ValueError(
+            f"upstream declared state {payload.get('state')!r} disagrees "
+            f"with recomputed state {expected_state!r}"
+        )
+    derived_counts = {
+        "total_checked": len(rows),
+        "needs_update_count": sum(
+            1 for row in rows if row.get("needs_update")
+        ),
+        "needs_review_count": sum(
+            1 for row in rows if row.get("needs_review")
+        ),
+        "check_error_count": sum(
+            1 for row in rows if row.get("check_error")
+        ),
+    }
+    for key, expected in derived_counts.items():
+        value = payload.get(key)
+        if not _is_count(value) or value != expected:
+            raise ValueError(
+                f"upstream {key} disagrees with rows: {value!r} != {expected}"
+            )
+    return expected_state
+
+
+def upstream_report_state(payload: dict, *, exists: bool) -> str:
+    if not exists:
+        return "failed"
+    try:
+        return validate_upstream(payload)
+    except ValueError:
+        return "failed"
+
+
+def combine_state(*states: str) -> str:
+    rank = {"complete": 0, "degraded": 1, "failed": 2}
+    return max(states, key=lambda value: rank.get(value, 2))
+
+
+def _resolve_path(value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def _read_json(path: Path, label: str) -> tuple[dict[str, Any], str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}, f"{label} report is missing: {path}"
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, f"{label} report cannot be read: {exc}"
+    if not isinstance(payload, dict):
+        return {}, f"{label} report must be a JSON object"
+    return payload, None
+
+
+def _write_outputs(state: str, has_updates: bool, needs_attention: bool) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a", encoding="utf-8") as handle:
+        handle.write(f"has_updates={'true' if has_updates else 'false'}\n")
+        handle.write(
+            f"needs_attention={'true' if needs_attention else 'false'}\n"
+        )
+        handle.write(f"sync_state={state}\n")
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate sync report.")
     parser.add_argument("--discovery", default="docs/sources/reports/discovery.json")
     parser.add_argument("--upstream", default="docs/sources/reports/upstream-check.json")
     parser.add_argument("--output", default="docs/sources/reports/sync-report.md")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     
-    discovery_path = REPO_ROOT / args.discovery
-    upstream_path = REPO_ROOT / args.upstream
-    output_path = REPO_ROOT / args.output
+    discovery_path = _resolve_path(args.discovery)
+    upstream_path = _resolve_path(args.upstream)
+    output_path = _resolve_path(args.output)
     
-    # Load data
-    discovery = {}
-    if discovery_path.exists():
-        discovery = json.loads(discovery_path.read_text(encoding="utf-8"))
+    discovery, discovery_read_error = _read_json(discovery_path, "discovery")
+    upstream, upstream_read_error = _read_json(upstream_path, "upstream")
+    validation_errors = [
+        error
+        for error in (discovery_read_error, upstream_read_error)
+        if error
+    ]
+    discovery_status = "failed"
+    upstream_status = "failed"
+    discovery_valid = False
+    upstream_valid = False
+    if not discovery_read_error:
+        try:
+            discovery_status = validate_discovery(discovery)
+            discovery_valid = True
+        except ValueError as exc:
+            validation_errors.append(f"invalid discovery report: {exc}")
+    if not upstream_read_error:
+        try:
+            upstream_status = validate_upstream(upstream)
+            upstream_valid = True
+        except ValueError as exc:
+            validation_errors.append(f"invalid upstream report: {exc}")
     
-    upstream = {}
-    if upstream_path.exists():
-        upstream = json.loads(upstream_path.read_text(encoding="utf-8"))
-    
-    new_skills = discovery.get("discoveries", [])
-    upstream_updates = [r for r in upstream.get("rows", []) if r.get("needs_update")]
+    new_skills = (
+        discovery.get("discoveries", [])
+        if discovery_valid
+        else []
+    )
+    upstream_rows = (
+        upstream.get("rows", [])
+        if upstream_valid
+        else []
+    )
+    upstream_updates = [r for r in upstream_rows if r.get("needs_update")]
+    upstream_reviews = [
+        row
+        for row in upstream_rows
+        if row.get("needs_review")
+        or row.get("check_error")
+        or row.get("change_type") == "unavailable"
+    ]
+    state = combine_state(
+        discovery_status,
+        upstream_status,
+    )
     
     has_updates = bool(new_skills or upstream_updates)
-    
-    # Set GitHub Actions output
-    github_output = os.environ.get("GITHUB_OUTPUT")
-    if github_output:
-        with open(github_output, "a") as f:
-            f.write(f"has_updates={'true' if has_updates else 'false'}\n")
+    needs_attention = bool(has_updates or upstream_reviews or state != "complete")
     
     # Generate report
     lines = [
-        f"# Weekly Skill Sync Report",
-        f"",
+        "# Weekly Skill Sync Report",
+        "",
         f"**Generated**: {datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')}",
+        f"**Automation state**: `{state}`",
         f"**Local skills**: {discovery.get('local_skill_count', 'N/A')}",
-        f"",
+        "",
     ]
+    if validation_errors:
+        lines.append("## Report Validation Failures")
+        lines.append("")
+        for error in validation_errors:
+            lines.append(f"- {escape_table_cell(error)}")
+        lines.append("")
+    discovery_errors = (
+        discovery.get("errors", []) if discovery_valid else []
+    )
+    if discovery_errors:
+        lines.append(
+            f"## Discovery Source Errors ({len(discovery_errors)})"
+        )
+        lines.append("")
+        for error in discovery_errors:
+            source = escape_table_cell(error.get("source") or "unknown")
+            kind = escape_table_cell(error.get("kind") or "request_failed")
+            message = escape_table_cell(error.get("message") or "")
+            status_code = error.get("status_code")
+            status = (
+                f" HTTP {status_code}"
+                if type(status_code) is int
+                else ""
+            )
+            lines.append(
+                f"- **{source}** (`{kind}`{status}): {message}"
+            )
+        lines.append("")
     
     if new_skills:
         lines.append(f"## New Skills Discovered ({len(new_skills)})")
@@ -111,23 +525,44 @@ def main() -> None:
         for u in upstream_updates:
             lines.append(f"- **{upstream_skill_name(u)}**: {upstream_update_reason(u)}")
         lines.append("")
+
+    if upstream_reviews:
+        lines.append(f"## Upstream Review / Failures ({len(upstream_reviews)})")
+        lines.append("")
+        for row in upstream_reviews:
+            change_type = row.get("change_type") or "unavailable"
+            detail = row.get("check_error") or upstream_update_reason(row)
+            lines.append(
+                f"- **{upstream_skill_name(row)}** (`{change_type}`): "
+                f"{escape_table_cell(detail)}"
+            )
+        lines.append("")
     
-    if not has_updates:
+    if not needs_attention:
         lines.append("No new discoveries or upstream updates this week. All skills are up to date.")
+        lines.append("")
+    elif state == "failed" and not (new_skills or upstream_updates or upstream_reviews):
+        lines.append(
+            "The scan did not complete. No up-to-date conclusion can be drawn "
+            "until the failed source is checked again."
+        )
         lines.append("")
     
     lines.append("---")
     lines.append("*This report was auto-generated by the [upstream-sync workflow](.github/workflows/upstream-sync.yml).*")
     
     report = "\n".join(lines)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(report, encoding="utf-8")
+    _atomic_write_text(output_path, report)
+    # Outputs are a trust signal for the workflow. Publish them only after the
+    # report itself has been durably replaced.
+    _write_outputs(state, has_updates, needs_attention)
     print(f"Wrote sync report: {output_path}")
-    if has_updates:
+    if needs_attention:
         print(f"Updates found: {len(new_skills)} new skills, {len(upstream_updates)} upstream updates")
     else:
         print("No updates found.")
+    return 1 if validation_errors else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/github_artifact_provider.py
+++ b/scripts/github_artifact_provider.py
@@ -80,6 +80,7 @@ class ArtifactInventory:
 
     files: dict[str, bytes]
     source_blobs: dict[str, str]
+    modes: dict[str, str]
     resolved: ResolvedRef
 
 
@@ -588,6 +589,7 @@ class GitHubArtifactProvider:
         tree = self.tree(repo, resolved.commit)
         pending_files: list[tuple[str, str, str]] = []
         source_blobs: dict[str, str] = {}
+        modes: dict[str, str] = {}
         missing: list[str] = []
         claimed_targets: set[str] = set()
 
@@ -622,6 +624,7 @@ class GitHubArtifactProvider:
                 claimed_targets.add(target)
                 pending_files.append((source, target, blob_sha))
                 source_blobs[source] = blob_sha
+                modes[target] = str(item["mode"])
                 continue
 
             if artifact_type != "directory":
@@ -665,6 +668,7 @@ class GitHubArtifactProvider:
                 claimed_targets.add(mapped_target)
                 pending_files.append((path, mapped_target, blob_sha))
                 source_blobs[path] = blob_sha
+                modes[mapped_target] = str(item["mode"])
 
         if missing:
             raise ArtifactNotFound(missing)
@@ -672,7 +676,7 @@ class GitHubArtifactProvider:
             target: self.blob(repo, blob_sha)
             for _source, target, blob_sha in pending_files
         }
-        return ArtifactInventory(files, source_blobs, resolved)
+        return ArtifactInventory(files, source_blobs, modes, resolved)
 
     def compare(self, repo: str, base: str, head: str) -> dict[str, Any]:
         repo = self._validate_repo(repo)

--- a/scripts/github_artifact_provider.py
+++ b/scripts/github_artifact_provider.py
@@ -1,0 +1,784 @@
+"""Cached, binary-safe GitHub artifact access for provenance v2 synchronization."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+FULL_COMMIT_RE = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
+GITHUB_REPO_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9._-]+$"
+)
+GIT_OBJECT_RE = FULL_COMMIT_RE
+REGULAR_BLOB_MODES = frozenset({"100644", "100755"})
+TREE_MODE = "040000"
+SYMLINK_BLOB_MODE = "120000"
+GITLINK_MODE = "160000"
+CANONICAL_LICENSE_NORMALIZED_SHA256 = {
+    # GitHub License API canonical templates, normalized with collapsed
+    # whitespace and lowercase UTF-8. Explicit API SPDX remains authoritative;
+    # these fingerprints are used only for NOASSERTION/missing SPDX evidence.
+    "948703bcf1cb4a2dafd21676dd01e40a58fe21bd9b425c000b9070eccb441092": (
+        "Apache-2.0"
+    ),
+    "78f11354a160ad5309cb9d24f8c4385dc807d9d098e8d8878f8732a5c2d395cd": (
+        "BSD-2-Clause"
+    ),
+    "d86113948e206c727e862360f035d45432d06f72987bdc27bc8edd49660d8609": (
+        "BSD-3-Clause"
+    ),
+    "3de3b5118df8d74984d5d56a03ca27484aae85fac8339e6c9faa8b5c4e69460c": (
+        "CC0-1.0"
+    ),
+    "75b9da4d2b27f2f9a0cd5cca74ed1d40b9e2bc01d49d2c7f38daacad6122c016": (
+        "MIT"
+    ),
+    "da4c44c6f085e773c147576dd132ed4985b336dca115e13d73555d0aaef1f87b": (
+        "MPL-2.0"
+    ),
+    "a46a9193a46751396c49892e9518697927dd0af3947170a6b4c8e81be182dbef": (
+        "Unlicense"
+    ),
+}
+
+
+class GitHubProviderError(RuntimeError):
+    """Base class for deterministic upstream provider failures."""
+
+
+class GitHubUnavailable(GitHubProviderError):
+    """The GitHub API could not provide an authoritative response."""
+
+
+class ArtifactNotFound(GitHubProviderError):
+    """One or more declared artifact sources do not exist at the resolved commit."""
+
+    def __init__(self, missing_sources: list[str]) -> None:
+        self.missing_sources = sorted(set(missing_sources))
+        super().__init__(
+            "declared upstream artifact source is missing: "
+            + ", ".join(self.missing_sources)
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedRef:
+    channel: str
+    ref: str
+    commit: str
+
+
+@dataclass(frozen=True)
+class ArtifactInventory:
+    """Materialized source-to-target mapping for one immutable commit."""
+
+    files: dict[str, bytes]
+    source_blobs: dict[str, str]
+    resolved: ResolvedRef
+
+
+@dataclass(frozen=True)
+class LicenseEvidence:
+    """Strict immutable license bytes plus deterministic SPDX candidates."""
+
+    path: str
+    blob_sha: str
+    content_sha256: str
+    resolved_commit: str
+    spdx_candidates: tuple[str, ...]
+    api_spdx: str | None
+
+
+class GitHubArtifactProvider:
+    """Fetch immutable GitHub trees and blobs with per-run caching.
+
+    The provider intentionally uses the Git Trees and Git Blobs APIs instead of
+    raw text URLs.  This preserves binary bytes, provides a complete directory
+    inventory, and makes rename diagnosis possible without guessing paths.
+    """
+
+    def __init__(
+        self,
+        token: str | None = None,
+        *,
+        api_get=None,
+    ) -> None:
+        self.token = token
+        self._api_get_override = api_get
+        self._json_cache: dict[str, Any] = {}
+        self._commit_cache: dict[tuple[str, str], str] = {}
+        self._release_cache: dict[str, ResolvedRef] = {}
+        self._tree_cache: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
+        self._blob_cache: dict[tuple[str, str], bytes] = {}
+        self._path_commit_cache: dict[tuple[str, str, str], str] = {}
+        self._license_cache: dict[tuple[str, str], LicenseEvidence] = {}
+
+    def _get_json(self, url: str) -> Any:
+        if url in self._json_cache:
+            return self._json_cache[url]
+        if self._api_get_override is not None:
+            try:
+                value = self._api_get_override(url)
+            except TypeError:
+                value = self._api_get_override(url, self.token)
+            if value is None:
+                raise GitHubUnavailable(f"GitHub API returned no data for {url}")
+            self._json_cache[url] = value
+            return value
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "skills-sync-bot",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                value = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raise GitHubUnavailable(
+                f"GitHub API HTTP {exc.code} for {url}"
+            ) from exc
+        except (OSError, ValueError) as exc:
+            raise GitHubUnavailable(f"GitHub API failed for {url}: {exc}") from exc
+        self._json_cache[url] = value
+        return value
+
+    @staticmethod
+    def _validate_repo(repo: str) -> str:
+        if (
+            not isinstance(repo, str)
+            or not GITHUB_REPO_RE.fullmatch(repo)
+            or repo.endswith(("/", ".git"))
+            or repo.rsplit("/", 1)[1] in {".", ".."}
+        ):
+            raise GitHubUnavailable(f"invalid GitHub repository slug: {repo!r}")
+        return repo
+
+    @classmethod
+    def _repo_api(cls, repo: str, suffix: str) -> str:
+        repo = cls._validate_repo(repo)
+        return f"https://api.github.com/repos/{repo}/{suffix.lstrip('/')}"
+
+    @staticmethod
+    def _quoted_ref(value: str, *, label: str) -> str:
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > 1024
+            or any(ord(character) < 0x20 for character in value)
+        ):
+            raise GitHubUnavailable(f"invalid GitHub {label}: {value!r}")
+        return urllib.parse.quote(value, safe="")
+
+    @staticmethod
+    def _safe_repo_path(value: object) -> bool:
+        if (
+            not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            or value.startswith("/")
+            or "\\" in value
+            or any(ord(character) < 0x20 for character in value)
+        ):
+            return False
+        parts = value.split("/")
+        return all(part not in {"", ".", ".."} for part in parts)
+
+    def resolve_commit(self, repo: str, ref: str) -> str:
+        repo = self._validate_repo(repo)
+        key = (repo, ref)
+        if key in self._commit_cache:
+            return self._commit_cache[key]
+        quoted = self._quoted_ref(ref, label="ref")
+        data = self._get_json(self._repo_api(repo, f"commits/{quoted}"))
+        sha = data.get("sha") if isinstance(data, dict) else None
+        if not isinstance(sha, str) or not FULL_COMMIT_RE.fullmatch(sha):
+            raise GitHubUnavailable(f"could not resolve {repo}@{ref} to a full commit")
+        sha = sha.lower()
+        self._commit_cache[key] = sha
+        return sha
+
+    def resolve_tracking(self, repo: str, tracking: dict[str, Any]) -> ResolvedRef:
+        repo = self._validate_repo(repo)
+        channel = tracking.get("channel")
+        ref = tracking.get("ref")
+        if not isinstance(channel, str) or not isinstance(ref, str) or not ref:
+            raise GitHubUnavailable("tracking.channel and tracking.ref are required")
+        self._quoted_ref(ref, label="tracking ref")
+
+        if channel == "latest_release":
+            if repo in self._release_cache:
+                return self._release_cache[repo]
+            data = self._get_json(self._repo_api(repo, "releases/latest"))
+            if (
+                not isinstance(data, dict)
+                or data.get("draft") is True
+                or data.get("prerelease") is True
+            ):
+                raise GitHubUnavailable(
+                    f"{repo} has no authoritative latest stable release"
+                )
+            tag = data.get("tag_name")
+            if not isinstance(tag, str) or not tag:
+                raise GitHubUnavailable(f"{repo} latest release has no tag_name")
+            resolved = ResolvedRef(channel, tag, self.resolve_commit(repo, tag))
+            self._release_cache[repo] = resolved
+            return resolved
+
+        if channel == "fixed_ref":
+            if not FULL_COMMIT_RE.fullmatch(ref):
+                raise GitHubUnavailable(
+                    "fixed_ref must be a full 40- or 64-character commit SHA"
+                )
+            commit = self.resolve_commit(repo, ref)
+            if commit != ref.lower():
+                raise GitHubUnavailable(
+                    f"fixed_ref resolved to unexpected commit {commit}"
+                )
+            return ResolvedRef(channel, ref.lower(), commit)
+
+        if channel in {"default_branch", "canary"}:
+            return ResolvedRef(channel, ref, self.resolve_commit(repo, ref))
+
+        raise GitHubUnavailable(f"unsupported external tracking channel: {channel!r}")
+
+    @classmethod
+    def _validate_tree_entry(
+        cls,
+        repo: str,
+        commit: str,
+        item: object,
+        *,
+        nested_name: bool = False,
+    ) -> dict[str, Any]:
+        """Validate one Git Trees API entry and preserve known Git objects.
+
+        GitHub represents symlinks as ``blob`` entries with mode ``120000`` and
+        submodules/gitlinks as ``commit`` entries with mode ``160000``.  Neither
+        can be materialized safely as a regular artifact file.  They remain in
+        the inventory so artifact declarations can reject them within their own
+        source scope without unrelated special objects blocking the repository.
+        Unknown type/mode combinations still fail closed globally.  Executable
+        regular blobs remain byte payloads; accepting mode ``100755`` does not
+        alter their content.
+        """
+        if not isinstance(item, dict):
+            raise GitHubUnavailable(
+                f"invalid Git tree entry for {repo}@{commit}"
+            )
+        path = item.get("path")
+        item_type = item.get("type")
+        mode = item.get("mode")
+        sha = item.get("sha")
+        safe_path = cls._safe_repo_path(path)
+        if nested_name and isinstance(path, str) and "/" in path:
+            safe_path = False
+        if (
+            not safe_path
+            or not isinstance(sha, str)
+            or not GIT_OBJECT_RE.fullmatch(sha)
+        ):
+            raise GitHubUnavailable(
+                f"invalid Git tree entry for {repo}@{commit}"
+            )
+        if not (
+            (item_type == "blob" and mode in REGULAR_BLOB_MODES)
+            or (item_type == "blob" and mode == SYMLINK_BLOB_MODE)
+            or (item_type == "tree" and mode == TREE_MODE)
+            or (item_type == "commit" and mode == GITLINK_MODE)
+        ):
+            raise GitHubUnavailable(
+                "unsupported Git tree entry type/mode requires manual review "
+                f"for {repo}@{commit}:{path}: {item_type!r}/{mode!r}"
+            )
+        return item
+
+    @staticmethod
+    def _is_regular_blob(item: object) -> bool:
+        return (
+            isinstance(item, dict)
+            and item.get("type") == "blob"
+            and item.get("mode") in REGULAR_BLOB_MODES
+        )
+
+    @staticmethod
+    def _is_special_git_object(item: object) -> bool:
+        return isinstance(item, dict) and (
+            (
+                item.get("type") == "blob"
+                and item.get("mode") == SYMLINK_BLOB_MODE
+            )
+            or (
+                item.get("type") == "commit"
+                and item.get("mode") == GITLINK_MODE
+            )
+        )
+
+    def tree(self, repo: str, commit: str) -> dict[str, dict[str, Any]]:
+        repo = self._validate_repo(repo)
+        if not FULL_COMMIT_RE.fullmatch(commit):
+            raise GitHubUnavailable(f"invalid resolved commit: {commit!r}")
+        key = (repo, commit)
+        if key in self._tree_cache:
+            return self._tree_cache[key]
+        data = self._get_json(
+            self._repo_api(
+                repo,
+                f"git/trees/{self._quoted_ref(commit, label='commit')}?recursive=1",
+            )
+        )
+        if not isinstance(data, dict):
+            raise GitHubUnavailable(
+                f"invalid recursive tree for {repo}@{commit}"
+            )
+        if data.get("truncated") is True:
+            inventory = self._walk_git_trees(repo, commit)
+            self._tree_cache[key] = inventory
+            return inventory
+        raw_tree = data.get("tree")
+        if not isinstance(raw_tree, list):
+            raise GitHubUnavailable(f"invalid recursive tree for {repo}@{commit}")
+        inventory: dict[str, dict[str, Any]] = {}
+        for item in raw_tree:
+            item = self._validate_tree_entry(repo, commit, item)
+            path = item["path"]
+            if path in inventory:
+                raise GitHubUnavailable(
+                    f"duplicate recursive tree path for {repo}@{commit}: {path}"
+                )
+            inventory[str(path)] = item
+        self._tree_cache[key] = inventory
+        return inventory
+
+    def _walk_git_trees(
+        self, repo: str, commit: str
+    ) -> dict[str, dict[str, Any]]:
+        """Build a complete inventory through non-recursive Git Trees calls."""
+        inventory: dict[str, dict[str, Any]] = {}
+        pending: list[tuple[str, str]] = [("", commit)]
+        visited_nodes = 0
+        while pending:
+            prefix, tree_sha = pending.pop()
+            visited_nodes += 1
+            if visited_nodes > 1_000_000:
+                raise GitHubUnavailable(
+                    f"Git tree inventory exceeds safety limit for {repo}@{commit}"
+                )
+            data = self._get_json(
+                self._repo_api(
+                    repo,
+                    f"git/trees/{self._quoted_ref(tree_sha, label='tree SHA')}",
+                )
+            )
+            if not isinstance(data, dict) or data.get("truncated") is True:
+                raise GitHubUnavailable(
+                    f"complete non-recursive Git tree unavailable for "
+                    f"{repo}@{commit}:{prefix or '/'}"
+                )
+            raw_tree = data.get("tree")
+            if not isinstance(raw_tree, list):
+                raise GitHubUnavailable(
+                    f"invalid non-recursive Git tree for "
+                    f"{repo}@{commit}:{prefix or '/'}"
+                )
+            for item in raw_tree:
+                item = self._validate_tree_entry(
+                    repo,
+                    commit,
+                    item,
+                    nested_name=True,
+                )
+                name = item["path"]
+                item_type = item["type"]
+                sha = item["sha"]
+                path = f"{prefix}/{name}" if prefix else str(name)
+                if path in inventory:
+                    raise GitHubUnavailable(
+                        f"duplicate Git tree path for {repo}@{commit}: {path}"
+                    )
+                inventory[path] = {
+                    "path": path,
+                    "type": item_type,
+                    "mode": item["mode"],
+                    "sha": sha,
+                    "size": item.get("size"),
+                }
+                if item_type == "tree":
+                    pending.append((path, sha))
+        return inventory
+
+    def blob(self, repo: str, blob_sha: str) -> bytes:
+        repo = self._validate_repo(repo)
+        if not GIT_OBJECT_RE.fullmatch(blob_sha):
+            raise GitHubUnavailable(f"invalid Git blob SHA: {blob_sha!r}")
+        key = (repo, blob_sha)
+        if key in self._blob_cache:
+            return self._blob_cache[key]
+        data = self._get_json(
+            self._repo_api(
+                repo,
+                f"git/blobs/{self._quoted_ref(blob_sha, label='blob SHA')}",
+            )
+        )
+        if not isinstance(data, dict):
+            raise GitHubUnavailable(f"invalid blob response for {repo}@{blob_sha}")
+        encoding = data.get("encoding")
+        content = data.get("content")
+        if encoding != "base64" or not isinstance(content, str):
+            raise GitHubUnavailable(
+                f"unsupported blob encoding for {repo}@{blob_sha}: {encoding!r}"
+            )
+        try:
+            compact = re.sub(r"[ \t\r\n\f\v]+", "", content)
+            raw = base64.b64decode(compact.encode("ascii"), validate=True)
+        except (ValueError, TypeError, UnicodeEncodeError) as exc:
+            raise GitHubUnavailable(
+                f"invalid base64 blob for {repo}@{blob_sha}"
+            ) from exc
+        size = data.get("size")
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size < 0
+            or size != len(raw)
+        ):
+            raise GitHubUnavailable(
+                f"Git blob size mismatch for {repo}@{blob_sha}"
+            )
+        algorithm = hashlib.sha1 if len(blob_sha) == 40 else hashlib.sha256
+        header = f"blob {len(raw)}\0".encode("ascii")
+        actual_sha = algorithm(header + raw).hexdigest()
+        if actual_sha.lower() != blob_sha.lower():
+            raise GitHubUnavailable(
+                f"Git blob hash mismatch for {repo}@{blob_sha}"
+            )
+        self._blob_cache[key] = raw
+        return raw
+
+    @staticmethod
+    def _detect_license_spdx(raw: bytes) -> tuple[str, ...]:
+        """Match complete normalized text to GitHub canonical templates."""
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return ()
+        normalized = re.sub(r"\s+", " ", text).strip().lower().encode("utf-8")
+        detected = CANONICAL_LICENSE_NORMALIZED_SHA256.get(
+            hashlib.sha256(normalized).hexdigest()
+        )
+        return (detected,) if detected is not None else ()
+
+    def license_evidence(self, repo: str, commit: str) -> LicenseEvidence:
+        """Fetch and verify GitHub's license file at one immutable commit."""
+        repo = self._validate_repo(repo)
+        if not FULL_COMMIT_RE.fullmatch(commit):
+            raise GitHubUnavailable(
+                "license query ref must be a full immutable commit SHA"
+            )
+        commit = commit.lower()
+        key = (repo, commit)
+        if key in self._license_cache:
+            return self._license_cache[key]
+        query = urllib.parse.urlencode({"ref": commit})
+        data = self._get_json(self._repo_api(repo, f"license?{query}"))
+        if not isinstance(data, dict):
+            raise GitHubUnavailable(
+                f"invalid license response for {repo}@{commit}"
+            )
+        path = data.get("path")
+        blob_sha = data.get("sha")
+        encoding = data.get("encoding")
+        content = data.get("content")
+        size = data.get("size")
+        if not self._safe_repo_path(path):
+            raise GitHubUnavailable(
+                f"invalid license path for {repo}@{commit}: {path!r}"
+            )
+        if not isinstance(blob_sha, str) or not GIT_OBJECT_RE.fullmatch(blob_sha):
+            raise GitHubUnavailable(
+                f"invalid license blob SHA for {repo}@{commit}"
+            )
+        if encoding != "base64" or not isinstance(content, str):
+            raise GitHubUnavailable(
+                f"unsupported license encoding for {repo}@{commit}: {encoding!r}"
+            )
+        try:
+            compact = re.sub(r"[ \t\r\n\f\v]+", "", content)
+            raw = base64.b64decode(compact.encode("ascii"), validate=True)
+        except (ValueError, TypeError, UnicodeEncodeError) as exc:
+            raise GitHubUnavailable(
+                f"invalid base64 license content for {repo}@{commit}"
+            ) from exc
+        if (
+            isinstance(size, bool)
+            or not isinstance(size, int)
+            or size < 0
+            or size != len(raw)
+        ):
+            raise GitHubUnavailable(
+                f"license size mismatch for {repo}@{commit}"
+            )
+        algorithm = hashlib.sha1 if len(blob_sha) == 40 else hashlib.sha256
+        actual_sha = algorithm(
+            f"blob {len(raw)}\0".encode("ascii") + raw
+        ).hexdigest()
+        if actual_sha.lower() != blob_sha.lower():
+            raise GitHubUnavailable(
+                f"license Git blob hash mismatch for {repo}@{commit}"
+            )
+        license_value = data.get("license")
+        api_spdx = (
+            license_value.get("spdx_id")
+            if isinstance(license_value, dict)
+            else None
+        )
+        if api_spdx is not None and (
+            not isinstance(api_spdx, str)
+            or not api_spdx
+            or api_spdx != api_spdx.strip()
+            or len(api_spdx) > 128
+            or any(ord(character) < 0x20 for character in api_spdx)
+        ):
+            raise GitHubUnavailable(
+                f"invalid GitHub SPDX evidence for {repo}@{commit}"
+            )
+        evidence = LicenseEvidence(
+            path=str(path),
+            blob_sha=blob_sha.lower(),
+            content_sha256=hashlib.sha256(raw).hexdigest(),
+            resolved_commit=commit,
+            spdx_candidates=self._detect_license_spdx(raw),
+            api_spdx=api_spdx,
+        )
+        self._license_cache[key] = evidence
+        return evidence
+
+    def fetch_artifacts(
+        self,
+        repo: str,
+        tracking: dict[str, Any],
+        artifacts: list[dict[str, Any]],
+    ) -> ArtifactInventory:
+        repo = self._validate_repo(repo)
+        if not isinstance(artifacts, list) or not artifacts:
+            raise GitHubUnavailable("artifact inventory must be a non-empty array")
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                raise GitHubUnavailable("artifact declarations must be objects")
+            source = artifact.get("source")
+            target = artifact.get("target")
+            if (
+                not self._safe_repo_path(source)
+                or not self._safe_repo_path(target)
+                or artifact.get("type", "file") not in {"file", "directory"}
+            ):
+                raise GitHubUnavailable(
+                    "artifact source and target must be safe paths"
+                )
+        resolved = self.resolve_tracking(repo, tracking)
+        tree = self.tree(repo, resolved.commit)
+        pending_files: list[tuple[str, str, str]] = []
+        source_blobs: dict[str, str] = {}
+        missing: list[str] = []
+        claimed_targets: set[str] = set()
+
+        for artifact in artifacts:
+            source = artifact.get("source")
+            target = artifact.get("target")
+            artifact_type = artifact.get("type", "file")
+            if not isinstance(source, str) or not isinstance(target, str):
+                raise GitHubUnavailable("artifact source and target must be strings")
+            if not self._safe_repo_path(source) or not self._safe_repo_path(target):
+                raise GitHubUnavailable("artifact source and target must be safe paths")
+            if artifact_type == "file":
+                item = tree.get(source)
+                if item is None:
+                    missing.append(source)
+                    continue
+                if self._is_special_git_object(item):
+                    raise GitHubUnavailable(
+                        "declared artifact source is a symlink or gitlink and "
+                        "requires manual review: "
+                        f"{repo}@{resolved.commit}:{source} "
+                        f"({item.get('type')}/{item.get('mode')})"
+                    )
+                if not self._is_regular_blob(item):
+                    missing.append(source)
+                    continue
+                blob_sha = item.get("sha")
+                if not isinstance(blob_sha, str):
+                    raise GitHubUnavailable(f"artifact {source} has no blob SHA")
+                if target in claimed_targets:
+                    raise GitHubUnavailable(f"multiple artifacts claim target {target}")
+                claimed_targets.add(target)
+                pending_files.append((source, target, blob_sha))
+                source_blobs[source] = blob_sha
+                continue
+
+            if artifact_type != "directory":
+                raise GitHubUnavailable(f"unsupported artifact type: {artifact_type!r}")
+            prefix = source.rstrip("/") + "/"
+            scoped_special = [
+                (
+                    f"{path} "
+                    f"({item.get('type')}/{item.get('mode')})"
+                )
+                for path, item in tree.items()
+                if (path == source or path.startswith(prefix))
+                and self._is_special_git_object(item)
+            ]
+            if scoped_special:
+                raise GitHubUnavailable(
+                    "declared directory artifact contains a symlink or gitlink "
+                    "and requires manual review: "
+                    f"{repo}@{resolved.commit}:"
+                    + ", ".join(sorted(scoped_special))
+                )
+            members = [
+                (path, item)
+                for path, item in tree.items()
+                if path.startswith(prefix)
+                and self._is_regular_blob(item)
+            ]
+            if not members:
+                missing.append(source)
+                continue
+            for path, item in sorted(members):
+                relative = path[len(prefix) :]
+                mapped_target = target.rstrip("/") + "/" + relative
+                if mapped_target in claimed_targets:
+                    raise GitHubUnavailable(
+                        f"multiple artifacts claim target {mapped_target}"
+                    )
+                blob_sha = item.get("sha")
+                if not isinstance(blob_sha, str):
+                    raise GitHubUnavailable(f"artifact {path} has no blob SHA")
+                claimed_targets.add(mapped_target)
+                pending_files.append((path, mapped_target, blob_sha))
+                source_blobs[path] = blob_sha
+
+        if missing:
+            raise ArtifactNotFound(missing)
+        files = {
+            target: self.blob(repo, blob_sha)
+            for _source, target, blob_sha in pending_files
+        }
+        return ArtifactInventory(files, source_blobs, resolved)
+
+    def compare(self, repo: str, base: str, head: str) -> dict[str, Any]:
+        repo = self._validate_repo(repo)
+        if not FULL_COMMIT_RE.fullmatch(base) or not FULL_COMMIT_RE.fullmatch(head):
+            raise GitHubUnavailable(
+                "compare base and head must be full commit SHAs"
+            )
+        quoted_base = self._quoted_ref(base, label="compare base")
+        quoted_head = self._quoted_ref(head, label="compare head")
+        data = self._get_json(
+            self._repo_api(repo, f"compare/{quoted_base}...{quoted_head}")
+        )
+        if not isinstance(data, dict) or data.get("status") not in {
+            "ahead",
+            "behind",
+            "diverged",
+            "identical",
+        }:
+            raise GitHubUnavailable(
+                f"could not compare {repo}@{base}...{head}"
+            )
+        return {
+            "status": data["status"],
+            "ahead_by": int(data.get("ahead_by", 0)),
+            "behind_by": int(data.get("behind_by", 0)),
+        }
+
+    def path_commit(self, repo: str, ref: str, path: str) -> str:
+        repo = self._validate_repo(repo)
+        if not FULL_COMMIT_RE.fullmatch(ref):
+            raise GitHubUnavailable(
+                "path commit query ref must be a full commit SHA"
+            )
+        if not self._safe_repo_path(path):
+            raise GitHubUnavailable(f"invalid GitHub path: {path!r}")
+        key = (repo, ref, path)
+        if key in self._path_commit_cache:
+            return self._path_commit_cache[key]
+        query = urllib.parse.urlencode({"sha": ref, "path": path, "per_page": 1})
+        data = self._get_json(self._repo_api(repo, f"commits?{query}"))
+        if not isinstance(data, list) or not data:
+            raise GitHubUnavailable(
+                f"could not resolve path commit for {repo}@{ref}:{path}"
+            )
+        sha = data[0].get("sha") if isinstance(data[0], dict) else None
+        if not isinstance(sha, str) or not FULL_COMMIT_RE.fullmatch(sha):
+            raise GitHubUnavailable(
+                f"invalid path commit for {repo}@{ref}:{path}"
+            )
+        self._path_commit_cache[key] = sha.lower()
+        return sha.lower()
+
+    def moved_candidates(
+        self,
+        repo: str,
+        old_commit: str | None,
+        new_commit: str,
+        missing_sources: list[str],
+        *,
+        local_files: dict[str, bytes] | None = None,
+    ) -> dict[str, list[str]]:
+        """Locate exact-blob rename candidates; never chooses one automatically."""
+        new_tree = self.tree(repo, new_commit)
+        old_tree = self.tree(repo, old_commit) if old_commit else {}
+        local_files = local_files or {}
+        candidates: dict[str, list[str]] = {}
+
+        for source in missing_sources:
+            old_sha = None
+            old_type = "blob"
+            old_item = old_tree.get(source)
+            if (
+                isinstance(old_item, dict)
+                and (
+                    self._is_regular_blob(old_item)
+                    or (
+                        old_item.get("type") == "tree"
+                        and old_item.get("mode") == TREE_MODE
+                    )
+                )
+            ):
+                candidate_sha = old_item.get("sha")
+                if isinstance(candidate_sha, str):
+                    old_sha = candidate_sha
+                    old_type = str(old_item.get("type"))
+            if old_sha is None and source in local_files:
+                raw = local_files[source]
+                header = f"blob {len(raw)}\0".encode("ascii")
+                old_sha = hashlib.sha1(header + raw).hexdigest()
+            if old_sha is None:
+                continue
+            matches = sorted(
+                path
+                for path, item in new_tree.items()
+                if isinstance(item, dict)
+                and item.get("type") == old_type
+                and (
+                    self._is_regular_blob(item)
+                    or (
+                        item.get("type") == "tree"
+                        and item.get("mode") == TREE_MODE
+                    )
+                )
+                and item.get("sha") == old_sha
+                and path != source
+            )
+            if matches:
+                candidates[source] = matches
+        return candidates

--- a/scripts/ingest_skill.py
+++ b/scripts/ingest_skill.py
@@ -2704,11 +2704,14 @@ def run_pipeline(
 
 IGNORED_STAGE_NAMES = {
     ".git",
+    ".hvs-stage-index-modes.json",
     ".hvs-transactions",
     ".pytest_cache",
     "__pycache__",
     ".DS_Store",
 }
+
+STAGE_INDEX_MODES_NAME = ".hvs-stage-index-modes.json"
 
 
 def _read_regular_at(
@@ -2884,6 +2887,7 @@ def _copy_stage_repository(repo_root: Path, destination: Path) -> None:
         repo_root,
         directory_modes=directory_modes,
     )
+    index_modes = _trusted_git_index_modes(repo_root)
     destination.mkdir(mode=0o700)
     for relative, mode in sorted(
         directory_modes.items(),
@@ -2912,6 +2916,89 @@ def _copy_stage_repository(repo_root: Path, destination: Path) -> None:
         finally:
             if descriptor >= 0:
                 os.close(descriptor)
+    if index_modes is not None:
+        snapshot = (
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "source": "trusted-git-index",
+                    "modes": index_modes,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+        snapshot_flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            snapshot_flags |= os.O_NOFOLLOW
+        snapshot_fd = os.open(
+            destination / STAGE_INDEX_MODES_NAME,
+            snapshot_flags,
+            0o600,
+        )
+        try:
+            remaining = memoryview(snapshot)
+            while remaining:
+                written = os.write(snapshot_fd, remaining)
+                if written <= 0:
+                    raise OSError("stage index snapshot write made no progress")
+                remaining = remaining[written:]
+            os.fsync(snapshot_fd)
+        finally:
+            os.close(snapshot_fd)
+
+
+def _trusted_git_index_modes(repo_root: Path) -> dict[str, str] | None:
+    """Capture the real worktree index without copying any .git control data."""
+    try:
+        top = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"cannot inspect staging Git index: {exc}") from exc
+    if top.returncode != 0:
+        return None
+    try:
+        resolved_repo = repo_root.resolve(strict=True)
+        git_root = Path(top.stdout.strip()).resolve(strict=True)
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise RuntimeError(f"cannot resolve staging Git worktree: {exc}") from exc
+    if resolved_repo != git_root:
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(resolved_repo), "ls-files", "--stage", "-z"],
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"cannot capture staging Git index: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            "cannot capture staging Git index"
+            + (f": {detail}" if detail else "")
+        )
+    modes: dict[str, str] = {}
+    for record in completed.stdout.split(b"\0"):
+        if not record:
+            continue
+        metadata, separator, raw_path = record.partition(b"\t")
+        fields = metadata.split()
+        if not separator or len(fields) != 3 or fields[2] != b"0":
+            raise RuntimeError("Git index snapshot contains a malformed record")
+        mode = fields[0].decode("ascii")
+        if mode not in {"100644", "100755", "120000", "160000"}:
+            raise RuntimeError(f"Git index snapshot contains invalid mode {mode}")
+        relative = raw_path.decode("utf-8", errors="surrogateescape")
+        modes[relative] = mode
+    return dict(sorted(modes.items()))
 
 
 def _translate_plan_to_stage(

--- a/scripts/ingest_skill.py
+++ b/scripts/ingest_skill.py
@@ -23,18 +23,63 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import copy
+import contextlib
+import hashlib
 import json
+import os
 import re
+import secrets
+import stat
 import subprocess
 import sys
+import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import date
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    from provenance_v2 import infer_channel, safe_relative_path
+except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
+    from scripts.provenance_v2 import infer_channel, safe_relative_path
+try:
+    from sync_upstream import (
+        mapping_advisory_lock,
+        validate_license_evidence,
+    )
+    from artifact_set_sync import skill_advisory_lock
+    from durable_file_batch import (
+        DurableBatchGuard,
+        durable_batch_lock_and_recover,
+    )
+    from github_artifact_provider import (
+        GitHubArtifactProvider,
+        GitHubProviderError,
+    )
+except ModuleNotFoundError:  # pragma: no cover - package-style unit import
+    from scripts.sync_upstream import (
+        mapping_advisory_lock,
+        validate_license_evidence,
+    )
+    from scripts.artifact_set_sync import skill_advisory_lock
+    from scripts.durable_file_batch import (
+        DurableBatchGuard,
+        durable_batch_lock_and_recover,
+    )
+    from scripts.github_artifact_provider import (
+        GitHubArtifactProvider,
+        GitHubProviderError,
+    )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = REPO_ROOT / "skills"
 PROVENANCE_FILE = REPO_ROOT / "docs" / "sources" / "in-house.skills.json"
+EXTERNAL_PROVENANCE_FILE = (
+    REPO_ROOT / "docs" / "sources" / "ingested-external.skills.json"
+)
 INHOUSE_SOURCES = {"in-house", "", "local-repo/in-house"}
 PERMISSIVE_LICENSES = {
     "MIT", "Apache-2.0", "Apache 2.0", "BSD-2-Clause", "BSD-3-Clause",
@@ -43,6 +88,7 @@ PERMISSIVE_LICENSES = {
 GITHUB_LICENSE_KEYS = {
     "mit": "MIT",
     "apache-2.0": "Apache-2.0",
+    "apache 2.0": "Apache-2.0",
     "bsd-2-clause": "BSD-2-Clause",
     "bsd-3-clause": "BSD-3-Clause",
     "isc": "ISC",
@@ -52,6 +98,8 @@ GITHUB_LICENSE_KEYS = {
     "0bsd": "0BSD",
     "mpl-2.0": "MPL-2.0",
 }
+GITHUB_HOSTS = {"github.com", "www.github.com"}
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
 
 def parse_frontmatter(text: str) -> dict[str, str]:
@@ -76,50 +124,369 @@ def normalize_license_tag(value: str) -> str:
     return GITHUB_LICENSE_KEYS.get(raw.lower(), raw)
 
 
-def github_repo_from_source(source: str, source_url: str = "") -> str | None:
-    source = source.strip().strip('"').strip("'")
-    if source.startswith("github:"):
-        repo = source.removeprefix("github:")
-        if re.match(r"^[^/]+/[^/]+$", repo):
-            return repo
-    match = re.search(r"github\.com/([^/\s]+/[^/\s#?]+)", source_url)
-    if match:
-        return match.group(1).removesuffix(".git")
-    return None
-
-
-def fetch_github_repo_license(repo: str) -> str | None:
-    req = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}",
-        headers={
-            "Accept": "application/vnd.github.v3+json",
-            "User-Agent": "skills-ingest-license-check",
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
-    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+def _normalize_github_repo(repo: str) -> str | None:
+    value = repo.strip().removesuffix(".git")
+    if not re.fullmatch(
+        r"[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,99})/"
+        r"[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,99})",
+        value,
+    ):
         return None
-    key = ((payload.get("license") or {}).get("key") or "").lower()
-    return GITHUB_LICENSE_KEYS.get(key)
+    if any(part in {".", ".."} for part in value.split("/")):
+        return None
+    return value
 
 
-def resolve_external_license(fm: dict[str, str], source: str, source_url: str) -> tuple[str | None, str | None]:
+def github_repo_from_url(source_url: str) -> str | None:
+    """Parse only an explicit HTTPS github.com repository URL."""
+    if not source_url:
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(source_url)
+        hostname = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() != "https"
+        or hostname not in GITHUB_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+    ):
+        return None
+    parts = [urllib.parse.unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        return None
+    return _normalize_github_repo(f"{parts[0]}/{parts[1]}")
+
+
+def github_repo_from_source(source: str, source_url: str = "") -> str | None:
+    """Return a GitHub repository only when every declaration agrees."""
+    normalized_source = source.strip().strip('"').strip("'")
+    declared_repo: str | None = None
+    if normalized_source.startswith("github:"):
+        declared_repo = _normalize_github_repo(
+            normalized_source.removeprefix("github:")
+        )
+        if declared_repo is None:
+            return None
+    url_repo = github_repo_from_url(source_url)
+    if source_url and "github" in normalized_source.lower() and url_repo is None:
+        return None
+    if declared_repo and url_repo and declared_repo.lower() != url_repo.lower():
+        return None
+    return declared_repo or url_repo
+
+
+def resolve_github_token() -> str | None:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
+    try:
+        completed = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+def resolve_github_checkpoint(
+    repo: str,
+    ref: str,
+    upstream_path: str,
+) -> tuple[str | None, str | None]:
+    """Resolve immutable repository and path commits using authenticated GitHub."""
+    token = resolve_github_token()
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "skills-ingest-provenance",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    def request_json(url: str) -> object:
+        request = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    try:
+        encoded_ref = urllib.parse.quote(ref, safe="")
+        commit_payload = request_json(
+            f"https://api.github.com/repos/{repo}/commits/{encoded_ref}"
+        )
+        resolved_commit = (
+            commit_payload.get("sha")
+            if isinstance(commit_payload, dict)
+            else None
+        )
+        if (
+            not isinstance(resolved_commit, str)
+            or not COMMIT_RE.fullmatch(resolved_commit)
+        ):
+            return None, None
+        query = urllib.parse.urlencode(
+            {"path": upstream_path, "sha": resolved_commit, "per_page": 1}
+        )
+        path_payload = request_json(
+            f"https://api.github.com/repos/{repo}/commits?{query}"
+        )
+        path_commit = (
+            path_payload[0].get("sha")
+            if isinstance(path_payload, list)
+            and path_payload
+            and isinstance(path_payload[0], dict)
+            else None
+        )
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        json.JSONDecodeError,
+        TimeoutError,
+    ):
+        return None, None
+    if not isinstance(path_commit, str) or not COMMIT_RE.fullmatch(path_commit):
+        path_commit = None
+    return resolved_commit, path_commit
+
+
+def document_body(text: str) -> str:
+    match = re.match(r"^---\s*\n.*?\n---(?:\s*\n|$)", text, re.DOTALL)
+    body = text[match.end() :] if match else text
+    return body.replace("\r\n", "\n").strip()
+
+
+def regular_skill_files(skill_dir: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(skill_dir.rglob("*")):
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or "__pycache__" in path.parts
+            or path.suffix in {".pyc", ".pyo"}
+            or path.name == ".DS_Store"
+        ):
+            continue
+        files.append(path)
+    return files
+
+
+def classify_github_artifacts(
+    *,
+    skill_dir: Path,
+    repo_root: Path,
+    repo: str,
+    resolved_commit: str,
+    upstream_skill_path: str,
+    artifact_maps: list[tuple[str, str]] | None = None,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Prove explicitly mapped upstream files and classify the rest as local."""
+    try:
+        from github_artifact_provider import (
+            GitHubArtifactProvider,
+            GitHubProviderError,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - package-style test import
+        from scripts.github_artifact_provider import (
+            GitHubArtifactProvider,
+            GitHubProviderError,
+        )
+
+    provider = GitHubArtifactProvider(resolve_github_token())
+    try:
+        tree = provider.tree(repo, resolved_commit)
+    except GitHubProviderError as exc:
+        raise ValueError(
+            f"cannot inspect immutable upstream tree {repo}@{resolved_commit}: {exc}"
+        ) from exc
+
+    target_to_source: dict[str, str] = {}
+    skill_root = skill_dir.relative_to(repo_root).as_posix()
+    for source_path, target in artifact_maps or []:
+        if not safe_relative_path(source_path) or not safe_relative_path(target):
+            raise ValueError(
+                f"artifact mapping must use safe relative paths: "
+                f"{source_path!r}={target!r}"
+            )
+        if target in target_to_source:
+            raise ValueError(f"duplicate artifact target: {target}")
+        if target != skill_root and not target.startswith(f"{skill_root}/"):
+            raise ValueError(
+                f"artifact target is outside the skill directory: {target}"
+            )
+        target_to_source[target] = source_path
+
+    external: list[dict[str, str]] = []
+    local: list[dict[str, str]] = []
+    used_targets: set[str] = set()
+    for local_path in regular_skill_files(skill_dir):
+        target = local_path.relative_to(repo_root).as_posix()
+        if local_path.name == "SKILL.md":
+            source_path = upstream_skill_path
+            declared_source = target_to_source.get(target)
+            if declared_source is not None:
+                used_targets.add(target)
+                if declared_source != source_path:
+                    raise ValueError(
+                        "canonical SKILL.md artifact mapping disagrees with "
+                        f"--upstream-path: {declared_source} != {source_path}"
+                    )
+        else:
+            source_path = target_to_source.get(target)
+            if source_path is None:
+                local.append({"source": target, "target": target, "type": "file"})
+                continue
+            used_targets.add(target)
+        item = tree.get(source_path)
+        upstream_bytes: bytes | None = None
+        if isinstance(item, dict) and item.get("type") == "blob":
+            blob_sha = item.get("sha")
+            if not isinstance(blob_sha, str):
+                raise ValueError(f"upstream artifact has no blob SHA: {source_path}")
+            try:
+                upstream_bytes = provider.blob(repo, blob_sha)
+            except GitHubProviderError as exc:
+                raise ValueError(
+                    f"cannot read immutable upstream artifact {source_path}: {exc}"
+                ) from exc
+
+        if local_path.name == "SKILL.md":
+            if upstream_bytes is None:
+                raise ValueError(
+                    f"declared upstream SKILL.md does not exist: {source_path}"
+                )
+            try:
+                upstream_text = upstream_bytes.decode("utf-8")
+                local_text = local_path.read_text(encoding="utf-8")
+            except UnicodeError as exc:
+                raise ValueError("canonical external SKILL.md must be UTF-8") from exc
+            if document_body(upstream_text) != document_body(local_text):
+                raise ValueError(
+                    "local SKILL.md body does not match the declared immutable "
+                    "upstream; adapted canonical bodies must be ingested as an "
+                    "original in-house skill instead"
+                )
+            external.append(
+                {"source": source_path, "target": target, "type": "file"}
+            )
+        elif upstream_bytes is None:
+            raise ValueError(
+                f"explicitly mapped upstream artifact does not exist: {source_path}"
+            )
+        elif upstream_bytes == local_path.read_bytes():
+            external.append(
+                {"source": source_path, "target": target, "type": "file"}
+            )
+        else:
+            raise ValueError(
+                f"explicitly mapped artifact bytes differ from upstream: "
+                f"{source_path} -> {target}"
+            )
+    unused = sorted(set(target_to_source) - used_targets)
+    if unused:
+        raise ValueError(
+            "artifact mappings target missing files: " + ", ".join(unused)
+        )
+    return external, local
+
+
+def resolve_external_license(
+    fm: dict[str, str],
+    source: str,
+    source_url: str,
+) -> tuple[str | None, str | None]:
     current = normalize_license_tag(fm.get("license", ""))
-    if current:
-        if current in PERMISSIVE_LICENSES:
-            return current, None
+    if current and current not in PERMISSIVE_LICENSES:
         return None, f"license {current!r} is not in the permissive allowlist"
 
+    source_value = source.strip().strip('"').strip("'")
+    source_declares_github = source_value.startswith("github:")
+    try:
+        url_hostname = (
+            urllib.parse.urlsplit(source_url).hostname or ""
+        ).lower()
+    except ValueError:
+        url_hostname = ""
+    url_looks_github = bool(source_url) and url_hostname in GITHUB_HOSTS
     repo = github_repo_from_source(source, source_url)
-    if repo:
-        detected = fetch_github_repo_license(repo)
-        if detected in PERMISSIVE_LICENSES:
-            return detected, None
-        return None, f"external GitHub source {repo!r} has no detectable permissive license"
+    if source_declares_github or url_looks_github:
+        if repo is None:
+            return None, "GitHub source and source_url are invalid or disagree"
+        return (
+            None,
+            "GitHub license authorization requires an immutable resolved "
+            "commit checkpoint",
+        )
 
-    return None, "external source lacks a license tag"
+    if repo is not None:
+        return None, "GitHub repository must be declared with a strict GitHub source"
+    return (
+        None,
+        "non-GitHub license evidence cannot prove immutable content lineage; "
+        "ingest an original in-house rewrite or declare its authoritative "
+        "GitHub repository",
+    )
+
+
+def resolve_commit_bound_github_license(
+    fm: dict[str, str],
+    source: str,
+    source_url: str,
+    *,
+    repo: str,
+    resolved_commit: str,
+) -> tuple[str | None, dict[str, str] | None, str | None]:
+    """Verify complete license bytes at the exact immutable source commit."""
+    declared = normalize_license_tag(fm.get("license", ""))
+    if declared and declared not in PERMISSIVE_LICENSES:
+        return (
+            None,
+            None,
+            f"license {declared!r} is not in the permissive allowlist",
+        )
+    if github_repo_from_source(source, source_url) != repo:
+        return (
+            None,
+            None,
+            "GitHub source and source_url are invalid or disagree",
+        )
+    if not COMMIT_RE.fullmatch(resolved_commit):
+        return (
+            None,
+            None,
+            "GitHub license authorization requires a full immutable commit",
+        )
+    provider = GitHubArtifactProvider(resolve_github_token())
+    try:
+        evidence = provider.license_evidence(repo, resolved_commit.lower())
+    except GitHubProviderError as exc:
+        return (
+            None,
+            None,
+            f"cannot verify immutable GitHub license: {exc}",
+        )
+    candidate = (
+        evidence.api_spdx
+        if evidence.api_spdx not in {None, "NOASSERTION"}
+        else (
+            evidence.spdx_candidates[0]
+            if len(evidence.spdx_candidates) == 1
+            else None
+        )
+    )
+    checkpoint, error = validate_license_evidence(
+        declared or candidate,
+        evidence,
+    )
+    if error is not None or checkpoint is None:
+        return None, None, error or "immutable license evidence is unavailable"
+    return checkpoint["spdx"], checkpoint, None
 
 
 def update_frontmatter_field(content: str, key: str, value: str) -> str:
@@ -142,14 +509,29 @@ def update_frontmatter_field(content: str, key: str, value: str) -> str:
 
 
 def get_tracked_skills(provenance_path: Path) -> set[str]:
-    """Return set of skill names already in the provenance file."""
-    if not provenance_path.exists():
-        return set()
-    data = json.loads(provenance_path.read_text(encoding="utf-8"))
-    return {
-        entry.get("video_name", "")
-        for entry in data.get("skills", [])
-    }
+    """Return every active claim from one mapping or a mappings directory."""
+    mappings = (
+        sorted(provenance_path.glob("*.skills.json"))
+        if provenance_path.is_dir()
+        else [provenance_path]
+    )
+    tracked: set[str] = set()
+    for mapping in mappings:
+        if not mapping.exists():
+            continue
+        data = json.loads(mapping.read_text(encoding="utf-8"))
+        if data.get("schema_version") != 2:
+            raise ValueError(f"active mapping must use provenance v2: {mapping}")
+        entries = data.get("skills")
+        if not isinstance(entries, list):
+            raise ValueError(f"mapping skills must be a list: {mapping}")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError(f"mapping contains a non-object claim: {mapping}")
+            name = entry.get("normalized_slug") or entry.get("video_name")
+            if isinstance(name, str) and name:
+                tracked.add(name)
+    return tracked
 
 
 def find_untracked_skills(skills_dir: Path, tracked: set[str]) -> list[Path]:
@@ -176,38 +558,1100 @@ def get_git_created_date(filepath: Path) -> str:
     return date.today().isoformat()
 
 
-def ingest_one(skill_dir: Path, source: str, source_url: str, dry_run: bool) -> bool:
-    """Ingest a single skill directory."""
-    skill_md = skill_dir / "SKILL.md"
-    if not skill_md.exists():
-        print(f"  ERROR: {skill_md} does not exist", file=sys.stderr)
-        return False
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
-    content = skill_md.read_text(encoding="utf-8", errors="replace")
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def github_location(
+    *,
+    source: str,
+    source_url: str,
+    skill_name: str,
+    upstream_path: str | None,
+    upstream_ref: str,
+) -> tuple[str, str, str] | None:
+    """Resolve a GitHub repository, ref and SKILL path for v2 provenance."""
+    source_value = source.strip().strip('"').strip("'")
+    repo = github_repo_from_source(source, source_url)
+    try:
+        parsed = urllib.parse.urlsplit(source_url) if source_url else None
+    except ValueError as exc:
+        raise ValueError("source_url is invalid") from exc
+    github_url = (
+        parsed is not None
+        and (parsed.hostname or "").lower() in GITHUB_HOSTS
+    )
+    if source_value.startswith("github:") or github_url:
+        if repo is None:
+            raise ValueError("GitHub source and source_url are invalid or disagree")
+    elif repo is not None:
+        raise ValueError("GitHub repository declaration is ambiguous")
+    if not repo:
+        return None
+
+    resolved_ref = upstream_ref
+    resolved_path = upstream_path
+    if parsed is not None:
+        parts = [
+            urllib.parse.unquote(part)
+            for part in parsed.path.split("/")
+            if part
+        ]
+        if len(parts) >= 5 and parts[2] in {"blob", "tree"}:
+            if upstream_ref == "main":
+                resolved_ref = parts[3]
+            if not resolved_path:
+                resolved_path = "/".join(parts[4:]).rstrip("/")
+
+    if not resolved_path:
+        resolved_path = f"skills/{skill_name}/SKILL.md"
+    elif not resolved_path.endswith("/SKILL.md") and resolved_path != "SKILL.md":
+        resolved_path = f"{resolved_path.rstrip('/')}/SKILL.md"
+    return repo, resolved_ref, resolved_path
+
+
+def _mapping_payload(path: Path, source_url: str, today: str) -> dict:
+    if path.exists():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("schema_version") != 2:
+            raise ValueError(f"external provenance mapping must use schema v2: {path}")
+        if not isinstance(payload.get("skills"), list):
+            raise ValueError(f"external provenance mapping has invalid skills list: {path}")
+        if not isinstance(payload.get("video"), dict):
+            raise ValueError(f"external provenance mapping has invalid video: {path}")
+        if not isinstance(payload.get("official_references"), list):
+            raise ValueError(
+                f"external provenance mapping has invalid official_references: "
+                f"{path}"
+            )
+        if not isinstance(payload.get("verification_attempts"), list):
+            raise ValueError(
+                f"external provenance mapping has invalid verification_attempts: "
+                f"{path}"
+            )
+        return payload
+    return {
+        "schema_version": 2,
+        "video": {
+            "url": source_url,
+            "checked_at": today,
+            "note": "External skills registered by scripts/ingest_skill.py.",
+        },
+        "official_references": [],
+        "skills": [],
+        "verification_attempts": [],
+    }
+
+
+def _assert_unclaimed(
+    *,
+    repo_root: Path,
+    target_mapping: Path,
+    repo_skill: str,
+    skill_name: str,
+) -> None:
+    sources_dir = repo_root / "docs" / "sources"
+    for mapping in sorted(sources_dir.glob("*.skills.json")):
+        if mapping.resolve() == target_mapping.resolve():
+            continue
+        payload = json.loads(mapping.read_text(encoding="utf-8"))
+        for entry in payload.get("skills", []):
+            if not isinstance(entry, dict):
+                continue
+            if (
+                entry.get("repo_skill") == repo_skill
+                or (
+                    entry.get("normalized_slug") == skill_name
+                    and entry.get("status") in {"verified_in_repo", "in_house"}
+                )
+            ):
+                raise ValueError(
+                    f"{skill_name} is already claimed by {mapping.relative_to(repo_root)}"
+                )
+
+
+def build_external_provenance_payload(
+    *,
+    skill_dir: Path,
+    skill_content: str,
+    source: str,
+    source_url: str,
+    license_value: str,
+    mapping_path: Path,
+    repo_root: Path,
+    upstream_path: str | None = None,
+    upstream_ref: str = "main",
+    resolved_commit: str | None = None,
+    path_commit: str | None = None,
+    license_checkpoint: dict[str, str] | None = None,
+    artifact_maps: list[tuple[str, str]] | None = None,
+    existing_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a fully validated v2 mapping without mutating the repository."""
+    skill_md = skill_dir / "SKILL.md"
+    frontmatter = parse_frontmatter(skill_content)
+    skill_name = frontmatter.get("name") or skill_dir.name
+    try:
+        repo_skill = skill_md.relative_to(repo_root).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"skill directory is outside repository: {skill_dir}") from exc
+    expected_repo_skill = f"skills/{skill_dir.parent.name}/{skill_name}/SKILL.md"
+    if repo_skill != expected_repo_skill or not safe_relative_path(repo_skill):
+        raise ValueError(
+            "external skill must use canonical path "
+            f"{expected_repo_skill!r}; got {repo_skill!r}"
+        )
+
+    location = github_location(
+        source=source,
+        source_url=source_url,
+        skill_name=skill_name,
+        upstream_path=upstream_path,
+        upstream_ref=upstream_ref,
+    )
+    if location:
+        repo, ref, source_path = location
+        kind = "mirror"
+        sync_mode = "monitor"
+        discovered_commit, discovered_path_commit = resolve_github_checkpoint(
+            repo,
+            ref,
+            source_path,
+        )
+        if discovered_commit is None or discovered_path_commit is None:
+            raise ValueError(
+                f"cannot resolve immutable GitHub checkpoint for "
+                f"{repo}@{ref}:{source_path}"
+            )
+        if (
+            resolved_commit is not None
+            and resolved_commit.lower() != discovered_commit.lower()
+        ):
+            raise ValueError(
+                "caller supplied --resolved-commit does not match the online "
+                f"checkpoint: {resolved_commit} != {discovered_commit}"
+            )
+        if (
+            path_commit is not None
+            and path_commit.lower() != discovered_path_commit.lower()
+        ):
+            raise ValueError(
+                "caller supplied --path-commit does not match the online path "
+                f"checkpoint: {path_commit} != {discovered_path_commit}"
+            )
+        resolved_commit = discovered_commit
+        path_commit = discovered_path_commit
+    else:
+        raise ValueError(
+            "non-GitHub content lineage cannot own canonical artifacts; "
+            "use an original in-house rewrite"
+        )
+    if not safe_relative_path(source_path):
+        raise ValueError(f"upstream path must be a safe relative path: {source_path!r}")
+    if (
+        not isinstance(license_checkpoint, dict)
+        or license_checkpoint.get("resolved_commit")
+        != str(resolved_commit).lower()
+        or license_checkpoint.get("spdx") != license_value
+    ):
+        raise ValueError(
+            "immutable license checkpoint is missing or disagrees with the "
+            "resolved source commit"
+        )
+    channel = infer_channel(ref, repo)
+
+    today = date.today().isoformat()
+    skill_bytes = skill_content.encode("utf-8")
+    digest = sha256_bytes(skill_bytes)
+    if location:
+        external_artifacts, local_artifacts = classify_github_artifacts(
+            skill_dir=skill_dir,
+            repo_root=repo_root,
+            repo=repo,
+            resolved_commit=str(resolved_commit),
+            upstream_skill_path=source_path,
+            artifact_maps=artifact_maps,
+        )
+    else:
+        external_artifacts = [
+            {
+                "source": source_path,
+                "target": repo_skill,
+                "type": "file",
+            }
+        ]
+        external_targets = {repo_skill}
+        local_artifacts = [
+            {
+                "source": path.relative_to(repo_root).as_posix(),
+                "target": path.relative_to(repo_root).as_posix(),
+                "type": "file",
+            }
+            for path in regular_skill_files(skill_dir)
+            if path.relative_to(repo_root).as_posix() not in external_targets
+        ]
+    source_link = source_url or (
+        f"https://github.com/{repo}" if location else f"https://{repo}"
+    )
+    origins = [
+        {
+            "repo": repo,
+            "path": source_path,
+            "license": license_value,
+            "sync_mode": sync_mode,
+            "artifacts": external_artifacts,
+            "tracking": {
+                "channel": channel,
+                "ref": ref,
+                "resolved_commit": resolved_commit,
+                "path_commit": path_commit,
+                "content_sha256": digest,
+                "license_checkpoint": copy.deepcopy(license_checkpoint),
+                "last_checked_at": today,
+                "last_synced_at": today,
+            },
+        }
+    ]
+    if local_artifacts:
+        origins.append(
+            {
+                "repo": "local-repo/curation",
+                "path": skill_md.parent.relative_to(repo_root).as_posix(),
+                "license": None,
+                "sync_mode": "local-only",
+                "artifacts": local_artifacts,
+                "tracking": {
+                    "channel": "local",
+                    "ref": "local",
+                    "resolved_commit": None,
+                    "path_commit": None,
+                    "content_sha256": None,
+                    "last_checked_at": today,
+                    "last_synced_at": today,
+                },
+            }
+        )
+        if kind != "snapshot":
+            kind = "overlay"
+            sync_mode = "monitor"
+    entry = {
+        "video_name": skill_name,
+        "normalized_slug": skill_name,
+        "status": "verified_in_repo",
+        "repo_skill": repo_skill,
+        "source": source_link,
+        "notes": "External skill registered by scripts/ingest_skill.py.",
+        "upstream": {
+            "repo": repo,
+            "path": source_path,
+            "ref": ref,
+            "last_checked_at": today,
+            "last_synced_at": today,
+            "last_synced_commit": resolved_commit,
+            "sync_mode": sync_mode,
+        },
+        "kind": kind,
+        "sync_mode": sync_mode,
+        "origins": origins,
+        "managed_files": [
+            {
+                "path": path.relative_to(repo_root).as_posix(),
+                "owner": skill_name,
+                "sha256": (
+                    digest
+                    if path == skill_md
+                    else sha256_file(path)
+                ),
+            }
+            for path in regular_skill_files(skill_dir)
+        ],
+    }
+
+    _assert_unclaimed(
+        repo_root=repo_root,
+        target_mapping=mapping_path,
+        repo_skill=repo_skill,
+        skill_name=skill_name,
+    )
+    payload = (
+        copy.deepcopy(existing_payload)
+        if existing_payload is not None
+        else _mapping_payload(mapping_path, source_link, today)
+    )
+    payload["video"]["checked_at"] = today
+    entries = [
+        existing
+        for existing in payload["skills"]
+        if isinstance(existing, dict)
+        and existing.get("repo_skill") != repo_skill
+        and existing.get("normalized_slug") != skill_name
+    ]
+    entries.append(entry)
+    entries.sort(key=lambda item: str(item.get("normalized_slug") or ""))
+    payload["skills"] = entries
+    payload.setdefault("official_references", [])
+    if source_link and not any(
+        isinstance(reference, dict) and reference.get("url") == source_link
+        for reference in payload["official_references"]
+    ):
+        payload["official_references"].append(
+            {
+                "name": f"{skill_name} upstream",
+                "url": source_link,
+                "purpose": "Original external source registered during ingestion.",
+            }
+        )
+    attempt = {
+        "date": today,
+        "method": "ingest-skill",
+        "target": repo_skill,
+        "result": "success",
+        "evidence": f"Registered external provenance for {skill_name}",
+    }
+    attempts = payload.setdefault("verification_attempts", [])
+    if attempt not in attempts:
+        attempts.append(attempt)
+    return payload
+
+
+def register_external_provenance(
+    *,
+    skill_dir: Path,
+    source: str,
+    source_url: str,
+    license_value: str,
+    mapping_path: Path,
+    repo_root: Path,
+    upstream_path: str | None = None,
+    upstream_ref: str = "main",
+    resolved_commit: str | None = None,
+    path_commit: str | None = None,
+    artifact_maps: list[tuple[str, str]] | None = None,
+) -> None:
+    """Compatibility wrapper for callers that already enriched SKILL.md."""
+    with acquire_ingest_locks(
+        repo_root=repo_root,
+        skill_dirs=[skill_dir],
+        mapping_paths=[mapping_path],
+    ) as durable_guard:
+        plan = prepare_ingest(
+            skill_dir,
+            source,
+            source_url,
+            external_mapping=mapping_path,
+            repo_root=repo_root,
+            upstream_path=upstream_path,
+            upstream_ref=upstream_ref,
+            resolved_commit=resolved_commit,
+            path_commit=path_commit,
+            artifact_maps=artifact_maps,
+        )
+        planned_license = normalize_license_tag(
+            parse_frontmatter(
+                plan.after_skill.decode("utf-8")
+            ).get("license", "")
+        )
+        if normalize_license_tag(license_value) != planned_license:
+            raise ValueError(
+                "caller license disagrees with verified upstream license"
+            )
+        commit_ingest_plans(
+            [plan],
+            locks_held=True,
+            durable_guard=durable_guard,
+        )
+
+
+class IngestPlan:
+    def __init__(
+        self,
+        *,
+        skill_name: str,
+        skill_md: Path,
+        before_skill: bytes | None,
+        after_skill: bytes,
+        mapping_path: Path | None = None,
+        before_mapping: bytes | None = None,
+        after_mapping: bytes | None = None,
+        mapping_payload: dict[str, Any] | None = None,
+        repo_root: Path | None = None,
+        input_fingerprint: str | None = None,
+        before_checkpoint: dict[str, Any] | None = None,
+        mapping_checkpoint: dict[str, Any] | None = None,
+        before_parent_checkpoint: list[dict[str, Any]] | None = None,
+        mapping_parent_checkpoint: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.skill_name = skill_name
+        self.skill_md = skill_md
+        self.before_skill = before_skill
+        self.after_skill = after_skill
+        self.mapping_path = mapping_path
+        self.before_mapping = before_mapping
+        self.after_mapping = after_mapping
+        self.mapping_payload = mapping_payload
+        self.repo_root = repo_root
+        self.input_fingerprint = input_fingerprint
+        self.before_checkpoint = before_checkpoint
+        self.mapping_checkpoint = mapping_checkpoint
+        self.before_parent_checkpoint = before_parent_checkpoint
+        self.mapping_parent_checkpoint = mapping_parent_checkpoint
+
+
+def _directory_open_flags() -> int:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    return flags
+
+
+def open_directory_nofollow(path: Path) -> int:
+    """Open an absolute directory by walking every ancestor without symlinks."""
+    absolute = Path(os.path.abspath(path))
+    descriptor = os.open("/", _directory_open_flags())
+    try:
+        for component in absolute.parts[1:]:
+            next_descriptor = os.open(
+                component,
+                _directory_open_flags(),
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"not a directory: {path}")
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def open_parent_from_repo_nofollow(
+    repo_root: Path,
+    target: Path,
+) -> tuple[int, str]:
+    root_absolute = Path(os.path.abspath(repo_root))
+    target_absolute = Path(os.path.abspath(target))
+    try:
+        relative = target_absolute.relative_to(root_absolute)
+    except ValueError as exc:
+        raise ValueError(f"target escapes repository root: {target}") from exc
+    if not relative.parts or any(
+        component in {"", ".", ".."} for component in relative.parts
+    ):
+        raise ValueError(f"unsafe repository target: {target}")
+    descriptor = open_directory_nofollow(root_absolute)
+    try:
+        for component in relative.parts[:-1]:
+            next_descriptor = os.open(
+                component,
+                _directory_open_flags(),
+                dir_fd=descriptor,
+            )
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor, relative.parts[-1]
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def capture_parent_checkpoint(
+    repo_root: Path,
+    target: Path,
+) -> list[dict[str, Any]]:
+    """Capture every target-parent directory without following symlinks."""
+    root_absolute = Path(os.path.abspath(repo_root))
+    target_absolute = Path(os.path.abspath(target))
+    try:
+        relative = target_absolute.relative_to(root_absolute)
+    except ValueError as exc:
+        raise ValueError(f"target escapes repository root: {target}") from exc
+    if not relative.parts or any(
+        component in {"", ".", ".."} for component in relative.parts
+    ):
+        raise ValueError(f"unsafe repository target: {target}")
+    parent_parts = relative.parts[:-1]
+    checkpoint: list[dict[str, Any]] = []
+    descriptor = open_directory_nofollow(root_absolute)
+    missing = False
+    try:
+        traversed: list[str] = []
+        for component in parent_parts:
+            traversed.append(component)
+            relative_directory = PurePosixPath(*traversed).as_posix()
+            if missing:
+                checkpoint.append(
+                    {
+                        "path": relative_directory,
+                        "exists": False,
+                        "dev": None,
+                        "ino": None,
+                        "mode": None,
+                    }
+                )
+                continue
+            try:
+                metadata = os.stat(
+                    component,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                missing = True
+                checkpoint.append(
+                    {
+                        "path": relative_directory,
+                        "exists": False,
+                        "dev": None,
+                        "ino": None,
+                        "mode": None,
+                    }
+                )
+                continue
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(
+                metadata.st_mode
+            ):
+                raise ValueError(
+                    f"target parent is not a regular directory: "
+                    f"{root_absolute / relative_directory}"
+                )
+            next_descriptor = os.open(
+                component,
+                _directory_open_flags(),
+                dir_fd=descriptor,
+            )
+            opened = os.fstat(next_descriptor)
+            if (
+                opened.st_dev != metadata.st_dev
+                or opened.st_ino != metadata.st_ino
+            ):
+                os.close(next_descriptor)
+                raise RuntimeError(
+                    f"target parent changed while reading: {target}"
+                )
+            os.close(descriptor)
+            descriptor = next_descriptor
+            checkpoint.append(
+                {
+                    "path": relative_directory,
+                    "exists": True,
+                    "dev": opened.st_dev,
+                    "ino": opened.st_ino,
+                    "mode": stat.S_IMODE(opened.st_mode),
+                }
+            )
+    finally:
+        os.close(descriptor)
+    return checkpoint
+
+
+def assert_parent_checkpoint(
+    repo_root: Path,
+    target: Path,
+    expected: list[dict[str, Any]],
+) -> None:
+    if capture_parent_checkpoint(repo_root, target) != expected:
+        raise RuntimeError(
+            f"transaction target parent changed after staging: {target}"
+        )
+
+
+def _checkpoint_from_stat(
+    path: Path,
+    metadata: os.stat_result | None,
+    content: bytes | None,
+) -> dict[str, Any]:
+    if metadata is None:
+        return {
+            "exists": False,
+            "dev": None,
+            "ino": None,
+            "mode": None,
+            "size": None,
+            "sha256": None,
+        }
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"transaction target must be a regular file: {path}")
+    if content is None:
+        content = path.read_bytes()
+    return {
+        "exists": True,
+        "dev": metadata.st_dev,
+        "ino": metadata.st_ino,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "size": metadata.st_size,
+        "sha256": sha256_bytes(content),
+    }
+
+
+def capture_target_checkpoint(
+    path: Path,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    if repo_root is None:
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return _checkpoint_from_stat(path, None, None)
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"transaction target must not be a symlink: {path}")
+        return _checkpoint_from_stat(path, metadata, path.read_bytes())
+
+    parent_checkpoint = capture_parent_checkpoint(repo_root, path)
+    if any(not item["exists"] for item in parent_checkpoint):
+        return _checkpoint_from_stat(path, None, None)
+    parent_fd, leaf = open_parent_from_repo_nofollow(repo_root, path)
+    try:
+        return _capture_target_at(parent_fd, leaf, path)
+    finally:
+        os.close(parent_fd)
+
+
+def _capture_target_at(
+    parent_fd: int,
+    leaf: str,
+    path: Path,
+) -> dict[str, Any]:
+    try:
+        metadata = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return _checkpoint_from_stat(path, None, None)
+    if stat.S_ISLNK(metadata.st_mode):
+        raise ValueError(f"transaction target must not be a symlink: {path}")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    file_descriptor = os.open(leaf, flags, dir_fd=parent_fd)
+    try:
+        opened = os.fstat(file_descriptor)
+        if (
+            opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+        ):
+            raise RuntimeError(f"target inode changed while reading: {path}")
+        with os.fdopen(os.dup(file_descriptor), "rb") as stream:
+            content = stream.read()
+        completed = os.fstat(file_descriptor)
+        if (
+            completed.st_dev != opened.st_dev
+            or completed.st_ino != opened.st_ino
+            or completed.st_mode != opened.st_mode
+            or completed.st_size != opened.st_size
+            or completed.st_mtime_ns != opened.st_mtime_ns
+        ):
+            raise RuntimeError(f"target changed while reading: {path}")
+    finally:
+        os.close(file_descriptor)
+    return _checkpoint_from_stat(path, completed, content)
+
+
+def assert_target_checkpoint(
+    path: Path,
+    expected: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+) -> None:
+    current = capture_target_checkpoint(path, repo_root=repo_root)
+    if current != expected:
+        raise RuntimeError(
+            f"transaction target changed after staging: {path}"
+        )
+
+
+def _path_state(path: Path) -> dict[str, str]:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return {"type": "missing", "sha256": ""}
+    if stat.S_ISLNK(metadata.st_mode):
+        return {"type": "symlink", "sha256": os.readlink(path)}
+    if not stat.S_ISREG(metadata.st_mode):
+        return {"type": "other", "sha256": str(metadata.st_mode)}
+    return {"type": "file", "sha256": sha256_file(path)}
+
+
+def capture_ingest_fingerprint(
+    *,
+    skill_dir: Path,
+    mapping_path: Path | None,
+    repo_root: Path,
+) -> str:
+    """Hash the entire skill tree and every provenance claim input."""
+    inventory: dict[str, dict[str, str]] = {}
+    repo_absolute = Path(os.path.abspath(repo_root))
+    skill_absolute = Path(os.path.abspath(skill_dir))
+    try:
+        skill_relative = skill_absolute.relative_to(repo_absolute).as_posix()
+    except ValueError as exc:
+        raise ValueError("skill directory escapes repository root") from exc
+    repository_files = _walk_repository_regular_files(repo_absolute)
+    skill_prefix = skill_relative.rstrip("/") + "/"
+    for relative, (content, _mode) in repository_files.items():
+        is_skill_input = (
+            relative == f"{skill_relative}/SKILL.md"
+            or relative.startswith(skill_prefix)
+        )
+        is_claim = (
+            relative.startswith("docs/sources/")
+            and "/" not in relative.removeprefix("docs/sources/")
+            and relative.endswith(".skills.json")
+        )
+        if is_skill_input or is_claim:
+            inventory[relative] = {
+                "type": "file",
+                "sha256": sha256_bytes(content),
+            }
+    if mapping_path is not None:
+        mapping_absolute = Path(os.path.abspath(mapping_path))
+        try:
+            mapping_relative = mapping_absolute.relative_to(
+                repo_absolute
+            ).as_posix()
+        except ValueError as exc:
+            raise ValueError("mapping path escapes repository root") from exc
+        inventory.setdefault(
+            mapping_relative,
+            _path_state(mapping_absolute),
+        )
+    encoded = json.dumps(
+        inventory,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@contextlib.contextmanager
+def _acquire_ingest_locks_after_recovery(
+    *,
+    repo_root: Path,
+    skill_dirs: list[Path],
+    mapping_paths: list[Path],
+    timeout: float = 10.0,
+    recover_pending: bool = True,
+):
+    """Acquire the exact sync mapping/skill locks in one global order."""
+    repo_absolute = Path(os.path.abspath(repo_root))
+    root_fd = open_directory_nofollow(repo_absolute)
+    os.close(root_fd)
+    sources_dir = repo_absolute / "docs" / "sources"
+    sources_fd = open_directory_nofollow(sources_dir)
+    try:
+        with os.scandir(sources_fd) as entries:
+            mapping_names = sorted(
+                entry.name
+                for entry in entries
+                if entry.name.endswith(".skills.json")
+            )
+    finally:
+        os.close(sources_fd)
+    all_mappings = {
+        sources_dir / name for name in mapping_names
+    }
+    all_mappings.update(Path(path) for path in mapping_paths)
+    normalized_mappings: list[Path] = []
+    for path in all_mappings:
+        absolute = Path(os.path.abspath(path))
+        parent_fd, leaf = open_parent_from_repo_nofollow(
+            repo_absolute,
+            absolute,
+        )
+        try:
+            try:
+                metadata = os.stat(
+                    leaf,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                metadata = None
+            if metadata is not None and (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISREG(metadata.st_mode)
+            ):
+                raise ValueError(f"unsafe mapping lock target: {absolute}")
+        finally:
+            os.close(parent_fd)
+        normalized_mappings.append(absolute)
+
+    skill_roots: dict[str, Path] = {}
+    for skill_dir in skill_dirs:
+        absolute = Path(os.path.abspath(skill_dir))
+        try:
+            relative = absolute.relative_to(repo_absolute).as_posix()
+        except ValueError as exc:
+            raise ValueError(
+                f"skill lock target escapes repository: {skill_dir}"
+            ) from exc
+        if not safe_relative_path(relative):
+            raise ValueError(f"unsafe skill lock identity: {relative}")
+        # A crashed artifact transaction may have moved the old canonical
+        # directory aside. Validate the complete parent chain without
+        # requiring the final directory to exist; the engine's public lock
+        # performs journal recovery after acquisition.
+        parent_fd, leaf = open_parent_from_repo_nofollow(
+            repo_absolute,
+            absolute,
+        )
+        try:
+            try:
+                metadata = os.stat(
+                    leaf,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                metadata = None
+            if metadata is not None and (
+                stat.S_ISLNK(metadata.st_mode)
+                or not stat.S_ISDIR(metadata.st_mode)
+            ):
+                raise ValueError(f"unsafe skill lock target: {absolute}")
+        finally:
+            os.close(parent_fd)
+        skill_roots[relative] = absolute
+
+    claims_identity = sources_dir / ".claims.lock-identity"
+    with contextlib.ExitStack() as locks:
+        # Global order: claims -> every mapping (sorted) -> every skill (sorted).
+        locks.enter_context(
+            mapping_advisory_lock(claims_identity, timeout=timeout)
+        )
+        for mapping in sorted(set(normalized_mappings), key=str):
+            locks.enter_context(
+                mapping_advisory_lock(mapping, timeout=timeout)
+            )
+        for skill_root in sorted(skill_roots):
+            locks.enter_context(
+                skill_advisory_lock(
+                    repo_absolute,
+                    skill_root,
+                    timeout=timeout,
+                    recover_pending=recover_pending,
+                )
+            )
+            # Recovery is complete when the public lock context is entered.
+            # Re-open every ancestor and the recovered canonical directory
+            # before any caller fingerprints or writes it.
+            recovered_fd = open_directory_nofollow(
+                skill_roots[skill_root]
+            )
+            os.close(recovered_fd)
+        yield
+
+
+@contextlib.contextmanager
+def acquire_ingest_locks(
+    *,
+    repo_root: Path,
+    skill_dirs: list[Path],
+    mapping_paths: list[Path],
+    timeout: float = 10.0,
+    durable: bool = True,
+):
+    """Acquire durable-global, claims, mappings, then skills in fixed order."""
+    if not durable:
+        with _acquire_ingest_locks_after_recovery(
+            repo_root=repo_root,
+            skill_dirs=skill_dirs,
+            mapping_paths=mapping_paths,
+            timeout=timeout,
+            recover_pending=False,
+        ):
+            yield None
+        return
+    with durable_batch_lock_and_recover(
+        repo_root,
+        timeout=timeout,
+    ) as durable_guard:
+        with _acquire_ingest_locks_after_recovery(
+            repo_root=repo_root,
+            skill_dirs=skill_dirs,
+            mapping_paths=mapping_paths,
+            timeout=timeout,
+            recover_pending=True,
+        ):
+            yield durable_guard
+
+
+def parse_artifact_map(value: str) -> tuple[str, str]:
+    source, separator, target = value.partition("=")
+    if not separator or not safe_relative_path(source) or not safe_relative_path(target):
+        raise ValueError(
+            "artifact map must be a safe repository-relative source=target pair"
+        )
+    return source, target
+
+
+def load_artifact_manifest(path: Path) -> list[tuple[str, str]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    raw_items: object = payload.get("artifacts") if isinstance(payload, dict) else payload
+    if not isinstance(raw_items, list):
+        raise ValueError("artifact manifest must be a list or contain artifacts[]")
+    result: list[tuple[str, str]] = []
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, dict):
+            raise ValueError(f"artifact manifest item {index} must be an object")
+        source = item.get("source")
+        target = item.get("target")
+        if not isinstance(source, str) or not isinstance(target, str):
+            raise ValueError(
+                f"artifact manifest item {index} requires source and target"
+            )
+        result.append(parse_artifact_map(f"{source}={target}"))
+    return result
+
+
+def _json_bytes(payload: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    ).encode("utf-8")
+
+
+def prepare_ingest(
+    skill_dir: Path,
+    source: str,
+    source_url: str,
+    *,
+    external_mapping: Path | None = None,
+    repo_root: Path = REPO_ROOT,
+    upstream_path: str | None = None,
+    upstream_ref: str = "main",
+    resolved_commit: str | None = None,
+    path_commit: str | None = None,
+    artifact_maps: list[tuple[str, str]] | None = None,
+    existing_mapping_payload: dict[str, Any] | None = None,
+) -> IngestPlan:
+    """Run every filesystem/network preflight and return an immutable plan."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file() or skill_md.is_symlink():
+        raise ValueError(f"{skill_md} must be a regular file")
+    fingerprint_mapping = external_mapping or (
+        repo_root / "docs" / "sources" / "ingested-external.skills.json"
+    )
+    initial_fingerprint = capture_ingest_fingerprint(
+        skill_dir=skill_dir,
+        mapping_path=fingerprint_mapping,
+        repo_root=repo_root,
+    )
+
+    before_skill = skill_md.read_bytes()
+    try:
+        content = before_skill.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{skill_md} must be UTF-8") from exc
     fm = parse_frontmatter(content)
 
     if not fm.get("name"):
-        print(f"  ERROR: {skill_dir.name} — missing 'name' in frontmatter", file=sys.stderr)
-        return False
+        raise ValueError(f"{skill_dir.name} — missing 'name' in frontmatter")
 
     skill_name = fm["name"]
-    category = skill_dir.parent.name
+    if skill_name != skill_dir.name:
+        raise ValueError(
+            f"frontmatter name {skill_name!r} must match directory "
+            f"{skill_dir.name!r}"
+        )
     today = date.today().isoformat()
-    effective_source = fm.get("source") if fm.get("source") and fm.get("source") != "in-house" else source
+    declared_source = fm.get("source", "")
+    if (
+        declared_source
+        and declared_source not in INHOUSE_SOURCES
+        and source not in INHOUSE_SOURCES
+        and declared_source != source
+    ):
+        raise ValueError(
+            f"frontmatter source {declared_source!r} disagrees with "
+            f"caller source {source!r}"
+        )
+    effective_source = (
+        declared_source
+        if declared_source and declared_source not in INHOUSE_SOURCES
+        else source
+    )
     effective_source_url = fm.get("source_url") or source_url
-
-    print(f"  Ingesting: {skill_name} ({category})")
+    if fm.get("source_url") and source_url and fm["source_url"] != source_url:
+        raise ValueError("frontmatter source_url disagrees with caller source_url")
 
     detected_license: str | None = None
+    immutable_license_checkpoint: dict[str, str] | None = None
     if is_external_source(effective_source):
-        detected_license, license_error = resolve_external_license(fm, effective_source, effective_source_url)
+        location = github_location(
+            source=effective_source,
+            source_url=effective_source_url,
+            skill_name=skill_name,
+            upstream_path=upstream_path,
+            upstream_ref=upstream_ref,
+        )
+        if location is None:
+            _detected, license_error = resolve_external_license(
+                fm,
+                effective_source,
+                effective_source_url,
+            )
+            raise ValueError(
+                f"{skill_name} — {license_error or 'external source is unsupported'}"
+            )
+        repo, resolved_ref, resolved_path = location
+        if not safe_relative_path(resolved_path):
+            raise ValueError(
+                f"upstream path must be a safe relative path: {resolved_path!r}"
+            )
+        discovered_commit, discovered_path_commit = (
+            resolve_github_checkpoint(
+                repo,
+                resolved_ref,
+                resolved_path,
+            )
+        )
+        if discovered_commit is None or discovered_path_commit is None:
+            raise ValueError(
+                f"cannot resolve immutable GitHub checkpoint for "
+                f"{repo}@{resolved_ref}:{resolved_path}"
+            )
+        if (
+            resolved_commit is not None
+            and resolved_commit.lower() != discovered_commit.lower()
+        ):
+            raise ValueError(
+                "caller supplied --resolved-commit does not match the online "
+                f"checkpoint: {resolved_commit} != {discovered_commit}"
+            )
+        if (
+            path_commit is not None
+            and path_commit.lower() != discovered_path_commit.lower()
+        ):
+            raise ValueError(
+                "caller supplied --path-commit does not match the online path "
+                f"checkpoint: {path_commit} != {discovered_path_commit}"
+            )
+        resolved_commit = discovered_commit
+        path_commit = discovered_path_commit
+        (
+            detected_license,
+            immutable_license_checkpoint,
+            license_error,
+        ) = resolve_commit_bound_github_license(
+            fm,
+            effective_source,
+            effective_source_url,
+            repo=repo,
+            resolved_commit=discovered_commit,
+        )
         if license_error:
-            print(f"  ERROR: {skill_name} — {license_error}", file=sys.stderr)
-            return False
-
-    if dry_run:
-        print(f"    [DRY RUN] Would enrich frontmatter and update provenance")
-        return True
+            raise ValueError(f"{skill_name} — {license_error}")
 
     # Enrich frontmatter with source info
     updated = content
@@ -224,37 +1668,1268 @@ def ingest_one(skill_dir: Path, source: str, source_url: str, dry_run: bool) -> 
     if not fm.get("updated_at"):
         updated = update_frontmatter_field(updated, "updated_at", f'"{today}"')
 
-    if updated != content:
-        skill_md.write_text(updated, encoding="utf-8")
-        print(f"    Updated frontmatter")
+    mapping_path: Path | None = None
+    mapping_before: bytes | None = None
+    mapping_after: bytes | None = None
+    mapping_payload: dict[str, Any] | None = None
+    if is_external_source(effective_source):
+        mapping_path = external_mapping or (
+            repo_root / "docs" / "sources" / "ingested-external.skills.json"
+        )
+        try:
+            mapping_path.resolve().relative_to(
+                (repo_root / "docs" / "sources").resolve()
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "external mapping must stay under docs/sources"
+            ) from exc
+        if not mapping_path.name.endswith(".skills.json"):
+            raise ValueError("external mapping name must end with .skills.json")
+        if mapping_path.is_symlink() or (
+            mapping_path.exists() and not mapping_path.is_file()
+        ):
+            raise ValueError(
+                f"external mapping must be a regular non-symlink file: "
+                f"{mapping_path}"
+            )
+        mapping_before = (
+            mapping_path.read_bytes() if mapping_path.exists() else None
+        )
+        mapping_payload = build_external_provenance_payload(
+            skill_dir=skill_dir,
+            skill_content=updated,
+            source=effective_source,
+            source_url=effective_source_url,
+            license_value=detected_license or normalize_license_tag(fm.get("license", "")),
+            mapping_path=mapping_path,
+            repo_root=repo_root,
+            upstream_path=upstream_path,
+            upstream_ref=upstream_ref,
+            resolved_commit=resolved_commit,
+            path_commit=path_commit,
+            license_checkpoint=immutable_license_checkpoint,
+            artifact_maps=artifact_maps,
+            existing_payload=existing_mapping_payload,
+        )
+        mapping_after = _json_bytes(mapping_payload)
 
+    final_fingerprint = capture_ingest_fingerprint(
+        skill_dir=skill_dir,
+        mapping_path=fingerprint_mapping,
+        repo_root=repo_root,
+    )
+    if final_fingerprint != initial_fingerprint:
+        raise ValueError(
+            "ingest inputs changed during preflight; retry under a stable "
+            "claim/mapping/skill snapshot"
+        )
+    return IngestPlan(
+        skill_name=skill_name,
+        skill_md=skill_md,
+        before_skill=before_skill,
+        after_skill=updated.encode("utf-8"),
+        mapping_path=mapping_path,
+        before_mapping=mapping_before,
+        after_mapping=mapping_after,
+        mapping_payload=mapping_payload,
+        repo_root=repo_root,
+        input_fingerprint=final_fingerprint,
+        before_checkpoint=capture_target_checkpoint(
+            skill_md,
+            repo_root=repo_root,
+        ),
+        mapping_checkpoint=(
+            capture_target_checkpoint(mapping_path, repo_root=repo_root)
+            if mapping_path is not None
+            else None
+        ),
+        before_parent_checkpoint=capture_parent_checkpoint(
+            repo_root,
+            skill_md,
+        ),
+        mapping_parent_checkpoint=(
+            capture_parent_checkpoint(repo_root, mapping_path)
+            if mapping_path is not None
+            else None
+        ),
+    )
+
+
+def _write_atomic_bytes(
+    path: Path,
+    content: bytes,
+    *,
+    repo_root: Path | None = None,
+    expected_checkpoint: dict[str, Any] | None = None,
+    expected_parent_checkpoint: list[dict[str, Any]] | None = None,
+) -> None:
+    if repo_root is not None and expected_checkpoint is not None:
+        _write_atomic_bytes_secure(
+            path,
+            content,
+            repo_root=repo_root,
+            expected_checkpoint=expected_checkpoint,
+            expected_parent_checkpoint=expected_parent_checkpoint,
+        )
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original_mode: int | None = None
+    try:
+        destination_stat = path.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        if stat.S_ISLNK(destination_stat.st_mode):
+            raise ValueError(f"refusing to replace symlink destination: {path}")
+        if not stat.S_ISREG(destination_stat.st_mode):
+            raise ValueError(
+                f"refusing to replace non-regular destination: {path}"
+            )
+        original_mode = stat.S_IMODE(destination_stat.st_mode)
+    fd, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temp_path = Path(temporary)
+    try:
+        created_stat = os.fstat(fd)
+        if not stat.S_ISREG(created_stat.st_mode):
+            raise RuntimeError(f"temporary path is not regular: {temp_path}")
+        if original_mode is not None:
+            os.fchmod(fd, original_mode)
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        named_stat = temp_path.lstat()
+        if (
+            not stat.S_ISREG(named_stat.st_mode)
+            or named_stat.st_dev != created_stat.st_dev
+            or named_stat.st_ino != created_stat.st_ino
+        ):
+            raise RuntimeError(f"temporary path changed before replace: {temp_path}")
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        temp_path.unlink(missing_ok=True)
+
+
+def _write_atomic_bytes_secure(
+    path: Path,
+    content: bytes,
+    *,
+    repo_root: Path,
+    expected_checkpoint: dict[str, Any],
+    expected_parent_checkpoint: list[dict[str, Any]] | None = None,
+) -> None:
+    """Replace one target through stable dirfds after checkpoint revalidation."""
+    if expected_parent_checkpoint is not None:
+        assert_parent_checkpoint(
+            repo_root,
+            path,
+            expected_parent_checkpoint,
+        )
+    assert_target_checkpoint(
+        path,
+        expected_checkpoint,
+        repo_root=repo_root,
+    )
+    parent_fd, leaf = open_parent_from_repo_nofollow(repo_root, path)
+    temp_name = f".{leaf}.{secrets.token_hex(12)}.tmp"
+    temporary_created = False
+    try:
+        parent_identity = os.fstat(parent_fd)
+        if expected_parent_checkpoint:
+            expected_parent = expected_parent_checkpoint[-1]
+            if (
+                not expected_parent["exists"]
+                or parent_identity.st_dev != expected_parent["dev"]
+                or parent_identity.st_ino != expected_parent["ino"]
+            ):
+                raise RuntimeError(
+                    f"transaction target parent inode changed: {path}"
+                )
+        if _capture_target_at(parent_fd, leaf, path) != expected_checkpoint:
+            raise RuntimeError(
+                f"transaction target changed before writer prepare: {path}"
+            )
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(temp_name, flags, 0o600, dir_fd=parent_fd)
+        temporary_created = True
+        try:
+            created_metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(created_metadata.st_mode):
+                raise RuntimeError(
+                    f"transaction temporary is not regular: {path}"
+                )
+            mode = (
+                int(expected_checkpoint["mode"])
+                if expected_checkpoint.get("exists")
+                else 0o644
+            )
+            os.fchmod(descriptor, mode)
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        temporary_metadata = os.stat(
+            temp_name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        if not stat.S_ISREG(temporary_metadata.st_mode):
+            raise RuntimeError(f"transaction temporary is not regular: {path}")
+        if (
+            temporary_metadata.st_dev != created_metadata.st_dev
+            or temporary_metadata.st_ino != created_metadata.st_ino
+        ):
+            raise RuntimeError(
+                f"transaction temporary inode changed before replace: {path}"
+            )
+        # The destination checkpoint (including inode) is checked again at the
+        # exact replace boundary.
+        if expected_parent_checkpoint is not None:
+            assert_parent_checkpoint(
+                repo_root,
+                path,
+                expected_parent_checkpoint,
+            )
+        if _capture_target_at(parent_fd, leaf, path) != expected_checkpoint:
+            raise RuntimeError(
+                f"transaction target changed immediately before replace: {path}"
+            )
+        os.replace(
+            temp_name,
+            leaf,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        temporary_created = False
+        os.fsync(parent_fd)
+
+        verification_fd, verification_leaf = open_parent_from_repo_nofollow(
+            repo_root,
+            path,
+        )
+        try:
+            reopened_identity = os.fstat(verification_fd)
+            if (
+                reopened_identity.st_dev != parent_identity.st_dev
+                or reopened_identity.st_ino != parent_identity.st_ino
+            ):
+                raise RuntimeError(
+                    f"target parent changed across replace: {path}"
+                )
+            installed = _capture_target_at(
+                verification_fd,
+                verification_leaf,
+                path,
+            )
+            if (
+                not installed["exists"]
+                or installed["size"] != len(content)
+                or installed["sha256"] != sha256_bytes(content)
+                or installed["mode"] != mode
+            ):
+                raise RuntimeError(
+                    f"installed target failed byte verification: {path}"
+                )
+        finally:
+            os.close(verification_fd)
+    finally:
+        if temporary_created:
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+        os.close(parent_fd)
+
+
+def _unlink_target_secure(
+    path: Path,
+    *,
+    repo_root: Path | None,
+    expected_checkpoint: dict[str, Any],
+    expected_parent_checkpoint: list[dict[str, Any]] | None = None,
+) -> None:
+    if repo_root is None:
+        assert_target_checkpoint(path, expected_checkpoint)
+        path.unlink(missing_ok=True)
+        return
+    if expected_parent_checkpoint is not None:
+        assert_parent_checkpoint(
+            repo_root,
+            path,
+            expected_parent_checkpoint,
+        )
+    assert_target_checkpoint(
+        path,
+        expected_checkpoint,
+        repo_root=repo_root,
+    )
+    parent_fd, leaf = open_parent_from_repo_nofollow(repo_root, path)
+    try:
+        if expected_parent_checkpoint:
+            parent_identity = os.fstat(parent_fd)
+            expected_parent = expected_parent_checkpoint[-1]
+            if (
+                parent_identity.st_dev != expected_parent["dev"]
+                or parent_identity.st_ino != expected_parent["ino"]
+            ):
+                raise RuntimeError(
+                    f"unlink target parent inode changed: {path}"
+                )
+        if _capture_target_at(parent_fd, leaf, path) != expected_checkpoint:
+            raise RuntimeError(f"unlink target changed before removal: {path}")
+        os.unlink(leaf, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+
+
+def _assert_ingest_inputs_unchanged(plans: list[IngestPlan]) -> None:
+    for plan in plans:
+        if plan.input_fingerprint is None or plan.repo_root is None:
+            continue
+        mapping_path = plan.mapping_path or (
+            plan.repo_root
+            / "docs"
+            / "sources"
+            / "ingested-external.skills.json"
+        )
+        current = capture_ingest_fingerprint(
+            skill_dir=plan.skill_md.parent,
+            mapping_path=mapping_path,
+            repo_root=plan.repo_root,
+        )
+        if current != plan.input_fingerprint:
+            raise RuntimeError(
+                f"ingest race detected for {plan.skill_name}; skill sidecars, "
+                "mapping, or global claims changed after preflight"
+            )
+
+
+def _materialize_transaction_parents(
+    *,
+    repo_root: Path,
+    targets: dict[Path, list[dict[str, Any]]],
+    created: list[Path],
+) -> dict[Path, list[dict[str, Any]]]:
+    missing: set[str] = {
+        str(item["path"])
+        for checkpoint in targets.values()
+        for item in checkpoint
+        if not item["exists"]
+    }
+    for relative in sorted(
+        missing,
+        key=lambda value: (len(PurePosixPath(value).parts), value),
+    ):
+        directory = repo_root.joinpath(*PurePosixPath(relative).parts)
+        parent_fd, leaf = open_parent_from_repo_nofollow(
+            repo_root,
+            directory,
+        )
+        try:
+            try:
+                os.stat(
+                    leaf,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                pass
+            else:
+                raise RuntimeError(
+                    f"transaction parent appeared concurrently: {directory}"
+                )
+            os.mkdir(leaf, 0o755, dir_fd=parent_fd)
+            created.append(directory)
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+        directory_fd = open_directory_nofollow(directory)
+        os.close(directory_fd)
+
+    current: dict[Path, list[dict[str, Any]]] = {}
+    for target, expected in targets.items():
+        observed = capture_parent_checkpoint(repo_root, target)
+        if len(observed) != len(expected):
+            raise RuntimeError(
+                f"transaction target parent depth changed: {target}"
+            )
+        for before, after in zip(expected, observed, strict=True):
+            if before["exists"] and before != after:
+                raise RuntimeError(
+                    f"transaction target parent changed: {target}"
+                )
+            if not before["exists"] and not after["exists"]:
+                raise RuntimeError(
+                    f"transaction target parent was not created: {target}"
+                )
+        current[target] = observed
+    return current
+
+
+def _apply_ingest_output_batch(
+    *,
+    outputs: dict[Path, bytes],
+    before: dict[Path, bytes | None],
+    checkpoints: dict[Path, dict[str, Any]],
+    parent_checkpoints: dict[Path, list[dict[str, Any]]],
+    roots: dict[Path, Path | None],
+    fault_injector=None,
+) -> None:
+    """Run the existing hardened writers under an already-durable journal."""
+    created_directories: list[Path] = []
+    writer_parent_checkpoints = dict(parent_checkpoints)
+    try:
+        by_root: dict[Path, dict[Path, list[dict[str, Any]]]] = {}
+        for path, repo_root in roots.items():
+            if repo_root is not None:
+                by_root.setdefault(repo_root, {})[path] = parent_checkpoints[path]
+        for repo_root, targets in by_root.items():
+            writer_parent_checkpoints.update(
+                _materialize_transaction_parents(
+                    repo_root=repo_root,
+                    targets=targets,
+                    created=created_directories,
+                )
+            )
+        for path, content in outputs.items():
+            _write_atomic_bytes(
+                path,
+                content,
+                repo_root=roots[path],
+                expected_checkpoint=checkpoints[path],
+                expected_parent_checkpoint=writer_parent_checkpoints.get(path),
+            )
+            if fault_injector is not None:
+                fault_injector("after_replace", path)
+    except Exception:
+        rollback_errors: list[str] = []
+        # A post-rename directory fsync may fail after the destination already
+        # changed. Restore every transaction target, not only successful calls.
+        for path in reversed(list(outputs)):
+            try:
+                prior = before[path]
+                repo_root = roots[path]
+                current_checkpoint = capture_target_checkpoint(
+                    path,
+                    repo_root=repo_root,
+                )
+                if prior is None:
+                    if current_checkpoint["exists"]:
+                        if current_checkpoint["sha256"] != sha256_bytes(
+                            outputs[path]
+                        ):
+                            raise RuntimeError(
+                                f"rollback target changed concurrently: {path}"
+                            )
+                        _unlink_target_secure(
+                            path,
+                            repo_root=repo_root,
+                            expected_checkpoint=current_checkpoint,
+                            expected_parent_checkpoint=(
+                                writer_parent_checkpoints.get(path)
+                            ),
+                        )
+                elif (
+                    current_checkpoint["exists"]
+                    and current_checkpoint["sha256"] == sha256_bytes(prior)
+                ):
+                    continue
+                else:
+                    if (
+                        not current_checkpoint["exists"]
+                        or current_checkpoint["sha256"]
+                        != sha256_bytes(outputs[path])
+                    ):
+                        raise RuntimeError(
+                            f"rollback target changed concurrently: {path}"
+                        )
+                    _write_atomic_bytes(
+                        path,
+                        prior,
+                        repo_root=repo_root,
+                        expected_checkpoint=current_checkpoint,
+                        expected_parent_checkpoint=(
+                            writer_parent_checkpoints.get(path)
+                        ),
+                    )
+            except Exception as rollback_exc:  # pragma: no cover - catastrophic I/O
+                rollback_errors.append(f"{path}: {rollback_exc}")
+        if rollback_errors:
+            raise RuntimeError(
+                "ingest transaction failed and rollback was incomplete: "
+                + "; ".join(rollback_errors)
+            )
+        for directory in sorted(
+            created_directories,
+            key=lambda candidate: len(candidate.parts),
+            reverse=True,
+        ):
+            try:
+                directory.rmdir()
+            except (FileNotFoundError, OSError):
+                pass
+        raise
+
+
+def commit_ingest_plans(
+    plans: list[IngestPlan],
+    *,
+    locks_held: bool = False,
+    durable_guard: DurableBatchGuard | None = None,
+    fault_injector=None,
+) -> None:
+    """Atomically replace all planned files and restore every prior byte on error."""
+    if not plans:
+        return
+    if not locks_held:
+        repo_root = plans[0].repo_root
+        if repo_root is not None:
+            with acquire_ingest_locks(
+                repo_root=repo_root,
+                skill_dirs=[plan.skill_md.parent for plan in plans],
+                mapping_paths=[
+                    plan.mapping_path
+                    for plan in plans
+                    if plan.mapping_path is not None
+                ],
+            ) as acquired_guard:
+                commit_ingest_plans(
+                    plans,
+                    locks_held=True,
+                    durable_guard=acquired_guard,
+                    fault_injector=fault_injector,
+                )
+                return
+    if durable_guard is None:
+        repo_roots = {
+            Path(plan.repo_root)
+            for plan in plans
+            if plan.repo_root is not None
+        }
+        if not repo_roots:
+            legacy_targets = [
+                target
+                for plan in plans
+                for target in (plan.skill_md, plan.mapping_path)
+                if target is not None
+            ]
+            if not legacy_targets:
+                return
+            common = Path(
+                os.path.commonpath(
+                    [str(Path(target).absolute()) for target in legacy_targets]
+                )
+            )
+            if common in {Path(target).absolute() for target in legacy_targets}:
+                common = common.parent
+            repo_roots = {common}
+            for plan in plans:
+                plan.repo_root = common
+        if len(repo_roots) != 1:
+            raise RuntimeError(
+                "durable ingest requires exactly one repository root"
+            )
+        with durable_batch_lock_and_recover(
+            next(iter(repo_roots))
+        ) as acquired_guard:
+            commit_ingest_plans(
+                plans,
+                locks_held=True,
+                durable_guard=acquired_guard,
+                fault_injector=fault_injector,
+            )
+        return
+    _assert_ingest_inputs_unchanged(plans)
+    outputs: dict[Path, bytes] = {}
+    before: dict[Path, bytes | None] = {}
+    checkpoints: dict[Path, dict[str, Any]] = {}
+    parent_checkpoints: dict[Path, list[dict[str, Any]]] = {}
+    roots: dict[Path, Path | None] = {}
+    for plan in plans:
+        if plan.before_skill != plan.after_skill:
+            outputs[plan.skill_md] = plan.after_skill
+            before.setdefault(plan.skill_md, plan.before_skill)
+            roots.setdefault(plan.skill_md, plan.repo_root)
+            checkpoints.setdefault(
+                plan.skill_md,
+                plan.before_checkpoint
+                or capture_target_checkpoint(
+                    plan.skill_md,
+                    repo_root=plan.repo_root,
+                ),
+            )
+            if plan.repo_root is not None:
+                parent_checkpoints.setdefault(
+                    plan.skill_md,
+                    plan.before_parent_checkpoint
+                    or capture_parent_checkpoint(
+                        plan.repo_root,
+                        plan.skill_md,
+                    ),
+                )
+        if (
+            plan.mapping_path is not None
+            and plan.after_mapping is not None
+            and plan.before_mapping != plan.after_mapping
+        ):
+            outputs[plan.mapping_path] = plan.after_mapping
+            before.setdefault(plan.mapping_path, plan.before_mapping)
+            roots.setdefault(plan.mapping_path, plan.repo_root)
+            checkpoints.setdefault(
+                plan.mapping_path,
+                plan.mapping_checkpoint
+                or capture_target_checkpoint(
+                    plan.mapping_path,
+                    repo_root=plan.repo_root,
+                ),
+            )
+            if plan.repo_root is not None:
+                parent_checkpoints.setdefault(
+                    plan.mapping_path,
+                    plan.mapping_parent_checkpoint
+                    or capture_parent_checkpoint(
+                        plan.repo_root,
+                        plan.mapping_path,
+                    ),
+                )
+
+    if not outputs:
+        return
+
+    # Revalidate the complete batch before the first byte can be replaced.
+    for path in outputs:
+        repo_root = roots[path]
+        if repo_root is not None:
+            assert_parent_checkpoint(
+                repo_root,
+                path,
+                parent_checkpoints[path],
+            )
+        assert_target_checkpoint(
+            path,
+            checkpoints[path],
+            repo_root=roots[path],
+        )
+
+    after_modes = {
+        path: (
+            int(checkpoints[path]["mode"])
+            if checkpoints[path].get("exists")
+            else 0o644
+        )
+        for path in outputs
+    }
+    durable_guard.commit_batch(
+        outputs,
+        lambda: _apply_ingest_output_batch(
+            outputs=outputs,
+            before=before,
+            checkpoints=checkpoints,
+            parent_checkpoints=parent_checkpoints,
+            roots=roots,
+            fault_injector=fault_injector,
+        ),
+        after_modes=after_modes,
+    )
+
+
+def ingest_one(
+    skill_dir: Path,
+    source: str,
+    source_url: str,
+    dry_run: bool,
+    *,
+    external_mapping: Path | None = None,
+    repo_root: Path = REPO_ROOT,
+    upstream_path: str | None = None,
+    upstream_ref: str = "main",
+    resolved_commit: str | None = None,
+    path_commit: str | None = None,
+    artifact_maps: list[tuple[str, str]] | None = None,
+    run_full_validation: bool = True,
+) -> bool:
+    """Preflight and atomically ingest one skill."""
+    lock_mapping = external_mapping or (
+        repo_root / "docs" / "sources" / "ingested-external.skills.json"
+    )
+    try:
+        with acquire_ingest_locks(
+            repo_root=repo_root,
+            skill_dirs=[skill_dir],
+            mapping_paths=[lock_mapping],
+            durable=not dry_run,
+        ) as durable_guard:
+            plan = prepare_ingest(
+                skill_dir,
+                source,
+                source_url,
+                external_mapping=external_mapping,
+                repo_root=repo_root,
+                upstream_path=upstream_path,
+                upstream_ref=upstream_ref,
+                resolved_commit=resolved_commit,
+                path_commit=path_commit,
+                artifact_maps=artifact_maps,
+            )
+            action = (
+                "external v2 provenance"
+                if plan.mapping_path is not None
+                else "in-house provenance"
+            )
+            print(f"  Ingesting: {plan.skill_name} ({skill_dir.parent.name})")
+            if run_full_validation:
+                if not execute_validated_ingest(
+                    [plan],
+                    repo_root=repo_root,
+                    dry_run=dry_run,
+                    locks_held=True,
+                    durable_guard=durable_guard,
+                ):
+                    raise RuntimeError(
+                        "isolated full pipeline validation failed"
+                    )
+                return True
+            if dry_run:
+                print(
+                    f"    [DRY RUN] Preflight passed for {action}; "
+                    "zero files written"
+                )
+                return True
+            commit_ingest_plans(
+                [plan],
+                locks_held=True,
+                durable_guard=durable_guard,
+            )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"  ERROR: {skill_dir.name} — {exc}", file=sys.stderr)
+        return False
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(
+            f"  ERROR: {skill_dir.name} — atomic ingest failed: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    if plan.after_skill != plan.before_skill:
+        print("    Updated frontmatter")
+    if plan.mapping_path is not None:
+        print(f"    Registered external v2 provenance: {plan.mapping_path}")
     return True
 
 
-def run_pipeline(dry_run: bool) -> None:
+def pipeline_commands() -> list[list[str]]:
+    python = sys.executable or "python"
+    return [
+        [python, "scripts/enrich_frontmatter.py"],
+        [python, "scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"],
+        [python, "scripts/refresh_repo_views.py"],
+        [python, "scripts/generate_tags_index.py"],
+        [python, "scripts/build_catalog_json.py"],
+        [python, "scripts/check_readme_sync.py"],
+        [python, "scripts/lint_skill_quality.py", "--min-lines", "50"],
+        [python, "scripts/audit_skill_portfolio.py", "--check-policy"],
+        [python, "scripts/audit_licenses.py"],
+        [python, "scripts/validate_skill_sources.py"],
+        [
+            python,
+            "scripts/reconcile_artifact_inventory.py",
+            "--offline",
+            "--check-clean",
+            "--quiet",
+        ],
+        [python, "scripts/check_source_coverage.py", "--min-percent", "100"],
+        [python, "-m", "pytest", "-q", "tests"],
+    ]
+
+
+def run_pipeline(
+    dry_run: bool,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> bool:
     """Run the post-ingestion pipeline."""
     if dry_run:
-        print("\n[DRY RUN] Would run pipeline scripts")
-        return
+        print(
+            "\n[DRY RUN] Pipeline must run in an isolated staging root; "
+            "use validate_ingest_plans()."
+        )
+        return False
 
     print("\nRunning post-ingestion pipeline...")
-    scripts = [
-        ["python", "scripts/enrich_frontmatter.py"],
-        ["python", "scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"],
-        ["python", "scripts/refresh_repo_views.py"],
-        ["python", "scripts/generate_tags_index.py"],
-        ["python", "scripts/build_catalog_json.py"],
-    ]
-    for cmd in scripts:
+    for cmd in pipeline_commands():
         print(f"  Running: {' '.join(cmd)}")
-        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=120)
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            print(f"    ERROR: command failed to run: {exc}", file=sys.stderr)
+            return False
         if result.returncode != 0:
-            print(f"    WARNING: {cmd[1]} returned {result.returncode}", file=sys.stderr)
+            print(
+                f"    ERROR: {' '.join(cmd)} returned {result.returncode}",
+                file=sys.stderr,
+            )
+            if result.stdout:
+                print(result.stdout.strip()[-2000:], file=sys.stderr)
             if result.stderr:
-                print(f"    {result.stderr.strip()[:200]}", file=sys.stderr)
+                print(result.stderr.strip()[-2000:], file=sys.stderr)
+            return False
+    return True
 
 
-def main() -> None:
+IGNORED_STAGE_NAMES = {
+    ".git",
+    ".hvs-transactions",
+    ".pytest_cache",
+    "__pycache__",
+    ".DS_Store",
+}
+
+
+def _read_regular_at(
+    directory_fd: int,
+    name: str,
+    *,
+    display_path: Path,
+) -> tuple[bytes, int]:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(name, flags, dir_fd=directory_fd)
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError(f"non-regular repository entry: {display_path}")
+        with os.fdopen(os.dup(descriptor), "rb") as stream:
+            content = stream.read()
+        after = os.fstat(descriptor)
+        if (
+            before.st_dev != after.st_dev
+            or before.st_ino != after.st_ino
+            or before.st_size != after.st_size
+            or before.st_mtime_ns != after.st_mtime_ns
+        ):
+            raise RuntimeError(
+                f"repository file changed while staging: {display_path}"
+            )
+        return content, stat.S_IMODE(before.st_mode)
+    finally:
+        os.close(descriptor)
+
+
+def _walk_repository_regular_files(
+    repo_root: Path,
+    *,
+    directory_modes: dict[str, int] | None = None,
+) -> dict[str, tuple[bytes, int]]:
+    """Read a symlink-free repository tree through stable directory fds."""
+    results: dict[str, tuple[bytes, int]] = {}
+    root_fd = open_directory_nofollow(repo_root)
+
+    def visit(directory_fd: int, relative: Path) -> None:
+        with os.scandir(directory_fd) as entries:
+            names = sorted(entry.name for entry in entries)
+        for name in names:
+            child_relative = relative / name
+            metadata = os.stat(
+                name,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            if stat.S_ISLNK(metadata.st_mode):
+                raise ValueError(
+                    f"repository tree contains a symlink: {child_relative}"
+                )
+            if name in IGNORED_STAGE_NAMES:
+                continue
+            if stat.S_ISDIR(metadata.st_mode):
+                if directory_modes is not None:
+                    directory_modes[child_relative.as_posix()] = (
+                        stat.S_IMODE(metadata.st_mode)
+                    )
+                child_fd = os.open(
+                    name,
+                    _directory_open_flags(),
+                    dir_fd=directory_fd,
+                )
+                try:
+                    opened = os.fstat(child_fd)
+                    if (
+                        opened.st_dev != metadata.st_dev
+                        or opened.st_ino != metadata.st_ino
+                    ):
+                        raise RuntimeError(
+                            "repository directory changed while staging: "
+                            f"{child_relative}"
+                        )
+                    visit(child_fd, child_relative)
+                finally:
+                    os.close(child_fd)
+                continue
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(
+                    f"repository tree contains a non-regular entry: "
+                    f"{child_relative}"
+                )
+            results[child_relative.as_posix()] = _read_regular_at(
+                directory_fd,
+                name,
+                display_path=child_relative,
+            )
+
+    try:
+        visit(root_fd, Path())
+    finally:
+        os.close(root_fd)
+    return results
+
+
+def repository_bytes_snapshot(repo_root: Path) -> dict[str, bytes]:
+    return {
+        relative: content
+        for relative, (content, _mode) in _walk_repository_regular_files(
+            repo_root
+        ).items()
+    }
+
+
+def tracked_report_paths(repo_root: Path) -> set[str]:
+    """Return report files explicitly tracked despite the generated-report ignore."""
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "ls-files",
+                "-z",
+                "--",
+                "docs/sources/reports",
+            ],
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return set()
+    if completed.returncode != 0:
+        return set()
+    return {
+        item.decode("utf-8", errors="surrogateescape")
+        for item in completed.stdout.split(b"\0")
+        if item
+    }
+
+
+def transactional_repository_bytes_snapshot(
+    repo_root: Path,
+    *,
+    tracked_reports: set[str],
+) -> dict[str, bytes]:
+    """Exclude only ignored generated reports from transaction materialization."""
+    snapshot = repository_bytes_snapshot(repo_root)
+    report_root = PurePosixPath("docs/sources/reports")
+    return {
+        relative: content
+        for relative, content in snapshot.items()
+        if not (
+            PurePosixPath(relative).parent == report_root
+            and PurePosixPath(relative).suffix.lower() in {".json", ".md"}
+            and relative not in tracked_reports
+        )
+    }
+
+
+def repository_checkpoint_snapshot(
+    repo_root: Path,
+    relatives: list[str] | set[str],
+) -> dict[str, dict[str, Any]]:
+    return {
+        relative: capture_target_checkpoint(
+            repo_root.joinpath(*PurePosixPath(relative).parts),
+            repo_root=repo_root,
+        )
+        for relative in sorted(relatives)
+    }
+
+
+def _copy_stage_repository(repo_root: Path, destination: Path) -> None:
+    directory_modes: dict[str, int] = {}
+    files = _walk_repository_regular_files(
+        repo_root,
+        directory_modes=directory_modes,
+    )
+    destination.mkdir(mode=0o700)
+    for relative, mode in sorted(
+        directory_modes.items(),
+        key=lambda item: (len(PurePosixPath(item[0]).parts), item[0]),
+    ):
+        target = destination.joinpath(*PurePosixPath(relative).parts)
+        target.mkdir(mode=mode)
+        target.chmod(mode)
+    for relative, (content, mode) in files.items():
+        target = destination.joinpath(*PurePosixPath(relative).parts)
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(
+            target,
+            flags,
+            mode,
+        )
+        try:
+            os.fchmod(descriptor, mode)
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = -1
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+
+def _translate_plan_to_stage(
+    plan: IngestPlan,
+    *,
+    repo_root: Path,
+    stage_root: Path,
+) -> IngestPlan:
+    skill_relative = plan.skill_md.relative_to(repo_root)
+    mapping_relative = (
+        plan.mapping_path.relative_to(repo_root)
+        if plan.mapping_path is not None
+        else None
+    )
+    return IngestPlan(
+        skill_name=plan.skill_name,
+        skill_md=stage_root / skill_relative,
+        before_skill=(stage_root / skill_relative).read_bytes(),
+        after_skill=plan.after_skill,
+        mapping_path=stage_root / mapping_relative if mapping_relative else None,
+        before_mapping=(
+            (stage_root / mapping_relative).read_bytes()
+            if mapping_relative
+            and (stage_root / mapping_relative).exists()
+            else None
+        ),
+        after_mapping=plan.after_mapping,
+        mapping_payload=plan.mapping_payload,
+        repo_root=stage_root,
+        before_checkpoint=capture_target_checkpoint(
+            stage_root / skill_relative,
+            repo_root=stage_root,
+        ),
+        mapping_checkpoint=(
+            capture_target_checkpoint(
+                stage_root / mapping_relative,
+                repo_root=stage_root,
+            )
+            if mapping_relative
+            else None
+        ),
+        before_parent_checkpoint=capture_parent_checkpoint(
+            stage_root,
+            stage_root / skill_relative,
+        ),
+        mapping_parent_checkpoint=(
+            capture_parent_checkpoint(
+                stage_root,
+                stage_root / mapping_relative,
+            )
+            if mapping_relative
+            else None
+        ),
+    )
+
+
+def validate_ingest_plans(
+    plans: list[IngestPlan],
+    *,
+    repo_root: Path,
+) -> tuple[
+    list[IngestPlan],
+    dict[str, bytes],
+    dict[str, dict[str, Any]],
+    set[str],
+] | None:
+    """Run the complete pipeline in a copy and materialize its exact diff."""
+    tracked_reports = tracked_report_paths(repo_root)
+    baseline = transactional_repository_bytes_snapshot(
+        repo_root,
+        tracked_reports=tracked_reports,
+    )
+    baseline_checkpoints = repository_checkpoint_snapshot(
+        repo_root,
+        set(baseline),
+    )
+    # macOS exposes /var as a symlink to /private/var. Resolve the OS-provided
+    # temporary root first, then validate and use its symlink-free absolute
+    # path so the secure dirfd traversal applies inside staging as well.
+    temporary_parent = Path(tempfile.gettempdir()).resolve(strict=True)
+    temporary_parent_fd = open_directory_nofollow(temporary_parent)
+    os.close(temporary_parent_fd)
+    with tempfile.TemporaryDirectory(
+        prefix="skill-ingest-stage-",
+        dir=temporary_parent,
+    ) as temporary:
+        stage_root = Path(temporary) / "repo"
+        _copy_stage_repository(repo_root, stage_root)
+        if (
+            transactional_repository_bytes_snapshot(
+                repo_root,
+                tracked_reports=tracked_reports,
+            )
+            != baseline
+            or repository_checkpoint_snapshot(repo_root, set(baseline))
+            != baseline_checkpoints
+        ):
+            raise RuntimeError("repository changed while staging ingest inputs")
+        stage_plans = [
+            _translate_plan_to_stage(
+                plan,
+                repo_root=repo_root,
+                stage_root=stage_root,
+            )
+            for plan in plans
+        ]
+        commit_ingest_plans(stage_plans)
+        if not run_pipeline(False, repo_root=stage_root):
+            return None
+        staged = transactional_repository_bytes_snapshot(
+            stage_root,
+            tracked_reports=tracked_reports,
+        )
+        if (
+            transactional_repository_bytes_snapshot(
+                repo_root,
+                tracked_reports=tracked_reports,
+            )
+            != baseline
+            or repository_checkpoint_snapshot(repo_root, set(baseline))
+            != baseline_checkpoints
+        ):
+            raise RuntimeError(
+                "repository changed while validating the staged pipeline"
+            )
+        removed = sorted(set(baseline) - set(staged))
+        if removed:
+            raise RuntimeError(
+                "staged pipeline attempted unmanaged deletions: "
+                + ", ".join(removed[:10])
+            )
+        mutations: list[IngestPlan] = []
+        for relative in sorted(staged):
+            before = baseline.get(relative)
+            after = staged[relative]
+            if before == after:
+                continue
+            target = repo_root / relative
+            mutations.append(
+                IngestPlan(
+                    skill_name=f"staged:{relative}",
+                    skill_md=target,
+                    before_skill=before,
+                    after_skill=after,
+                    repo_root=repo_root,
+                    before_checkpoint=(
+                        baseline_checkpoints[relative]
+                        if relative in baseline_checkpoints
+                        else capture_target_checkpoint(
+                            target,
+                            repo_root=repo_root,
+                        )
+                    ),
+                    before_parent_checkpoint=capture_parent_checkpoint(
+                        repo_root,
+                        target,
+                    ),
+                )
+            )
+        return mutations, baseline, baseline_checkpoints, tracked_reports
+
+
+def execute_validated_ingest(
+    plans: list[IngestPlan],
+    *,
+    repo_root: Path,
+    dry_run: bool,
+    locks_held: bool = False,
+    durable_guard: DurableBatchGuard | None = None,
+) -> bool:
+    if not locks_held:
+        with acquire_ingest_locks(
+            repo_root=repo_root,
+            skill_dirs=[plan.skill_md.parent for plan in plans],
+            mapping_paths=[
+                plan.mapping_path
+                for plan in plans
+                if plan.mapping_path is not None
+            ],
+            durable=not dry_run,
+        ) as acquired_guard:
+            return execute_validated_ingest(
+                plans,
+                repo_root=repo_root,
+                dry_run=dry_run,
+                locks_held=True,
+                durable_guard=acquired_guard,
+            )
+    validated = validate_ingest_plans(plans, repo_root=repo_root)
+    if validated is None:
+        return False
+    mutations, baseline, baseline_checkpoints, tracked_reports = validated
+    if (
+        transactional_repository_bytes_snapshot(
+            repo_root,
+            tracked_reports=tracked_reports,
+        )
+        != baseline
+        or repository_checkpoint_snapshot(repo_root, set(baseline))
+        != baseline_checkpoints
+    ):
+        raise RuntimeError(
+            "repository changed after staged validation; refusing stale apply"
+        )
+    if dry_run:
+        print(
+            f"  [DRY RUN] isolated full pipeline passed; "
+            f"{len(mutations)} staged file changes, zero repository writes"
+        )
+        return True
+    commit_ingest_plans(
+        mutations,
+        locks_held=True,
+        durable_guard=durable_guard,
+    )
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Register new skills into the repository's provenance system.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -269,43 +2944,194 @@ Examples:
     parser.add_argument("--source", default="in-house",
                         help="Source identifier (in-house, skills.sh, clawhub, github:<owner>/<repo>, community)")
     parser.add_argument("--source-url", default="", help="Original source URL")
+    parser.add_argument(
+        "--external-mapping",
+        type=Path,
+        default=Path("docs/sources/ingested-external.skills.json"),
+        help="v2 mapping used for newly ingested external skills",
+    )
+    parser.add_argument(
+        "--upstream-path",
+        help="Exact upstream SKILL.md path (recommended for external sources)",
+    )
+    parser.add_argument(
+        "--upstream-ref",
+        default="main",
+        help="Upstream ref recorded for external provenance (default: main)",
+    )
+    parser.add_argument(
+        "--resolved-commit",
+        help="Pre-resolved immutable upstream repository commit",
+    )
+    parser.add_argument(
+        "--path-commit",
+        help="Pre-resolved immutable commit for the upstream artifact path",
+    )
+    parser.add_argument(
+        "--artifact-map",
+        action="append",
+        default=[],
+        metavar="SOURCE=TARGET",
+        help=(
+            "Explicit upstream source to canonical target mapping; repeat for "
+            "cross-directory sidecars"
+        ),
+    )
+    parser.add_argument(
+        "--artifact-manifest",
+        type=Path,
+        help="JSON artifact mapping list or object containing artifacts[]",
+    )
     parser.add_argument("--batch", action="store_true",
                         help="Batch ingest all untracked skills")
     parser.add_argument("--dry-run", action="store_true",
                         help="Show what would be done without writing")
     parser.add_argument("--skip-pipeline", action="store_true",
-                        help="Skip the post-ingestion pipeline")
-    args = parser.parse_args()
+                        help="Deprecated; safety gates always run in staging")
+    args = parser.parse_args(argv)
+    if args.skip_pipeline:
+        print(
+            "WARNING: --skip-pipeline is deprecated and ignored; all safety "
+            "gates run in isolated staging.",
+            file=sys.stderr,
+        )
 
     if not args.dir and not args.batch:
         parser.error("Specify --dir <path> for single ingestion or --batch for all untracked skills")
 
     success_count = 0
     fail_count = 0
-
+    external_mapping = (
+        args.external_mapping
+        if args.external_mapping.is_absolute()
+        else REPO_ROOT / args.external_mapping
+    )
     if args.batch:
-        tracked = get_tracked_skills(PROVENANCE_FILE)
-        untracked = find_untracked_skills(SKILLS_DIR, tracked)
-        print(f"Found {len(untracked)} untracked skills (out of {len(tracked)} tracked)")
-        for skill_dir in untracked:
-            ok = ingest_one(skill_dir, args.source, args.source_url, args.dry_run)
-            if ok:
-                success_count += 1
-            else:
-                fail_count += 1
+        try:
+            preliminary_tracked = get_tracked_skills(
+                REPO_ROOT / "docs" / "sources"
+            )
+            candidate_skill_dirs = find_untracked_skills(
+                SKILLS_DIR, preliminary_tracked
+            )
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"ERROR: cannot inventory v2 claims: {exc}", file=sys.stderr)
+            return 1
     else:
-        skill_dir = REPO_ROOT / args.dir if not args.dir.is_absolute() else args.dir
-        ok = ingest_one(skill_dir, args.source, args.source_url, args.dry_run)
-        if ok:
-            success_count += 1
-        else:
-            fail_count += 1
+        candidate_skill_dirs = [
+            REPO_ROOT / args.dir
+            if not args.dir.is_absolute()
+            else args.dir
+        ]
+    manifest_path = None
+    if args.artifact_manifest:
+        manifest_path = (
+            args.artifact_manifest
+            if args.artifact_manifest.is_absolute()
+            else REPO_ROOT / args.artifact_manifest
+        )
+    try:
+        with acquire_ingest_locks(
+            repo_root=REPO_ROOT,
+            skill_dirs=candidate_skill_dirs,
+            mapping_paths=[external_mapping],
+            durable=not args.dry_run,
+        ) as durable_guard:
+            artifact_maps = [
+                parse_artifact_map(item) for item in args.artifact_map
+            ]
+            manifest_before = (
+                manifest_path.read_bytes() if manifest_path is not None else None
+            )
+            if manifest_path is not None:
+                artifact_maps.extend(load_artifact_manifest(manifest_path))
+            targets = [target for _, target in artifact_maps]
+            if len(targets) != len(set(targets)):
+                raise ValueError("artifact mappings contain duplicate targets")
+
+            if args.batch:
+                tracked = get_tracked_skills(REPO_ROOT / "docs" / "sources")
+                skill_dirs = find_untracked_skills(SKILLS_DIR, tracked)
+                if {
+                    path.resolve() for path in skill_dirs
+                } != {
+                    path.resolve() for path in candidate_skill_dirs
+                }:
+                    raise RuntimeError(
+                        "global claims changed before batch lock acquisition; "
+                        "retry"
+                    )
+                print(
+                    f"Found {len(skill_dirs)} untracked skills "
+                    f"(out of {len(tracked)} tracked)"
+                )
+            else:
+                skill_dirs = candidate_skill_dirs
+
+            plans: list[IngestPlan] = []
+            virtual_mapping: dict[str, Any] | None = None
+            for skill_dir in skill_dirs:
+                try:
+                    plan = prepare_ingest(
+                        skill_dir,
+                        args.source,
+                        args.source_url,
+                        external_mapping=external_mapping,
+                        repo_root=REPO_ROOT,
+                        upstream_path=args.upstream_path,
+                        upstream_ref=args.upstream_ref,
+                        resolved_commit=args.resolved_commit,
+                        path_commit=args.path_commit,
+                        artifact_maps=artifact_maps,
+                        existing_mapping_payload=virtual_mapping,
+                    )
+                except (OSError, ValueError, json.JSONDecodeError) as exc:
+                    print(
+                        f"  ERROR: {skill_dir.name} — {exc}",
+                        file=sys.stderr,
+                    )
+                    fail_count += 1
+                    continue
+                plans.append(plan)
+                if plan.mapping_payload is not None:
+                    virtual_mapping = plan.mapping_payload
+                success_count += 1
+
+            if fail_count:
+                raise ValueError(
+                    "preflight failed; no skill or mapping files were written"
+                )
+            if virtual_mapping is not None:
+                final_mapping = _json_bytes(virtual_mapping)
+                for plan in plans:
+                    if plan.mapping_path == external_mapping:
+                        plan.after_mapping = final_mapping
+            if (
+                manifest_path is not None
+                and manifest_path.read_bytes() != manifest_before
+            ):
+                raise RuntimeError("artifact manifest changed during preflight")
+            _assert_ingest_inputs_unchanged(plans)
+            if not execute_validated_ingest(
+                plans,
+                repo_root=REPO_ROOT,
+                dry_run=args.dry_run,
+                locks_held=True,
+                durable_guard=durable_guard,
+            ):
+                raise RuntimeError("isolated full pipeline validation failed")
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"ERROR: ingest transaction aborted: {exc}", file=sys.stderr)
+        return 1
 
     print(f"\nIngestion complete: {success_count} succeeded, {fail_count} failed")
-
-    if success_count > 0 and not args.skip_pipeline:
-        run_pipeline(args.dry_run)
+    return 1 if fail_count else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/ingest_skill.py
+++ b/scripts/ingest_skill.py
@@ -345,7 +345,37 @@ def classify_github_artifacts(
             used_targets.add(target)
         item = tree.get(source_path)
         upstream_bytes: bytes | None = None
-        if isinstance(item, dict) and item.get("type") == "blob":
+        upstream_mode: str | None = None
+        if isinstance(item, dict):
+            item_type = item.get("type")
+            upstream_mode = item.get("mode")
+            if item_type == "blob" and upstream_mode not in {
+                "100644",
+                "100755",
+            }:
+                raise ValueError(
+                    "declared upstream artifact is not a regular Git blob: "
+                    f"{source_path} ({item_type}/{upstream_mode})"
+                )
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "blob"
+            and upstream_mode in {"100644", "100755"}
+        ):
+            local_metadata = local_path.lstat()
+            if stat.S_ISLNK(local_metadata.st_mode) or not stat.S_ISREG(
+                local_metadata.st_mode
+            ):
+                raise ValueError(
+                    f"canonical artifact is not a regular file: {target}"
+                )
+            local_mode = _git_file_mode(local_metadata)
+            if upstream_mode != local_mode:
+                raise ValueError(
+                    "declared upstream artifact mode does not match the "
+                    f"canonical file: {source_path} -> {target} "
+                    f"({upstream_mode} != {local_mode})"
+                )
             blob_sha = item.get("sha")
             if not isinstance(blob_sha, str):
                 raise ValueError(f"upstream artifact has no blob SHA: {source_path}")
@@ -842,6 +872,8 @@ def build_external_provenance_payload(
         if kind != "snapshot":
             kind = "overlay"
             sync_mode = "monitor"
+    managed_paths = regular_skill_files(skill_dir)
+    _assert_tracked_modes_clean(repo_root, managed_paths)
     entry = {
         "video_name": skill_name,
         "normalized_slug": skill_name,
@@ -870,8 +902,9 @@ def build_external_provenance_payload(
                     if path == skill_md
                     else sha256_file(path)
                 ),
+                "mode": _git_file_mode(path.lstat()),
             }
-            for path in regular_skill_files(skill_dir)
+            for path in managed_paths
         ],
     }
 
@@ -978,6 +1011,7 @@ class IngestPlan:
         skill_md: Path,
         before_skill: bytes | None,
         after_skill: bytes,
+        after_mode: int | None = None,
         mapping_path: Path | None = None,
         before_mapping: bytes | None = None,
         after_mapping: bytes | None = None,
@@ -993,6 +1027,7 @@ class IngestPlan:
         self.skill_md = skill_md
         self.before_skill = before_skill
         self.after_skill = after_skill
+        self.after_mode = after_mode
         self.mapping_path = mapping_path
         self.before_mapping = before_mapping
         self.after_mapping = after_mapping
@@ -1279,7 +1314,121 @@ def _path_state(path: Path) -> dict[str, str]:
         return {"type": "symlink", "sha256": os.readlink(path)}
     if not stat.S_ISREG(metadata.st_mode):
         return {"type": "other", "sha256": str(metadata.st_mode)}
-    return {"type": "file", "sha256": sha256_file(path)}
+    return {
+        "type": "file",
+        "sha256": sha256_file(path),
+        "mode": _git_file_mode(metadata),
+    }
+
+
+def _git_file_mode(metadata: os.stat_result) -> str:
+    """Normalize a regular filesystem mode to the two Git blob modes."""
+    return "100755" if stat.S_IMODE(metadata.st_mode) & 0o111 else "100644"
+
+
+def _assert_tracked_modes_clean(repo_root: Path, paths: list[Path]) -> None:
+    """Reject chmod drift from the Git index before it becomes ownership state.
+
+    New, untracked skill files have no index authority yet and are allowed.
+    Existing tracked files must retain the executable bit recorded by Git.
+    Nested test repositories are deliberately not compared against an outer
+    worktree's index.
+    """
+    if not paths:
+        return
+    try:
+        top_level = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"cannot inspect Git index modes: {exc}") from exc
+    if top_level.returncode != 0:
+        return
+    try:
+        git_root = Path(top_level.stdout.strip()).resolve(strict=True)
+        resolved_repo = repo_root.resolve(strict=True)
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise ValueError(f"cannot resolve Git worktree for mode audit: {exc}") from exc
+    if git_root != resolved_repo:
+        return
+
+    relative_paths: list[str] = []
+    by_relative: dict[str, Path] = {}
+    for path in paths:
+        try:
+            relative = path.resolve(strict=True).relative_to(resolved_repo).as_posix()
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            raise ValueError(f"managed skill file escapes repository: {path}") from exc
+        relative_paths.append(relative)
+        by_relative[relative] = path
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(resolved_repo),
+                "ls-files",
+                "--stage",
+                "-z",
+                "--",
+                *relative_paths,
+            ],
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"cannot read Git index modes: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(
+            "cannot read Git index modes"
+            + (f": {detail}" if detail else "")
+        )
+
+    index_modes: dict[str, str] = {}
+    for record in completed.stdout.split(b"\0"):
+        if not record:
+            continue
+        metadata, separator, raw_path = record.partition(b"\t")
+        fields = metadata.split()
+        if not separator or len(fields) != 3:
+            raise ValueError("Git index returned a malformed stage record")
+        try:
+            mode = fields[0].decode("ascii")
+            relative = raw_path.decode("utf-8", errors="surrogateescape")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Git index returned an invalid mode") from exc
+        if fields[2] != b"0":
+            raise ValueError(
+                f"Git index contains an unmerged managed file: {relative}"
+            )
+        if mode not in {"100644", "100755"}:
+            raise ValueError(
+                f"Git index managed file is not a regular blob: {relative}: {mode}"
+            )
+        index_modes[relative] = mode
+
+    dirty: list[str] = []
+    for relative, expected in index_modes.items():
+        path = by_relative.get(relative)
+        if path is None:
+            continue
+        metadata = path.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"managed skill file is not regular: {relative}")
+        actual = _git_file_mode(metadata)
+        if actual != expected:
+            dirty.append(f"{relative} ({expected} -> {actual})")
+    if dirty:
+        raise ValueError(
+            "refusing to authorize dirty executable-mode changes: "
+            + ", ".join(sorted(dirty))
+        )
 
 
 def capture_ingest_fingerprint(
@@ -1298,7 +1447,7 @@ def capture_ingest_fingerprint(
         raise ValueError("skill directory escapes repository root") from exc
     repository_files = _walk_repository_regular_files(repo_absolute)
     skill_prefix = skill_relative.rstrip("/") + "/"
-    for relative, (content, _mode) in repository_files.items():
+    for relative, (content, mode) in repository_files.items():
         is_skill_input = (
             relative == f"{skill_relative}/SKILL.md"
             or relative.startswith(skill_prefix)
@@ -1312,6 +1461,7 @@ def capture_ingest_fingerprint(
             inventory[relative] = {
                 "type": "file",
                 "sha256": sha256_bytes(content),
+                "mode": str(mode),
             }
     if mapping_path is not None:
         mapping_absolute = Path(os.path.abspath(mapping_path))
@@ -1539,6 +1689,7 @@ def prepare_ingest(
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.is_file() or skill_md.is_symlink():
         raise ValueError(f"{skill_md} must be a regular file")
+    _assert_tracked_modes_clean(repo_root, regular_skill_files(skill_dir))
     fingerprint_mapping = external_mapping or (
         repo_root / "docs" / "sources" / "ingested-external.skills.json"
     )
@@ -1729,6 +1880,7 @@ def prepare_ingest(
         skill_md=skill_md,
         before_skill=before_skill,
         after_skill=updated.encode("utf-8"),
+        after_mode=stat.S_IMODE(skill_md.lstat().st_mode),
         mapping_path=mapping_path,
         before_mapping=mapping_before,
         after_mapping=mapping_after,
@@ -1763,7 +1915,15 @@ def _write_atomic_bytes(
     repo_root: Path | None = None,
     expected_checkpoint: dict[str, Any] | None = None,
     expected_parent_checkpoint: list[dict[str, Any]] | None = None,
+    desired_mode: int | None = None,
 ) -> None:
+    if desired_mode is not None and (
+        isinstance(desired_mode, bool)
+        or not isinstance(desired_mode, int)
+        or desired_mode < 0
+        or desired_mode > 0o777
+    ):
+        raise ValueError(f"invalid desired file mode for {path}: {desired_mode!r}")
     if repo_root is not None and expected_checkpoint is not None:
         _write_atomic_bytes_secure(
             path,
@@ -1771,6 +1931,7 @@ def _write_atomic_bytes(
             repo_root=repo_root,
             expected_checkpoint=expected_checkpoint,
             expected_parent_checkpoint=expected_parent_checkpoint,
+            desired_mode=desired_mode,
         )
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1797,8 +1958,14 @@ def _write_atomic_bytes(
         created_stat = os.fstat(fd)
         if not stat.S_ISREG(created_stat.st_mode):
             raise RuntimeError(f"temporary path is not regular: {temp_path}")
-        if original_mode is not None:
-            os.fchmod(fd, original_mode)
+        installed_mode = (
+            desired_mode
+            if desired_mode is not None
+            else original_mode
+            if original_mode is not None
+            else 0o644
+        )
+        os.fchmod(fd, installed_mode)
         with os.fdopen(fd, "wb") as handle:
             fd = -1
             handle.write(content)
@@ -1817,6 +1984,15 @@ def _write_atomic_bytes(
             os.fsync(directory_fd)
         finally:
             os.close(directory_fd)
+        installed = path.lstat()
+        if (
+            not stat.S_ISREG(installed.st_mode)
+            or stat.S_IMODE(installed.st_mode) != installed_mode
+            or path.read_bytes() != content
+        ):
+            raise RuntimeError(
+                f"installed target failed byte/mode verification: {path}"
+            )
     finally:
         if fd >= 0:
             os.close(fd)
@@ -1830,6 +2006,7 @@ def _write_atomic_bytes_secure(
     repo_root: Path,
     expected_checkpoint: dict[str, Any],
     expected_parent_checkpoint: list[dict[str, Any]] | None = None,
+    desired_mode: int | None = None,
 ) -> None:
     """Replace one target through stable dirfds after checkpoint revalidation."""
     if expected_parent_checkpoint is not None:
@@ -1874,7 +2051,9 @@ def _write_atomic_bytes_secure(
                     f"transaction temporary is not regular: {path}"
                 )
             mode = (
-                int(expected_checkpoint["mode"])
+                desired_mode
+                if desired_mode is not None
+                else int(expected_checkpoint["mode"])
                 if expected_checkpoint.get("exists")
                 else 0o644
             )
@@ -2089,6 +2268,7 @@ def _materialize_transaction_parents(
 def _apply_ingest_output_batch(
     *,
     outputs: dict[Path, bytes],
+    after_modes: dict[Path, int],
     before: dict[Path, bytes | None],
     checkpoints: dict[Path, dict[str, Any]],
     parent_checkpoints: dict[Path, list[dict[str, Any]]],
@@ -2118,6 +2298,7 @@ def _apply_ingest_output_batch(
                 repo_root=roots[path],
                 expected_checkpoint=checkpoints[path],
                 expected_parent_checkpoint=writer_parent_checkpoints.get(path),
+                desired_mode=after_modes[path],
             )
             if fault_injector is not None:
                 fault_injector("after_replace", path)
@@ -2135,8 +2316,10 @@ def _apply_ingest_output_batch(
                 )
                 if prior is None:
                     if current_checkpoint["exists"]:
-                        if current_checkpoint["sha256"] != sha256_bytes(
-                            outputs[path]
+                        if (
+                            current_checkpoint["sha256"]
+                            != sha256_bytes(outputs[path])
+                            or current_checkpoint["mode"] != after_modes[path]
                         ):
                             raise RuntimeError(
                                 f"rollback target changed concurrently: {path}"
@@ -2152,6 +2335,7 @@ def _apply_ingest_output_batch(
                 elif (
                     current_checkpoint["exists"]
                     and current_checkpoint["sha256"] == sha256_bytes(prior)
+                    and current_checkpoint["mode"] == checkpoints[path]["mode"]
                 ):
                     continue
                 else:
@@ -2159,6 +2343,7 @@ def _apply_ingest_output_batch(
                         not current_checkpoint["exists"]
                         or current_checkpoint["sha256"]
                         != sha256_bytes(outputs[path])
+                        or current_checkpoint["mode"] != after_modes[path]
                     ):
                         raise RuntimeError(
                             f"rollback target changed concurrently: {path}"
@@ -2171,6 +2356,7 @@ def _apply_ingest_output_batch(
                         expected_parent_checkpoint=(
                             writer_parent_checkpoints.get(path)
                         ),
+                        desired_mode=int(checkpoints[path]["mode"]),
                     )
             except Exception as rollback_exc:  # pragma: no cover - catastrophic I/O
                 rollback_errors.append(f"{path}: {rollback_exc}")
@@ -2265,19 +2451,35 @@ def commit_ingest_plans(
     checkpoints: dict[Path, dict[str, Any]] = {}
     parent_checkpoints: dict[Path, list[dict[str, Any]]] = {}
     roots: dict[Path, Path | None] = {}
+    after_modes: dict[Path, int] = {}
     for plan in plans:
-        if plan.before_skill != plan.after_skill:
+        skill_checkpoint = (
+            plan.before_checkpoint
+            or capture_target_checkpoint(
+                plan.skill_md,
+                repo_root=plan.repo_root,
+            )
+        )
+        skill_after_mode = (
+            int(plan.after_mode)
+            if plan.after_mode is not None
+            else int(skill_checkpoint["mode"])
+            if skill_checkpoint.get("exists")
+            else 0o644
+        )
+        if (
+            plan.before_skill != plan.after_skill
+            or not skill_checkpoint.get("exists")
+            or skill_checkpoint.get("mode") != skill_after_mode
+        ):
             outputs[plan.skill_md] = plan.after_skill
             before.setdefault(plan.skill_md, plan.before_skill)
             roots.setdefault(plan.skill_md, plan.repo_root)
             checkpoints.setdefault(
                 plan.skill_md,
-                plan.before_checkpoint
-                or capture_target_checkpoint(
-                    plan.skill_md,
-                    repo_root=plan.repo_root,
-                ),
+                skill_checkpoint,
             )
+            after_modes[plan.skill_md] = skill_after_mode
             if plan.repo_root is not None:
                 parent_checkpoints.setdefault(
                     plan.skill_md,
@@ -2302,6 +2504,12 @@ def commit_ingest_plans(
                     plan.mapping_path,
                     repo_root=plan.repo_root,
                 ),
+            )
+            mapping_checkpoint = checkpoints[plan.mapping_path]
+            after_modes[plan.mapping_path] = (
+                int(mapping_checkpoint["mode"])
+                if mapping_checkpoint.get("exists")
+                else 0o644
             )
             if plan.repo_root is not None:
                 parent_checkpoints.setdefault(
@@ -2331,18 +2539,11 @@ def commit_ingest_plans(
             repo_root=roots[path],
         )
 
-    after_modes = {
-        path: (
-            int(checkpoints[path]["mode"])
-            if checkpoints[path].get("exists")
-            else 0o644
-        )
-        for path in outputs
-    }
     durable_guard.commit_batch(
         outputs,
         lambda: _apply_ingest_output_batch(
             outputs=outputs,
+            after_modes=after_modes,
             before=before,
             checkpoints=checkpoints,
             parent_checkpoints=parent_checkpoints,
@@ -2730,6 +2931,7 @@ def _translate_plan_to_stage(
         skill_md=stage_root / skill_relative,
         before_skill=(stage_root / skill_relative).read_bytes(),
         after_skill=plan.after_skill,
+        after_mode=plan.after_mode,
         mapping_path=stage_root / mapping_relative if mapping_relative else None,
         before_mapping=(
             (stage_root / mapping_relative).read_bytes()
@@ -2787,6 +2989,19 @@ def validate_ingest_plans(
         repo_root,
         set(baseline),
     )
+    baseline_modes: dict[str, int] = {}
+    for relative, content in baseline.items():
+        checkpoint = baseline_checkpoints[relative]
+        if (
+            not checkpoint.get("exists")
+            or checkpoint.get("sha256") != sha256_bytes(content)
+            or not isinstance(checkpoint.get("mode"), int)
+        ):
+            raise RuntimeError(
+                "repository changed while capturing ingest baseline: "
+                f"{relative}"
+            )
+        baseline_modes[relative] = int(checkpoint["mode"])
     # macOS exposes /var as a symlink to /private/var. Resolve the OS-provided
     # temporary root first, then validate and use its symlink-free absolute
     # path so the secure dirfd traversal applies inside staging as well.
@@ -2824,6 +3039,23 @@ def validate_ingest_plans(
             stage_root,
             tracked_reports=tracked_reports,
         )
+        staged_checkpoints = repository_checkpoint_snapshot(
+            stage_root,
+            set(staged),
+        )
+        staged_modes: dict[str, int] = {}
+        for relative, content in staged.items():
+            checkpoint = staged_checkpoints[relative]
+            if (
+                not checkpoint.get("exists")
+                or checkpoint.get("sha256") != sha256_bytes(content)
+                or not isinstance(checkpoint.get("mode"), int)
+            ):
+                raise RuntimeError(
+                    "staged repository changed while capturing pipeline output: "
+                    f"{relative}"
+                )
+            staged_modes[relative] = int(checkpoint["mode"])
         if (
             transactional_repository_bytes_snapshot(
                 repo_root,
@@ -2846,7 +3078,9 @@ def validate_ingest_plans(
         for relative in sorted(staged):
             before = baseline.get(relative)
             after = staged[relative]
-            if before == after:
+            before_mode = baseline_modes.get(relative)
+            after_mode = staged_modes[relative]
+            if before == after and before_mode == after_mode:
                 continue
             target = repo_root / relative
             mutations.append(
@@ -2855,6 +3089,7 @@ def validate_ingest_plans(
                     skill_md=target,
                     before_skill=before,
                     after_skill=after,
+                    after_mode=after_mode,
                     repo_root=repo_root,
                     before_checkpoint=(
                         baseline_checkpoints[relative]

--- a/scripts/provenance_pipeline.py
+++ b/scripts/provenance_pipeline.py
@@ -17,9 +17,16 @@ def resolve_python_cmd() -> list[str]:
     return [sys.executable] if sys.executable else ["python"]
 
 
-def run(cmd: list[str], root: Path) -> None:
+def run(
+    cmd: list[str],
+    root: Path,
+    *,
+    accepted_codes: frozenset[int] = frozenset({0}),
+) -> None:
     print("$", " ".join(cmd))
-    subprocess.run(cmd, cwd=root, check=True)
+    result = subprocess.run(cmd, cwd=root, check=False)
+    if result.returncode not in accepted_codes:
+        raise subprocess.CalledProcessError(result.returncode, cmd)
 
 
 def main() -> int:
@@ -37,6 +44,16 @@ def main() -> int:
 
     run(python_cmd + ["scripts/bootstrap_in_house_sources.py", "--write-json", p["in_house_mapping"]], root)
     run(python_cmd + ["scripts/validate_skill_sources.py"], root)
+    run(
+        python_cmd
+        + [
+            "scripts/reconcile_artifact_inventory.py",
+            "--offline",
+            "--check-clean",
+            "--quiet",
+        ],
+        root,
+    )
     run(python_cmd + ["scripts/audit_licenses.py"], root)
     run(python_cmd + ["scripts/check_source_coverage.py", "--min-percent", coverage], root)
     run(
@@ -53,7 +70,19 @@ def main() -> int:
             + ["scripts/skills_bulk_update_stub.py", "--queue", p["refresh_queue"], "--write-plan", p["bulk_plan"]],
             root,
         )
-        run(python_cmd + ["scripts/check_upstream_github_updates.py", "--write-json", p["upstream_check"]], root)
+        # The deterministic offline inventory is deliberately degraded rather
+        # than pretending to be a fresh upstream check. Code 2 is therefore an
+        # expected report state here, while every actual gate remains fail-fast.
+        run(
+            python_cmd
+            + [
+                "scripts/check_upstream_github_updates.py",
+                "--write-json",
+                p["upstream_check"],
+            ],
+            root,
+            accepted_codes=frozenset({0, 2}),
+        )
 
     print("Provenance pipeline completed.")
     return 0

--- a/scripts/provenance_v2.py
+++ b/scripts/provenance_v2.py
@@ -59,6 +59,7 @@ GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$", re.IGNORECASE)
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+GIT_FILE_MODES = frozenset({"100644", "100755"})
 
 
 def parse_frontmatter(path: Path) -> dict[str, str]:
@@ -90,6 +91,27 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def git_file_mode(path: Path) -> str | None:
+    """Return the regular-file mode representable by a Git tree.
+
+    Git persists only the executable bit for ordinary files.  Symlinks,
+    non-regular files, and special permission bits cannot be authorized by a
+    managed-file checkpoint.
+    """
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return None
+    permissions = stat.S_IMODE(metadata.st_mode)
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or permissions & 0o7000
+    ):
+        return None
+    return "100755" if permissions & 0o111 else "100644"
 
 
 def valid_github_repo(value: object) -> bool:
@@ -500,6 +522,8 @@ def _managed_file(
             if candidate.is_file() and not candidate.is_symlink()
             else None
         )
+    if refresh_hash or "mode" not in record:
+        record["mode"] = git_file_mode(candidate)
     return record
 
 
@@ -605,6 +629,7 @@ def _refresh_declared_managed_digests(
             continue
         digest = sha256_file(candidate)
         managed["sha256"] = digest
+        managed["mode"] = git_file_mode(candidate)
         if path == repo_skill:
             repo_skill_digest = digest
 

--- a/scripts/provenance_v2.py
+++ b/scripts/provenance_v2.py
@@ -16,6 +16,7 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import Any
+from urllib.parse import urlsplit
 
 SCHEMA_VERSION = 2
 
@@ -40,6 +41,7 @@ VALID_CHANNELS = {
 }
 ACTIVE_STATUSES = {"verified_in_repo", "in_house"}
 LOCAL_SOURCE_VALUES = {"", "in-house", "in_house", "local"}
+LOCAL_CURATION_REPO = "local-repo/curation"
 UNKNOWN_LICENSE_VALUES = {
     "",
     "unknown",
@@ -50,9 +52,10 @@ UNKNOWN_LICENSE_VALUES = {
 }
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---(?:\s*\n|$)", re.DOTALL)
-GITHUB_REPO_RE = re.compile(
-    r"(?:github\.com/|^github:)([^/\s]+/[^/\s#?]+)", re.IGNORECASE
+GITHUB_OWNER_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
 )
+GITHUB_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$", re.IGNORECASE)
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -89,17 +92,66 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def valid_github_repo(value: object) -> bool:
+    """Whether ``value`` is one canonical GitHub ``owner/repository`` id."""
+    if not isinstance(value, str) or value != value.strip():
+        return False
+    if value.count("/") != 1:
+        return False
+    owner, repository = value.split("/", 1)
+    if repository.lower().endswith(".git"):
+        return False
+    return bool(
+        GITHUB_OWNER_RE.fullmatch(owner)
+        and GITHUB_REPOSITORY_RE.fullmatch(repository)
+        and repository not in {".", ".."}
+    )
+
+
 def github_repo(value: str | None) -> str | None:
-    """Return a normalized ``owner/repo`` from a GitHub source declaration."""
-    if not value:
+    """Return a normalized GitHub repository from an exact declaration.
+
+    Substring matching is intentionally forbidden: hosts such as
+    ``evilgithub.com`` and credential-bearing URLs must never establish source
+    lineage.
+    """
+    if not isinstance(value, str) or not value or value != value.strip():
         return None
-    match = GITHUB_REPO_RE.search(value.strip())
-    if not match:
+    candidate = value
+    if candidate.lower().startswith("github:"):
+        repository = candidate[len("github:") :]
+        if repository.lower().endswith(".git"):
+            repository = repository[:-4]
+        if not valid_github_repo(repository):
+            return None
+        return repository.lower()
+
+    try:
+        parsed = urlsplit(candidate)
+        parsed_port = parsed.port
+    except ValueError:
         return None
-    result = match.group(1).rstrip("/")
-    if result.lower().endswith(".git"):
-        result = result[:-4]
-    return result.lower()
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or parsed.hostname is None
+        or parsed.hostname.lower() != "github.com"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed_port is not None
+    ):
+        return None
+    raw_parts = parsed.path.split("/")
+    if (
+        len(raw_parts) < 3
+        or raw_parts[0] != ""
+        or not raw_parts[1]
+        or not raw_parts[2]
+    ):
+        return None
+    repository = f"{raw_parts[1]}/{raw_parts[2]}"
+    if repository.lower().endswith(".git"):
+        repository = repository[:-4]
+    return repository.lower() if valid_github_repo(repository) else None
 
 
 def is_local_repo(repo: str | None) -> bool:
@@ -307,24 +359,27 @@ def _requested_sync_mode(item: dict[str, Any], kind: str) -> str:
 
 
 def _normalize_entry_sync_modes(item: dict[str, Any], kind: str) -> None:
-    """Keep origin, v2 entry, and legacy upstream modes policy-identical."""
+    """Normalize entry modes while preserving mixed local-overlay semantics."""
     requested = _requested_sync_mode(item, kind)
     origins = item.get("origins")
     proposals: list[str] = []
+    origin_proposals: list[tuple[dict[str, Any], str]] = []
     if isinstance(origins, list):
         for origin in origins:
             if not isinstance(origin, dict):
                 continue
             tracking = origin.get("tracking")
-            proposals.append(
-                normalize_sync_mode(
-                    kind=kind,
-                    tracking=tracking,
-                    repo=origin.get("repo"),
-                    requested_mode=requested,
-                    status=item.get("status"),
-                )
+            proposal = normalize_sync_mode(
+                kind=kind,
+                tracking=tracking,
+                repo=origin.get("repo"),
+                requested_mode=requested,
+                status=item.get("status"),
             )
+            if origin.get("repo") == LOCAL_CURATION_REPO:
+                proposal = "local-only"
+            proposals.append(proposal)
+            origin_proposals.append((origin, proposal))
 
     if not proposals:
         upstream = (
@@ -358,10 +413,8 @@ def _normalize_entry_sync_modes(item: dict[str, Any], kind: str) -> None:
         normalized = "replace"
 
     item["sync_mode"] = normalized
-    if isinstance(origins, list):
-        for origin in origins:
-            if isinstance(origin, dict):
-                origin["sync_mode"] = normalized
+    for origin, proposal in origin_proposals:
+        origin["sync_mode"] = proposal
     upstream = item.get("upstream")
     if isinstance(upstream, dict):
         upstream["sync_mode"] = normalized
@@ -474,7 +527,18 @@ def _migrate_managed_files(
             if record is not None:
                 existing_by_path[path] = record
 
-    targets = local_targets if local_targets is not None else existing_paths
+    if local_targets is not None:
+        # Preserve the reviewed manifest order and append only newly discovered
+        # local files in the scanner's deterministic order.  Reconciliation
+        # tools may use bytewise POSIX sorting while Path sorts by components;
+        # reordering otherwise-identical ownership records is not a migration.
+        local_target_set = set(local_targets)
+        targets = [
+            path for path in existing_paths if path in local_target_set
+        ]
+        targets.extend(path for path in local_targets if path not in targets)
+    else:
+        targets = existing_paths
     if local_targets is None and not targets:
         target = _artifact_target(item)
         targets = [target] if target else []
@@ -572,8 +636,15 @@ def _refresh_local_origin(
 ) -> dict[str, Any]:
     """Refresh repository-local facts without changing external checkpoints."""
     refreshed = deepcopy(origin)
-    artifacts = _local_artifacts(item, repo_root)
-    refreshed["artifacts"] = artifacts
+    curated_overlay = refreshed.get("repo") == LOCAL_CURATION_REPO
+    if curated_overlay:
+        # A curation origin owns only the explicit supplements assigned to it.
+        # Expanding it to the whole skill directory would steal ownership of
+        # the externally sourced SKILL.md and exact sidecars.
+        artifacts = deepcopy(refreshed.get("artifacts"))
+        refreshed["artifacts"] = artifacts if isinstance(artifacts, list) else []
+    else:
+        refreshed["artifacts"] = _local_artifacts(item, repo_root)
 
     upstream = item.get("upstream") if isinstance(item.get("upstream"), dict) else {}
     target = _artifact_target(item)
@@ -584,26 +655,37 @@ def _refresh_local_origin(
     skill_target = target
     skill_path = repo_root / skill_target if skill_target else None
     tracking["channel"] = "local"
-    tracking["ref"] = str(upstream.get("ref") or tracking.get("ref") or "local")
-    tracking.setdefault("resolved_commit", None)
-    tracking.setdefault("path_commit", None)
+    tracking["ref"] = (
+        "local"
+        if curated_overlay
+        else str(upstream.get("ref") or tracking.get("ref") or "local")
+    )
+    if curated_overlay:
+        tracking["resolved_commit"] = None
+        tracking["path_commit"] = None
+    else:
+        tracking.setdefault("resolved_commit", None)
+        tracking.setdefault("path_commit", None)
     previous_content_hash = tracking.get("content_sha256")
-    current_content_hash = (
-        sha256_file(skill_path)
-        if skill_path is not None
+    if curated_overlay:
+        current_content_hash = None
+    elif (
+        skill_path is not None
         and skill_path.is_file()
         and not skill_path.is_symlink()
-        else None
-    )
+    ):
+        current_content_hash = sha256_file(skill_path)
+    else:
+        current_content_hash = None
     tracking["content_sha256"] = current_content_hash
     checked_at = (
         tracking_date
-        or upstream.get("last_checked_at")
         or tracking.get("last_checked_at")
+        or (None if curated_overlay else upstream.get("last_checked_at"))
     )
     previous_synced_at = (
-        upstream.get("last_synced_at")
-        or tracking.get("last_synced_at")
+        tracking.get("last_synced_at")
+        or (None if curated_overlay else upstream.get("last_synced_at"))
     )
     content_changed = current_content_hash != previous_content_hash
     synced_at = (
@@ -613,8 +695,9 @@ def _refresh_local_origin(
     )
     tracking["last_checked_at"] = checked_at
     tracking["last_synced_at"] = synced_at
-    upstream["last_checked_at"] = checked_at
-    upstream["last_synced_at"] = synced_at
+    if not curated_overlay:
+        upstream["last_checked_at"] = checked_at
+        upstream["last_synced_at"] = synced_at
     refreshed["tracking"] = tracking
     return refreshed
 
@@ -737,12 +820,16 @@ def migrate_entry(
 
     _normalize_entry_sync_modes(migrated, kind)
 
-    has_local_origin = any(
-        isinstance(origin, dict) and is_local_repo(origin.get("repo"))
+    has_full_local_origin = any(
+        isinstance(origin, dict)
+        and is_local_repo(origin.get("repo"))
+        and origin.get("repo") != LOCAL_CURATION_REPO
         for origin in migrated.get("origins", [])
     )
     local_targets = (
-        _skill_artifact_paths(migrated, repo_root) if has_local_origin else None
+        _skill_artifact_paths(migrated, repo_root)
+        if has_full_local_origin
+        else None
     )
     migrated["managed_files"] = _migrate_managed_files(
         migrated,

--- a/scripts/provenance_v2.py
+++ b/scripts/provenance_v2.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 import stat
-import tempfile
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -900,72 +899,166 @@ def migrate_payload(
     return migrated
 
 
-def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Durably replace JSON through an exclusively-created sibling file.
+def _validate_atomic_temporary(
+    directory_fd: int,
+    name: str,
+    descriptors: tuple[int, ...],
+    identity: tuple[int, int],
+) -> None:
+    """Require a temporary name and every retained fd to bind one inode."""
+    named = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    if stat.S_ISLNK(named.st_mode) or not stat.S_ISREG(named.st_mode):
+        raise RuntimeError(f"unsafe JSON temporary: {name}")
+    if (named.st_dev, named.st_ino) != identity:
+        raise RuntimeError(f"JSON temporary inode changed: {name}")
+    for descriptor in descriptors:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != identity
+        ):
+            raise RuntimeError(f"JSON temporary descriptor changed: {name}")
 
-    ``mkstemp`` avoids the predictable temporary pathname used by the legacy
-    writer, so a pre-created symlink cannot redirect the write.  Existing
-    destination permissions are retained, and both file contents and the
-    containing directory are synced around the atomic rename.
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Durably replace JSON while pinning its created inode until rename.
+
+    The writer fd remains open until an O_NOFOLLOW read fd pins the exact
+    creation-time inode. Cleanup unlinks only that inode, never a foreign file
+    that appears under the temporary name after an ABA replacement.
     """
     path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    directory_fd = os.open(path.parent, directory_flags)
     original_mode: int | None = None
     try:
-        destination_stat = path.lstat()
+        destination_stat = os.stat(
+            path.name,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
     except FileNotFoundError:
         pass
+    except BaseException:
+        os.close(directory_fd)
+        raise
     else:
         if stat.S_ISLNK(destination_stat.st_mode):
+            os.close(directory_fd)
             raise ValueError(f"refusing to replace symlink destination: {path}")
         if not stat.S_ISREG(destination_stat.st_mode):
+            os.close(directory_fd)
             raise ValueError(
                 f"refusing to replace non-regular destination: {path}"
             )
         original_mode = stat.S_IMODE(destination_stat.st_mode)
 
-    file_descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-    )
-    temporary = Path(temporary_name)
+    temporary_name = ""
+    file_descriptor = -1
+    pinned_descriptor = -1
+    identity: tuple[int, int] | None = None
     try:
-        created_stat = os.fstat(file_descriptor)
-        if not stat.S_ISREG(created_stat.st_mode):
-            raise RuntimeError(f"temporary path is not a regular file: {temporary}")
-        if original_mode is not None:
-            os.fchmod(file_descriptor, original_mode)
-
-        handle = os.fdopen(file_descriptor, "w", encoding="utf-8")
-        file_descriptor = -1
-        with handle:
-            handle.write(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-
-        named_stat = temporary.lstat()
-        if (
-            not stat.S_ISREG(named_stat.st_mode)
-            or named_stat.st_dev != created_stat.st_dev
-            or named_stat.st_ino != created_stat.st_ino
-        ):
-            raise RuntimeError(
-                f"temporary path changed before atomic replace: {temporary}"
+        create_flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        for _ in range(128):
+            candidate = f".{path.name}.{os.urandom(16).hex()}.tmp"
+            try:
+                file_descriptor = os.open(
+                    candidate,
+                    create_flags,
+                    0o600,
+                    dir_fd=directory_fd,
+                )
+            except FileExistsError:
+                continue
+            temporary_name = candidate
+            break
+        else:
+            raise FileExistsError(
+                f"unable to allocate JSON temporary beside {path}"
             )
 
-        os.replace(temporary, path)
-        directory_fd = os.open(
-            path.parent,
-            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+        created_stat = os.fstat(file_descriptor)
+        if not stat.S_ISREG(created_stat.st_mode):
+            raise RuntimeError(
+                f"JSON temporary is not regular: {temporary_name}"
+            )
+        identity = (created_stat.st_dev, created_stat.st_ino)
+        encoded = (
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        ).encode("utf-8")
+        remaining = memoryview(encoded)
+        while remaining:
+            written = os.write(file_descriptor, remaining)
+            if written <= 0:
+                raise OSError("JSON temporary write made no progress")
+            remaining = remaining[written:]
+        os.fchmod(
+            file_descriptor,
+            original_mode if original_mode is not None else 0o600,
         )
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        os.fsync(file_descriptor)
+
+        pinned_descriptor = os.open(
+            temporary_name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory_fd,
+        )
+        _validate_atomic_temporary(
+            directory_fd,
+            temporary_name,
+            (file_descriptor, pinned_descriptor),
+            identity,
+        )
+        os.close(file_descriptor)
+        file_descriptor = -1
+        _validate_atomic_temporary(
+            directory_fd,
+            temporary_name,
+            (pinned_descriptor,),
+            identity,
+        )
+        os.replace(
+            temporary_name,
+            path.name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_name = ""
+        os.fsync(directory_fd)
     finally:
+        if temporary_name and identity is not None:
+            try:
+                cleanup_descriptors = tuple(
+                    descriptor
+                    for descriptor in (pinned_descriptor,)
+                    if descriptor >= 0
+                )
+                if not cleanup_descriptors and file_descriptor >= 0:
+                    cleanup_descriptors = (file_descriptor,)
+                _validate_atomic_temporary(
+                    directory_fd,
+                    temporary_name,
+                    cleanup_descriptors,
+                    identity,
+                )
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except (OSError, RuntimeError):
+                pass
         if file_descriptor >= 0:
             os.close(file_descriptor)
-        temporary.unlink(missing_ok=True)
+        if pinned_descriptor >= 0:
+            os.close(pinned_descriptor)
+        os.close(directory_fd)
 
 
 def discover_source_mappings(sources_dir: Path) -> list[Path]:

--- a/scripts/provenance_v2.schema.json
+++ b/scripts/provenance_v2.schema.json
@@ -116,9 +116,9 @@
         "tracking"
       ],
       "properties": {
-        "repo": {
-          "type": "string",
-          "pattern": "^[^/]+/[^/]+$"
+      "repo": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]+$"
         },
         "path": {
           "oneOf": [
@@ -154,7 +154,59 @@
         "tracking": {
           "$ref": "#/$defs/tracking"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "repo": {
+                "const": "local-repo/curation"
+              }
+            },
+            "required": [
+              "repo"
+            ]
+          },
+          "then": {
+            "properties": {
+              "license": {
+                "type": "null"
+              },
+              "sync_mode": {
+                "const": "local-only"
+              },
+              "tracking": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/tracking"
+                  },
+                  {
+                    "properties": {
+                      "channel": {
+                        "const": "local"
+                      },
+                      "ref": {
+                        "const": "local"
+                      },
+                      "resolved_commit": {
+                        "type": "null"
+                      },
+                      "path_commit": {
+                        "type": "null"
+                      }
+                    },
+                    "not": {
+                      "required": [
+                        "license_checkpoint"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
     },
     "artifact": {
       "type": "object",
@@ -237,8 +289,45 @@
         },
         "last_synced_at": {
           "$ref": "#/$defs/nullableDate"
+        },
+        "license_checkpoint": {
+          "$ref": "#/$defs/licenseCheckpoint"
         }
       }
+    },
+    "licenseCheckpoint": {
+      "type": "object",
+      "required": [
+        "path",
+        "blob_sha",
+        "content_sha256",
+        "spdx",
+        "resolved_commit"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "blob_sha": {
+          "$ref": "#/$defs/commit"
+        },
+        "content_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "spdx": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resolved_commit": {
+          "$ref": "#/$defs/commit"
+        },
+        "api_spdx": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      },
+      "additionalProperties": false
     },
     "composition": {
       "type": "object",
@@ -271,9 +360,9 @@
           "type": "string",
           "minLength": 1
         },
-        "source_package": {
-          "type": "string",
-          "pattern": "^[^/]+/[^/]+$"
+      "source_package": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]+$"
         },
         "role": {
           "type": "string",
@@ -303,13 +392,11 @@
         }
       ]
     },
-    "relativePath": {
-      "type": "string",
-      "minLength": 1,
-      "not": {
-        "pattern": "(^\\.?/?$|^/|^[A-Za-z]:[\\\\/]|(^|/)\\.\\.(/|$))"
-      }
-    },
+  "relativePath": {
+    "type": "string",
+    "minLength": 1,
+    "pattern": "^(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.{1,2}(?:/|$))[^/]+(?:/[^/]+)*$"
+  },
     "nullableCommit": {
       "oneOf": [
         {

--- a/scripts/provenance_v2.schema.json
+++ b/scripts/provenance_v2.schema.json
@@ -234,7 +234,8 @@
       "required": [
         "path",
         "sha256",
-        "owner"
+        "owner",
+        "mode"
       ],
       "properties": {
         "path": {
@@ -246,6 +247,12 @@
         "owner": {
           "type": "string",
           "minLength": 1
+        },
+        "mode": {
+          "enum": [
+            "100644",
+            "100755"
+          ]
         }
       },
       "additionalProperties": false

--- a/scripts/reconcile_artifact_inventory.py
+++ b/scripts/reconcile_artifact_inventory.py
@@ -1,0 +1,2193 @@
+#!/usr/bin/env python3
+"""Reconcile canonical skill directories with provenance artifact inventories.
+
+The command is read-only unless ``--write`` is supplied.  It compares every
+regular file in an active external skill directory with the artifact and
+managed-file declarations in provenance v2.  Undeclared files are classified
+against the exact bytes at each origin's resolved commit:
+
+* ``external_exact``: the inferred upstream sibling exists with identical bytes;
+* ``local_overlay``: the source tree is available, but no inferred exact source
+  exists (or its bytes differ);
+* ``unavailable``: the immutable source tree/blob cannot be inspected.
+
+Only exact, path-preserving proposals are admitted automatically.  This is
+deliberately narrower than a repository-wide content search: a runtime snapshot
+copied from an unrelated upstream directory must remain a local overlay instead
+of being falsely claimed by the official skill artifact origin.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import contextlib
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import uuid
+from collections import Counter
+from copy import deepcopy
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+try:
+    from provenance_v2 import (
+        ACTIVE_STATUSES,
+        COMMIT_RE,
+        EXTERNAL_KINDS,
+        LOCAL_CURATION_REPO,
+        atomic_write_json,
+        discover_source_mappings,
+        is_local_repo,
+        safe_relative_path,
+    )
+except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
+    from scripts.provenance_v2 import (
+        ACTIVE_STATUSES,
+        COMMIT_RE,
+        EXTERNAL_KINDS,
+        LOCAL_CURATION_REPO,
+        atomic_write_json,
+        discover_source_mappings,
+        is_local_repo,
+        safe_relative_path,
+    )
+
+
+REPORT_SCHEMA_VERSION = 1
+LOCAL_OVERLAY_REPO = LOCAL_CURATION_REPO
+IGNORED_DIRECTORY_NAMES = {
+    "__pycache__",
+    ".cache",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+}
+IGNORED_FILE_NAMES = {".DS_Store"}
+IGNORED_FILE_SUFFIXES = {".pyc", ".pyo"}
+
+
+class SourceUnavailable(RuntimeError):
+    """Raised when an immutable upstream object cannot be inspected."""
+
+
+class CacheMiss(SourceUnavailable):
+    """A secure cache path is simply absent, rather than malformed/unsafe."""
+
+
+class ReconciliationWriteError(RuntimeError):
+    """A batch mapping write failed and may have durable recovery material."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        recovery_paths: Iterable[Path] = (),
+        committed: bool = False,
+    ) -> None:
+        self.recovery_paths = tuple(Path(path) for path in recovery_paths)
+        self.committed = committed
+        suffix = (
+            "; recovery_paths="
+            + ", ".join(str(path) for path in self.recovery_paths)
+            if self.recovery_paths
+            else ""
+        )
+        super().__init__(message + suffix)
+
+
+def _cache_repo_key(repo: str) -> str:
+    return repo.replace("/", "__")
+
+
+def _git_blob_oid(content: bytes, algorithm: str) -> str:
+    """Return the Git content address for exact local blob bytes."""
+    payload = f"blob {len(content)}\0".encode("ascii") + content
+    if algorithm == "sha1":
+        return hashlib.sha1(payload).hexdigest()
+    if algorithm == "sha256":
+        return hashlib.sha256(payload).hexdigest()
+    raise ValueError(f"unsupported Git object algorithm: {algorithm}")
+
+
+def _open_directory_chain(
+    anchor: Path,
+    relative_parts: Iterable[str],
+    *,
+    create: bool,
+) -> int:
+    """Open a directory below ``anchor`` without following any symlink."""
+    try:
+        if create:
+            anchor.mkdir(parents=True, exist_ok=True)
+        anchor_stat = anchor.lstat()
+    except FileNotFoundError as exc:
+        raise CacheMiss(f"directory anchor is absent: {anchor}") from exc
+    except OSError as exc:
+        raise SourceUnavailable(f"cannot inspect directory anchor {anchor}: {exc}") from exc
+    if stat.S_ISLNK(anchor_stat.st_mode) or not stat.S_ISDIR(anchor_stat.st_mode):
+        raise SourceUnavailable(f"directory anchor is a symlink or not a directory: {anchor}")
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(anchor, flags)
+    except OSError as exc:
+        raise SourceUnavailable(f"cannot open directory anchor safely: {anchor}: {exc}") from exc
+    current_display = anchor
+    try:
+        for component in relative_parts:
+            if component in {"", ".", ".."} or "/" in component or "\\" in component:
+                raise SourceUnavailable(
+                    f"unsafe directory component below {anchor}: {component!r}"
+                )
+            current_display = current_display / component
+            if create:
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=descriptor)
+                except FileExistsError:
+                    pass
+                except OSError as exc:
+                    raise SourceUnavailable(
+                        f"cannot create cache directory safely: {current_display}: {exc}"
+                    ) from exc
+            try:
+                next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            except OSError as exc:
+                try:
+                    metadata = os.stat(
+                        component,
+                        dir_fd=descriptor,
+                        follow_symlinks=False,
+                    )
+                except OSError:
+                    metadata = None
+                issue = (
+                    "symlink"
+                    if metadata is not None and stat.S_ISLNK(metadata.st_mode)
+                    else "unsafe ancestor"
+                )
+                if metadata is None and isinstance(exc, FileNotFoundError):
+                    raise CacheMiss(
+                        f"cache/directory path is absent: {current_display}"
+                    ) from exc
+                raise SourceUnavailable(
+                    f"{issue} in directory chain: {current_display}: {exc}"
+                ) from exc
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _read_regular_beneath(anchor: Path, relative: PurePosixPath) -> tuple[bytes, os.stat_result]:
+    parent_fd = _open_directory_chain(anchor, relative.parts[:-1], create=False)
+    descriptor = -1
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(relative.name, flags, dir_fd=parent_fd)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise SourceUnavailable(
+                f"cache/file destination is not a regular file: {anchor / relative}"
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after = os.fstat(descriptor)
+        if (
+            after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+        ):
+            raise SourceUnavailable(f"file changed while reading: {anchor / relative}")
+        return b"".join(chunks), opened
+    except FileNotFoundError as exc:
+        raise CacheMiss(f"cache/file path is absent: {anchor / relative}") from exc
+    except OSError as exc:
+        raise SourceUnavailable(
+            f"cannot read regular file safely: {anchor / relative}: {exc}"
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
+def _atomic_write_bytes(
+    path: Path,
+    content: bytes,
+    *,
+    anchor: Path | None = None,
+    mode: int = 0o600,
+) -> None:
+    """Atomically cache bytes without following a hostile destination symlink."""
+    if anchor is not None:
+        try:
+            relative = PurePosixPath(path.relative_to(anchor).as_posix())
+        except ValueError as exc:
+            raise SourceUnavailable(f"cache path escapes cache root: {path}") from exc
+        parent_fd = _open_directory_chain(anchor, relative.parts[:-1], create=True)
+        temporary_name = f".{relative.name}.{uuid.uuid4().hex}.tmp"
+        descriptor = -1
+        try:
+            flags = (
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            descriptor = os.open(
+                temporary_name,
+                flags,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise SourceUnavailable(
+                        f"short cache write for {path}"
+                    )
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            try:
+                destination_stat = os.stat(
+                    relative.name,
+                    dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                destination_stat = None
+            if destination_stat is not None and not stat.S_ISREG(
+                destination_stat.st_mode
+            ):
+                raise SourceUnavailable(
+                    f"cache destination is not a regular file: {path}"
+                )
+            os.replace(
+                temporary_name,
+                relative.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.fsync(parent_fd)
+            return
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            try:
+                os.unlink(temporary_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        destination_stat = path.lstat()
+    except FileNotFoundError:
+        destination_stat = None
+    if destination_stat is not None and not stat.S_ISREG(destination_stat.st_mode):
+        raise SourceUnavailable(f"cache destination is not a regular file: {path}")
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(content)
+            handle.flush()
+            os.fchmod(handle.fileno(), mode)
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+class GitHubObjectCache:
+    """GitHub recursive-tree/blob reader with deterministic on-disk fixtures."""
+
+    def __init__(
+        self,
+        cache_dir: Path,
+        *,
+        offline: bool = False,
+        gh_binary: str = "gh",
+    ) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.offline = offline
+        self.gh_binary = gh_binary
+        self._trees: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
+        self._online_verified_trees: set[tuple[str, str]] = set()
+        self._blobs: dict[tuple[str, str], bytes] = {}
+
+    def tree_cache_path(self, repo: str, commit: str) -> Path:
+        return self.cache_dir / "trees" / _cache_repo_key(repo) / f"{commit}.json"
+
+    def blob_cache_path(self, repo: str, object_sha: str) -> Path:
+        return self.cache_dir / "blobs" / _cache_repo_key(repo) / f"{object_sha}.bin"
+
+    def blob_is_cached(self, repo: str, object_sha: str) -> bool:
+        if not re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", object_sha):
+            return False
+        path = self.blob_cache_path(repo, object_sha)
+        try:
+            relative = PurePosixPath(path.relative_to(self.cache_dir).as_posix())
+            _read_regular_beneath(self.cache_dir, relative)
+        except (SourceUnavailable, ValueError):
+            return False
+        return True
+
+    def _gh_json(self, endpoint: str, *, fields: dict[str, str] | None = None) -> Any:
+        if self.offline:
+            raise SourceUnavailable(f"offline cache miss: {endpoint}")
+        command = [self.gh_binary, "api", "--method", "GET", endpoint]
+        for key, value in (fields or {}).items():
+            command.extend(["-f", f"{key}={value}"])
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            raise SourceUnavailable(f"cannot run gh for {endpoint}: {exc}") from exc
+        if result.returncode != 0:
+            detail = result.stderr.decode("utf-8", errors="replace").strip()
+            raise SourceUnavailable(
+                f"GitHub object unavailable for {endpoint}: "
+                f"{detail or f'exit {result.returncode}'}"
+            )
+        try:
+            return json.loads(result.stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SourceUnavailable(f"invalid GitHub JSON for {endpoint}: {exc}") from exc
+
+    def get_tree(self, repo: str, commit: str) -> dict[str, dict[str, Any]]:
+        commit = commit.lower()
+        key = (repo, commit)
+        if key in self._trees and (
+            self.offline or key in self._online_verified_trees
+        ):
+            return self._trees[key]
+        if not COMMIT_RE.fullmatch(commit):
+            raise SourceUnavailable(
+                f"{repo} has no immutable resolved commit: {commit!r}"
+            )
+
+        cache_path = self.tree_cache_path(repo, commit)
+        if self.offline:
+            try:
+                relative_cache_path = PurePosixPath(
+                    cache_path.relative_to(self.cache_dir).as_posix()
+                )
+                cached_bytes, _ = _read_regular_beneath(
+                    self.cache_dir,
+                    relative_cache_path,
+                )
+            except CacheMiss as exc:
+                raise SourceUnavailable(
+                    f"offline tree cache miss: {repo}@{commit}"
+                ) from exc
+            try:
+                payload = json.loads(cached_bytes.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise SourceUnavailable(f"invalid tree cache {cache_path}: {exc}") from exc
+        else:
+            # A mutable on-disk cache is never source authority. Resolve the
+            # immutable commit object online, bind it to its root tree, then
+            # require the recursive tree response to carry that exact tree OID.
+            commit_payload = self._gh_json(
+                f"repos/{repo}/git/commits/{commit}",
+            )
+            commit_sha = (
+                commit_payload.get("sha")
+                if isinstance(commit_payload, dict)
+                else None
+            )
+            tree_record = (
+                commit_payload.get("tree")
+                if isinstance(commit_payload, dict)
+                else None
+            )
+            root_tree_sha = (
+                tree_record.get("sha")
+                if isinstance(tree_record, dict)
+                else None
+            )
+            if (
+                not isinstance(commit_sha, str)
+                or commit_sha.lower() != commit
+                or not isinstance(root_tree_sha, str)
+                or not re.fullmatch(
+                    r"(?:[0-9a-f]{40}|[0-9a-f]{64})",
+                    root_tree_sha,
+                )
+            ):
+                raise SourceUnavailable(
+                    f"commit/root-tree binding is invalid for {repo}@{commit}"
+                )
+            payload = self._gh_json(
+                f"repos/{repo}/git/trees/{root_tree_sha.lower()}",
+                fields={"recursive": "1"},
+            )
+            if (
+                not isinstance(payload, dict)
+                or not isinstance(payload.get("sha"), str)
+                or payload["sha"].lower() != root_tree_sha.lower()
+            ):
+                raise SourceUnavailable(f"invalid tree response for {repo}@{commit}")
+            _atomic_write_bytes(
+                cache_path,
+                (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode(
+                    "utf-8"
+                ),
+                anchor=self.cache_dir,
+            )
+
+        if payload.get("truncated") is True:
+            raise SourceUnavailable(f"recursive tree is truncated for {repo}@{commit}")
+        entries = payload.get("tree")
+        if not isinstance(entries, list):
+            raise SourceUnavailable(f"tree response has no entries for {repo}@{commit}")
+
+        normalized: dict[str, dict[str, Any]] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise SourceUnavailable(
+                    f"tree response contains a non-object entry for {repo}@{commit}"
+                )
+            entry_type = entry.get("type")
+            if entry_type != "blob":
+                continue
+            path = entry.get("path")
+            object_sha = entry.get("sha")
+            size = entry.get("size")
+            if not isinstance(path, str) or not safe_relative_path(path):
+                raise SourceUnavailable(
+                    f"tree response contains an unsafe blob path for {repo}@{commit}"
+                )
+            if (
+                not isinstance(object_sha, str)
+                or not re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", object_sha)
+            ):
+                raise SourceUnavailable(
+                    f"tree response contains an invalid blob object id: {object_sha!r}"
+                )
+            if (
+                isinstance(size, bool) or not isinstance(size, int) or size < 0
+            ):
+                raise SourceUnavailable(
+                    f"tree response contains a missing or invalid blob size for {path}"
+                )
+            if path in normalized:
+                raise SourceUnavailable(
+                    f"tree response contains duplicate blob path: {path}"
+                )
+            normalized[path] = {
+                **entry,
+                "sha": object_sha.lower(),
+                "size": size,
+            }
+        self._trees[key] = normalized
+        if not self.offline:
+            self._online_verified_trees.add(key)
+        return normalized
+
+    def get_blob(
+        self,
+        repo: str,
+        object_sha: str,
+        *,
+        expected_size: int | None = None,
+    ) -> bytes:
+        if not isinstance(object_sha, str) or not re.fullmatch(
+            r"(?:[0-9a-f]{40}|[0-9a-f]{64})",
+            object_sha,
+        ):
+            raise SourceUnavailable(
+                f"invalid Git blob object id for {repo}: {object_sha!r}"
+            )
+        if expected_size is not None and (
+            isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size < 0
+        ):
+            raise SourceUnavailable(
+                f"invalid expected Git blob size for {repo}:{object_sha}"
+            )
+        key = (repo, object_sha)
+        if key in self._blobs:
+            content = self._blobs[key]
+            self._validate_blob(
+                repo,
+                object_sha,
+                content,
+                expected_size=expected_size,
+            )
+            return content
+        cache_path = self.blob_cache_path(repo, object_sha)
+        try:
+            relative_cache_path = PurePosixPath(
+                cache_path.relative_to(self.cache_dir).as_posix()
+            )
+            content, _ = _read_regular_beneath(
+                self.cache_dir,
+                relative_cache_path,
+            )
+            cache_hit = True
+        except CacheMiss:
+            cache_hit = False
+        if cache_hit:
+            self._validate_blob(
+                repo,
+                object_sha,
+                content,
+                expected_size=expected_size,
+            )
+        else:
+            payload = self._gh_json(f"repos/{repo}/git/blobs/{object_sha}")
+            if not isinstance(payload, dict):
+                raise SourceUnavailable(f"invalid blob response for {repo}:{object_sha}")
+            encoded = payload.get("content")
+            encoding = payload.get("encoding")
+            response_sha = payload.get("sha")
+            response_size = payload.get("size")
+            if (
+                not isinstance(encoded, str)
+                or encoding != "base64"
+                or response_sha != object_sha
+                or isinstance(response_size, bool)
+                or not isinstance(response_size, int)
+                or response_size < 0
+            ):
+                raise SourceUnavailable(
+                    f"unsupported or inconsistent blob response for "
+                    f"{repo}:{object_sha}"
+                )
+            try:
+                compact = re.sub(r"[ \t\r\n]", "", encoded)
+                content = base64.b64decode(compact, validate=True)
+            except (ValueError, TypeError, binascii.Error) as exc:
+                raise SourceUnavailable(
+                    f"invalid base64 blob for {repo}:{object_sha}"
+                ) from exc
+            if len(content) != response_size:
+                raise SourceUnavailable(
+                    f"blob response size mismatch for {repo}:{object_sha}: "
+                    f"declared {response_size}, decoded {len(content)}"
+                )
+            self._validate_blob(
+                repo,
+                object_sha,
+                content,
+                expected_size=expected_size,
+            )
+            _atomic_write_bytes(cache_path, content, anchor=self.cache_dir)
+        self._blobs[key] = content
+        return content
+
+    @staticmethod
+    def _validate_blob(
+        repo: str,
+        object_sha: str,
+        content: bytes,
+        *,
+        expected_size: int | None,
+    ) -> None:
+        algorithm = "sha1" if len(object_sha) == 40 else "sha256"
+        actual_oid = _git_blob_oid(content, algorithm)
+        if actual_oid != object_sha:
+            raise SourceUnavailable(
+                f"Git blob object id mismatch for {repo}:{object_sha}; "
+                f"computed {actual_oid}"
+            )
+        if expected_size is not None and len(content) != expected_size:
+            raise SourceUnavailable(
+                f"Git blob size mismatch for {repo}:{object_sha}; "
+                f"expected {expected_size}, got {len(content)}"
+            )
+
+
+def _is_active_external_canonical(entry: dict[str, Any]) -> bool:
+    repo_skill = entry.get("repo_skill")
+    slug = entry.get("normalized_slug")
+    if (
+        entry.get("status") not in ACTIVE_STATUSES
+        or entry.get("kind") not in EXTERNAL_KINDS
+        or not isinstance(repo_skill, str)
+        or not safe_relative_path(repo_skill)
+        or not isinstance(slug, str)
+        or not slug
+    ):
+        return False
+    path = PurePosixPath(repo_skill)
+    return (
+        len(path.parts) == 4
+        and path.parts[0] == "skills"
+        and path.parts[2] == slug
+        and path.parts[3] == "SKILL.md"
+    )
+
+
+def _display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _read_regular_file(path: Path) -> bytes:
+    """Read one regular file while refusing a final-component symlink."""
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise OSError(f"not a regular non-symlink file: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+        ):
+            raise OSError(f"file changed while opening: {path}")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def _sha256_regular_file(path: Path) -> str:
+    return hashlib.sha256(_read_regular_file(path)).hexdigest()
+
+
+def _scan_issue(
+    *,
+    path: Path,
+    repo_root: Path,
+    issue: str,
+    operation: str,
+    detail: str,
+) -> dict[str, str]:
+    return {
+        "path": _display_path(path, repo_root),
+        "issue": issue,
+        "operation": operation,
+        "detail": detail,
+    }
+
+
+def _iter_regular_skill_files(
+    repo_root: Path,
+    repo_skill: str,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Walk a skill directory without following an ancestor or child symlink."""
+    paths, issues, _, _ = _scan_regular_skill_files(
+        repo_root,
+        repo_skill,
+        capture_bytes=False,
+    )
+    return paths, issues
+
+
+def _scan_regular_skill_files(
+    repo_root: Path,
+    repo_skill: str,
+    *,
+    capture_bytes: bool,
+) -> tuple[
+    list[str],
+    list[dict[str, str]],
+    dict[str, dict[str, int | str]],
+    dict[str, bytes],
+]:
+    """Securely scan and optionally capture every canonical skill file.
+
+    Directory file descriptors bind the walk to the repository root.  A
+    symlink in ``skills/<category>/<slug>`` is therefore reported rather than
+    traversed, even when the final skill directory itself looks ordinary
+    through normal path resolution.
+    """
+    skill_root = PurePosixPath(repo_skill).parent
+    root = repo_root.joinpath(*skill_root.parts)
+    issues: list[dict[str, str]] = []
+    try:
+        root_fd = _open_directory_chain(repo_root, skill_root.parts, create=False)
+    except SourceUnavailable as exc:
+        issue = "symlink" if "symlink" in str(exc).lower() else "io_error"
+        issues.append(
+            _scan_issue(
+                path=root,
+                repo_root=repo_root,
+                issue=issue,
+                operation="open_skill_root",
+                detail=str(exc),
+            )
+        )
+        return [], issues, {}, {}
+
+    paths: list[str] = []
+    snapshots: dict[str, dict[str, int | str]] = {}
+    contents: dict[str, bytes] = {}
+
+    def walk(directory_fd: int, relative_parts: tuple[str, ...]) -> None:
+        try:
+            with os.scandir(directory_fd) as iterator:
+                entries = sorted(list(iterator), key=lambda item: item.name)
+        except OSError as exc:
+            directory = repo_root.joinpath(*relative_parts)
+            issues.append(
+                _scan_issue(
+                    path=directory,
+                    repo_root=repo_root,
+                    issue="io_error",
+                    operation="scandir",
+                    detail=str(exc),
+                )
+            )
+            return
+        for item in entries:
+            item_path = repo_root.joinpath(*relative_parts, item.name)
+            try:
+                metadata = os.stat(
+                    item.name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if stat.S_ISLNK(metadata.st_mode):
+                    issues.append(
+                        _scan_issue(
+                            path=item_path,
+                            repo_root=repo_root,
+                            issue="symlink",
+                            operation="walk",
+                            detail="symlink was not followed",
+                        )
+                    )
+                    continue
+                if (
+                    item.name in IGNORED_DIRECTORY_NAMES
+                    or item.name in IGNORED_FILE_NAMES
+                ):
+                    continue
+                if stat.S_ISDIR(metadata.st_mode):
+                    flags = (
+                        os.O_RDONLY
+                        | getattr(os, "O_DIRECTORY", 0)
+                        | getattr(os, "O_NOFOLLOW", 0)
+                    )
+                    child_fd = os.open(item.name, flags, dir_fd=directory_fd)
+                    try:
+                        opened = os.fstat(child_fd)
+                        if (
+                            opened.st_dev != metadata.st_dev
+                            or opened.st_ino != metadata.st_ino
+                        ):
+                            raise OSError(
+                                f"directory changed while opening: {item_path}"
+                            )
+                        walk(child_fd, (*relative_parts, item.name))
+                    finally:
+                        os.close(child_fd)
+                elif stat.S_ISREG(metadata.st_mode):
+                    if item_path.suffix in IGNORED_FILE_SUFFIXES:
+                        continue
+                    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                    descriptor = os.open(
+                        item.name,
+                        flags,
+                        dir_fd=directory_fd,
+                    )
+                    try:
+                        opened = os.fstat(descriptor)
+                        if (
+                            not stat.S_ISREG(opened.st_mode)
+                            or opened.st_dev != metadata.st_dev
+                            or opened.st_ino != metadata.st_ino
+                        ):
+                            raise OSError(f"file changed while opening: {item_path}")
+                        chunks: list[bytes] = []
+                        while True:
+                            chunk = os.read(descriptor, 1024 * 1024)
+                            if not chunk:
+                                break
+                            chunks.append(chunk)
+                        after = os.fstat(descriptor)
+                        if (
+                            after.st_dev != opened.st_dev
+                            or after.st_ino != opened.st_ino
+                            or after.st_size != opened.st_size
+                            or after.st_mtime_ns != opened.st_mtime_ns
+                        ):
+                            raise OSError(f"file changed while reading: {item_path}")
+                        data = b"".join(chunks)
+                    finally:
+                        os.close(descriptor)
+                    target = PurePosixPath(*relative_parts, item.name).as_posix()
+                    digest = hashlib.sha256(data).hexdigest()
+                    paths.append(target)
+                    snapshots[target] = {
+                        "dev": opened.st_dev,
+                        "ino": opened.st_ino,
+                        "size": len(data),
+                        "mtime_ns": opened.st_mtime_ns,
+                        "sha256": digest,
+                    }
+                    if capture_bytes:
+                        contents[target] = data
+                else:
+                    issues.append(
+                        _scan_issue(
+                            path=item_path,
+                            repo_root=repo_root,
+                            issue="unsupported_file_type",
+                            operation="walk",
+                            detail="non-directory, non-regular entry was not scanned",
+                        )
+                    )
+            except OSError as exc:
+                issues.append(
+                    _scan_issue(
+                        path=item_path,
+                        repo_root=repo_root,
+                        issue="io_error",
+                        operation="inspect_directory_entry",
+                        detail=str(exc),
+                    )
+                )
+                continue
+
+    try:
+        walk(root_fd, tuple(skill_root.parts))
+    finally:
+        os.close(root_fd)
+    return sorted(paths), issues, snapshots, contents
+
+
+def _artifact_covers(artifact: object, target: str) -> bool:
+    if (
+        not isinstance(artifact, dict)
+        or not safe_relative_path(artifact.get("target"))
+        or not safe_relative_path(target)
+    ):
+        return False
+    declared = PurePosixPath(str(artifact["target"]))
+    requested = PurePosixPath(target)
+    if artifact.get("type", "file") == "directory":
+        return requested == declared or declared in requested.parents
+    return requested == declared
+
+
+def _artifact_owners(
+    entry: dict[str, Any],
+    target: str,
+) -> list[tuple[int, dict[str, Any], dict[str, Any]]]:
+    owners: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+    for origin_index, origin in enumerate(entry.get("origins", [])):
+        if not isinstance(origin, dict):
+            continue
+        matches = [
+            artifact
+            for artifact in origin.get("artifacts", [])
+            if isinstance(artifact, dict) and _artifact_covers(artifact, target)
+        ]
+        if not matches:
+            continue
+        # Ownership belongs to an origin, not to each overlapping declaration
+        # inside that origin.  Retain the most specific declaration only so a
+        # directory plus an explicit file mapping does not become a false
+        # cross-origin conflict.
+        artifact = max(
+            matches,
+            key=lambda candidate: (
+                candidate.get("type", "file") != "directory",
+                len(PurePosixPath(str(candidate["target"])).parts),
+            ),
+        )
+        owners.append((origin_index, origin, artifact))
+    return owners
+
+
+def _source_candidates(
+    origin: dict[str, Any],
+    target: str,
+    skill_root: PurePosixPath,
+) -> list[str]:
+    """Infer only path-preserving sources from declared transformation roots."""
+    requested = PurePosixPath(target)
+    proposals: list[tuple[int, str]] = []
+    for artifact in origin.get("artifacts", []):
+        if not isinstance(artifact, dict):
+            continue
+        source = artifact.get("source")
+        declared_target = artifact.get("target")
+        if not safe_relative_path(source) or not safe_relative_path(declared_target):
+            continue
+        source_path = PurePosixPath(str(source))
+        target_path = PurePosixPath(str(declared_target))
+        if artifact.get("type", "file") == "directory":
+            if requested == target_path or target_path in requested.parents:
+                relative = requested.relative_to(target_path)
+                proposals.append(
+                    (len(target_path.parts), (source_path / relative).as_posix())
+                )
+            continue
+
+        # A transformed standalone entrypoint (for example
+        # ``graphify/skill-codex.md`` -> ``SKILL.md``) does not establish that
+        # its entire upstream package directory is part of the skill artifact
+        # set.  Only a canonical upstream SKILL.md establishes the implicit
+        # sibling root; explicit non-entrypoint sidecars still establish their
+        # own path-preserving sibling roots.
+        if (
+            target_path.name == "SKILL.md"
+            and source_path.name.lower() != "skill.md"
+        ):
+            continue
+        local_base = target_path.parent
+        if requested == local_base or local_base not in requested.parents:
+            continue
+        relative = requested.relative_to(local_base)
+        proposals.append(
+            (len(local_base.parts), (source_path.parent / relative).as_posix())
+        )
+
+    if not proposals:
+        origin_path = origin.get("path")
+        if safe_relative_path(origin_path) and (
+            requested == skill_root or skill_root in requested.parents
+        ):
+            source_path = PurePosixPath(str(origin_path))
+            if source_path.name.lower().endswith((".md", ".markdown")):
+                if source_path.name.lower() != "skill.md":
+                    return []
+                source_path = source_path.parent
+            relative = requested.relative_to(skill_root)
+            proposals.append(
+                (len(skill_root.parts), (source_path / relative).as_posix())
+            )
+
+    result: list[str] = []
+    for _, proposal in sorted(proposals, key=lambda value: (-value[0], value[1])):
+        if safe_relative_path(proposal) and proposal not in result:
+            result.append(proposal)
+    return result
+
+
+def _classify_unowned_file(
+    *,
+    entry: dict[str, Any],
+    target: str,
+    local_bytes: bytes,
+    cache: GitHubObjectCache,
+    origin_indexes: set[int] | None = None,
+) -> dict[str, Any]:
+    repo_skill = PurePosixPath(str(entry["repo_skill"]))
+    skill_root = repo_skill.parent
+    checked_sources: list[dict[str, Any]] = []
+    unavailable: list[str] = []
+
+    for origin_index, origin in enumerate(entry.get("origins", [])):
+        if origin_indexes is not None and origin_index not in origin_indexes:
+            continue
+        if not isinstance(origin, dict) or is_local_repo(origin.get("repo")):
+            continue
+        repo = origin.get("repo")
+        tracking = origin.get("tracking")
+        commit = (
+            tracking.get("resolved_commit")
+            if isinstance(tracking, dict)
+            else None
+        )
+        if not isinstance(repo, str) or not isinstance(commit, str):
+            unavailable.append(
+                f"origin[{origin_index}] lacks repo or resolved_commit"
+            )
+            continue
+        try:
+            tree = cache.get_tree(repo, commit)
+        except SourceUnavailable as exc:
+            unavailable.append(str(exc))
+            continue
+
+        candidates = _source_candidates(origin, target, skill_root)
+        if not candidates:
+            checked_sources.append(
+                {
+                    "origin_index": origin_index,
+                    "repo": repo,
+                    "resolved_commit": commit,
+                    "source": None,
+                    "result": "no_path_preserving_candidate",
+                }
+            )
+            continue
+        for source in candidates:
+            tree_entry = tree.get(source)
+            if tree_entry is None:
+                checked_sources.append(
+                    {
+                        "origin_index": origin_index,
+                        "repo": repo,
+                        "resolved_commit": commit,
+                        "source": source,
+                        "result": "source_missing",
+                    }
+                )
+                continue
+            object_sha = str(tree_entry["sha"]).lower()
+            declared_size = tree_entry.get("size")
+            algorithm = (
+                "sha1"
+                if len(object_sha) == 40
+                else "sha256"
+                if len(object_sha) == 64
+                else None
+            )
+            if (
+                algorithm is not None
+                and _git_blob_oid(local_bytes, algorithm) == object_sha
+            ):
+                if declared_size != len(local_bytes):
+                    unavailable.append(
+                        f"Git tree blob size mismatch for {repo}:{source}: "
+                        f"declared {declared_size}, local {len(local_bytes)}"
+                    )
+                    checked_sources.append(
+                        {
+                            "origin_index": origin_index,
+                            "repo": repo,
+                            "resolved_commit": commit,
+                            "source": source,
+                            "result": "size_mismatch",
+                        }
+                    )
+                    continue
+                if cache.offline:
+                    unavailable.append(
+                        "offline tree cache cannot authorize new external "
+                        f"ownership for {repo}@{commit}:{source}"
+                    )
+                    checked_sources.append(
+                        {
+                            "origin_index": origin_index,
+                            "repo": repo,
+                            "resolved_commit": commit,
+                            "source": source,
+                            "result": "offline_authority_forbidden",
+                        }
+                    )
+                    continue
+                return {
+                    "target": target,
+                    "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "classification": "external_exact",
+                    "origin_index": origin_index,
+                    "repo": repo,
+                    "resolved_commit": commit,
+                    "source": source,
+                    "reason": (
+                        "path-preserving Git blob content address matches "
+                        "exact local bytes"
+                    ),
+                    "checked_sources": checked_sources,
+                }
+            # A valid Git object id that differs proves the bytes differ.  A
+            # cached blob is still read (and offline cache fixtures therefore
+            # exercise byte comparison), while live scans avoid one API call
+            # per known mismatch.
+            if algorithm is not None and not (
+                cache.offline or cache.blob_is_cached(repo, object_sha)
+            ):
+                checked_sources.append(
+                    {
+                        "origin_index": origin_index,
+                        "repo": repo,
+                        "resolved_commit": commit,
+                        "source": source,
+                        "result": "content_address_mismatch",
+                    }
+                )
+                continue
+            try:
+                upstream_bytes = cache.get_blob(
+                    repo,
+                    object_sha,
+                    expected_size=declared_size,
+                )
+            except SourceUnavailable as exc:
+                unavailable.append(str(exc))
+                checked_sources.append(
+                    {
+                        "origin_index": origin_index,
+                        "repo": repo,
+                        "resolved_commit": commit,
+                        "source": source,
+                        "result": "blob_unavailable",
+                    }
+                )
+                continue
+            if upstream_bytes == local_bytes:
+                return {
+                    "target": target,
+                    "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "classification": "external_exact",
+                    "origin_index": origin_index,
+                    "repo": repo,
+                    "resolved_commit": commit,
+                    "source": source,
+                    "reason": "path-preserving upstream bytes match",
+                    "checked_sources": checked_sources,
+                }
+            checked_sources.append(
+                {
+                    "origin_index": origin_index,
+                    "repo": repo,
+                    "resolved_commit": commit,
+                    "source": source,
+                    "result": "content_mismatch",
+                }
+            )
+
+    result = {
+        "target": target,
+        "sha256": hashlib.sha256(local_bytes).hexdigest(),
+        "checked_sources": checked_sources,
+    }
+    if unavailable:
+        result.update(
+            {
+                "classification": "unavailable",
+                "source": None,
+                "reason": "; ".join(sorted(set(unavailable))),
+            }
+        )
+    else:
+        result.update(
+            {
+                "classification": "local_overlay",
+                "source": target,
+                "repo": LOCAL_OVERLAY_REPO,
+                "reason": (
+                    "no path-preserving source at resolved external commit "
+                    "matches local bytes"
+                ),
+            }
+        )
+    return result
+
+
+def _managed_by_path(entry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for managed in entry.get("managed_files", []):
+        if isinstance(managed, dict) and safe_relative_path(managed.get("path")):
+            result[str(managed["path"])] = managed
+    return result
+
+
+def inspect_entry(
+    entry: dict[str, Any],
+    *,
+    repo_root: Path,
+    cache: GitHubObjectCache,
+) -> dict[str, Any]:
+    slug = str(entry["normalized_slug"])
+    repo_skill = str(entry["repo_skill"])
+    actual, scan_errors, filesystem_checkpoint, local_contents = (
+        _scan_regular_skill_files(
+            repo_root,
+            repo_skill,
+            capture_bytes=True,
+        )
+    )
+    actual_set = set(actual)
+    managed = _managed_by_path(entry)
+    managed_set = set(managed)
+    unowned: list[dict[str, Any]] = []
+    ownership_conflicts: list[dict[str, Any]] = []
+
+    for target in actual:
+        owners = _artifact_owners(entry, target)
+        if len(owners) > 1:
+            ownership_conflicts.append(
+                {
+                    "target": target,
+                    "owners": [
+                        {
+                            "origin_index": index,
+                            "repo": origin.get("repo"),
+                            "source": artifact.get("source"),
+                        }
+                        for index, origin, artifact in owners
+                    ],
+                }
+            )
+        # An artifact declaration is not a deletion/pruning checkpoint.
+        # Missing managed state must still be re-verified against exact source
+        # bytes before the file may become managed.
+        if owners and target in managed_set:
+            continue
+        local_bytes = local_contents.get(target)
+        if local_bytes is None:
+            unowned.append(
+                {
+                    "target": target,
+                    "sha256": None,
+                    "classification": "unavailable",
+                    "source": None,
+                    "reason": "cannot read local file from secure scan checkpoint",
+                }
+            )
+            continue
+        declared_owner = None
+        if len(owners) == 1:
+            owner_index, owner_origin, owner_artifact = owners[0]
+            declared_owner = {
+                "origin_index": owner_index,
+                "repo": owner_origin.get("repo"),
+                "source": owner_artifact.get("source"),
+                "local": is_local_repo(owner_origin.get("repo")),
+            }
+            if declared_owner["local"]:
+                classified = {
+                    "target": target,
+                    "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "classification": "local_overlay",
+                    "origin_index": owner_index,
+                    "repo": owner_origin.get("repo"),
+                    "source": target,
+                    "reason": (
+                        "declared local artifact lacks a managed checkpoint"
+                    ),
+                    "checked_sources": [],
+                }
+            else:
+                classified = _classify_unowned_file(
+                    entry=entry,
+                    target=target,
+                    local_bytes=local_bytes,
+                    cache=cache,
+                    origin_indexes={owner_index},
+                )
+        else:
+            classified = _classify_unowned_file(
+                entry=entry,
+                target=target,
+                local_bytes=local_bytes,
+                cache=cache,
+            )
+        if declared_owner is not None:
+            classified["declared_owner"] = declared_owner
+        unowned.append(classified)
+
+    stale_artifact_targets: list[str] = []
+    for origin in entry.get("origins", []):
+        if not isinstance(origin, dict):
+            continue
+        for artifact in origin.get("artifacts", []):
+            if (
+                isinstance(artifact, dict)
+                and artifact.get("type", "file") == "file"
+                and safe_relative_path(artifact.get("target"))
+                and artifact["target"] not in actual_set
+            ):
+                stale_artifact_targets.append(str(artifact["target"]))
+
+    hash_mismatches: list[str] = []
+    for target in sorted(actual_set & managed_set):
+        try:
+            current_hash = _sha256_regular_file(repo_root / target)
+        except OSError as exc:
+            scan_errors.append(
+                _scan_issue(
+                    path=repo_root / target,
+                    repo_root=repo_root,
+                    issue="io_error",
+                    operation="hash_managed_file",
+                    detail=str(exc),
+                )
+            )
+            continue
+        checkpoint_hash = filesystem_checkpoint.get(target, {}).get("sha256")
+        if current_hash != checkpoint_hash:
+            scan_errors.append(
+                _scan_issue(
+                    path=repo_root / target,
+                    repo_root=repo_root,
+                    issue="concurrent_modification",
+                    operation="hash_managed_file",
+                    detail="managed file changed after secure scan",
+                )
+            )
+            continue
+        if managed[target].get("sha256") != current_hash:
+            hash_mismatches.append(target)
+
+    return {
+        "slug": slug,
+        "repo_skill": repo_skill,
+        "kind": entry.get("kind"),
+        "actual_files": actual,
+        "missing_managed": sorted(actual_set - managed_set),
+        "stale_managed": sorted(managed_set - actual_set),
+        "stale_artifact_targets": sorted(set(stale_artifact_targets)),
+        "hash_mismatches": hash_mismatches,
+        "scan_errors": scan_errors,
+        "ownership_conflicts": ownership_conflicts,
+        "unowned": unowned,
+        "filesystem_checkpoint": filesystem_checkpoint,
+    }
+
+
+def _local_overlay_origin(
+    entry: dict[str, Any],
+    artifacts: list[dict[str, str]],
+    *,
+    today: str,
+) -> dict[str, Any]:
+    repo_skill = PurePosixPath(str(entry["repo_skill"]))
+    return {
+        "repo": LOCAL_OVERLAY_REPO,
+        "path": repo_skill.parent.as_posix(),
+        "license": None,
+        "sync_mode": "local-only",
+        "artifacts": artifacts,
+        "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": None,
+            "path_commit": None,
+            "content_sha256": None,
+            "last_checked_at": today,
+            "last_synced_at": today,
+        },
+    }
+
+
+def apply_entry_reconciliation(
+    entry: dict[str, Any],
+    inspection: dict[str, Any],
+    *,
+    repo_root: Path,
+    today: str,
+) -> tuple[dict[str, Any], bool, str | None]:
+    """Apply only classifications with proven owners to a copied entry."""
+    updated = deepcopy(entry)
+    unavailable = [
+        item
+        for item in inspection["unowned"]
+        if item["classification"] == "unavailable"
+    ]
+    conflicts = inspection["ownership_conflicts"]
+    hash_mismatches = inspection.get("hash_mismatches", [])
+    stale_managed = inspection.get("stale_managed", [])
+    stale_artifact_targets = inspection.get("stale_artifact_targets", [])
+    scan_errors = inspection.get("scan_errors", [])
+    declared_owner_mismatches = [
+        item
+        for item in inspection["unowned"]
+        if item["classification"] == "local_overlay"
+        and isinstance(item.get("declared_owner"), dict)
+        and not item["declared_owner"].get("local")
+    ]
+    if (
+        unavailable
+        or conflicts
+        or hash_mismatches
+        or stale_managed
+        or stale_artifact_targets
+        or scan_errors
+        or declared_owner_mismatches
+    ):
+        reasons = []
+        if unavailable:
+            reasons.append(f"{len(unavailable)} unavailable source(s)")
+        if conflicts:
+            reasons.append(f"{len(conflicts)} ownership conflict(s)")
+        if hash_mismatches:
+            reasons.append(f"{len(hash_mismatches)} managed hash mismatch(es)")
+        if stale_managed:
+            reasons.append(f"{len(stale_managed)} stale managed file(s)")
+        if stale_artifact_targets:
+            reasons.append(
+                f"{len(stale_artifact_targets)} stale artifact target(s)"
+            )
+        if scan_errors:
+            reasons.append(f"{len(scan_errors)} scan/read error(s)")
+        if declared_owner_mismatches:
+            reasons.append(
+                f"{len(declared_owner_mismatches)} declared owner mismatch(es)"
+            )
+        return updated, False, ", ".join(reasons)
+
+    exact = [
+        item
+        for item in inspection["unowned"]
+        if item["classification"] == "external_exact"
+    ]
+    overlays = [
+        item
+        for item in inspection["unowned"]
+        if item["classification"] == "local_overlay"
+    ]
+
+    origins = updated.get("origins")
+    if not isinstance(origins, list):
+        return updated, False, "origins is not an array"
+    for proposal in exact:
+        origin_index = proposal.get("origin_index")
+        if not isinstance(origin_index, int) or not (0 <= origin_index < len(origins)):
+            return updated, False, "external proposal has invalid origin index"
+        origin = origins[origin_index]
+        if not isinstance(origin, dict):
+            return updated, False, "external proposal origin is invalid"
+        artifacts = origin.setdefault("artifacts", [])
+        artifact = {
+            "source": proposal["source"],
+            "target": proposal["target"],
+            "type": "file",
+        }
+        if not any(
+            _artifact_covers(existing, proposal["target"])
+            for existing in artifacts
+        ):
+            artifacts.append(artifact)
+
+    if overlays:
+        local_origin = next(
+            (
+                origin
+                for origin in origins
+                if isinstance(origin, dict)
+                and origin.get("repo") == LOCAL_OVERLAY_REPO
+            ),
+            None,
+        )
+        overlay_artifacts = [
+            {
+                "source": item["target"],
+                "target": item["target"],
+                "type": "file",
+            }
+            for item in overlays
+        ]
+        if local_origin is None:
+            local_origin = _local_overlay_origin(
+                updated,
+                overlay_artifacts,
+                today=today,
+            )
+            origins.append(local_origin)
+        else:
+            local_origin["license"] = None
+            local_origin["sync_mode"] = "local-only"
+            existing_artifacts = local_origin.setdefault("artifacts", [])
+            for artifact in overlay_artifacts:
+                if not any(
+                    _artifact_covers(existing, artifact["target"])
+                    for existing in existing_artifacts
+                ):
+                    existing_artifacts.append(artifact)
+        if updated.get("kind") != "snapshot":
+            updated["kind"] = "overlay"
+            updated["sync_mode"] = "monitor"
+            upstream = updated.get("upstream")
+            if isinstance(upstream, dict):
+                upstream["sync_mode"] = "monitor"
+            for origin in origins:
+                if isinstance(origin, dict) and not is_local_repo(origin.get("repo")):
+                    origin["sync_mode"] = "monitor"
+
+    for origin in origins:
+        if isinstance(origin, dict) and isinstance(origin.get("artifacts"), list):
+            origin["artifacts"] = sorted(
+                origin["artifacts"],
+                key=lambda artifact: (
+                    str(artifact.get("target")),
+                    str(artifact.get("source")),
+                    str(artifact.get("type", "file")),
+                ),
+            )
+
+    owner = str(updated["normalized_slug"])
+    filesystem_checkpoint = inspection.get("filesystem_checkpoint")
+    if not isinstance(filesystem_checkpoint, dict):
+        return deepcopy(entry), False, "filesystem checkpoint is missing"
+    managed_files: list[dict[str, str]] = []
+    for target in inspection["actual_files"]:
+        snapshot = filesystem_checkpoint.get(target)
+        digest = snapshot.get("sha256") if isinstance(snapshot, dict) else None
+        if not isinstance(digest, str):
+            return (
+                deepcopy(entry),
+                False,
+                f"filesystem checkpoint is incomplete for {target}",
+            )
+        managed_files.append(
+            {
+                "path": target,
+                "sha256": digest,
+                "owner": owner,
+            }
+        )
+    updated["managed_files"] = managed_files
+    return updated, updated != entry, None
+
+
+def _verify_inspection_checkpoint(
+    entry: dict[str, Any],
+    inspection: dict[str, Any],
+    *,
+    repo_root: Path,
+) -> str | None:
+    """Bind a classification to the same full file set immediately pre-write."""
+    actual, issues, current, _ = _scan_regular_skill_files(
+        repo_root,
+        str(entry["repo_skill"]),
+        capture_bytes=False,
+    )
+    if issues:
+        return f"{len(issues)} scan/read error(s) during write preflight"
+    expected_actual = inspection.get("actual_files")
+    if actual != expected_actual:
+        return "canonical skill file set changed after classification"
+    expected = inspection.get("filesystem_checkpoint")
+    if not isinstance(expected, dict):
+        return "filesystem checkpoint is missing"
+    for target in actual:
+        before = expected.get(target)
+        after = current.get(target)
+        if not isinstance(before, dict) or not isinstance(after, dict):
+            return f"filesystem checkpoint is incomplete for {target}"
+        for field in ("dev", "ino", "size", "mtime_ns", "sha256"):
+            if before.get(field) != after.get(field):
+                return (
+                    f"canonical skill changed after classification: "
+                    f"{target} ({field})"
+                )
+    return None
+
+
+def _default_cache_dir() -> Path:
+    root = os.environ.get("XDG_CACHE_HOME")
+    if root:
+        return Path(root) / "high-value-skills" / "artifact-inventory"
+    return Path.home() / ".cache" / "high-value-skills" / "artifact-inventory"
+
+
+def _mapping_snapshot(mapping: Path, repo_root: Path) -> dict[str, Any]:
+    try:
+        relative = PurePosixPath(mapping.relative_to(repo_root).as_posix())
+    except ValueError as exc:
+        raise ReconciliationWriteError(
+            f"mapping escapes repository root: {mapping}"
+        ) from exc
+    if not safe_relative_path(relative.as_posix()):
+        raise ReconciliationWriteError(f"mapping path is unsafe: {mapping}")
+    try:
+        content, metadata = _read_regular_beneath(repo_root, relative)
+    except SourceUnavailable as exc:
+        raise ReconciliationWriteError(
+            f"cannot read mapping safely: {mapping}: {exc}"
+        ) from exc
+    return {
+        "bytes": content,
+        "dev": metadata.st_dev,
+        "ino": metadata.st_ino,
+        "size": metadata.st_size,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def _mapping_matches_snapshot(
+    mapping: Path,
+    repo_root: Path,
+    snapshot: dict[str, Any],
+) -> bool:
+    try:
+        current = _mapping_snapshot(mapping, repo_root)
+    except ReconciliationWriteError:
+        return False
+    return all(
+        current.get(field) == snapshot.get(field)
+        for field in ("dev", "ino", "size", "mode", "sha256")
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _mapping_snapshot_at(
+    parent_fd: int,
+    leaf: str,
+    *,
+    display_path: Path,
+) -> dict[str, Any]:
+    descriptor = -1
+    try:
+        metadata = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise ReconciliationWriteError(
+                f"mapping target is not a regular file: {display_path}"
+            )
+        descriptor = os.open(
+            leaf,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_fd,
+        )
+        opened = os.fstat(descriptor)
+        if (
+            opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+            or not stat.S_ISREG(opened.st_mode)
+        ):
+            raise ReconciliationWriteError(
+                f"mapping changed while opening: {display_path}"
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        content = b"".join(chunks)
+        completed = os.fstat(descriptor)
+        named = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+        if (
+            completed.st_dev != opened.st_dev
+            or completed.st_ino != opened.st_ino
+            or completed.st_size != opened.st_size
+            or completed.st_mtime_ns != opened.st_mtime_ns
+            or named.st_dev != opened.st_dev
+            or named.st_ino != opened.st_ino
+        ):
+            raise ReconciliationWriteError(
+                f"mapping changed while reading: {display_path}"
+            )
+        return {
+            "bytes": content,
+            "dev": opened.st_dev,
+            "ino": opened.st_ino,
+            "size": opened.st_size,
+            "mode": stat.S_IMODE(opened.st_mode),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+    except OSError as exc:
+        raise ReconciliationWriteError(
+            f"cannot inspect mapping safely: {display_path}: {exc}"
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _assert_active_mapping_parent(
+    repo_root: Path,
+    relative: PurePosixPath,
+    expected: tuple[int, int],
+) -> None:
+    descriptor = _open_directory_chain(
+        repo_root,
+        relative.parts[:-1],
+        create=False,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if (metadata.st_dev, metadata.st_ino) != expected:
+            raise ReconciliationWriteError(
+                f"mapping parent changed concurrently: {repo_root / relative}"
+            )
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_replace_mapping(
+    mapping: Path,
+    content: bytes,
+    snapshot: dict[str, Any],
+    *,
+    repo_root: Path,
+) -> None:
+    try:
+        relative = PurePosixPath(mapping.relative_to(repo_root).as_posix())
+    except ValueError as exc:
+        raise ReconciliationWriteError(
+            f"mapping escapes repository root: {mapping}"
+        ) from exc
+    if not safe_relative_path(relative.as_posix()):
+        raise ReconciliationWriteError(f"mapping path is unsafe: {mapping}")
+    parent_fd = _open_directory_chain(
+        repo_root,
+        relative.parts[:-1],
+        create=False,
+    )
+    temporary_name = (
+        f".{relative.name}.inventory-stage-{uuid.uuid4().hex}.tmp"
+    )
+    temporary_created = False
+    descriptor = -1
+    try:
+        parent_metadata = os.fstat(parent_fd)
+        parent_identity = (parent_metadata.st_dev, parent_metadata.st_ino)
+        if _mapping_snapshot_at(
+            parent_fd,
+            relative.name,
+            display_path=mapping,
+        ) != snapshot:
+            raise ReconciliationWriteError(
+                f"mapping changed after reconciliation preflight: {mapping}"
+            )
+        descriptor = os.open(
+            temporary_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_fd,
+        )
+        temporary_created = True
+        temporary_metadata = os.fstat(descriptor)
+        offset = 0
+        while offset < len(content):
+            written = os.write(descriptor, content[offset:])
+            if written <= 0:
+                raise ReconciliationWriteError(
+                    f"short mapping stage write: {mapping}"
+                )
+            offset += written
+        os.fchmod(descriptor, int(snapshot["mode"]))
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        named_temporary = os.stat(
+            temporary_name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        if (
+            stat.S_ISLNK(named_temporary.st_mode)
+            or not stat.S_ISREG(named_temporary.st_mode)
+            or named_temporary.st_dev != temporary_metadata.st_dev
+            or named_temporary.st_ino != temporary_metadata.st_ino
+        ):
+            raise ReconciliationWriteError(
+                f"mapping stage changed before replace: {mapping}"
+            )
+        if _mapping_snapshot_at(
+            parent_fd,
+            relative.name,
+            display_path=mapping,
+        ) != snapshot:
+            raise ReconciliationWriteError(
+                f"mapping changed immediately before replace: {mapping}"
+            )
+        _assert_active_mapping_parent(
+            repo_root,
+            relative,
+            parent_identity,
+        )
+        os.replace(
+            temporary_name,
+            relative.name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        temporary_created = False
+        os.fsync(parent_fd)
+        _assert_active_mapping_parent(
+            repo_root,
+            relative,
+            parent_identity,
+        )
+        installed = _mapping_snapshot_at(
+            parent_fd,
+            relative.name,
+            display_path=mapping,
+        )
+        if (
+            installed["bytes"] != content
+            or installed["sha256"] != hashlib.sha256(content).hexdigest()
+            or installed["mode"] != snapshot["mode"]
+            or installed["dev"] != temporary_metadata.st_dev
+            or installed["ino"] != temporary_metadata.st_ino
+        ):
+            raise ReconciliationWriteError(
+                f"installed mapping failed verification: {mapping}"
+            )
+    except ReconciliationWriteError:
+        raise
+    except Exception as exc:
+        raise ReconciliationWriteError(
+            f"failed to atomically replace mapping {mapping}: {exc}"
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_created:
+            try:
+                os.unlink(temporary_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+        os.close(parent_fd)
+
+
+def _atomic_write_mapping_batch(
+    writes: list[tuple[Path, bytes, dict[str, Any]]],
+    *,
+    repo_root: Path,
+) -> None:
+    """Install a locked batch; the outer durable guard owns rollback."""
+    for mapping, _content, snapshot in writes:
+        if not _mapping_matches_snapshot(mapping, repo_root, snapshot):
+            raise ReconciliationWriteError(
+                f"mapping changed after reconciliation preflight: {mapping}"
+            )
+    for mapping, content, snapshot in writes:
+        _atomic_replace_mapping(
+            mapping,
+            content,
+            snapshot,
+            repo_root=repo_root,
+        )
+
+
+def reconcile_mappings(
+    mappings: Iterable[Path],
+    *,
+    repo_root: Path,
+    cache: GitHubObjectCache,
+    write: bool = False,
+    today: str | None = None,
+    lock_timeout: float = 10.0,
+) -> dict[str, Any]:
+    mappings = sorted(Path(mapping) for mapping in mappings)
+    if write:
+        try:
+            from sync_upstream import mapping_advisory_lock
+            from durable_file_batch import durable_batch_lock_and_recover
+        except ModuleNotFoundError:  # pragma: no cover - package-style import
+            from scripts.sync_upstream import mapping_advisory_lock
+            from scripts.durable_file_batch import (
+                durable_batch_lock_and_recover,
+            )
+        # Global order shared by sync, ingest, and reconciliation:
+        # durable repository batch -> sorted mappings -> sorted skills.
+        with durable_batch_lock_and_recover(
+            repo_root,
+            timeout=lock_timeout,
+        ) as batch_guard:
+            with contextlib.ExitStack() as locks:
+                # The first mapping snapshot is captured only after every
+                # mapping lock is held, so the following CAS window cannot
+                # overlap another conforming writer.
+                for mapping in mappings:
+                    locks.enter_context(
+                        mapping_advisory_lock(mapping, timeout=lock_timeout)
+                    )
+                return _reconcile_mappings_locked(
+                    mappings,
+                    repo_root=repo_root,
+                    cache=cache,
+                    write=True,
+                    today=today,
+                    batch_guard=batch_guard,
+                )
+    return _reconcile_mappings_locked(
+        mappings,
+        repo_root=repo_root,
+        cache=cache,
+        write=False,
+        today=today,
+        batch_guard=None,
+    )
+
+
+def _reconcile_mappings_locked(
+    mappings: list[Path],
+    *,
+    repo_root: Path,
+    cache: GitHubObjectCache,
+    write: bool,
+    today: str | None,
+    batch_guard: Any | None,
+) -> dict[str, Any]:
+    report_entries: list[dict[str, Any]] = []
+    mappings_changed = 0
+    scanned = 0
+    write_blocked = 0
+    today = today or date.today().isoformat()
+    planned_payloads: dict[Path, dict[str, Any]] = {}
+    mapping_snapshots: dict[Path, dict[str, Any]] = {}
+    mapping_changed_flags: dict[Path, bool] = {}
+    entries_for_preflight: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    write_error: str | None = None
+    recovery_paths: list[str] = []
+
+    for mapping in mappings:
+        snapshot = _mapping_snapshot(mapping, repo_root)
+        mapping_snapshots[mapping] = snapshot
+        payload = json.loads(snapshot["bytes"].decode("utf-8"))
+        updated_payload = deepcopy(payload)
+        mapping_changed = False
+        for index, entry in enumerate(payload.get("skills", [])):
+            if not isinstance(entry, dict) or not _is_active_external_canonical(entry):
+                continue
+            scanned += 1
+            inspection = inspect_entry(entry, repo_root=repo_root, cache=cache)
+            if write and cache.offline and inspection["unowned"]:
+                for proposal in inspection["unowned"]:
+                    proposal["classification"] = "unavailable"
+                    proposal["source"] = None
+                    proposal["reason"] = (
+                        "offline reconciliation cannot authorize ownership "
+                        "changes; rerun online"
+                    )
+            inspection["mapping"] = mapping.relative_to(repo_root).as_posix()
+            updated, changed, blocked_reason = apply_entry_reconciliation(
+                entry,
+                inspection,
+                repo_root=repo_root,
+                today=today,
+            )
+            inspection["would_change"] = changed
+            inspection["write_blocked_reason"] = blocked_reason
+            if blocked_reason:
+                write_blocked += 1
+            entries_for_preflight.append((entry, inspection))
+            if changed and not blocked_reason:
+                updated_payload["skills"][index] = updated
+                mapping_changed = True
+            report_entries.append(inspection)
+        planned_payloads[mapping] = updated_payload
+        mapping_changed_flags[mapping] = mapping_changed
+
+    if write and write_blocked == 0:
+        for entry, inspection in entries_for_preflight:
+            checkpoint_error = _verify_inspection_checkpoint(
+                entry,
+                inspection,
+                repo_root=repo_root,
+            )
+            if checkpoint_error is None:
+                continue
+            inspection["write_blocked_reason"] = checkpoint_error
+            write_blocked += 1
+
+    if write and write_blocked == 0:
+        writes = [
+            (
+                mapping,
+                (
+                    json.dumps(
+                        planned_payloads[mapping],
+                        ensure_ascii=False,
+                        indent=2,
+                    )
+                    + "\n"
+                ).encode("utf-8"),
+                mapping_snapshots[mapping],
+            )
+            for mapping in mappings
+            if mapping_changed_flags[mapping]
+        ]
+        if writes:
+            try:
+                replacements = {
+                    mapping: content
+                    for mapping, content, _snapshot in writes
+                }
+                if batch_guard is None:
+                    raise ReconciliationWriteError(
+                        "reconciliation write has no durable batch guard"
+                    )
+                batch_guard.commit_batch(
+                    replacements,
+                    lambda: _atomic_write_mapping_batch(
+                        writes,
+                        repo_root=repo_root,
+                    ),
+                )
+                mappings_changed = len(writes)
+            except ReconciliationWriteError as exc:
+                write_error = str(exc)
+                recovery_paths = [str(path) for path in exc.recovery_paths]
+                if exc.committed:
+                    mappings_changed = len(writes)
+
+    classification_counts = Counter(
+        item["classification"]
+        for entry in report_entries
+        for item in entry["unowned"]
+    )
+    summary = {
+        "mappings_scanned": len(mappings),
+        "entries_scanned": scanned,
+        "actual_files": sum(len(entry["actual_files"]) for entry in report_entries),
+        "external_exact": classification_counts["external_exact"],
+        "local_overlay": classification_counts["local_overlay"],
+        "unavailable": classification_counts["unavailable"],
+        "missing_managed": sum(
+            len(entry["missing_managed"]) for entry in report_entries
+        ),
+        "stale_managed": sum(
+            len(entry["stale_managed"]) for entry in report_entries
+        ),
+        "stale_artifact_targets": sum(
+            len(entry["stale_artifact_targets"]) for entry in report_entries
+        ),
+        "hash_mismatches": sum(
+            len(entry["hash_mismatches"]) for entry in report_entries
+        ),
+        "scan_errors": sum(
+            len(entry.get("scan_errors", [])) for entry in report_entries
+        ),
+        "ownership_conflicts": sum(
+            len(entry["ownership_conflicts"]) for entry in report_entries
+        ),
+        "write_blocked_entries": write_blocked,
+        "mappings_changed": mappings_changed,
+        "write_error": write_error,
+        "recovery_paths": recovery_paths,
+    }
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "mode": "write" if write else "dry-run",
+        "summary": summary,
+        "entries": report_entries,
+    }
+
+
+def _mapping_paths(args: argparse.Namespace, repo_root: Path) -> list[Path]:
+    if args.mapping:
+        result = []
+        for value in args.mapping:
+            path = Path(value)
+            result.append(path if path.is_absolute() else repo_root / path)
+        return sorted(result)
+    return discover_source_mappings(repo_root / "docs/sources")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[1]))
+    parser.add_argument(
+        "--mapping",
+        action="append",
+        help="Mapping path relative to repo root; repeat for multiple mappings.",
+    )
+    parser.add_argument("--cache-dir", default=str(_default_cache_dir()))
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Use only pre-recorded tree/blob cache fixtures.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Atomically write safe reconciliation proposals.",
+    )
+    parser.add_argument(
+        "--check-clean",
+        action="store_true",
+        help=(
+            "Exit non-zero unless the dry-run inventory has no ownership, "
+            "hash, availability, or scan debt"
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        help="Write the JSON report to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Print only the summary instead of the full JSON report.",
+    )
+    args = parser.parse_args(argv)
+    if args.write and args.check_clean:
+        parser.error("--check-clean cannot be combined with --write")
+
+    repo_root = Path(args.repo_root).resolve()
+    mappings = _mapping_paths(args, repo_root)
+    cache = GitHubObjectCache(
+        Path(args.cache_dir),
+        offline=args.offline,
+    )
+    report = reconcile_mappings(
+        mappings,
+        repo_root=repo_root,
+        cache=cache,
+        write=args.write,
+    )
+    if args.output and args.quiet:
+        parser.error("--quiet cannot be combined with --output")
+    if args.output:
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(output, report)
+    elif args.quiet:
+        print(json.dumps(report["summary"], ensure_ascii=False, sort_keys=True))
+    else:
+        json.dump(report, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    if args.write and (
+        report["summary"].get("write_blocked_entries", 0)
+        or report["summary"].get("write_error")
+    ):
+        return 1
+    if args.check_clean:
+        debt_fields = (
+            "external_exact",
+            "local_overlay",
+            "unavailable",
+            "missing_managed",
+            "stale_managed",
+            "stale_artifact_targets",
+            "hash_mismatches",
+            "scan_errors",
+            "ownership_conflicts",
+            "write_blocked_entries",
+        )
+        if any(report["summary"].get(field, 0) for field in debt_fields):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_artifact_inventory.py
+++ b/scripts/reconcile_artifact_inventory.py
@@ -63,6 +63,7 @@ except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
 
 REPORT_SCHEMA_VERSION = 1
 LOCAL_OVERLAY_REPO = LOCAL_CURATION_REPO
+VALID_GIT_FILE_MODES = {"100644", "100755"}
 IGNORED_DIRECTORY_NAMES = {
     "__pycache__",
     ".cache",
@@ -485,6 +486,12 @@ class GitHubObjectCache:
             path = entry.get("path")
             object_sha = entry.get("sha")
             size = entry.get("size")
+            git_mode = entry.get("mode")
+            if git_mode not in VALID_GIT_FILE_MODES:
+                raise SourceUnavailable(
+                    "tree response contains a non-regular or unknown blob mode "
+                    f"for {repo}@{commit}: {entry.get('path')}: {git_mode!r}"
+                )
             if not isinstance(path, str) or not safe_relative_path(path):
                 raise SourceUnavailable(
                     f"tree response contains an unsafe blob path for {repo}@{commit}"
@@ -510,6 +517,7 @@ class GitHubObjectCache:
                 **entry,
                 "sha": object_sha.lower(),
                 "size": size,
+                "mode": git_mode,
             }
         self._trees[key] = normalized
         if not self.offline:
@@ -659,8 +667,15 @@ def _display_path(path: Path, repo_root: Path) -> str:
         return str(path)
 
 
-def _read_regular_file(path: Path) -> bytes:
-    """Read one regular file while refusing a final-component symlink."""
+def _git_mode_from_stat(metadata: os.stat_result) -> str:
+    """Project one regular worktree inode into Git's portable file modes."""
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OSError("file mode cannot be projected from a non-regular inode")
+    return "100755" if stat.S_IMODE(metadata.st_mode) & 0o111 else "100644"
+
+
+def _regular_file_snapshot(path: Path) -> tuple[bytes, dict[str, int | str]]:
+    """Bind bytes and portable mode to one stable, nofollow descriptor."""
     before = path.lstat()
     if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
         raise OSError(f"not a regular non-symlink file: {path}")
@@ -680,13 +695,40 @@ def _read_regular_file(path: Path) -> bytes:
             if not chunk:
                 break
             chunks.append(chunk)
-        return b"".join(chunks)
+        content = b"".join(chunks)
+        after = os.fstat(descriptor)
+        named = path.lstat()
+        if (
+            after.st_dev != opened.st_dev
+            or after.st_ino != opened.st_ino
+            or after.st_size != opened.st_size
+            or after.st_mtime_ns != opened.st_mtime_ns
+            or after.st_ctime_ns != opened.st_ctime_ns
+            or after.st_mode != opened.st_mode
+            or named.st_dev != opened.st_dev
+            or named.st_ino != opened.st_ino
+            or stat.S_ISLNK(named.st_mode)
+        ):
+            raise OSError(f"file changed while reading: {path}")
+        return content, {
+            "dev": opened.st_dev,
+            "ino": opened.st_ino,
+            "size": len(content),
+            "mtime_ns": opened.st_mtime_ns,
+            "ctime_ns": opened.st_ctime_ns,
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "mode": _git_mode_from_stat(opened),
+        }
     finally:
         os.close(descriptor)
 
 
+def _read_regular_file(path: Path) -> bytes:
+    return _regular_file_snapshot(path)[0]
+
+
 def _sha256_regular_file(path: Path) -> str:
-    return hashlib.sha256(_read_regular_file(path)).hexdigest()
+    return str(_regular_file_snapshot(path)[1]["sha256"])
 
 
 def _scan_issue(
@@ -846,6 +888,8 @@ def _scan_regular_skill_files(
                             or after.st_ino != opened.st_ino
                             or after.st_size != opened.st_size
                             or after.st_mtime_ns != opened.st_mtime_ns
+                            or after.st_ctime_ns != opened.st_ctime_ns
+                            or after.st_mode != opened.st_mode
                         ):
                             raise OSError(f"file changed while reading: {item_path}")
                         data = b"".join(chunks)
@@ -859,7 +903,9 @@ def _scan_regular_skill_files(
                         "ino": opened.st_ino,
                         "size": len(data),
                         "mtime_ns": opened.st_mtime_ns,
+                        "ctime_ns": opened.st_ctime_ns,
                         "sha256": digest,
+                        "mode": _git_mode_from_stat(opened),
                     }
                     if capture_bytes:
                         contents[target] = data
@@ -1007,9 +1053,12 @@ def _classify_unowned_file(
     entry: dict[str, Any],
     target: str,
     local_bytes: bytes,
+    local_mode: str,
     cache: GitHubObjectCache,
     origin_indexes: set[int] | None = None,
 ) -> dict[str, Any]:
+    if local_mode not in VALID_GIT_FILE_MODES:
+        raise ValueError(f"invalid local Git file mode: {local_mode!r}")
     repo_skill = PurePosixPath(str(entry["repo_skill"]))
     skill_root = repo_skill.parent
     checked_sources: list[dict[str, Any]] = []
@@ -1065,6 +1114,20 @@ def _classify_unowned_file(
                 continue
             object_sha = str(tree_entry["sha"]).lower()
             declared_size = tree_entry.get("size")
+            upstream_mode = tree_entry.get("mode")
+            if upstream_mode != local_mode:
+                checked_sources.append(
+                    {
+                        "origin_index": origin_index,
+                        "repo": repo,
+                        "resolved_commit": commit,
+                        "source": source,
+                        "result": "mode_mismatch",
+                        "local_mode": local_mode,
+                        "upstream_mode": upstream_mode,
+                    }
+                )
+                continue
             algorithm = (
                 "sha1"
                 if len(object_sha) == 40
@@ -1109,6 +1172,7 @@ def _classify_unowned_file(
                 return {
                     "target": target,
                     "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "mode": local_mode,
                     "classification": "external_exact",
                     "origin_index": origin_index,
                     "repo": repo,
@@ -1156,9 +1220,25 @@ def _classify_unowned_file(
                 )
                 continue
             if upstream_bytes == local_bytes:
+                if cache.offline:
+                    unavailable.append(
+                        "offline tree/blob cache cannot authorize new external "
+                        f"ownership for {repo}@{commit}:{source}"
+                    )
+                    checked_sources.append(
+                        {
+                            "origin_index": origin_index,
+                            "repo": repo,
+                            "resolved_commit": commit,
+                            "source": source,
+                            "result": "offline_authority_forbidden",
+                        }
+                    )
+                    continue
                 return {
                     "target": target,
                     "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "mode": local_mode,
                     "classification": "external_exact",
                     "origin_index": origin_index,
                     "repo": repo,
@@ -1180,6 +1260,7 @@ def _classify_unowned_file(
     result = {
         "target": target,
         "sha256": hashlib.sha256(local_bytes).hexdigest(),
+        "mode": local_mode,
         "checked_sources": checked_sources,
     }
     if unavailable:
@@ -1256,14 +1337,24 @@ def inspect_entry(
         if owners and target in managed_set:
             continue
         local_bytes = local_contents.get(target)
-        if local_bytes is None:
+        local_snapshot = filesystem_checkpoint.get(target)
+        local_mode = (
+            local_snapshot.get("mode")
+            if isinstance(local_snapshot, dict)
+            else None
+        )
+        if local_bytes is None or local_mode not in VALID_GIT_FILE_MODES:
             unowned.append(
                 {
                     "target": target,
                     "sha256": None,
+                    "mode": local_mode,
                     "classification": "unavailable",
                     "source": None,
-                    "reason": "cannot read local file from secure scan checkpoint",
+                    "reason": (
+                        "cannot bind local bytes and regular Git mode from "
+                        "secure scan checkpoint"
+                    ),
                 }
             )
             continue
@@ -1280,6 +1371,7 @@ def inspect_entry(
                 classified = {
                     "target": target,
                     "sha256": hashlib.sha256(local_bytes).hexdigest(),
+                    "mode": local_mode,
                     "classification": "local_overlay",
                     "origin_index": owner_index,
                     "repo": owner_origin.get("repo"),
@@ -1294,6 +1386,7 @@ def inspect_entry(
                     entry=entry,
                     target=target,
                     local_bytes=local_bytes,
+                    local_mode=local_mode,
                     cache=cache,
                     origin_indexes={owner_index},
                 )
@@ -1302,6 +1395,7 @@ def inspect_entry(
                 entry=entry,
                 target=target,
                 local_bytes=local_bytes,
+                local_mode=local_mode,
                 cache=cache,
             )
         if declared_owner is not None:
@@ -1322,9 +1416,12 @@ def inspect_entry(
                 stale_artifact_targets.append(str(artifact["target"]))
 
     hash_mismatches: list[str] = []
+    mode_mismatches: list[str] = []
     for target in sorted(actual_set & managed_set):
         try:
-            current_hash = _sha256_regular_file(repo_root / target)
+            _current_bytes, current_snapshot = _regular_file_snapshot(
+                repo_root / target
+            )
         except OSError as exc:
             scan_errors.append(
                 _scan_issue(
@@ -1336,8 +1433,19 @@ def inspect_entry(
                 )
             )
             continue
-        checkpoint_hash = filesystem_checkpoint.get(target, {}).get("sha256")
-        if current_hash != checkpoint_hash:
+        checkpoint = filesystem_checkpoint.get(target, {})
+        if any(
+            current_snapshot.get(field) != checkpoint.get(field)
+            for field in (
+                "dev",
+                "ino",
+                "size",
+                "mtime_ns",
+                "ctime_ns",
+                "sha256",
+                "mode",
+            )
+        ):
             scan_errors.append(
                 _scan_issue(
                     path=repo_root / target,
@@ -1348,8 +1456,10 @@ def inspect_entry(
                 )
             )
             continue
-        if managed[target].get("sha256") != current_hash:
+        if managed[target].get("sha256") != current_snapshot["sha256"]:
             hash_mismatches.append(target)
+        if managed[target].get("mode") != current_snapshot["mode"]:
+            mode_mismatches.append(target)
 
     return {
         "slug": slug,
@@ -1360,6 +1470,7 @@ def inspect_entry(
         "stale_managed": sorted(managed_set - actual_set),
         "stale_artifact_targets": sorted(set(stale_artifact_targets)),
         "hash_mismatches": hash_mismatches,
+        "mode_mismatches": mode_mismatches,
         "scan_errors": scan_errors,
         "ownership_conflicts": ownership_conflicts,
         "unowned": unowned,
@@ -1408,6 +1519,7 @@ def apply_entry_reconciliation(
     ]
     conflicts = inspection["ownership_conflicts"]
     hash_mismatches = inspection.get("hash_mismatches", [])
+    mode_mismatches = inspection.get("mode_mismatches", [])
     stale_managed = inspection.get("stale_managed", [])
     stale_artifact_targets = inspection.get("stale_artifact_targets", [])
     scan_errors = inspection.get("scan_errors", [])
@@ -1422,6 +1534,7 @@ def apply_entry_reconciliation(
         unavailable
         or conflicts
         or hash_mismatches
+        or mode_mismatches
         or stale_managed
         or stale_artifact_targets
         or scan_errors
@@ -1434,6 +1547,8 @@ def apply_entry_reconciliation(
             reasons.append(f"{len(conflicts)} ownership conflict(s)")
         if hash_mismatches:
             reasons.append(f"{len(hash_mismatches)} managed hash mismatch(es)")
+        if mode_mismatches:
+            reasons.append(f"{len(mode_mismatches)} managed mode mismatch(es)")
         if stale_managed:
             reasons.append(f"{len(stale_managed)} stale managed file(s)")
         if stale_artifact_targets:
@@ -1545,7 +1660,8 @@ def apply_entry_reconciliation(
     for target in inspection["actual_files"]:
         snapshot = filesystem_checkpoint.get(target)
         digest = snapshot.get("sha256") if isinstance(snapshot, dict) else None
-        if not isinstance(digest, str):
+        mode = snapshot.get("mode") if isinstance(snapshot, dict) else None
+        if not isinstance(digest, str) or mode not in VALID_GIT_FILE_MODES:
             return (
                 deepcopy(entry),
                 False,
@@ -1556,6 +1672,7 @@ def apply_entry_reconciliation(
                 "path": target,
                 "sha256": digest,
                 "owner": owner,
+                "mode": mode,
             }
         )
     updated["managed_files"] = managed_files
@@ -1587,7 +1704,15 @@ def _verify_inspection_checkpoint(
         after = current.get(target)
         if not isinstance(before, dict) or not isinstance(after, dict):
             return f"filesystem checkpoint is incomplete for {target}"
-        for field in ("dev", "ino", "size", "mtime_ns", "sha256"):
+        for field in (
+            "dev",
+            "ino",
+            "size",
+            "mtime_ns",
+            "ctime_ns",
+            "sha256",
+            "mode",
+        ):
             if before.get(field) != after.get(field):
                 return (
                     f"canonical skill changed after classification: "
@@ -2074,6 +2199,9 @@ def _reconcile_mappings_locked(
         "hash_mismatches": sum(
             len(entry["hash_mismatches"]) for entry in report_entries
         ),
+        "mode_mismatches": sum(
+            len(entry.get("mode_mismatches", [])) for entry in report_entries
+        ),
         "scan_errors": sum(
             len(entry.get("scan_errors", [])) for entry in report_entries
         ),
@@ -2127,7 +2255,7 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "Exit non-zero unless the dry-run inventory has no ownership, "
-            "hash, availability, or scan debt"
+            "hash, mode, availability, or scan debt"
         ),
     )
     parser.add_argument(
@@ -2180,6 +2308,7 @@ def main(argv: list[str] | None = None) -> int:
             "stale_managed",
             "stale_artifact_targets",
             "hash_mismatches",
+            "mode_mismatches",
             "scan_errors",
             "ownership_conflicts",
             "write_blocked_entries",

--- a/scripts/sync_all_upstream_skills.py
+++ b/scripts/sync_all_upstream_skills.py
@@ -3,99 +3,112 @@
 
 This is the one-command entrypoint for routine repository maintenance:
 
-1. refresh addyosmani/agent-skills with its richer bundle-aware importer
-2. refresh all other externally mapped skills through docs/sources provenance
-3. optionally run the repository generation, lint, and test pipeline
-4. optionally install/sync the result into a local Codex skills root
+1. check or apply every provenance-v2 artifact set through one governed engine
+2. optionally run the repository generation, lint, and test pipeline
+
+Installation is intentionally outside this repository-maintenance command.
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import subprocess
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ADDY_SOURCE = "github:addyosmani/agent-skills"
-SIMOTA_SOURCE = "github:simota/agent-skills"
-
+PYTHON = sys.executable or "python"
 POST_SYNC_PIPELINE = (
-    ("python", "scripts/enrich_frontmatter.py"),
-    ("python", "scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"),
-    ("python", "scripts/refresh_repo_views.py"),
-    ("python", "scripts/generate_tags_index.py"),
-    ("python", "scripts/build_catalog_json.py"),
-    ("python", "scripts/generate_sources_index.py"),
-    ("python", "scripts/lint_skill_quality.py", "--min-lines", "50"),
-    ("python", "-m", "unittest", "discover", "tests", "-v"),
+    (PYTHON, "scripts/enrich_frontmatter.py"),
+    (PYTHON, "scripts/bootstrap_in_house_sources.py", "--write-json", "docs/sources/in-house.skills.json"),
+    (PYTHON, "scripts/refresh_repo_views.py"),
+    (PYTHON, "scripts/generate_tags_index.py"),
+    (PYTHON, "scripts/build_catalog_json.py"),
+    (PYTHON, "scripts/check_readme_sync.py"),
+    (PYTHON, "scripts/generate_sources_index.py"),
+    (PYTHON, "scripts/lint_skill_quality.py", "--min-lines", "50"),
+    (PYTHON, "scripts/validate_skill_sources.py"),
+    (
+        PYTHON,
+        "scripts/reconcile_artifact_inventory.py",
+        "--offline",
+        "--check-clean",
+        "--quiet",
+    ),
+    (PYTHON, "scripts/check_source_coverage.py", "--min-percent", "100"),
+    (PYTHON, "scripts/audit_skill_portfolio.py", "--check-policy"),
+    (PYTHON, "scripts/audit_licenses.py"),
+    (PYTHON, "-m", "pytest", "-q", "tests"),
 )
 
 
-def run(command: tuple[str, ...] | list[str], *, repo_root: Path, enabled: bool = True) -> None:
+def run(command: tuple[str, ...] | list[str], *, repo_root: Path) -> int:
     print("Running:", " ".join(command))
-    if enabled:
-        subprocess.run(command, cwd=repo_root, check=True)
+    result = subprocess.run(command, cwd=repo_root, check=False)
+    return result.returncode
 
 
-def main() -> int:
+def repository_digest(repo_root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(repo_root.rglob("*")):
+        relative = path.relative_to(repo_root)
+        if any(
+            part in {".git", ".pytest_cache", "__pycache__"}
+            for part in relative.parts
+        ):
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        digest.update(relative.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Sync all externally tracked upstream skills.")
     parser.add_argument("--apply", action="store_true", help="Write updates. Without this, performs check/dry-run style commands.")
     parser.add_argument("--repo-root", default=str(REPO_ROOT), help="Repository root.")
     parser.add_argument("--run-pipeline", action="store_true", help="Run generation, lint, and tests after syncing.")
-    parser.add_argument("--sync-codex-root", type=Path, help="Sync all repo skills into this Codex skills root after applying.")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     repo_root = Path(args.repo_root).resolve()
+    before = repository_digest(repo_root) if args.apply else None
 
     if args.apply:
-        run(("python", "scripts/sync_addyosmani_agent_skills.py", "--apply"), repo_root=repo_root)
-        run(("python", "scripts/sync_simota_agent_skills.py", "--apply"), repo_root=repo_root)
-        run(
+        sync_state = run(
             (
-                "python",
+                PYTHON,
                 "scripts/sync_upstream.py",
                 "--apply",
-                "--exclude-source",
-                ADDY_SOURCE,
-                "--exclude-source",
-                SIMOTA_SOURCE,
             ),
             repo_root=repo_root,
         )
     else:
-        run(("python", "scripts/sync_addyosmani_agent_skills.py"), repo_root=repo_root)
-        run(("python", "scripts/sync_simota_agent_skills.py"), repo_root=repo_root)
-        run(
+        sync_state = run(
             (
-                "python",
+                PYTHON,
                 "scripts/sync_upstream.py",
                 "--check-only",
-                "--exclude-source",
-                ADDY_SOURCE,
-                "--exclude-source",
-                SIMOTA_SOURCE,
             ),
             repo_root=repo_root,
         )
 
-    if args.apply and args.run_pipeline:
+    if sync_state not in {0, 1, 2}:
+        sync_state = 1
+    wrote_files = (
+        args.apply
+        and before is not None
+        and repository_digest(repo_root) != before
+    )
+    if args.apply and args.run_pipeline and (sync_state == 0 or wrote_files):
         for command in POST_SYNC_PIPELINE:
-            run(command, repo_root=repo_root)
+            if run(command, repo_root=repo_root) != 0:
+                return 1
 
-    if args.apply and args.sync_codex_root:
-        run(
-            (
-                "python",
-                "scripts/sync_codex_skills.py",
-                "--source-root",
-                "skills",
-                "--codex-root",
-                str(args.sync_codex_root.expanduser()),
-            ),
-            repo_root=repo_root,
-        )
-
-    return 0
+    return sync_state
 
 
 if __name__ == "__main__":

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -11,6 +11,9 @@ Usage:
     # Check and explicitly record successful comparison timestamps
     python scripts/sync_upstream.py --check-only --record-check
 
+    # Also write a machine-readable complete/degraded/failed report
+    python scripts/sync_upstream.py --check-only --report-json report.json
+
     # Apply updates — download and replace with upstream versions
     python scripts/sync_upstream.py --apply
 
@@ -27,20 +30,75 @@ from __future__ import annotations
 
 import argparse
 import base64
+import copy
+import hashlib
 import http.client
 import json
+import math
 import os
 import re
 import socket
 import ssl
+import stat
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
+from contextlib import ExitStack, contextmanager
 from datetime import date
 from pathlib import Path, PurePosixPath
 from time import sleep
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - repository CI is POSIX
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    from github_artifact_provider import (
+        ArtifactNotFound,
+        GITHUB_REPO_RE,
+        GitHubArtifactProvider,
+        GitHubProviderError,
+        LicenseEvidence,
+    )
+except ModuleNotFoundError:  # pragma: no cover - import path used by test loaders
+    from scripts.github_artifact_provider import (
+        ArtifactNotFound,
+        GITHUB_REPO_RE,
+        GitHubArtifactProvider,
+        GitHubProviderError,
+        LicenseEvidence,
+    )
+
+try:
+    from audit_licenses import PERMISSIVE_LICENSES
+except ModuleNotFoundError:  # pragma: no cover - import path used by tests
+    from scripts.audit_licenses import PERMISSIVE_LICENSES
+
+try:
+    from durable_file_batch import (
+        DurableBatchGuard,
+        durable_batch_lock_and_recover,
+    )
+except ModuleNotFoundError:  # pragma: no cover - package-style unit import
+    from scripts.durable_file_batch import (
+        DurableBatchGuard,
+        durable_batch_lock_and_recover,
+    )
+
+try:
+    from validate_skill_sources import (
+        validate_mapping as validate_provenance_mapping,
+        validate_repository_mappings,
+    )
+except ModuleNotFoundError:  # pragma: no cover - import path used by tests
+    from scripts.validate_skill_sources import (
+        validate_mapping as validate_provenance_mapping,
+        validate_repository_mappings,
+    )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = REPO_ROOT / "skills"
@@ -53,6 +111,51 @@ NETWORK_ERRORS = (
     TimeoutError,
     socket.timeout,
     ssl.SSLError,
+)
+MONITOR_CHANNELS = {"default_branch", "canary"}
+AUTO_CHANNELS = {"latest_release", "fixed_ref"}
+COMMIT_RE = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+VALID_KINDS = {
+    "mirror",
+    "overlay",
+    "composite",
+    "bundle",
+    "snapshot",
+    "in_house",
+    "reference_only",
+}
+VALID_SYNC_MODES = {"replace", "monitor", "local-only", "archived", "manual"}
+VALID_CHANNELS = {
+    "latest_release",
+    "default_branch",
+    "canary",
+    "fixed_ref",
+    "local",
+}
+_ACTIVE_ARTIFACT_PROVIDER: GitHubArtifactProvider | None = None
+_TOKEN_UNRESOLVED = object()
+_ACTIVE_GITHUB_TOKEN: str | None | object = _TOKEN_UNRESOLVED
+LOCAL_AUTHORITY_FRONTMATTER_FIELDS = frozenset(
+    {
+        "zh_description",
+        "version",
+        "author",
+        "source",
+        "source_url",
+        "license",
+        "tags",
+        "created_at",
+        "updated_at",
+        "quality",
+        "complexity",
+    }
+)
+LOCAL_SUPPLEMENT_FRONTMATTER_FIELDS = frozenset({"upstream_slug"})
+LOCAL_FRONTMATTER_FIELDS = (
+    LOCAL_AUTHORITY_FRONTMATTER_FIELDS
+    | LOCAL_SUPPLEMENT_FRONTMATTER_FIELDS
 )
 
 
@@ -247,6 +350,80 @@ def split_frontmatter(text: str) -> tuple[str | None, str]:
     return match.group(1), match.group(2)
 
 
+def _frontmatter_field_blocks(text: str) -> tuple[list[str], dict[str, list[str]]]:
+    """Return ordered, complete top-level YAML field blocks."""
+    match = re.match(r"^---\s*\n(.*?)\n---(?:\s*\n|$)", text, re.DOTALL)
+    if not match:
+        return [], {}
+    order: list[str] = []
+    blocks: dict[str, list[str]] = {}
+    current: str | None = None
+    pending: list[str] = []
+    field_pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t].*)?$")
+    for line in match.group(1).splitlines():
+        field_match = field_pattern.match(line)
+        if field_match:
+            current = field_match.group(1)
+            if current in blocks:
+                raise RuntimeError(
+                    f"duplicate top-level frontmatter field: {current}"
+                )
+            order.append(current)
+            blocks[current] = [*pending, line]
+            pending = []
+            continue
+        if current is None:
+            if not line.strip() or line.lstrip().startswith("#"):
+                pending.append(line)
+                continue
+            raise RuntimeError(
+                "frontmatter contains content outside a top-level field"
+            )
+        blocks[current].append(line)
+    return order, blocks
+
+
+def _normalized_frontmatter_block(lines: list[str]) -> str:
+    normalized = [line.rstrip() for line in lines]
+    while normalized and not normalized[-1]:
+        normalized.pop()
+    return "\n".join(normalized)
+
+
+def _upstream_frontmatter_contract(text: str) -> dict[str, str]:
+    _order, blocks = _frontmatter_field_blocks(text)
+    return {
+        key: _normalized_frontmatter_block(lines)
+        for key, lines in blocks.items()
+        if key not in LOCAL_FRONTMATTER_FIELDS
+    }
+
+
+def _merge_frontmatter_authority(local_text: str, upstream_text: str) -> str:
+    """Preserve explicit local fields and replace every upstream-owned field."""
+    local_order, local_blocks = _frontmatter_field_blocks(local_text)
+    upstream_order, upstream_blocks = _frontmatter_field_blocks(upstream_text)
+    merged_order: list[str] = []
+    merged_blocks: dict[str, list[str]] = {}
+    for key in local_order:
+        if key in LOCAL_FRONTMATTER_FIELDS:
+            merged_order.append(key)
+            merged_blocks[key] = local_blocks[key]
+        elif key in upstream_blocks:
+            merged_order.append(key)
+            merged_blocks[key] = upstream_blocks[key]
+    for key in upstream_order:
+        if key in LOCAL_FRONTMATTER_FIELDS or key in merged_blocks:
+            continue
+        merged_order.append(key)
+        merged_blocks[key] = upstream_blocks[key]
+    lines = ["---"]
+    for key in merged_order:
+        lines.extend(merged_blocks[key])
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
 def update_frontmatter_field(frontmatter: str, key: str, value: str) -> str:
     pattern = re.compile(rf"^({re.escape(key)}:\s*).*$", re.MULTILINE)
     line = f"{key}: {value}"
@@ -350,7 +527,7 @@ def ensure_quality_floor(content: str, skill_name: str) -> str:
 
 
 def merge_frontmatter(local_content: str, upstream_content: str) -> str:
-    """Keep local enriched frontmatter and replace the body with upstream content."""
+    """Merge the explicit local allowlist with authoritative upstream metadata."""
     local_fm = parse_frontmatter(local_content)
     upstream_fm = parse_frontmatter(upstream_content)
     local_frontmatter, _ = split_frontmatter(local_content)
@@ -372,16 +549,10 @@ def merge_frontmatter(local_content: str, upstream_content: str) -> str:
             ]
         )
 
-    merged_frontmatter = local_frontmatter
-    if upstream_frontmatter is not None:
-        if upstream_fm.get("name"):
-            merged_frontmatter = update_frontmatter_field(merged_frontmatter, "name", upstream_fm["name"])
-        if upstream_fm.get("description") and len(upstream_fm["description"]) >= 20:
-            merged_frontmatter = update_frontmatter_field(
-                merged_frontmatter,
-                "description",
-                yaml_quote(upstream_fm["description"]),
-            )
+    merged_frontmatter = _merge_frontmatter_authority(
+        local_frontmatter,
+        upstream_frontmatter or "",
+    )
     if local_fm.get("version"):
         merged_frontmatter = update_frontmatter_field(
             merged_frontmatter,
@@ -467,19 +638,423 @@ def _artifact_source_for_target(artifact: object, target: str) -> str | None:
     return str(source_path) if requested == target_path else None
 
 
-def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict | None:
-    """Load one v2 entry from its unique origin/artifact owner.
+def _artifact_owns_target(artifact: dict, target: str) -> bool:
+    declared = artifact.get("target")
+    if not isinstance(declared, str):
+        return False
+    if artifact.get("type", "file") == "file":
+        return target == declared
+    boundary = PurePosixPath(declared)
+    candidate = PurePosixPath(target)
+    return candidate == boundary or boundary in candidate.parents
 
-    Legacy ``upstream`` is intentionally ignored.  If an active external entry
-    has no unique artifact mapping to ``repo_skill``, return an unavailable
-    descriptor so the caller fails closed instead of falling back to attacker-
-    controlled or stale legacy metadata.
+
+def _v2_sync_entry_errors(entry: dict) -> list[str]:
+    """Validate every sync-relevant v2 field before policy-based skipping."""
+    errors: list[str] = []
+    kind = entry.get("kind")
+    if kind not in VALID_KINDS:
+        errors.append(f"invalid kind: {kind!r}")
+        return errors
+    if kind not in {"mirror", "overlay", "snapshot"}:
+        return errors
+    if entry.get("status") not in {"verified_in_repo", "in_house"}:
+        errors.append(f"invalid active status: {entry.get('status')!r}")
+    slug = entry.get("normalized_slug")
+    repo_skill = entry.get("repo_skill")
+    if not isinstance(slug, str) or not slug:
+        errors.append("normalized_slug is required")
+    expected_repo_skill = (
+        f"/{slug}/SKILL.md" if isinstance(slug, str) and slug else None
+    )
+    if (
+        not _safe_mapping_path(repo_skill)
+        or expected_repo_skill is None
+        or not str(repo_skill).endswith(expected_repo_skill)
+        or not str(repo_skill).startswith("skills/")
+    ):
+        errors.append(f"repo_skill is not canonical for {slug!r}: {repo_skill!r}")
+        return errors
+    skill_root = PurePosixPath(str(repo_skill)).parent
+    entry_mode = entry.get("sync_mode")
+    if entry_mode not in VALID_SYNC_MODES:
+        errors.append(f"invalid entry sync_mode: {entry_mode!r}")
+
+    origins = entry.get("origins")
+    if not isinstance(origins, list) or not origins:
+        errors.append("origins must be a non-empty array")
+        return errors
+    managed = entry.get("managed_files")
+    if not isinstance(managed, list) or not managed:
+        errors.append("managed_files must be a non-empty array")
+        return errors
+
+    managed_by_path: dict[str, dict] = {}
+    for index, item in enumerate(managed):
+        if not isinstance(item, dict):
+            errors.append(f"managed_files[{index}] must be an object")
+            continue
+        path = item.get("path")
+        digest = item.get("sha256")
+        owner = item.get("owner")
+        if (
+            not _safe_mapping_path(path)
+            or not PurePosixPath(str(path)).is_relative_to(skill_root)
+        ):
+            errors.append(f"managed_files[{index}] has unsafe target: {path!r}")
+            continue
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            errors.append(f"managed_files[{index}] has invalid sha256")
+        if owner != slug:
+            errors.append(
+                f"managed_files[{index}] owner {owner!r} does not match {slug!r}"
+            )
+        if path in managed_by_path:
+            errors.append(f"duplicate managed path: {path}")
+        managed_by_path[str(path)] = item
+        if _safe_mapping_path(path):
+            candidate = REPO_ROOT / str(path)
+            try:
+                ancestor = REPO_ROOT
+                for component in PurePosixPath(str(path)).parts[:-1]:
+                    ancestor = ancestor / component
+                    if ancestor.is_symlink():
+                        raise ValueError("symlink ancestor")
+                resolved = candidate.resolve(strict=True)
+                resolved.relative_to(REPO_ROOT.resolve())
+                metadata = candidate.lstat()
+                if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(
+                    metadata.st_mode
+                ):
+                    raise ValueError("not a regular file")
+                if (
+                    isinstance(digest, str)
+                    and SHA256_RE.fullmatch(digest)
+                    and hashlib.sha256(candidate.read_bytes()).hexdigest()
+                    != digest.lower()
+                ):
+                    errors.append(
+                        f"managed_files[{index}] digest does not match disk"
+                    )
+            except (FileNotFoundError, OSError, ValueError):
+                errors.append(
+                    f"managed_files[{index}] target is missing or unsafe"
+                )
+
+    external_modes: list[str] = []
+    artifact_owners: dict[str, int] = {path: 0 for path in managed_by_path}
+    for origin_index, origin in enumerate(origins):
+        if not isinstance(origin, dict):
+            errors.append(f"origins[{origin_index}] must be an object")
+            continue
+        missing = {
+            "repo",
+            "path",
+            "license",
+            "sync_mode",
+            "artifacts",
+            "tracking",
+        } - set(origin)
+        if missing:
+            errors.append(
+                f"origins[{origin_index}] missing keys: {sorted(missing)}"
+            )
+            continue
+        repo = origin.get("repo")
+        is_local = isinstance(repo, str) and repo.startswith("local-repo/")
+        if not is_local and (
+            not isinstance(repo, str)
+            or not GITHUB_REPO_RE.fullmatch(repo)
+            or repo.endswith(".git")
+            or repo.rsplit("/", 1)[-1] in {".", ".."}
+        ):
+            errors.append(f"origins[{origin_index}] has invalid repo: {repo!r}")
+        if is_local and repo != "local-repo/curation":
+            errors.append(f"origins[{origin_index}] has invalid local repo")
+        origin_path = origin.get("path")
+        if origin_path is not None and not _safe_mapping_path(origin_path):
+            errors.append(f"origins[{origin_index}] has unsafe path")
+        license_value = origin.get("license")
+        if not is_local and (
+            not isinstance(license_value, str)
+            or license_value not in PERMISSIVE_LICENSES
+        ):
+            errors.append(
+                f"origins[{origin_index}] has no permitted external license"
+            )
+        mode = origin.get("sync_mode")
+        if mode not in VALID_SYNC_MODES:
+            errors.append(f"origins[{origin_index}] has invalid sync_mode")
+        elif not is_local:
+            external_modes.append(str(mode))
+
+        artifacts = origin.get("artifacts")
+        if not isinstance(artifacts, list) or (not artifacts and not is_local):
+            errors.append(f"origins[{origin_index}] has no artifact inventory")
+            artifacts = []
+        for artifact_index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict):
+                errors.append(
+                    f"origins[{origin_index}].artifacts[{artifact_index}] "
+                    "must be an object"
+                )
+                continue
+            source = artifact.get("source")
+            target = artifact.get("target")
+            artifact_type = artifact.get("type", "file")
+            if (
+                not _safe_mapping_path(source)
+                or not _safe_mapping_path(target)
+                or artifact_type not in {"file", "directory"}
+            ):
+                errors.append(
+                    f"origins[{origin_index}].artifacts[{artifact_index}] "
+                    "is invalid"
+                )
+                continue
+            target_path = PurePosixPath(str(target))
+            if not (
+                target_path.is_relative_to(skill_root)
+                or (
+                    artifact_type == "directory"
+                    and target_path == skill_root
+                )
+            ):
+                errors.append(
+                    f"origins[{origin_index}].artifacts[{artifact_index}] "
+                    "escapes the canonical skill root"
+                )
+            for managed_path in artifact_owners:
+                if _artifact_owns_target(artifact, managed_path):
+                    artifact_owners[managed_path] += 1
+
+        tracking = origin.get("tracking")
+        if not isinstance(tracking, dict):
+            errors.append(f"origins[{origin_index}] tracking must be an object")
+            continue
+        tracking_missing = {
+            "channel",
+            "ref",
+            "resolved_commit",
+            "path_commit",
+            "content_sha256",
+            "last_checked_at",
+            "last_synced_at",
+        } - set(tracking)
+        if tracking_missing:
+            errors.append(
+                f"origins[{origin_index}] tracking missing keys: "
+                f"{sorted(tracking_missing)}"
+            )
+            continue
+        channel = tracking.get("channel")
+        ref = tracking.get("ref")
+        if channel not in VALID_CHANNELS:
+            errors.append(f"origins[{origin_index}] has invalid channel")
+        if (
+            not isinstance(ref, str)
+            or not ref
+            or len(ref) > 1024
+            or any(ord(character) < 0x20 for character in ref)
+        ):
+            errors.append(f"origins[{origin_index}] has invalid ref")
+        if is_local != (channel == "local"):
+            errors.append(f"origins[{origin_index}] channel/repo semantics conflict")
+        if channel == "fixed_ref" and (
+            not isinstance(ref, str) or not COMMIT_RE.fullmatch(ref)
+        ):
+            errors.append(f"origins[{origin_index}] fixed_ref is not immutable")
+        for field in ("resolved_commit", "path_commit"):
+            value = tracking.get(field)
+            if value is not None and (
+                not isinstance(value, str) or not COMMIT_RE.fullmatch(value)
+            ):
+                errors.append(f"origins[{origin_index}] has invalid {field}")
+        content_hash = tracking.get("content_sha256")
+        if content_hash is not None and (
+            not isinstance(content_hash, str)
+            or not SHA256_RE.fullmatch(content_hash)
+        ):
+            errors.append(
+                f"origins[{origin_index}] has invalid content_sha256"
+            )
+        if (
+            any(
+                isinstance(artifact, dict)
+                and _artifact_owns_target(artifact, str(repo_skill))
+                for artifact in artifacts
+            )
+            and str(repo_skill) in managed_by_path
+            and isinstance(content_hash, str)
+            and content_hash.lower()
+            != str(managed_by_path[str(repo_skill)].get("sha256", "")).lower()
+        ):
+            errors.append(
+                f"origins[{origin_index}] content_sha256 does not match repo_skill"
+            )
+        for field in ("last_checked_at", "last_synced_at"):
+            value = tracking.get(field)
+            if value is not None and (
+                not isinstance(value, str) or not DATE_RE.fullmatch(value)
+            ):
+                errors.append(f"origins[{origin_index}] has invalid {field}")
+        license_checkpoint = tracking.get("license_checkpoint")
+        if license_checkpoint is not None:
+            if is_local or not isinstance(license_checkpoint, dict):
+                errors.append(
+                    f"origins[{origin_index}] has invalid license_checkpoint"
+                )
+            else:
+                expected_keys = {
+                    "path",
+                    "blob_sha",
+                    "content_sha256",
+                    "spdx",
+                    "resolved_commit",
+                }
+                allowed_keys = expected_keys | {"api_spdx"}
+                if set(license_checkpoint) - allowed_keys:
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "contains unknown fields"
+                    )
+                if not _safe_mapping_path(license_checkpoint.get("path")):
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint path "
+                        "is invalid"
+                    )
+                if not isinstance(
+                    license_checkpoint.get("blob_sha"), str
+                ) or not COMMIT_RE.fullmatch(
+                    str(license_checkpoint.get("blob_sha"))
+                ):
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "blob_sha is invalid"
+                    )
+                if not isinstance(
+                    license_checkpoint.get("content_sha256"), str
+                ) or not SHA256_RE.fullmatch(
+                    str(license_checkpoint.get("content_sha256"))
+                ):
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "content_sha256 is invalid"
+                    )
+                if license_checkpoint.get("spdx") != license_value:
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint SPDX "
+                        "does not match origin license"
+                    )
+                if not isinstance(
+                    license_checkpoint.get("resolved_commit"), str
+                ) or not COMMIT_RE.fullmatch(
+                    str(license_checkpoint.get("resolved_commit"))
+                ):
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "resolved_commit is invalid"
+                    )
+                api_spdx = license_checkpoint.get("api_spdx")
+                if api_spdx is not None and (
+                    not isinstance(api_spdx, str)
+                    or not api_spdx
+                    or api_spdx != api_spdx.strip()
+                    or len(api_spdx) > 128
+                    or any(ord(character) < 0x20 for character in api_spdx)
+                ):
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "api_spdx is invalid"
+                    )
+                elif api_spdx not in {None, "NOASSERTION", license_value}:
+                    errors.append(
+                        f"origins[{origin_index}] license_checkpoint "
+                        "api_spdx conflicts with detected SPDX"
+                    )
+
+    if len(external_modes) != 1:
+        errors.append(
+            f"expected exactly one external origin, found {len(external_modes)}"
+        )
+    elif entry_mode != external_modes[0]:
+        errors.append("entry/external origin sync_mode conflict")
+    for path, owners in artifact_owners.items():
+        if owners != 1:
+            errors.append(
+                f"managed file {path!r} must have exactly one artifact owner; "
+                f"found {owners}"
+            )
+    if str(repo_skill) not in managed_by_path:
+        errors.append("repo_skill is absent from managed_files")
+    return errors
+
+
+def _entry_origin_fingerprint(entry: dict, origin_index: int) -> str:
+    try:
+        selected_origin = entry["origins"][origin_index]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RuntimeError("cannot fingerprint malformed v2 entry") from exc
+
+    def authority_origin(origin: object) -> object:
+        if not isinstance(origin, dict):
+            return origin
+        tracking = origin.get("tracking")
+        return {
+            "repo": origin.get("repo"),
+            "path": origin.get("path"),
+            "license": origin.get("license"),
+            "sync_mode": origin.get("sync_mode"),
+            "artifacts": origin.get("artifacts"),
+            "tracking": (
+                {
+                    "channel": tracking.get("channel"),
+                    "ref": tracking.get("ref"),
+                    "resolved_commit": tracking.get("resolved_commit"),
+                    "path_commit": tracking.get("path_commit"),
+                    "content_sha256": tracking.get("content_sha256"),
+                    "license_checkpoint": tracking.get(
+                        "license_checkpoint"
+                    ),
+                }
+                if isinstance(tracking, dict)
+                else tracking
+            ),
+        }
+
+    authoritative = {
+        "kind": entry.get("kind"),
+        "status": entry.get("status"),
+        "normalized_slug": entry.get("normalized_slug"),
+        "repo_skill": entry.get("repo_skill"),
+        "entry_sync_mode": entry.get("sync_mode"),
+        "selected_origin_index": origin_index,
+        "selected_origin": authority_origin(selected_origin),
+        "all_origins": [
+            authority_origin(origin) for origin in entry.get("origins", [])
+        ],
+        "managed_files": entry.get("managed_files"),
+    }
+    encoded = json.dumps(
+        authoritative,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict | None:
+    """Load one v2 entry from its unique active external origin.
+
+    Legacy ``upstream`` fields are compatibility output, never authority.  All
+    source-to-target ownership comes from the selected origin's artifacts.
     """
     kind = entry.get("kind")
     status = entry.get("status")
     if status not in {"verified_in_repo", "in_house"}:
         return None
-    if kind in {"snapshot", "in_house", "reference_only", "composite"}:
+    if kind in {"in_house", "reference_only", "composite", "bundle"}:
         return None
 
     identity = _mapping_identity(entry, mapping_path, entry_index)
@@ -492,43 +1067,99 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
             "repo": "",
             "load_error": f"v2 repo_skill is not a safe relative path: {repo_skill!r}",
         }
+    structural_errors = _v2_sync_entry_errors(entry)
+    if structural_errors:
+        return {
+            **identity,
+            "schema_version": 2,
+            "source": "provenance:v2",
+            "repo": "",
+            "load_error": "invalid v2 sync entry: " + "; ".join(structural_errors),
+        }
     origins = entry.get("origins")
-    owner_candidates: list[tuple[int, int, dict, dict]] = []
-    if isinstance(repo_skill, str) and isinstance(origins, list):
+    if kind == "snapshot":
+        if not identity["local_path"].is_file():
+            return {
+                **identity,
+                "schema_version": 2,
+                "source": "provenance:v2",
+                "repo": "",
+                "load_error": f"mapped local skill is missing: {repo_skill}",
+            }
+        external_origins = [
+            (index, origin)
+            for index, origin in enumerate(origins or [])
+            if isinstance(origin, dict)
+            and isinstance(origin.get("repo"), str)
+            and not origin["repo"].startswith("local-repo/")
+        ]
+        if len(external_origins) != 1:
+            return {
+                **identity,
+                "schema_version": 2,
+                "source": "provenance:v2",
+                "repo": "",
+                "load_error": (
+                    "v2 snapshot requires exactly one external lineage origin; "
+                    f"found {len(external_origins)}"
+                ),
+            }
+        origin_index, origin = external_origins[0]
+        repo = origin["repo"]
+        return {
+            **identity,
+            "schema_version": 2,
+            "kind": "snapshot",
+            "source": f"github:{repo}",
+            "repo": repo,
+            "sync_mode": origin.get("sync_mode") or entry.get("sync_mode"),
+            "mapping_path": mapping_path,
+            "mapping_entry_index": entry_index,
+            "origin_index": origin_index,
+            "mapping_fingerprint": _entry_origin_fingerprint(
+                entry, origin_index
+            ),
+            "expected_skip_reason": (
+                "licensed immutable snapshot; automatic upstream checking is "
+                "disabled by provenance policy"
+            ),
+        }
+
+    origin_candidates: list[tuple[int, dict]] = []
+    if isinstance(origins, list):
         for origin_index, origin in enumerate(origins):
             if not isinstance(origin, dict):
                 continue
-            artifacts = origin.get("artifacts")
-            if not isinstance(artifacts, list):
-                continue
-            for artifact_index, artifact in enumerate(artifacts):
-                if _artifact_source_for_target(artifact, repo_skill) is not None:
-                    owner_candidates.append(
-                        (origin_index, artifact_index, origin, artifact)
-                    )
+            repo = origin.get("repo")
+            sync_mode = origin.get("sync_mode")
+            if (
+                isinstance(repo, str)
+                and not repo.startswith("local-repo/")
+                and sync_mode not in {"archived", "local-only"}
+            ):
+                origin_candidates.append((origin_index, origin))
 
-    if len(owner_candidates) != 1:
+    if len(origin_candidates) != 1:
         return {
             **identity,
             "schema_version": 2,
             "source": "provenance:v2",
             "repo": "",
             "load_error": (
-                "v2 provenance requires exactly one origin/artifact owner for "
-                f"{repo_skill!r}; found {len(owner_candidates)}"
+                "v2 provenance requires exactly one active external origin; "
+                f"found {len(origin_candidates)}"
             ),
         }
 
-    origin_index, artifact_index, origin, artifact = owner_candidates[0]
+    origin_index, origin = origin_candidates[0]
     tracking = origin.get("tracking")
     repo = origin.get("repo")
     origin_path = origin.get("path")
-    upstream_path = _artifact_source_for_target(artifact, repo_skill)
+    artifacts = origin.get("artifacts")
     sync_mode = origin.get("sync_mode")
     ref = tracking.get("ref") if isinstance(tracking, dict) else None
     required = {
         "origin.repo": repo,
-        "artifact.source": upstream_path,
         "origin.sync_mode": sync_mode,
         "origin.tracking.ref": ref,
     }
@@ -544,7 +1175,6 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
     if (
         not re.fullmatch(r"[^/\s]+/[^/\s]+", repo)
         or (origin_path is not None and not _safe_mapping_path(origin_path))
-        or not _safe_mapping_path(upstream_path)
     ):
         return {
             **identity,
@@ -554,11 +1184,48 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
             "load_error": "v2 owner contains an unsafe repo or artifact path",
         }
 
-    # Explicit non-syncable modes are outside this command's active input
-    # scope.  The summary states that scope rather than pretending they were
-    # checked.
-    if sync_mode in {"archived", "local-only"} or repo.startswith("local-repo/"):
-        return None
+    if not isinstance(artifacts, list) or not artifacts:
+        return {
+            **identity,
+            "schema_version": 2,
+            "source": f"github:{repo}",
+            "repo": repo,
+            "load_error": "v2 external origin has no declared artifacts",
+        }
+    invalid_artifacts = [
+        artifact
+        for artifact in artifacts
+        if not isinstance(artifact, dict)
+        or artifact.get("type", "file") not in {"file", "directory"}
+        or not _safe_mapping_path(artifact.get("source"))
+        or not _safe_mapping_path(artifact.get("target"))
+    ]
+    if invalid_artifacts:
+        return {
+            **identity,
+            "schema_version": 2,
+            "source": f"github:{repo}",
+            "repo": repo,
+            "load_error": "v2 external origin contains an invalid artifact mapping",
+        }
+
+    repo_skill_owners = [
+        artifact
+        for artifact in artifacts
+        if _artifact_source_for_target(artifact, str(repo_skill)) is not None
+    ]
+    if len(repo_skill_owners) != 1:
+        return {
+            **identity,
+            "schema_version": 2,
+            "source": "provenance:v2",
+            "repo": "",
+            "load_error": (
+                "v2 provenance requires exactly one origin/artifact owner for "
+                f"{repo_skill!r}; found {len(repo_skill_owners)}"
+            ),
+        }
+    upstream_path = _artifact_source_for_target(repo_skill_owners[0], str(repo_skill))
 
     local_path = identity["local_path"]
     if not local_path.is_file():
@@ -572,6 +1239,17 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
 
     content = local_path.read_text(encoding="utf-8", errors="replace")
     fm = parse_frontmatter(content)
+    other_origin_artifacts: list[dict] = []
+    for other_index, other_origin in enumerate(origins):
+        if other_index == origin_index or not isinstance(other_origin, dict):
+            continue
+        other_artifacts = other_origin.get("artifacts")
+        if isinstance(other_artifacts, list):
+            other_origin_artifacts.extend(
+                copy.deepcopy(item)
+                for item in other_artifacts
+                if isinstance(item, dict)
+            )
     return {
         **identity,
         "name": fm.get("name", identity["name"]),
@@ -584,6 +1262,13 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
         "origin_path": origin_path,
         "ref": ref,
         "sync_mode": sync_mode,
+        "tracking": copy.deepcopy(tracking),
+        "license": origin.get("license"),
+        "artifacts": copy.deepcopy(artifacts),
+        "other_origin_artifacts": other_origin_artifacts,
+        "managed_files": copy.deepcopy(entry.get("managed_files", [])),
+        "repo_skill": repo_skill,
+        "owner": entry.get("normalized_slug") or identity["name"],
         "last_synced_commit": (
             tracking.get("resolved_commit") if isinstance(tracking, dict) else None
         ),
@@ -591,7 +1276,8 @@ def _v2_loaded_skill(entry: dict, mapping_path: Path, entry_index: int) -> dict 
             tracking.get("path_commit") if isinstance(tracking, dict) else None
         ),
         "origin_index": origin_index,
-        "artifact_index": artifact_index,
+        "artifact_index": artifacts.index(repo_skill_owners[0]),
+        "mapping_fingerprint": _entry_origin_fingerprint(entry, origin_index),
     }
 
 
@@ -847,14 +1533,15 @@ def load_skills_with_upstream(*, allow_v1: bool = False) -> list[dict]:
     return mapped + results
 
 
-def check_upstream_changes(skill: dict, token: str | None) -> dict | None:
-    """Check if upstream has changes for a skill."""
+def _check_legacy_upstream_changes(skill: dict, token: str | None) -> dict | None:
+    """Legacy v1 single-file checker retained behind explicit ``--allow-v1``."""
     if skill.get("load_error"):
         return {
             "skill": skill,
             "changes": "unavailable",
             "reason": skill["load_error"],
         }
+    token = _github_token_for(token)
 
     repo = skill["repo"]
     skill_name = skill["name"]
@@ -970,6 +1657,446 @@ def check_upstream_changes(skill: dict, token: str | None) -> dict | None:
     }
 
 
+def _provider_for(token: str | None) -> GitHubArtifactProvider:
+    global _ACTIVE_ARTIFACT_PROVIDER
+    if _ACTIVE_ARTIFACT_PROVIDER is None:
+        _ACTIVE_ARTIFACT_PROVIDER = GitHubArtifactProvider(
+            _github_token_for(token)
+        )
+    return _ACTIVE_ARTIFACT_PROVIDER
+
+
+def _github_token_for(token: str | None) -> str | None:
+    if token is not None:
+        return token
+    global _ACTIVE_GITHUB_TOKEN
+    if _ACTIVE_GITHUB_TOKEN is _TOKEN_UNRESOLVED:
+        _ACTIVE_GITHUB_TOKEN = resolve_github_token()
+    return (
+        _ACTIVE_GITHUB_TOKEN
+        if isinstance(_ACTIVE_GITHUB_TOKEN, str)
+        else None
+    )
+
+
+def detected_license_spdx(
+    evidence: LicenseEvidence,
+) -> tuple[str | None, str | None]:
+    """Prefer explicit GitHub SPDX; otherwise require one canonical text match."""
+    if evidence.api_spdx not in {None, "NOASSERTION"}:
+        return evidence.api_spdx, None
+    candidates = evidence.spdx_candidates
+    if len(candidates) != 1:
+        return (
+            None,
+            "license review required: immutable license content produced "
+            f"{len(candidates)} canonical SPDX matches "
+            f"{list(candidates)!r}",
+        )
+    return candidates[0], None
+
+
+def license_checkpoint(evidence: LicenseEvidence) -> dict[str, str]:
+    """Serialize one uniquely classified immutable license observation."""
+    detected, error = detected_license_spdx(evidence)
+    if error is not None or detected is None:
+        raise RuntimeError(error or "license evidence has no SPDX result")
+    checkpoint = {
+        "path": evidence.path,
+        "blob_sha": evidence.blob_sha,
+        "content_sha256": evidence.content_sha256,
+        "spdx": detected,
+        "resolved_commit": evidence.resolved_commit,
+    }
+    if evidence.api_spdx is not None:
+        checkpoint["api_spdx"] = evidence.api_spdx
+    return checkpoint
+
+
+def validate_license_evidence(
+    declared_spdx: object,
+    evidence: LicenseEvidence,
+) -> tuple[dict[str, str] | None, str | None]:
+    """Validate commit-bound evidence against one declared SPDX identifier."""
+    detected, detection_error = detected_license_spdx(evidence)
+    if detection_error is not None or detected is None:
+        return None, detection_error or "license evidence has no SPDX result"
+    if detected not in PERMISSIVE_LICENSES:
+        return (
+            None,
+            f"license review required: detected SPDX {detected!r} is not permitted",
+        )
+    if declared_spdx != detected:
+        return (
+            None,
+            "license review required: detected SPDX "
+            f"{detected!r} does not match origin.license "
+            f"{declared_spdx!r}",
+        )
+    return license_checkpoint(evidence), None
+
+
+def _license_checkpoint(evidence: LicenseEvidence) -> dict[str, str]:
+    """Backward-compatible private alias for older callers and tests."""
+    return license_checkpoint(evidence)
+
+
+def _validate_license_evidence(
+    skill: dict,
+    evidence: LicenseEvidence,
+) -> tuple[dict[str, str] | None, str | None]:
+    """Validate current evidence and retain the sync drift policy."""
+    checkpoint, error = validate_license_evidence(
+        skill.get("license"),
+        evidence,
+    )
+    if error is not None or checkpoint is None:
+        return checkpoint, error
+    previous = (skill.get("tracking") or {}).get("license_checkpoint")
+    if isinstance(previous, dict):
+        immutable_fields = ("path", "blob_sha", "content_sha256", "spdx")
+        changed = [
+            field
+            for field in immutable_fields
+            if previous.get(field) != checkpoint.get(field)
+        ]
+        if changed:
+            return (
+                None,
+                "license review required: immutable license evidence changed: "
+                + ", ".join(changed),
+            )
+    return checkpoint, None
+
+
+def _artifact_local_bytes(skill: dict, target: str) -> bytes | None:
+    if not _safe_mapping_path(target):
+        return None
+    path = (REPO_ROOT / target).resolve()
+    try:
+        path.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return None
+    try:
+        return path.read_bytes()
+    except OSError:
+        return None
+
+
+def _main_artifact_equal(skill: dict, local: bytes, upstream: bytes) -> bool:
+    try:
+        local_text = local.decode("utf-8")
+        upstream_text = upstream.decode("utf-8")
+    except UnicodeDecodeError:
+        return local == upstream
+    upstream_text = apply_repository_adaptations(upstream_text, skill)
+    if comparable_body(local_text) != comparable_body(upstream_text):
+        return False
+    return _upstream_frontmatter_contract(
+        local_text
+    ) == _upstream_frontmatter_contract(upstream_text)
+
+
+def _artifact_diff(
+    skill: dict,
+    upstream_files: dict[str, bytes],
+) -> tuple[list[str], list[str], list[str]]:
+    desired = set(upstream_files)
+    previous_external_targets = _owned_targets_for_artifacts(
+        skill.get("artifacts", []),
+        skill.get("managed_files", []),
+    )
+    protected_targets = _owned_targets_for_artifacts(
+        skill.get("other_origin_artifacts", []),
+        skill.get("managed_files", []),
+    )
+    owned = previous_external_targets - protected_targets
+    # Ownership, not incidental disk equality, determines additions/removals.
+    # This ensures an unowned same-byte file still requires safe adoption and a
+    # missing formerly owned file is still reflected in the inventory delta.
+    added = sorted(desired - owned)
+    removed = sorted(owned - desired)
+    changed: list[str] = []
+    repo_skill = skill.get("repo_skill")
+    manifest_hashes = {
+        item.get("path"): item.get("sha256")
+        for item in skill.get("managed_files", [])
+        if isinstance(item, dict)
+    }
+    for path in sorted(desired & owned):
+        raw = _artifact_local_bytes(skill, path)
+        upstream = upstream_files[path]
+        expected = manifest_hashes.get(path)
+        content_changed = (
+            raw is None
+            or (
+                not _main_artifact_equal(skill, raw, upstream)
+                if path == repo_skill
+                else raw != upstream
+            )
+        )
+        manifest_drift = (
+            raw is not None
+            and isinstance(expected, str)
+            and hashlib.sha256(raw).hexdigest() != expected.lower()
+        )
+        if content_changed or manifest_drift:
+            changed.append(path)
+    return changed, added, removed
+
+
+def _owned_targets_for_artifacts(
+    artifacts: list[dict],
+    managed_files: list[dict],
+) -> set[str]:
+    """Expand prior artifact ownership only across manifest-owned files."""
+    managed_paths = {
+        item.get("path") if isinstance(item, dict) else item
+        for item in managed_files
+    }
+    managed_paths = {path for path in managed_paths if isinstance(path, str)}
+    owned: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        target = artifact.get("target")
+        if not isinstance(target, str):
+            continue
+        if artifact.get("type", "file") == "file":
+            if target in managed_paths:
+                owned.add(target)
+            continue
+        prefix = target.rstrip("/") + "/"
+        owned.update(path for path in managed_paths if path.startswith(prefix))
+    return owned
+
+
+def _local_source_bytes_for_missing(
+    skill: dict,
+    missing_sources: list[str],
+) -> dict[str, bytes]:
+    values: dict[str, bytes] = {}
+    for source in missing_sources:
+        for artifact in skill.get("artifacts", []):
+            if not isinstance(artifact, dict) or artifact.get("source") != source:
+                continue
+            target = artifact.get("target")
+            if artifact.get("type", "file") == "file" and isinstance(target, str):
+                raw = _artifact_local_bytes(skill, target)
+                if raw is not None:
+                    values[source] = raw
+    return values
+
+
+def _check_v2_upstream_changes(
+    skill: dict,
+    token: str | None,
+) -> dict:
+    tracking = skill.get("tracking")
+    if not isinstance(tracking, dict):
+        return {
+            "skill": skill,
+            "changes": "unavailable",
+            "reason": "v2 origin has no tracking object",
+        }
+    channel = tracking.get("channel")
+    monitor_only = (
+        channel in MONITOR_CHANNELS
+        or skill.get("sync_mode") == "monitor"
+    )
+    tracking_checkpoint = tracking.get("resolved_commit")
+    legacy_checkpoint = skill.get("last_synced_commit")
+    reviewed_checkpoint = (
+        tracking_checkpoint
+        if isinstance(tracking_checkpoint, str)
+        and COMMIT_RE.fullmatch(tracking_checkpoint)
+        else legacy_checkpoint
+        if isinstance(legacy_checkpoint, str)
+        and COMMIT_RE.fullmatch(legacy_checkpoint)
+        else None
+    )
+    if skill.get("sync_mode") == "manual":
+        return {
+            "skill": skill,
+            "changes": "expected_skipped",
+            "reason": "external origin is explicitly manual",
+        }
+    if monitor_only:
+        missing_checkpoint = []
+        if reviewed_checkpoint is None:
+            missing_checkpoint.append("resolved_commit")
+        path_checkpoint = tracking.get("path_commit")
+        if not (
+            isinstance(path_checkpoint, str)
+            and COMMIT_RE.fullmatch(path_checkpoint)
+        ):
+            missing_checkpoint.append("path_commit")
+        content_sha = tracking.get("content_sha256")
+        if not (
+            isinstance(content_sha, str)
+            and re.fullmatch(r"[0-9a-fA-F]{64}", content_sha)
+        ):
+            missing_checkpoint.append("content_sha256")
+        if missing_checkpoint:
+            return {
+                "skill": skill,
+                "changes": "unavailable",
+                "reason": (
+                    "monitor-only v2 source has no complete reviewed checkpoint: "
+                    + ", ".join(missing_checkpoint)
+                ),
+            }
+
+    provider = _provider_for(token)
+    try:
+        resolved = provider.resolve_tracking(skill["repo"], tracking)
+        license_evidence = provider.license_evidence(
+            skill["repo"], resolved.commit
+        )
+        license_checkpoint, license_error = _validate_license_evidence(
+            skill, license_evidence
+        )
+        if license_error is not None or license_checkpoint is None:
+            return {
+                "skill": skill,
+                "changes": "unavailable",
+                "reason": license_error or "license evidence is unavailable",
+                "resolved_ref": resolved.ref,
+                "current_commit": resolved.commit,
+            }
+        current_commit = resolved.commit.lower()
+        if license_checkpoint.get("resolved_commit") != current_commit:
+            return {
+                "skill": skill,
+                "changes": "unavailable",
+                "reason": (
+                    "license review required: immutable license evidence is "
+                    "not bound to the resolved upstream commit"
+                ),
+                "resolved_ref": resolved.ref,
+                "current_commit": current_commit,
+            }
+        checkpoint = reviewed_checkpoint
+        relation = None
+        checkpoint_matches_current = bool(
+            monitor_only
+            and checkpoint
+            and checkpoint.lower() == current_commit
+        )
+        if checkpoint and checkpoint.lower() != current_commit:
+            relation = provider.compare(
+                skill["repo"], checkpoint.lower(), current_commit
+            )
+            if relation["status"] == "behind":
+                path = skill.get("origin_path") or skill.get("upstream_path")
+                rollback_path_commit = provider.path_commit(
+                    skill["repo"], current_commit, str(path)
+                )
+                return {
+                    "skill": skill,
+                    "changes": "upstream_rollback",
+                    "resolved_ref": resolved.ref,
+                    "current_commit": current_commit,
+                    "path_commit": rollback_path_commit,
+                    "license_evidence": license_checkpoint,
+                    "ahead_by": relation["ahead_by"],
+                    "behind_by": relation["behind_by"],
+                }
+
+        inventory = provider.fetch_artifacts(
+            skill["repo"],
+            tracking,
+            skill["artifacts"],
+        )
+        path = skill.get("origin_path") or skill.get("upstream_path")
+        path_commit = provider.path_commit(
+            skill["repo"], inventory.resolved.commit, str(path)
+        )
+    except ArtifactNotFound as exc:
+        try:
+            resolved = provider.resolve_tracking(skill["repo"], tracking)
+            moved = provider.moved_candidates(
+                skill["repo"],
+                skill.get("last_synced_commit"),
+                resolved.commit,
+                exc.missing_sources,
+                local_files=_local_source_bytes_for_missing(
+                    skill, exc.missing_sources
+                ),
+            )
+        except GitHubProviderError:
+            moved = {}
+            resolved = None
+        return {
+            "skill": skill,
+            "changes": "unavailable",
+            "reason": str(exc),
+            "moved_candidates": moved,
+            "current_commit": resolved.commit if resolved else None,
+            "resolved_ref": resolved.ref if resolved else None,
+        }
+    except GitHubProviderError as exc:
+        return {
+            "skill": skill,
+            "changes": "unavailable",
+            "reason": str(exc),
+        }
+
+    changed, added, removed = _artifact_diff(skill, inventory.files)
+    artifact_changed = bool(changed or added or removed)
+    checkpoint_changed = bool(
+        reviewed_checkpoint
+        and reviewed_checkpoint.lower() != inventory.resolved.commit.lower()
+    )
+    common = {
+        "skill": skill,
+        "upstream_path": skill.get("upstream_path"),
+        "upstream_files": inventory.files,
+        "source_blobs": inventory.source_blobs,
+        "main_source_blob": inventory.source_blobs.get(
+            skill.get("upstream_path")
+        ),
+        "resolved_ref": inventory.resolved.ref,
+        "current_commit": inventory.resolved.commit,
+        "path_commit": path_commit,
+        "license_evidence": license_checkpoint,
+        "relation": relation["status"] if relation else "identical",
+        "changed_files": changed,
+        "added_files": added,
+        "removed_files": removed,
+    }
+    if checkpoint_matches_current:
+        # A monitor source is intentionally curated and need not byte-match the
+        # upstream artifact set at its already reviewed commit. We still fetch
+        # every declaration and refresh path_commit above so missing/moved
+        # sources or an invalid immutable checkpoint remain fail-closed.
+        return {**common, "changes": "none"}
+    if monitor_only and (artifact_changed or checkpoint_changed):
+        return {**common, "changes": "monitor_review"}
+    if artifact_changed:
+        return {**common, "changes": "artifact_changed"}
+    return {**common, "changes": "none"}
+
+
+def check_upstream_changes(skill: dict, token: str | None) -> dict | None:
+    """Check every authoritative artifact for a skill."""
+    if skill.get("load_error"):
+        return {
+            "skill": skill,
+            "changes": "unavailable",
+            "reason": skill["load_error"],
+        }
+    if skill.get("expected_skip_reason"):
+        return {
+            "skill": skill,
+            "changes": "expected_skipped",
+            "reason": skill["expected_skip_reason"],
+        }
+    if skill.get("schema_version") == 2:
+        return _check_v2_upstream_changes(skill, token)
+    return _check_legacy_upstream_changes(skill, token)
+
+
 def monitor_review_guidance(update: dict) -> list[str]:
     """Return human-review guidance for monitor-only upstream changes.
 
@@ -1007,8 +2134,15 @@ def monitor_review_guidance(update: dict) -> list[str]:
     return lines
 
 
+def _is_monitor_skill(skill: dict) -> bool:
+    return (
+        skill.get("sync_mode") == "monitor"
+        or (skill.get("tracking") or {}).get("channel") in MONITOR_CHANNELS
+    )
+
+
 def print_monitor_review_guidance(updates: list[dict]) -> None:
-    monitor_updates = [u for u in updates if u["skill"].get("sync_mode") == "monitor"]
+    monitor_updates = [u for u in updates if _is_monitor_skill(u["skill"])]
     if not monitor_updates:
         return
     print("\nMONITOR-ONLY REVIEW REQUIRED:", flush=True)
@@ -1052,6 +2186,7 @@ def print_monitor_rollbacks(results: list[dict]) -> None:
 def sync_github_auxiliary_files(skill: dict, upstream_path: str, token: str | None) -> int:
     """Sync non-SKILL.md files and directories beside the upstream SKILL.md."""
     repo = skill["repo"]
+    token = _github_token_for(token)
     upstream_dir = str(Path(upstream_path).parent)
     local_dir = skill["local_path"].parent
     ref = skill.get("ref", "main")
@@ -1091,30 +2226,1474 @@ def sync_github_auxiliary_files(skill: dict, upstream_path: str, token: str | No
     return sync_directory(api_url, Path())
 
 
-def atomic_write_json(path: Path, data: dict) -> None:
-    """Atomically replace a JSON mapping without exposing a partial write."""
+class MappingLockError(RuntimeError):
+    """A mapping is already being changed by another conforming process."""
+
+
+class AtomicMappingWriteError(RuntimeError):
+    """A mapping write failed before or after the atomic replace boundary."""
+
+    def __init__(self, message: str, *, replaced: bool, cause: BaseException):
+        self.replaced = replaced
+        self.cause = cause
+        phase = "after replace" if replaced else "before replace"
+        super().__init__(f"{message} ({phase}): {cause}")
+
+
+class AtomicMappingBatchError(RuntimeError):
+    """A multi-mapping record batch failed and reports rollback evidence."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        cause: BaseException,
+        rollback_succeeded: bool,
+        recovery_paths: list[Path] | None = None,
+    ) -> None:
+        self.cause = cause
+        self.rollback_succeeded = rollback_succeeded
+        self.recovery_paths = tuple(recovery_paths or ())
+        recovery = (
+            "; recovery=" + ", ".join(str(path) for path in self.recovery_paths)
+            if self.recovery_paths
+            else ""
+        )
+        super().__init__(
+            f"{message}; rollback_succeeded={rollback_succeeded}{recovery}: "
+            f"{cause}"
+        )
+
+
+class MappingSnapshot:
+    __slots__ = (
+        "content",
+        "sha256",
+        "device",
+        "inode",
+        "mode",
+        "parent_device",
+        "parent_inode",
+    )
+
+    def __init__(
+        self,
+        *,
+        content: bytes,
+        sha256: str,
+        device: int,
+        inode: int,
+        mode: int,
+        parent_device: int | None = None,
+        parent_inode: int | None = None,
+    ) -> None:
+        self.content = content
+        self.sha256 = sha256
+        self.device = device
+        self.inode = inode
+        self.mode = mode
+        self.parent_device = parent_device
+        self.parent_inode = parent_inode
+
+
+def serialize_mapping_json(data: dict) -> bytes:
+    return (
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    ).encode("utf-8")
+
+
+def _mapping_path_parts(path: Path) -> tuple[Path, tuple[str, ...]]:
+    """Return a lexical repository-relative mapping path without following it."""
+    root = Path(os.path.abspath(REPO_ROOT))
+    candidate = Path(os.path.abspath(path))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"provenance mapping escapes the repository root: {path}"
+        ) from exc
+    parts = relative.parts
+    if (
+        not parts
+        or any(part in {"", ".", ".."} for part in parts)
+        or candidate == root
+    ):
+        raise RuntimeError(f"invalid provenance mapping path: {path}")
+    return root, parts
+
+
+@contextmanager
+def _open_mapping_parent(path: Path):
+    """Pin every mapping ancestor with openat + O_NOFOLLOW."""
+    root, parts = _mapping_path_parts(Path(path))
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(root, flags)
+    try:
+        root_metadata = os.fstat(descriptor)
+        root_path_metadata = root.lstat()
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or stat.S_ISLNK(root_path_metadata.st_mode)
+            or root_metadata.st_dev != root_path_metadata.st_dev
+            or root_metadata.st_ino != root_path_metadata.st_ino
+        ):
+            raise RuntimeError(f"unsafe repository root for mapping: {root}")
+        for component in parts[:-1]:
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise RuntimeError(
+                    f"mapping ancestor is not a directory: {component}"
+                )
+        parent_metadata = os.fstat(descriptor)
+        yield (
+            descriptor,
+            parts[-1],
+            (parent_metadata.st_dev, parent_metadata.st_ino),
+        )
+    finally:
+        os.close(descriptor)
+
+
+def _validate_mapping_parent(
+    path: Path,
+    expected_identity: tuple[int, int],
+) -> None:
+    with _open_mapping_parent(path) as (_descriptor, _name, identity):
+        if identity != expected_identity:
+            raise RuntimeError(
+                f"mapping parent directory changed concurrently: {path.parent}"
+            )
+
+
+def capture_mapping_snapshot(path: Path) -> MappingSnapshot:
     path = Path(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    with _open_mapping_parent(path) as (
+        parent_descriptor,
+        name,
+        parent_identity,
+    ):
+        descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ValueError(f"mapping target is not a regular file: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            content = b"".join(chunks)
+            current = os.stat(
+                name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                stat.S_ISLNK(current.st_mode)
+                or not stat.S_ISREG(current.st_mode)
+                or current.st_dev != metadata.st_dev
+                or current.st_ino != metadata.st_ino
+            ):
+                raise RuntimeError(
+                    f"mapping inode changed while it was being read: {path}"
+                )
+            _validate_mapping_parent(path, parent_identity)
+            return MappingSnapshot(
+                content=content,
+                sha256=hashlib.sha256(content).hexdigest(),
+                device=metadata.st_dev,
+                inode=metadata.st_ino,
+                mode=metadata.st_mode & 0o777,
+                parent_device=parent_identity[0],
+                parent_inode=parent_identity[1],
+            )
+        finally:
+            os.close(descriptor)
+
+
+def _validate_mapping_snapshot(path: Path, expected: MappingSnapshot) -> None:
+    current = capture_mapping_snapshot(path)
+    if (
+        current.device != expected.device
+        or current.inode != expected.inode
+        or current.sha256 != expected.sha256
+        or current.content != expected.content
+        or (
+            expected.parent_device is not None
+            and current.parent_device != expected.parent_device
+        )
+        or (
+            expected.parent_inode is not None
+            and current.parent_inode != expected.parent_inode
+        )
+    ):
+        raise RuntimeError(
+            f"mapping changed before atomic replacement: {path}"
+        )
+
+
+def _mapping_target_exists(path: Path) -> bool:
+    try:
+        with _open_mapping_parent(Path(path)) as (descriptor, name, _identity):
+            os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _mapping_lock_path(path: Path) -> Path:
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    # Lock identity is lexical and repository-scoped; resolving here would
+    # follow an attacker-controlled mapping ancestor before nofollow checks.
+    digest = hashlib.sha256(
+        str(Path(os.path.abspath(path))).encode("utf-8")
+    ).hexdigest()
+    return (
+        Path(tempfile.gettempdir())
+        / f"high-value-skills-mapping-locks-{uid}"
+        / f"{digest}.lock"
+    )
+
+
+@contextmanager
+def mapping_advisory_lock(path: Path, *, timeout: float = 10.0):
+    """Hold a stable-inode POSIX lock for one provenance mapping."""
+    if fcntl is None:  # pragma: no cover - repository CI is POSIX
+        raise MappingLockError("mapping locks require POSIX flock")
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not math.isfinite(float(timeout))
+        or timeout < 0
+    ):
+        raise ValueError("mapping lock timeout must be finite and non-negative")
+    lock_path = _mapping_lock_path(Path(path))
+    lock_root = lock_path.parent
+    lock_root.mkdir(mode=0o700, exist_ok=True)
+    root_metadata = lock_root.lstat()
+    if (
+        stat.S_ISLNK(root_metadata.st_mode)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+        or (hasattr(os, "getuid") and root_metadata.st_uid != os.getuid())
+    ):
+        raise MappingLockError(f"unsafe mapping lock root: {lock_root}")
+    if root_metadata.st_mode & 0o077:
+        lock_root.chmod(0o700)
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags, 0o600)
+    acquired = False
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or (hasattr(os, "getuid") and metadata.st_uid != os.getuid())
+        ):
+            raise MappingLockError(f"unsafe mapping lock file: {lock_path}")
+        deadline = time.monotonic() + float(timeout)
+        while True:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError as exc:
+                if time.monotonic() >= deadline:
+                    raise MappingLockError(
+                        f"mapping transaction is already active: {lock_path}"
+                    ) from exc
+                time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+        os.ftruncate(descriptor, 0)
+        os.write(descriptor, f"pid={os.getpid()}\n".encode("ascii"))
+        os.fsync(descriptor)
+        yield
+    finally:
+        try:
+            if acquired:
+                os.ftruncate(descriptor, 0)
+                os.fsync(descriptor)
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+
+def atomic_write_json(
+    path: Path,
+    data: dict,
+    *,
+    fault_injector=None,
+    expected_snapshot: MappingSnapshot | None = None,
+) -> None:
+    """Hardened atomic mapping replacement with an explicit commit boundary."""
+    path = Path(path)
+    try:
+        if expected_snapshot is None and _mapping_target_exists(path):
+            expected_snapshot = capture_mapping_snapshot(path)
+    except BaseException as exc:
+        raise AtomicMappingWriteError(
+            f"cannot capture mapping authority: {path}",
+            replaced=False,
+            cause=exc,
+        ) from exc
+    temporary_path: Path | None = None
+    temporary_identity: tuple[int, int] | None = None
+    cleanup_directory_fd: int | None = None
+    replaced = False
+    payload = serialize_mapping_json(data)
+    try:
+        with _open_mapping_parent(path) as (
+            directory_fd,
+            target_name,
+            parent_identity,
+        ):
+            cleanup_directory_fd = os.dup(directory_fd)
+            if expected_snapshot is not None and (
+                expected_snapshot.parent_device is not None
+                and parent_identity
+                != (
+                    expected_snapshot.parent_device,
+                    expected_snapshot.parent_inode,
+                )
+            ):
+                raise RuntimeError(
+                    f"mapping parent directory changed concurrently: {path.parent}"
+                )
+            temporary_path = _stage_bytes_for_replace(
+                path,
+                payload,
+                mode=(
+                    expected_snapshot.mode
+                    if expected_snapshot is not None
+                    else 0o600
+                ),
+                directory_fd=directory_fd,
+                parent_identity=parent_identity,
+            )
+            temporary_name = temporary_path.name
+            temporary_metadata = _secure_temporary_metadata(
+                temporary_path,
+                directory_fd,
+            )
+            temporary_identity = (
+                temporary_metadata.st_dev,
+                temporary_metadata.st_ino,
+            )
+            installed_snapshot = MappingSnapshot(
+                content=payload,
+                sha256=hashlib.sha256(payload).hexdigest(),
+                device=temporary_metadata.st_dev,
+                inode=temporary_metadata.st_ino,
+                mode=(
+                    expected_snapshot.mode
+                    if expected_snapshot is not None
+                    else 0o600
+                ),
+                parent_device=parent_identity[0],
+                parent_inode=parent_identity[1],
+            )
+            if fault_injector is not None:
+                fault_injector("after_temp_fsync")
+            current_temporary = _secure_temporary_metadata(
+                temporary_path,
+                directory_fd,
+            )
+            if (
+                current_temporary.st_dev,
+                current_temporary.st_ino,
+            ) != temporary_identity:
+                raise RuntimeError(
+                    "mapping temporary inode changed before replace"
+                )
+            if expected_snapshot is not None:
+                _validate_mapping_snapshot(path, expected_snapshot)
+            elif _mapping_target_exists(path):
+                raise RuntimeError(
+                    f"mapping unexpectedly appeared before replacement: {path}"
+                )
+            _validate_mapping_parent(path, parent_identity)
+            os.replace(
+                temporary_name,
+                target_name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
+            replaced = True
+            temporary_path = None
+            if fault_injector is not None:
+                fault_injector("after_replace")
+            _validate_mapping_snapshot(path, installed_snapshot)
+            os.fsync(directory_fd)
+            _validate_mapping_snapshot(path, installed_snapshot)
+    except BaseException as exc:
+        if isinstance(exc, AtomicMappingWriteError):
+            raise
+        raise AtomicMappingWriteError(
+            f"failed to atomically replace mapping {path}",
+            replaced=replaced,
+            cause=exc,
+        ) from exc
+    finally:
+        if temporary_path is not None and cleanup_directory_fd is not None:
+            try:
+                current = _secure_temporary_metadata(
+                    temporary_path,
+                    cleanup_directory_fd,
+                )
+                if temporary_identity is not None and (
+                    current.st_dev,
+                    current.st_ino,
+                ) == temporary_identity:
+                    os.unlink(
+                        temporary_path.name,
+                        dir_fd=cleanup_directory_fd,
+                    )
+            except (FileNotFoundError, RuntimeError):
+                pass
+        if cleanup_directory_fd is not None:
+            os.close(cleanup_directory_fd)
+
+
+def _stage_bytes_for_replace(
+    path: Path,
+    payload: bytes,
+    *,
+    mode: int,
+    suffix: str = ".tmp",
+    directory_fd: int | None = None,
+    parent_identity: tuple[int, int] | None = None,
+) -> Path:
+    path = Path(path)
+    if directory_fd is None:
+        with _open_mapping_parent(path) as (
+            opened_descriptor,
+            _target_name,
+            opened_identity,
+        ):
+            return _stage_bytes_for_replace(
+                path,
+                payload,
+                mode=mode,
+                suffix=suffix,
+                directory_fd=opened_descriptor,
+                parent_identity=opened_identity,
+            )
+    if parent_identity is None:
+        metadata = os.fstat(directory_fd)
+        parent_identity = (metadata.st_dev, metadata.st_ino)
+    temporary_name = f".{path.name}.{os.urandom(16).hex()}{suffix}"
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    fd = os.open(temporary_name, flags, 0o600, dir_fd=directory_fd)
+    temporary = path.parent / temporary_name
+    descriptor_metadata = os.fstat(fd)
+    try:
+        if not stat.S_ISREG(descriptor_metadata.st_mode):
+            raise ValueError("mapping temporary inode is not regular")
+        with os.fdopen(fd, "wb") as stream:
+            fd = -1
+            stream.write(payload)
+            stream.flush()
+            os.fchmod(stream.fileno(), mode)
+            os.fsync(stream.fileno())
+        metadata = os.stat(
+            temporary_name,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_dev != descriptor_metadata.st_dev
+            or metadata.st_ino != descriptor_metadata.st_ino
+        ):
+            raise ValueError("mapping temporary inode changed before replace")
+        _validate_mapping_parent(path, parent_identity)
+        return temporary
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(temporary_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _secure_temporary_metadata(path: Path, directory_fd: int) -> os.stat_result:
+    metadata = os.stat(
+        path.name,
+        dir_fd=directory_fd,
+        follow_symlinks=False,
+    )
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"mapping temporary is unsafe: {path}")
+    return metadata
+
+
+def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:
+    """Preserve rollback bytes even when the canonical parent was detached."""
+    recovery_root = _mapping_lock_path(path).parent
+    recovery_root.mkdir(mode=0o700, exist_ok=True)
+    root_metadata = recovery_root.lstat()
+    if (
+        stat.S_ISLNK(root_metadata.st_mode)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+        or (hasattr(os, "getuid") and root_metadata.st_uid != os.getuid())
+    ):
+        raise RuntimeError(
+            f"unsafe private mapping recovery root: {recovery_root}"
+        )
+    if root_metadata.st_mode & 0o077:
+        recovery_root.chmod(0o700)
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    directory_fd = os.open(recovery_root, directory_flags)
+    name = (
+        f".{hashlib.sha256(str(path).encode('utf-8')).hexdigest()}."
+        f"{os.urandom(16).hex()}.recovery.json"
+    )
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory_fd,
+        )
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(payload)
+            stream.flush()
+            os.fchmod(stream.fileno(), 0o600)
+            os.fsync(stream.fileno())
+        metadata = os.stat(
+            name,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError("private mapping recovery inode is unsafe")
+        os.fsync(directory_fd)
+        current_root = recovery_root.lstat()
+        if (
+            current_root.st_dev != root_metadata.st_dev
+            or current_root.st_ino != root_metadata.st_ino
+            or stat.S_ISLNK(current_root.st_mode)
+            or not stat.S_ISDIR(current_root.st_mode)
+        ):
+            raise RuntimeError(
+                "private mapping recovery root changed concurrently"
+            )
+        recovery_path = recovery_root / name
+        current_file = recovery_path.lstat()
+        if (
+            current_file.st_dev != metadata.st_dev
+            or current_file.st_ino != metadata.st_ino
+            or stat.S_ISLNK(current_file.st_mode)
+            or not stat.S_ISREG(current_file.st_mode)
+        ):
+            raise RuntimeError(
+                "private mapping recovery file changed concurrently"
+            )
+        return recovery_path
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        os.close(directory_fd)
+
+
+def _atomic_write_json_batch_locked(
+    prepared: dict[Path, dict],
+    *,
+    fault_injector=None,
+    expected_snapshots: dict[Path, MappingSnapshot] | None = None,
+) -> None:
+    """Two-phase, rollback-safe replacement for an already-locked batch."""
+    if not prepared:
+        return
+    paths = sorted(Path(path) for path in prepared)
+    originals: dict[Path, bytes] = {}
+    modes: dict[Path, int] = {}
+    snapshots: dict[Path, MappingSnapshot] = {}
+    installed_snapshots: dict[Path, MappingSnapshot] = {}
+    staged: dict[Path, Path | None] = {}
+    directory_fds: dict[Path, int] = {}
+    target_names: dict[Path, str] = {}
+    parent_identities: dict[Path, tuple[int, int]] = {}
+    parent_stack = ExitStack()
+    replaced: list[Path] = []
+    try:
+        for path in paths:
+            expected = (
+                (expected_snapshots or {}).get(path)
+                or capture_mapping_snapshot(path)
+            )
+            snapshots[path] = expected
+            originals[path] = expected.content
+            modes[path] = expected.mode
+            descriptor, target_name, parent_identity = (
+                parent_stack.enter_context(_open_mapping_parent(path))
+            )
+            directory_fds[path] = descriptor
+            target_names[path] = target_name
+            parent_identities[path] = parent_identity
+            if expected.parent_device is not None and parent_identity != (
+                expected.parent_device,
+                expected.parent_inode,
+            ):
+                raise RuntimeError(
+                    f"mapping parent directory changed concurrently: {path.parent}"
+                )
+            payload = serialize_mapping_json(prepared[path])
+            staged[path] = _stage_bytes_for_replace(
+                path,
+                payload,
+                mode=modes[path],
+                directory_fd=descriptor,
+                parent_identity=parent_identity,
+            )
+            temporary_metadata = _secure_temporary_metadata(
+                staged[path],
+                descriptor,
+            )
+            installed_snapshots[path] = MappingSnapshot(
+                content=payload,
+                sha256=hashlib.sha256(payload).hexdigest(),
+                device=temporary_metadata.st_dev,
+                inode=temporary_metadata.st_ino,
+                mode=modes[path],
+                parent_device=parent_identity[0],
+                parent_inode=parent_identity[1],
+            )
+            if fault_injector is not None:
+                fault_injector("after_stage", path)
+
+        for path in paths:
+            _validate_mapping_snapshot(path, snapshots[path])
+        for path in paths:
+            temporary = staged[path]
+            if temporary is None:
+                raise RuntimeError(f"missing staged mapping: {path}")
+            _validate_mapping_snapshot(path, snapshots[path])
+            current_temporary = _secure_temporary_metadata(
+                temporary,
+                directory_fds[path],
+            )
+            if (
+                current_temporary.st_dev,
+                current_temporary.st_ino,
+            ) != (
+                installed_snapshots[path].device,
+                installed_snapshots[path].inode,
+            ):
+                raise RuntimeError(
+                    f"mapping temporary inode changed before replace: {temporary}"
+                )
+            _validate_mapping_parent(path, parent_identities[path])
+            os.replace(
+                temporary.name,
+                target_names[path],
+                src_dir_fd=directory_fds[path],
+                dst_dir_fd=directory_fds[path],
+            )
+            staged[path] = None
+            replaced.append(path)
+            if fault_injector is not None:
+                fault_injector("after_replace", path)
+            _validate_mapping_snapshot(path, installed_snapshots[path])
+        for path, descriptor in directory_fds.items():
+            if fault_injector is not None:
+                fault_injector("before_dir_fsync", path.parent)
+            os.fsync(descriptor)
+        for path in paths:
+            _validate_mapping_snapshot(path, installed_snapshots[path])
+    except BaseException as cause:
+        recovery_paths: list[Path] = []
+        recovery_recorded: set[Path] = set()
+        rollback_errors: list[BaseException] = []
+        rolled_back_snapshots: dict[Path, MappingSnapshot] = {}
+        for path in reversed(replaced):
+            rollback: Path | None = None
+            try:
+                _validate_mapping_snapshot(path, installed_snapshots[path])
+                rollback = _stage_bytes_for_replace(
+                    path,
+                    originals[path],
+                    mode=modes[path],
+                    suffix=".rollback.tmp",
+                    directory_fd=directory_fds[path],
+                    parent_identity=parent_identities[path],
+                )
+                rollback_metadata = _secure_temporary_metadata(
+                    rollback,
+                    directory_fds[path],
+                )
+                rollback_snapshot = MappingSnapshot(
+                    content=originals[path],
+                    sha256=hashlib.sha256(originals[path]).hexdigest(),
+                    device=rollback_metadata.st_dev,
+                    inode=rollback_metadata.st_ino,
+                    mode=modes[path],
+                    parent_device=parent_identities[path][0],
+                    parent_inode=parent_identities[path][1],
+                )
+                os.replace(
+                    rollback.name,
+                    target_names[path],
+                    src_dir_fd=directory_fds[path],
+                    dst_dir_fd=directory_fds[path],
+                )
+                _validate_mapping_snapshot(path, rollback_snapshot)
+                rolled_back_snapshots[path] = rollback_snapshot
+            except BaseException as rollback_error:
+                rollback_errors.append(rollback_error)
+                if rollback is not None:
+                    try:
+                        os.unlink(
+                            rollback.name,
+                            dir_fd=directory_fds[path],
+                        )
+                    except FileNotFoundError:
+                        pass
+                try:
+                    recovery = _stage_bytes_for_replace(
+                        path,
+                        originals[path],
+                        mode=0o600,
+                        suffix=".recovery.json",
+                        directory_fd=directory_fds[path],
+                        parent_identity=parent_identities[path],
+                    )
+                    recovery_paths.append(recovery)
+                    recovery_recorded.add(path)
+                except BaseException as recovery_error:
+                    rollback_errors.append(recovery_error)
+                    try:
+                        recovery_paths.append(
+                            _stage_private_mapping_recovery(
+                                path,
+                                originals[path],
+                            )
+                        )
+                        recovery_recorded.add(path)
+                    except BaseException as private_recovery_error:
+                        rollback_errors.append(private_recovery_error)
+        try:
+            for descriptor in directory_fds.values():
+                os.fsync(descriptor)
+            for path, rollback_snapshot in rolled_back_snapshots.items():
+                _validate_mapping_snapshot(path, rollback_snapshot)
+        except BaseException as rollback_fsync_error:
+            rollback_errors.append(rollback_fsync_error)
+        if rollback_errors:
+            for path in paths:
+                if path in recovery_recorded:
+                    continue
+                try:
+                    recovery_paths.append(
+                        _stage_bytes_for_replace(
+                            path,
+                            originals[path],
+                            mode=0o600,
+                            suffix=".recovery.json",
+                            directory_fd=directory_fds[path],
+                            parent_identity=parent_identities[path],
+                        )
+                    )
+                    recovery_recorded.add(path)
+                except BaseException as recovery_error:
+                    rollback_errors.append(recovery_error)
+                    try:
+                        recovery_paths.append(
+                            _stage_private_mapping_recovery(
+                                path,
+                                originals[path],
+                            )
+                        )
+                        recovery_recorded.add(path)
+                    except BaseException as private_recovery_error:
+                        rollback_errors.append(private_recovery_error)
+            detail = RuntimeError(
+                f"{cause}; rollback errors: "
+                + "; ".join(str(error) for error in rollback_errors)
+            )
+            raise AtomicMappingBatchError(
+                "mapping batch failed and rollback was incomplete",
+                cause=detail,
+                rollback_succeeded=False,
+                recovery_paths=recovery_paths,
+            ) from cause
+        raise AtomicMappingBatchError(
+            "mapping batch failed",
+            cause=cause,
+            rollback_succeeded=True,
+        ) from cause
+    finally:
+        for path, temporary in staged.items():
+            if temporary is not None:
+                try:
+                    current = _secure_temporary_metadata(
+                        temporary,
+                        directory_fds[path],
+                    )
+                    expected = installed_snapshots.get(path)
+                    if expected is not None and (
+                        current.st_dev,
+                        current.st_ino,
+                    ) == (expected.device, expected.inode):
+                        os.unlink(
+                            temporary.name,
+                            dir_fd=directory_fds[path],
+                        )
+                except (FileNotFoundError, RuntimeError):
+                    pass
+        parent_stack.close()
+
+
+def atomic_write_json_batch(
+    prepared: dict[Path, dict],
+    *,
+    fault_injector=None,
+    expected_snapshots: dict[Path, MappingSnapshot] | None = None,
+    durable_guard: DurableBatchGuard | None = None,
+) -> None:
+    """Crash-durable wrapper around the hardened mapping batch writer."""
+    if not prepared:
+        return
+    if durable_guard is None:
+        with durable_batch_lock_and_recover(REPO_ROOT) as guard:
+            atomic_write_json_batch(
+                prepared,
+                fault_injector=fault_injector,
+                expected_snapshots=expected_snapshots,
+                durable_guard=guard,
+            )
+        return
+
+    paths = sorted(Path(path) for path in prepared)
+    replacement_bytes = {
+        path: serialize_mapping_json(prepared[path]) for path in paths
+    }
+    after_modes: dict[Path, int | None] = {}
+    for path in paths:
+        snapshot = (expected_snapshots or {}).get(path)
+        if snapshot is None:
+            snapshot = capture_mapping_snapshot(path)
+        after_modes[path] = snapshot.mode
+
+    durable_guard.commit_batch(
+        replacement_bytes,
+        lambda: _atomic_write_json_batch_locked(
+            prepared,
+            fault_injector=fault_injector,
+            expected_snapshots=expected_snapshots,
+        ),
+        after_modes=after_modes,
+    )
+
+
+def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
+    """Run full provenance and unique-claim gates without replacing mappings."""
+    staged: dict[Path, Path] = {}
+    directory_fds: dict[Path, int] = {}
+    parent_identities: dict[Path, tuple[int, int]] = {}
+    temporary_identities: dict[Path, tuple[int, int]] = {}
+    parent_stack = ExitStack()
+    try:
+        for path, data in prepared.items():
+            descriptor, _target_name, parent_identity = (
+                parent_stack.enter_context(_open_mapping_parent(path))
+            )
+            directory_fds[path] = descriptor
+            parent_identities[path] = parent_identity
+            payload = serialize_mapping_json(data)
+            staged[path] = _stage_bytes_for_replace(
+                path,
+                payload,
+                mode=0o600,
+                suffix=".validation.skills.json",
+                directory_fd=descriptor,
+                parent_identity=parent_identity,
+            )
+            temporary_metadata = _secure_temporary_metadata(
+                staged[path],
+                descriptor,
+            )
+            temporary_identities[path] = (
+                temporary_metadata.st_dev,
+                temporary_metadata.st_ino,
+            )
+        errors: list[str] = []
+        for path in sorted(staged.values()):
+            errors.extend(
+                validate_provenance_mapping(path, REPO_ROOT, allow_v1=False)
+            )
+        staged_paths = set(staged.values())
+        original_paths = set(staged)
+        repository_paths = [
+            path
+            for pattern in ("*.skills.json", "*.bundle.json")
+            for path in SOURCE_MAPPINGS_DIR.glob(pattern)
+            if path not in original_paths and path not in staged_paths
+        ]
+        repository_paths.extend(staged.values())
+        errors.extend(
+            validate_repository_mappings(
+                sorted(repository_paths),
+                REPO_ROOT,
+            )
+        )
+        if errors:
+            raise RuntimeError(
+                "candidate mapping failed full provenance validation: "
+                + " | ".join(errors[:20])
+            )
+    finally:
+        cleanup_errors: list[BaseException] = []
+        for mapping_path, temporary in staged.items():
+            try:
+                _validate_mapping_parent(
+                    mapping_path,
+                    parent_identities[mapping_path],
+                )
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            try:
+                metadata = _secure_temporary_metadata(
+                    temporary,
+                    directory_fds[mapping_path],
+                )
+                if (metadata.st_dev, metadata.st_ino) != temporary_identities[
+                    mapping_path
+                ]:
+                    raise RuntimeError(
+                        f"validation mapping inode changed: {temporary}"
+                    )
+                os.unlink(
+                    temporary.name,
+                    dir_fd=directory_fds[mapping_path],
+                )
+            except FileNotFoundError:
+                cleanup_errors.append(
+                    RuntimeError(
+                        f"validation mapping disappeared: {temporary}"
+                    )
+                )
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        parent_stack.close()
+        if cleanup_errors and sys.exc_info()[0] is None:
+            raise RuntimeError(
+                "candidate mapping cleanup failed safely: "
+                + "; ".join(str(error) for error in cleanup_errors)
+            )
+
+
+def _v2_entry_and_origin(
+    data: dict,
+    skill: dict,
+    *,
+    for_apply: bool = False,
+) -> tuple[dict, dict]:
+    entry_index = skill.get("mapping_entry_index")
+    origin_index = skill.get("origin_index")
+    if type(entry_index) is not int or type(origin_index) is not int:
+        raise RuntimeError("v2 mapping coordinates are missing")
+    try:
+        entry = data["skills"][entry_index]
+        origin = entry["origins"][origin_index]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RuntimeError("v2 mapping coordinates are stale") from exc
+    if not isinstance(entry, dict) or not isinstance(origin, dict):
+        raise RuntimeError("v2 mapping entry/origin is malformed")
+    structural_errors = _v2_sync_entry_errors(entry)
+    if structural_errors:
+        raise RuntimeError(
+            "v2 mapping authority is no longer valid: "
+            + "; ".join(structural_errors)
+        )
+    if entry.get("status") != "verified_in_repo":
+        raise RuntimeError("v2 mapping entry is no longer active")
+    if entry.get("kind") not in {"mirror", "overlay"}:
+        raise RuntimeError(
+            f"v2 mapping kind is not synchronizable: {entry.get('kind')!r}"
+        )
+    active_external_indexes = [
+        index
+        for index, candidate in enumerate(entry.get("origins", []))
+        if isinstance(candidate, dict)
+        and isinstance(candidate.get("repo"), str)
+        and not candidate["repo"].startswith("local-repo/")
+        and candidate.get("sync_mode") not in {"archived", "local-only"}
+    ]
+    if active_external_indexes != [origin_index]:
+        raise RuntimeError(
+            "selected origin is no longer the unique active external origin"
+        )
+    if origin.get("repo") != skill.get("repo"):
+        raise RuntimeError("v2 mapping origin changed during synchronization")
+    expected_fingerprint = skill.get("mapping_fingerprint")
+    if not isinstance(expected_fingerprint, str) or not SHA256_RE.fullmatch(
+        expected_fingerprint
+    ):
+        raise RuntimeError("v2 checked mapping fingerprint is missing or invalid")
+    if _entry_origin_fingerprint(entry, origin_index) != expected_fingerprint:
+        raise RuntimeError(
+            "v2 mapping entry/origin changed after upstream check"
+        )
+    if for_apply:
+        tracking = origin.get("tracking")
+        channel = tracking.get("channel") if isinstance(tracking, dict) else None
+        if (
+            entry.get("sync_mode") != "replace"
+            or origin.get("sync_mode") != "replace"
+            or channel not in AUTO_CHANNELS
+        ):
+            raise RuntimeError(
+                "v2 mapping no longer permits automatic stable apply"
+            )
+    return entry, origin
+
+
+def _record_v2_result(
+    data: dict,
+    result: dict,
+    *,
+    synced: bool,
+    entry_origin: tuple[dict, dict] | None = None,
+) -> None:
+    skill = result["skill"]
+    entry, origin = (
+        entry_origin
+        if entry_origin is not None
+        else _v2_entry_and_origin(data, skill)
+    )
+    tracking = origin.get("tracking")
+    if not isinstance(tracking, dict):
+        raise RuntimeError("v2 origin tracking object is missing")
+    commit = result.get("current_commit")
+    if not isinstance(commit, str) or not COMMIT_RE.fullmatch(commit):
+        raise RuntimeError("successful v2 result has no full resolved commit")
+    path_commit = result.get("path_commit")
+    if not isinstance(path_commit, str) or not COMMIT_RE.fullmatch(path_commit):
+        raise RuntimeError("successful v2 result has an invalid path commit")
+    license_evidence = result.get("license_evidence")
+    if not isinstance(license_evidence, dict):
+        raise RuntimeError("successful v2 result has no license evidence")
+    required_license_keys = {
+        "path",
+        "blob_sha",
+        "content_sha256",
+        "spdx",
+        "resolved_commit",
+    }
+    if (
+        not required_license_keys.issubset(license_evidence)
+        or not _safe_mapping_path(license_evidence.get("path"))
+        or not isinstance(license_evidence.get("blob_sha"), str)
+        or not COMMIT_RE.fullmatch(str(license_evidence.get("blob_sha")))
+        or not isinstance(license_evidence.get("content_sha256"), str)
+        or not SHA256_RE.fullmatch(
+            str(license_evidence.get("content_sha256"))
+        )
+        or license_evidence.get("spdx") != origin.get("license")
+        or license_evidence.get("resolved_commit") != commit.lower()
+        or license_evidence.get("api_spdx")
+        not in {None, "NOASSERTION", origin.get("license")}
+    ):
+        raise RuntimeError("successful v2 result has invalid license evidence")
+
+    today = date.today().isoformat()
+    tracking["last_checked_at"] = today
+    if result.get("changes") != "upstream_rollback":
+        tracking["license_checkpoint"] = copy.deepcopy(license_evidence)
+    if synced or result.get("changes") == "none":
+        resolved_ref = result.get("resolved_ref")
+        channel = tracking.get("channel")
+        if isinstance(resolved_ref, str) and resolved_ref:
+            if channel == "latest_release":
+                tracking["ref"] = resolved_ref
+            elif channel == "fixed_ref" and resolved_ref != tracking.get("ref"):
+                raise RuntimeError(
+                    "fixed_ref observation attempted to rewrite immutable ref"
+                )
+            elif channel not in {"default_branch", "canary", "fixed_ref"}:
+                raise RuntimeError(f"unsupported tracking channel: {channel!r}")
+        tracking["resolved_commit"] = commit.lower()
+        if path_commit is not None:
+            tracking["path_commit"] = path_commit.lower()
+        tracking["last_synced_at"] = today
+
+    legacy = entry.setdefault("upstream", {})
+    if isinstance(legacy, dict):
+        legacy["repo"] = origin.get("repo")
+        legacy["last_checked_at"] = today
+        if synced or result.get("changes") == "none":
+            legacy["ref"] = tracking["ref"]
+            if path_commit is not None:
+                legacy["path_commit"] = path_commit.lower()
+            legacy["last_synced_at"] = today
+            legacy["last_synced_commit"] = commit.lower()
+    data.setdefault("video", {})["checked_at"] = today
+
+
+def record_v2_checks(results: list[dict]) -> None:
+    """Atomically persist observations only after every check succeeded."""
+    grouped: dict[Path, list[dict]] = {}
+    skill_roots: set[str] = set()
+    for result in results:
+        skill = result["skill"]
+        if skill.get("schema_version") != 2:
+            continue
+        if result.get("changes") in {"unavailable", "expected_skipped"}:
+            continue
+        mapping_path = skill.get("mapping_path")
+        if mapping_path is None:
+            raise RuntimeError("v2 result has no mapping path")
+        grouped.setdefault(Path(mapping_path), []).append(result)
+        repo_skill = skill.get("repo_skill")
+        if not _safe_mapping_path(repo_skill):
+            raise RuntimeError("v2 result has an invalid canonical skill path")
+        skill_root = PurePosixPath(str(repo_skill)).parent.as_posix()
+        if not skill_root.startswith("skills/"):
+            raise RuntimeError("v2 result canonical skill escapes skills/")
+        skill_roots.add(skill_root)
+
+    if not grouped:
+        return
+
+    # Cross-tool order is durable global, mappings, then canonical skills.
+    # The outer guard resolves any hard-exit batch before authority is reread.
+    with durable_batch_lock_and_recover(REPO_ROOT) as durable_guard:
+        with ExitStack() as locks:
+            for path in sorted(grouped):
+                locks.enter_context(mapping_advisory_lock(path))
+            engine = _load_artifact_engine()
+            for skill_root in sorted(skill_roots):
+                locks.enter_context(
+                    engine.skill_advisory_lock(
+                        REPO_ROOT,
+                        skill_root,
+                        timeout=0.0,
+                    )
+                )
+            prepared: dict[Path, dict] = {}
+            snapshots: dict[Path, MappingSnapshot] = {}
+            for path in sorted(grouped):
+                path_results = grouped[path]
+                # Re-read only after both batch and skill-tree crash recovery.
+                snapshot = capture_mapping_snapshot(path)
+                snapshots[path] = snapshot
+                data = json.loads(snapshot.content.decode("utf-8"))
+                for result in path_results:
+                    _record_v2_result(data, result, synced=False)
+                prepared[path] = data
+
+            _validate_candidate_mappings(prepared)
+            atomic_write_json_batch(
+                prepared,
+                expected_snapshots=snapshots,
+                durable_guard=durable_guard,
+            )
+
+
+def _artifact_payloads_for_engine(update: dict) -> list[dict]:
+    skill = update["skill"]
+    upstream_files = update.get("upstream_files")
+    source_blobs = update.get("source_blobs")
+    if not isinstance(upstream_files, dict) or not isinstance(source_blobs, dict):
+        raise RuntimeError("v2 update has no materialized artifact inventory")
+    payloads: list[dict] = []
+    repo_skill = skill.get("repo_skill")
+    for artifact in skill.get("artifacts", []):
+        source = artifact["source"]
+        target = artifact["target"]
+        if artifact.get("type", "file") == "file":
+            targets = [(source, target)]
+        else:
+            prefix = source.rstrip("/") + "/"
+            targets = [
+                (
+                    source_path,
+                    target.rstrip("/") + "/" + source_path[len(prefix) :],
+                )
+                for source_path in sorted(source_blobs)
+                if source_path.startswith(prefix)
+            ]
+        for expanded_source, expanded_target in targets:
+            raw = upstream_files[expanded_target]
+            if expanded_target == repo_skill:
+                try:
+                    upstream_text = raw.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise RuntimeError("canonical SKILL.md upstream is not UTF-8") from exc
+                upstream_text = apply_repository_adaptations(upstream_text, skill)
+                raw = merge_frontmatter(
+                    skill["local_path"].read_text(
+                        encoding="utf-8", errors="strict"
+                    ),
+                    upstream_text,
+                ).encode("utf-8")
+            payloads.append(
+                {
+                    "source": expanded_source,
+                    "target": expanded_target,
+                    "type": "file",
+                    "data": raw,
+                }
+            )
+    return payloads
+
+
+def _other_origin_target_conflicts(
+    entry: dict,
+    *,
+    selected_origin_index: int,
+    desired_targets: set[str],
+) -> list[str]:
+    conflicts: set[str] = set()
+    for index, origin in enumerate(entry.get("origins", [])):
+        if index == selected_origin_index or not isinstance(origin, dict):
+            continue
+        artifacts = origin.get("artifacts")
+        if not isinstance(artifacts, list):
+            continue
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            conflicts.update(
+                target
+                for target in desired_targets
+                if _artifact_owns_target(artifact, target)
+            )
+    return sorted(conflicts)
+
+
+def _load_artifact_engine():
+    try:
+        import artifact_set_sync as engine
+    except ModuleNotFoundError:
+        from scripts import artifact_set_sync as engine
+    return engine
+
+
+def apply_v2_update(
+    update: dict,
+    *,
+    dry_run: bool = False,
+    _durable_guard: DurableBatchGuard | None = None,
+):
+    """Apply one v2 artifact set transaction, then atomically advance mapping."""
+    if _durable_guard is None and not dry_run:
+        with durable_batch_lock_and_recover(REPO_ROOT) as durable_guard:
+            return apply_v2_update(
+                update,
+                dry_run=dry_run,
+                _durable_guard=durable_guard,
+            )
+    skill = update["skill"]
+    channel = (skill.get("tracking") or {}).get("channel")
+    if channel not in AUTO_CHANNELS or skill.get("sync_mode") != "replace":
+        raise RuntimeError(
+            f"automatic apply is forbidden for channel={channel!r} "
+            f"sync_mode={skill.get('sync_mode')!r}"
+        )
+    mapping_path = Path(skill["mapping_path"])
+    with mapping_advisory_lock(mapping_path):
+        mapping_snapshot = capture_mapping_snapshot(mapping_path)
+        mapping_before = mapping_snapshot.content
+        mapping_data = json.loads(mapping_before.decode("utf-8"))
+        entry, origin = _v2_entry_and_origin(
+            mapping_data, skill, for_apply=True
+        )
+        current_other_artifacts: list[dict] = []
+        for index, origin in enumerate(entry.get("origins", [])):
+            if index == skill["origin_index"] or not isinstance(origin, dict):
+                continue
+            artifacts = origin.get("artifacts")
+            if isinstance(artifacts, list):
+                current_other_artifacts.extend(
+                    item for item in artifacts if isinstance(item, dict)
+                )
+        engine = _load_artifact_engine()
+        payloads = _artifact_payloads_for_engine(update)
+        scope_conflicts = _other_origin_target_conflicts(
+            entry,
+            selected_origin_index=skill["origin_index"],
+            desired_targets={payload["target"] for payload in payloads},
+        )
+        if scope_conflicts:
+            raise RuntimeError(
+                "desired upstream targets collide with another origin scope: "
+                + ", ".join(scope_conflicts)
+            )
+        checkpoint = {
+            "resolved_commit": update["current_commit"],
+            "path_commit": update["path_commit"],
+            "resolved_ref": update.get("resolved_ref"),
+        }
+        plan = engine.plan_artifact_set_sync(
+            REPO_ROOT,
+            entry,
+            payloads,
+            checkpoint,
+            origin_index=skill["origin_index"],
+            protected_targets=_owned_targets_for_artifacts(
+                current_other_artifacts,
+                entry.get("managed_files", []),
+            ),
+        )
+        if dry_run:
+            return engine.apply_artifact_set_sync(plan, dry_run=True)
+
+        with engine.prepare_artifact_set_sync(plan) as transaction:
+            sync_result = transaction.result
+            # Keep the reviewed source→target declarations (including
+            # directory mappings). Expansion updates managed_files only.
+            entry["managed_files"] = [
+                dict(item) for item in sync_result.managed_files
+            ]
+            tracking = origin["tracking"]
+            tracking["content_sha256"] = sync_result.content_sha256
+            result_with_checkpoint = {
+                **update,
+                "current_commit": sync_result.checkpoint.get(
+                    "resolved_commit", update["current_commit"]
+                ),
+                "path_commit": sync_result.checkpoint.get(
+                    "path_commit", update["path_commit"]
+                ),
+                "resolved_ref": sync_result.checkpoint.get(
+                    "resolved_ref", update.get("resolved_ref")
+                ),
+            }
+            _record_v2_result(
+                mapping_data,
+                result_with_checkpoint,
+                synced=True,
+                entry_origin=(entry, origin),
+            )
+            _validate_candidate_mappings({mapping_path: mapping_data})
+            _validate_mapping_snapshot(mapping_path, mapping_snapshot)
+            mapping_after = serialize_mapping_json(mapping_data)
+            mapping_after_sha256 = hashlib.sha256(mapping_after).hexdigest()
+            if mapping_after_sha256 == mapping_snapshot.sha256:
+                raise RuntimeError(
+                    "artifact apply produced no mapping authority transition"
+                )
+            try:
+                mapping_authority_path = (
+                    mapping_path.resolve()
+                    .relative_to(REPO_ROOT.resolve())
+                    .as_posix()
+                )
+            except ValueError as exc:
+                raise RuntimeError(
+                    "provenance mapping escapes the repository root"
+                ) from exc
+            transaction.bind_authority(
+                mapping_authority_path,
+                mapping_snapshot.sha256,
+                mapping_after_sha256,
+            )
+            try:
+                atomic_write_json(
+                    mapping_path,
+                    mapping_data,
+                    expected_snapshot=mapping_snapshot,
+                )
+            except AtomicMappingWriteError as write_error:
+                if write_error.replaced:
+                    # A post-replace durability error commits the live tree
+                    # only when the canonical mapping still carries the exact
+                    # after-authority digest. A detached-parent replace must
+                    # roll the tree back.
+                    try:
+                        installed = capture_mapping_snapshot(mapping_path)
+                    except BaseException:
+                        installed = None
+                    if (
+                        installed is not None
+                        and installed.sha256 == mapping_after_sha256
+                    ):
+                        transaction.commit()
+                raise
+            transaction.commit()
+            return sync_result
+
+
+def _report_safe_result(result: dict) -> dict:
+    skill = result.get("skill", {})
+    safe = {
+        "name": skill.get("name"),
+        "source": skill.get("source"),
+        "repository": skill.get("repo"),
+        "status": result.get("changes"),
+    }
+    for key in (
+        "reason",
+        "resolved_ref",
+        "current_commit",
+        "path_commit",
+        "relation",
+        "ahead_by",
+        "behind_by",
+        "changed_files",
+        "added_files",
+        "removed_files",
+        "moved_candidates",
+        "main_source_blob",
+        "license_evidence",
+    ):
+        if key in result:
+            safe[key] = result[key]
+    return safe
+
+
+def write_report_json(path_value: str, report: dict) -> None:
+    text = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    path = Path(path_value)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
     )
-    temporary_path = Path(temporary_name)
+    temporary = Path(temporary_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            json.dump(data, stream, ensure_ascii=False, indent=2)
-            stream.write("\n")
+            stream.write(text)
             stream.flush()
             os.fsync(stream.fileno())
-        if path.exists():
-            os.chmod(temporary_path, path.stat().st_mode & 0o777)
-        os.replace(temporary_path, path)
+        os.replace(temporary, path)
     finally:
-        temporary_path.unlink(missing_ok=True)
+        temporary.unlink(missing_ok=True)
 
 
-def update_mapping_after_sync(update: dict) -> None:
+def _update_mapping_after_sync_locked(update: dict) -> None:
     """Update provenance timestamps for a successfully synced mapped skill."""
     skill = update["skill"]
     if skill.get("schema_version") == 2:
@@ -1139,7 +3718,7 @@ def update_mapping_after_sync(update: dict) -> None:
     atomic_write_json(Path(mapping_path), data)
 
 
-def update_mapping_after_check(result: dict) -> None:
+def _update_mapping_after_check_locked(result: dict) -> None:
     """Record a successful upstream comparison without claiming an unapplied sync."""
     skill = result["skill"]
     if skill.get("schema_version") == 2:
@@ -1168,6 +3747,98 @@ def update_mapping_after_check(result: dict) -> None:
     atomic_write_json(path, data)
 
 
+def update_mapping_after_sync(update: dict) -> None:
+    """Serialize legacy mapping writes behind the cross-tool recovery lock."""
+    mapping_path = update.get("skill", {}).get("mapping_path")
+    if mapping_path is None:
+        return _update_mapping_after_sync_locked(update)
+    path = Path(mapping_path)
+    with durable_batch_lock_and_recover(REPO_ROOT):
+        with mapping_advisory_lock(path):
+            _update_mapping_after_sync_locked(update)
+
+
+def update_mapping_after_check(result: dict) -> None:
+    """Serialize legacy check recording behind cross-tool recovery."""
+    mapping_path = result.get("skill", {}).get("mapping_path")
+    if mapping_path is None:
+        return _update_mapping_after_check_locked(result)
+    path = Path(mapping_path)
+    with durable_batch_lock_and_recover(REPO_ROOT):
+        with mapping_advisory_lock(path):
+            _update_mapping_after_check_locked(result)
+
+
+def _legacy_canonical_skill_root(local_path: Path) -> str | None:
+    """Return the artifact-engine lock identity for a canonical legacy skill."""
+    root = Path(os.path.abspath(REPO_ROOT))
+    candidate = Path(os.path.abspath(local_path))
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError:
+        return None
+    if (
+        len(relative.parts) < 4
+        or relative.parts[0] != "skills"
+        or relative.name.lower() != "skill.md"
+    ):
+        return None
+    return relative.parent.as_posix()
+
+
+def apply_legacy_update(update: dict, token: str | None) -> int:
+    """Apply an explicitly allowed v1 update under the global lock order.
+
+    Provenance v1 remains a compatibility path, but it must not bypass recovery
+    of a pending durable v2/ingest/reconcile batch.  The fixed order is global
+    durable guard, mapping lock, then canonical skill lock.
+    """
+    skill = update["skill"]
+    mapping_value = skill.get("mapping_path")
+    mapping_path = Path(mapping_value) if mapping_value is not None else None
+    skill_root = _legacy_canonical_skill_root(Path(skill["local_path"]))
+
+    with durable_batch_lock_and_recover(REPO_ROOT):
+        with ExitStack() as locks:
+            if mapping_path is not None:
+                locks.enter_context(mapping_advisory_lock(mapping_path))
+            if skill_root is not None:
+                engine = _load_artifact_engine()
+                locks.enter_context(
+                    engine.skill_advisory_lock(
+                        REPO_ROOT,
+                        skill_root,
+                        timeout=10.0,
+                    )
+                )
+
+            current_local = Path(skill["local_path"]).read_text(
+                encoding="utf-8",
+                errors="strict",
+            )
+            if current_local != skill["local_content"]:
+                raise RuntimeError(
+                    "legacy canonical skill changed after upstream check"
+                )
+            merged = apply_repository_adaptations(
+                merge_frontmatter(
+                    current_local,
+                    update["upstream_content"],
+                ),
+                skill,
+            )
+            Path(skill["local_path"]).write_text(merged, encoding="utf-8")
+            auxiliary_count = 0
+            if skill["source"].startswith("github:"):
+                auxiliary_count = sync_github_auxiliary_files(
+                    skill,
+                    update["upstream_path"],
+                    token,
+                )
+            _update_mapping_after_sync_locked(update)
+            return auxiliary_count
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Check and synchronize upstream changes for tracked skills."
@@ -1190,13 +3861,23 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--source", help="Filter to a specific source (e.g. 'github:obra/superpowers')")
+    parser.add_argument(
+        "--report-json",
+        metavar="PATH",
+        help="Write a machine-readable report atomically",
+    )
     parser.add_argument("--exclude-source", action="append", default=[],
                         help="Exclude a source/repo (can be passed multiple times; accepts github:owner/repo or owner/repo)")
     args = parser.parse_args(argv)
     if args.record_check and not args.check_only:
         parser.error("--record-check requires --check-only")
+    if args.report_json == "-":
+        parser.error("--report-json requires a file path, not stdout")
 
-    token = resolve_github_token()
+    global _ACTIVE_ARTIFACT_PROVIDER, _ACTIVE_GITHUB_TOKEN
+    _ACTIVE_ARTIFACT_PROVIDER = None
+    _ACTIVE_GITHUB_TOKEN = _TOKEN_UNRESOLVED
+    token = None
     skills = load_skills_with_upstream(allow_v1=args.allow_v1)
 
     if not args.allow_v1:
@@ -1240,7 +3921,10 @@ def main(argv: list[str] | None = None) -> int:
             if args.allow_v1
             else ""
         )
-        + "; archived/local-only mappings are excluded.",
+        + (
+            "; licensed snapshot/local-only/archived entries are counted as "
+            "expected_skipped, and bundles are checked by their bundle tooling."
+        ),
         flush=True,
     )
     
@@ -1274,6 +3958,7 @@ def main(argv: list[str] | None = None) -> int:
         elif result.get("changes") not in {
             "none",
             "body_changed",
+            "artifact_changed",
             "monitor_review",
             "upstream_rollback",
             "expected_skipped",
@@ -1288,8 +3973,12 @@ def main(argv: list[str] | None = None) -> int:
                 ),
             }
         checked_results.append(result)
-        if result.get("changes") in {"body_changed", "monitor_review"}:
-            print(f"    → Update available!", flush=True)
+        if result.get("changes") in {
+            "body_changed",
+            "artifact_changed",
+            "monitor_review",
+        }:
+            print("    → Update available!", flush=True)
         elif result.get("changes") == "unavailable":
             print(f"    → Unavailable: {result.get('reason', 'unknown error')}", flush=True)
 
@@ -1307,8 +3996,8 @@ def main(argv: list[str] | None = None) -> int:
             counts["equal"] += 1
         elif changes == "monitor_review":
             counts["monitor_review"] += 1
-        elif changes == "body_changed":
-            if result["skill"].get("sync_mode") == "monitor":
+        elif changes in {"body_changed", "artifact_changed"}:
+            if _is_monitor_skill(result["skill"]):
                 counts["monitor_review"] += 1
             else:
                 counts["changed"] += 1
@@ -1354,6 +4043,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"  - {skill['name']}: {result.get('reason', 'unknown error')}",
                 flush=True,
             )
+            moved = result.get("moved_candidates") or {}
+            for source_path, candidates in sorted(moved.items()):
+                print(
+                    f"    exact-blob move candidate for {source_path}: "
+                    + ", ".join(candidates),
+                    flush=True,
+                )
     empty_input = total == 0
     if empty_input:
         if args.source:
@@ -1372,15 +4068,15 @@ def main(argv: list[str] | None = None) -> int:
     updates = [
         result
         for result in checked_results
-        if result.get("changes") in {"body_changed", "monitor_review"}
+        if result.get("changes")
+        in {"body_changed", "artifact_changed", "monitor_review"}
     ]
     
     if updates:
         print("\nSkills with available updates:", flush=True)
         for u in updates:
             s = u["skill"]
-            mode = s.get("sync_mode", "replace")
-            mode_note = " [monitor-only]" if mode == "monitor" else ""
+            mode_note = " [monitor-only]" if _is_monitor_skill(s) else ""
             print(
                 f"  - {s['name']} ({s['category']}) ← "
                 f"{s.get('source', 'unknown')}{mode_note}",
@@ -1388,39 +4084,69 @@ def main(argv: list[str] | None = None) -> int:
             )
         print_monitor_review_guidance(updates)
     
-    auto_updates = [u for u in updates if u["skill"].get("sync_mode") != "monitor"]
-    v2_record_blocked = args.record_check and any(
-        skill.get("schema_version") == 2 for skill in skills
-    )
-    v2_apply_blocked = args.apply and any(
-        update["skill"].get("schema_version") == 2 for update in updates
-    )
+    auto_updates = [
+        update
+        for update in updates
+        if (
+            update["skill"].get("schema_version") == 1
+            and update["skill"].get("sync_mode") != "monitor"
+        )
+        or (
+            update["skill"].get("schema_version") == 2
+            and (update["skill"].get("tracking") or {}).get("channel")
+            in AUTO_CHANNELS
+            and update["skill"].get("sync_mode") == "replace"
+        )
+    ]
 
-    if v2_record_blocked:
-        print(
-            "\nBlocked: --record-check cannot write provenance v2 until the "
-            "origin-aware artifact-set writer is available; no files were changed.",
-            flush=True,
+    automation_state = (
+        "failed"
+        if unavailable or empty_input
+        else "degraded"
+        if counts["monitor_review"] or counts["rollback"]
+        else "complete"
+    )
+    apply_errors: list[dict[str, str]] = []
+
+    def emit_report(state: str = automation_state) -> None:
+        if not args.report_json:
+            return
+        write_report_json(
+            args.report_json,
+            {
+                "state": state,
+                "mode": "apply" if args.apply else "check",
+                "dry_run": bool(args.dry_run),
+                "summary": {"total": total, **counts},
+                "results": [
+                    _report_safe_result(result) for result in checked_results
+                ],
+                "apply_errors": list(apply_errors),
+            },
         )
-    if v2_apply_blocked:
-        print(
-            "\nBlocked: --apply cannot mutate provenance v2 with the legacy "
-            "single-file/sibling writer; no files were changed.",
-            flush=True,
-        )
-    if unavailable or empty_input or v2_record_blocked or v2_apply_blocked:
-        return 2 if (v2_record_blocked or v2_apply_blocked) else 1
+
+    if unavailable or empty_input:
+        emit_report("failed")
+        return 1
 
     if not args.dry_run and args.record_check:
-        for result in checked_results:
-            update_mapping_after_check(result)
+        try:
+            record_v2_checks(checked_results)
+            for result in checked_results:
+                if result["skill"].get("schema_version", 1) == 1:
+                    update_mapping_after_check(result)
+        except Exception as exc:
+            print(f"\nFailed to record check atomically: {exc}", flush=True)
+            emit_report("failed")
+            return 1
 
     if not updates:
         if counts["equal"] == total:
             print("All checked skills are equal to their authoritative upstream.", flush=True)
         else:
             print("No content updates are available; review non-equal states above.", flush=True)
-        return 0
+        emit_report()
+        return 2 if automation_state == "degraded" else 0
 
     if args.check_only:
         if auto_updates:
@@ -1430,7 +4156,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         else:
             print("\nAll reported updates are monitor-only; do the review above before closing the maintenance run.", flush=True)
-        return 0
+        emit_report()
+        return 2 if automation_state == "degraded" else 0
     
     if args.apply:
         if not args.dry_run:
@@ -1441,39 +4168,97 @@ def main(argv: list[str] | None = None) -> int:
                 ):
                     update_mapping_after_check(result)
         applied = 0
+        apply_failed = False
         for u in updates:
             s = u["skill"]
             print(f"\n  Applying update: {s['name']}", flush=True)
 
-            if s.get("sync_mode") == "monitor":
+            v2_channel = (s.get("tracking") or {}).get("channel")
+            if (
+                s.get("sync_mode") == "monitor"
+                or v2_channel in MONITOR_CHANNELS
+            ):
                 print("    Skipped: upstream is monitored for manual curation; automatic body replacement is disabled.", flush=True)
                 for line in monitor_review_guidance(u):
                     print(f"    {line}", flush=True)
                 continue
             
             if args.dry_run:
-                print(f"    [DRY RUN] Would merge upstream content into {s['local_path']}", flush=True)
-                applied += 1
+                try:
+                    if s.get("schema_version") == 2:
+                        preview = apply_v2_update(u, dry_run=True)
+                        print(
+                            "    [DRY RUN] Artifact plan: "
+                            f"{len(preview.changed)} changed, "
+                            f"{len(preview.pruned)} pruned",
+                            flush=True,
+                        )
+                    else:
+                        print(
+                            f"    [DRY RUN] Would merge upstream content into "
+                            f"{s['local_path']}",
+                            flush=True,
+                        )
+                    applied += 1
+                except Exception as exc:
+                    apply_failed = True
+                    apply_errors.append(
+                        {
+                            "name": str(s.get("name", "unknown")),
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                    )
+                    print(
+                        f"    [DRY RUN] FAILED: {type(exc).__name__}: {exc}",
+                        flush=True,
+                    )
+                    break
                 continue
             
-            merged = apply_repository_adaptations(
-                merge_frontmatter(s["local_content"], u["upstream_content"]),
-                s,
-            )
-            s["local_path"].write_text(merged, encoding="utf-8")
-            print(f"    Updated: {s['local_path']}", flush=True)
-            if s["source"].startswith("github:"):
-                aux_count = sync_github_auxiliary_files(s, u["upstream_path"], token)
-                if aux_count:
-                    print(f"    Synced auxiliary files: {aux_count}", flush=True)
-            update_mapping_after_sync(u)
-            applied += 1
+            try:
+                if s.get("schema_version") == 2:
+                    sync_result = apply_v2_update(u)
+                    print(
+                        "    Updated artifact set: "
+                        f"{len(sync_result.changed)} changed, "
+                        f"{len(sync_result.pruned)} pruned",
+                        flush=True,
+                    )
+                else:
+                    aux_count = apply_legacy_update(u, token)
+                    print(f"    Updated: {s['local_path']}", flush=True)
+                    if aux_count:
+                        print(
+                            f"    Synced auxiliary files: {aux_count}",
+                            flush=True,
+                        )
+                applied += 1
+            except Exception as exc:
+                apply_failed = True
+                apply_errors.append(
+                    {
+                        "name": str(s.get("name", "unknown")),
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                )
+                print(
+                    f"    FAILED; artifact transaction/mapping was not advanced: "
+                    f"{type(exc).__name__}: {exc}",
+                    flush=True,
+                )
+                break
         
         print(f"\nApplied {applied} updates.", flush=True)
         if not args.dry_run:
             print("Run the full pipeline to regenerate views:", flush=True)
             print("  python scripts/refresh_repo_views.py", flush=True)
-    return 0
+        if apply_failed:
+            emit_report("failed")
+            return 1
+    emit_report()
+    return 2 if automation_state == "degraded" else 0
 
 
 if __name__ == "__main__":

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -2546,6 +2546,7 @@ def atomic_write_json(
         ) from exc
     temporary_path: Path | None = None
     temporary_identity: tuple[int, int] | None = None
+    temporary_descriptor: int | None = None
     cleanup_directory_fd: int | None = None
     replaced = False
     payload = serialize_mapping_json(data)
@@ -2583,9 +2584,23 @@ def atomic_write_json(
                 temporary_path,
                 directory_fd,
             )
-            temporary_identity = (
+            temporary_descriptor, pinned_metadata = _pin_temporary_inode(
+                temporary_path,
+                directory_fd,
+            )
+            if (
+                pinned_metadata.st_dev,
+                pinned_metadata.st_ino,
+            ) != (
                 temporary_metadata.st_dev,
                 temporary_metadata.st_ino,
+            ):
+                raise RuntimeError(
+                    "mapping temporary inode changed while being pinned"
+                )
+            temporary_identity = (
+                pinned_metadata.st_dev,
+                pinned_metadata.st_ino,
             )
             installed_snapshot = MappingSnapshot(
                 content=payload,
@@ -2606,12 +2621,20 @@ def atomic_write_json(
                 temporary_path,
                 directory_fd,
             )
+            pinned_temporary = os.fstat(temporary_descriptor)
             if (
                 current_temporary.st_dev,
                 current_temporary.st_ino,
             ) != temporary_identity:
                 raise RuntimeError(
                     "mapping temporary inode changed before replace"
+                )
+            if (
+                pinned_temporary.st_dev,
+                pinned_temporary.st_ino,
+            ) != temporary_identity:
+                raise RuntimeError(
+                    "mapping pinned temporary inode changed before replace"
                 )
             if expected_snapshot is not None:
                 _validate_mapping_snapshot(path, expected_snapshot)
@@ -2648,9 +2671,17 @@ def atomic_write_json(
                     temporary_path,
                     cleanup_directory_fd,
                 )
+                pinned = (
+                    os.fstat(temporary_descriptor)
+                    if temporary_descriptor is not None
+                    else None
+                )
                 if temporary_identity is not None and (
                     current.st_dev,
                     current.st_ino,
+                ) == temporary_identity and pinned is not None and (
+                    pinned.st_dev,
+                    pinned.st_ino,
                 ) == temporary_identity:
                     os.unlink(
                         temporary_path.name,
@@ -2658,6 +2689,8 @@ def atomic_write_json(
                     )
             except (FileNotFoundError, RuntimeError):
                 pass
+        if temporary_descriptor is not None:
+            os.close(temporary_descriptor)
         if cleanup_directory_fd is not None:
             os.close(cleanup_directory_fd)
 
@@ -2741,6 +2774,43 @@ def _secure_temporary_metadata(path: Path, directory_fd: int) -> os.stat_result:
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
         raise RuntimeError(f"mapping temporary is unsafe: {path}")
     return metadata
+
+
+def _pin_temporary_inode(
+    path: Path,
+    directory_fd: int,
+) -> tuple[int, os.stat_result]:
+    """Open and retain a stable reference to one staged temporary inode.
+
+    Linux filesystems may immediately reuse an unlinked inode number.  Keeping
+    this descriptor open until replace/cleanup prevents a foreign file created
+    under the same temporary name from passing a dev/inode-only ABA check.
+    """
+    descriptor = os.open(
+        path.name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=directory_fd,
+    )
+    try:
+        opened = os.fstat(descriptor)
+        named = os.stat(
+            path.name,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or stat.S_ISLNK(named.st_mode)
+            or opened.st_dev != named.st_dev
+            or opened.st_ino != named.st_ino
+        ):
+            raise RuntimeError(
+                f"mapping temporary changed while being pinned: {path}"
+            )
+        return descriptor, opened
+    except BaseException:
+        os.close(descriptor)
+        raise
 
 
 def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -2333,6 +2333,33 @@ class MappingSnapshot:
         self.parent_inode = parent_inode
 
 
+class StagedMappingTemporary:
+    """One staged mapping whose original inode remains pinned by an open fd."""
+
+    def __init__(
+        self,
+        path: Path,
+        descriptor: int,
+        identity: tuple[int, int],
+    ) -> None:
+        self.path = path
+        self.descriptor = descriptor
+        self.identity = identity
+
+    def __enter__(self) -> "StagedMappingTemporary":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        descriptor = self.descriptor
+        if descriptor < 0:
+            return
+        self.descriptor = -1
+        os.close(descriptor)
+
+
 def serialize_mapping_json(data: dict) -> bytes:
     return (
         json.dumps(data, ensure_ascii=False, indent=2) + "\n"
@@ -2581,10 +2608,6 @@ def atomic_write_json(
             replaced=False,
             cause=exc,
         ) from exc
-    temporary_path: Path | None = None
-    temporary_identity: tuple[int, int] | None = None
-    temporary_descriptor: int | None = None
-    cleanup_directory_fd: int | None = None
     replaced = False
     payload = serialize_mapping_json(data)
     try:
@@ -2593,7 +2616,6 @@ def atomic_write_json(
             target_name,
             parent_identity,
         ):
-            cleanup_directory_fd = os.dup(directory_fd)
             if expected_snapshot is not None and (
                 expected_snapshot.parent_device is not None
                 and parent_identity
@@ -2605,7 +2627,7 @@ def atomic_write_json(
                 raise RuntimeError(
                     f"mapping parent directory changed concurrently: {path.parent}"
                 )
-            temporary_path = _stage_bytes_for_replace(
+            with _stage_bytes_for_replace(
                 path,
                 payload,
                 mode=(
@@ -2615,84 +2637,76 @@ def atomic_write_json(
                 ),
                 directory_fd=directory_fd,
                 parent_identity=parent_identity,
-            )
-            temporary_name = temporary_path.name
-            temporary_metadata = _secure_temporary_metadata(
-                temporary_path,
-                directory_fd,
-            )
-            temporary_descriptor, pinned_metadata = _pin_temporary_inode(
-                temporary_path,
-                directory_fd,
-            )
-            if (
-                pinned_metadata.st_dev,
-                pinned_metadata.st_ino,
-            ) != (
-                temporary_metadata.st_dev,
-                temporary_metadata.st_ino,
-            ):
-                raise RuntimeError(
-                    "mapping temporary inode changed while being pinned"
-                )
-            temporary_identity = (
-                pinned_metadata.st_dev,
-                pinned_metadata.st_ino,
-            )
-            installed_snapshot = MappingSnapshot(
-                content=payload,
-                sha256=hashlib.sha256(payload).hexdigest(),
-                device=temporary_metadata.st_dev,
-                inode=temporary_metadata.st_ino,
-                mode=(
-                    expected_snapshot.mode
-                    if expected_snapshot is not None
-                    else 0o600
-                ),
-                parent_device=parent_identity[0],
-                parent_inode=parent_identity[1],
-            )
-            if fault_injector is not None:
-                fault_injector("after_temp_fsync")
-            current_temporary = _secure_temporary_metadata(
-                temporary_path,
-                directory_fd,
-            )
-            pinned_temporary = os.fstat(temporary_descriptor)
-            if (
-                current_temporary.st_dev,
-                current_temporary.st_ino,
-            ) != temporary_identity:
-                raise RuntimeError(
-                    "mapping temporary inode changed before replace"
-                )
-            if (
-                pinned_temporary.st_dev,
-                pinned_temporary.st_ino,
-            ) != temporary_identity:
-                raise RuntimeError(
-                    "mapping pinned temporary inode changed before replace"
-                )
-            if expected_snapshot is not None:
-                _validate_mapping_snapshot(path, expected_snapshot)
-            elif _mapping_target_exists(path):
-                raise RuntimeError(
-                    f"mapping unexpectedly appeared before replacement: {path}"
-                )
-            _validate_mapping_parent(path, parent_identity)
-            os.replace(
-                temporary_name,
-                target_name,
-                src_dir_fd=directory_fd,
-                dst_dir_fd=directory_fd,
-            )
-            replaced = True
-            temporary_path = None
-            if fault_injector is not None:
-                fault_injector("after_replace")
-            _validate_mapping_snapshot(path, installed_snapshot)
-            os.fsync(directory_fd)
-            _validate_mapping_snapshot(path, installed_snapshot)
+            ) as temporary:
+                temporary_path = temporary.path
+                temporary_name = temporary_path.name
+                try:
+                    temporary_metadata = _secure_temporary_metadata(
+                        temporary_path,
+                        directory_fd,
+                    )
+                    if temporary.identity != (
+                        temporary_metadata.st_dev,
+                        temporary_metadata.st_ino,
+                    ):
+                        raise RuntimeError(
+                            "mapping staged inode identity is invalid"
+                        )
+                    installed_snapshot = MappingSnapshot(
+                        content=payload,
+                        sha256=hashlib.sha256(payload).hexdigest(),
+                        device=temporary_metadata.st_dev,
+                        inode=temporary_metadata.st_ino,
+                        mode=(
+                            expected_snapshot.mode
+                            if expected_snapshot is not None
+                            else 0o600
+                        ),
+                        parent_device=parent_identity[0],
+                        parent_inode=parent_identity[1],
+                    )
+                    if fault_injector is not None:
+                        fault_injector("after_temp_fsync")
+                    _validate_pinned_temporary(
+                        temporary_path,
+                        directory_fd,
+                        temporary.descriptor,
+                        temporary.identity,
+                    )
+                    if expected_snapshot is not None:
+                        _validate_mapping_snapshot(path, expected_snapshot)
+                    elif _mapping_target_exists(path):
+                        raise RuntimeError(
+                            "mapping unexpectedly appeared before "
+                            f"replacement: {path}"
+                        )
+                    _validate_mapping_parent(path, parent_identity)
+                    os.replace(
+                        temporary_name,
+                        target_name,
+                        src_dir_fd=directory_fd,
+                        dst_dir_fd=directory_fd,
+                    )
+                    replaced = True
+                    if fault_injector is not None:
+                        fault_injector("after_replace")
+                    _validate_mapping_snapshot(path, installed_snapshot)
+                    os.fsync(directory_fd)
+                    _validate_mapping_snapshot(path, installed_snapshot)
+                finally:
+                    try:
+                        _validate_pinned_temporary(
+                            temporary_path,
+                            directory_fd,
+                            temporary.descriptor,
+                            temporary.identity,
+                        )
+                        os.unlink(
+                            temporary_name,
+                            dir_fd=directory_fd,
+                        )
+                    except (FileNotFoundError, RuntimeError):
+                        pass
     except BaseException as exc:
         if isinstance(exc, AtomicMappingWriteError):
             raise
@@ -2701,35 +2715,6 @@ def atomic_write_json(
             replaced=replaced,
             cause=exc,
         ) from exc
-    finally:
-        if temporary_path is not None and cleanup_directory_fd is not None:
-            try:
-                current = _secure_temporary_metadata(
-                    temporary_path,
-                    cleanup_directory_fd,
-                )
-                pinned = (
-                    os.fstat(temporary_descriptor)
-                    if temporary_descriptor is not None
-                    else None
-                )
-                if temporary_identity is not None and (
-                    current.st_dev,
-                    current.st_ino,
-                ) == temporary_identity and pinned is not None and (
-                    pinned.st_dev,
-                    pinned.st_ino,
-                ) == temporary_identity:
-                    os.unlink(
-                        temporary_path.name,
-                        dir_fd=cleanup_directory_fd,
-                    )
-            except (FileNotFoundError, RuntimeError):
-                pass
-        if temporary_descriptor is not None:
-            os.close(temporary_descriptor)
-        if cleanup_directory_fd is not None:
-            os.close(cleanup_directory_fd)
 
 
 def _stage_bytes_for_replace(
@@ -2740,7 +2725,7 @@ def _stage_bytes_for_replace(
     suffix: str = ".tmp",
     directory_fd: int | None = None,
     parent_identity: tuple[int, int] | None = None,
-) -> Path:
+) -> StagedMappingTemporary:
     path = Path(path)
     if directory_fd is None:
         with _open_mapping_parent(path) as (
@@ -2769,15 +2754,18 @@ def _stage_bytes_for_replace(
     fd = os.open(temporary_name, flags, 0o600, dir_fd=directory_fd)
     temporary = path.parent / temporary_name
     descriptor_metadata = os.fstat(fd)
+    pinned_descriptor: int | None = None
     try:
         if not stat.S_ISREG(descriptor_metadata.st_mode):
             raise ValueError("mapping temporary inode is not regular")
-        with os.fdopen(fd, "wb") as stream:
-            fd = -1
-            stream.write(payload)
-            stream.flush()
-            os.fchmod(stream.fileno(), mode)
-            os.fsync(stream.fileno())
+        remaining = memoryview(payload)
+        while remaining:
+            written = os.write(fd, remaining)
+            if written <= 0:
+                raise OSError("mapping temporary write made no progress")
+            remaining = remaining[written:]
+        os.fchmod(fd, mode)
+        os.fsync(fd)
         metadata = os.stat(
             temporary_name,
             dir_fd=directory_fd,
@@ -2790,15 +2778,70 @@ def _stage_bytes_for_replace(
             or metadata.st_ino != descriptor_metadata.st_ino
         ):
             raise ValueError("mapping temporary inode changed before replace")
+        pinned_descriptor, pinned_metadata = _pin_temporary_inode(
+            temporary,
+            directory_fd,
+        )
+        if (
+            pinned_metadata.st_dev,
+            pinned_metadata.st_ino,
+        ) != (
+            descriptor_metadata.st_dev,
+            descriptor_metadata.st_ino,
+        ):
+            raise RuntimeError(
+                f"mapping temporary changed while being pinned: {temporary}"
+            )
+        identity = (
+            descriptor_metadata.st_dev,
+            descriptor_metadata.st_ino,
+        )
+        os.close(fd)
+        fd = -1
+        _validate_pinned_temporary(
+            temporary,
+            directory_fd,
+            pinned_descriptor,
+            identity,
+        )
         _validate_mapping_parent(path, parent_identity)
-        return temporary
+        _validate_pinned_temporary(
+            temporary,
+            directory_fd,
+            pinned_descriptor,
+            identity,
+        )
+        result = StagedMappingTemporary(
+            temporary,
+            pinned_descriptor,
+            identity,
+        )
+        pinned_descriptor = None
+        return result
     except BaseException:
+        cleanup_descriptor = (
+            pinned_descriptor
+            if pinned_descriptor is not None
+            else fd
+        )
+        try:
+            if cleanup_descriptor is not None and cleanup_descriptor >= 0:
+                _validate_pinned_temporary(
+                    temporary,
+                    directory_fd,
+                    cleanup_descriptor,
+                    (
+                        descriptor_metadata.st_dev,
+                        descriptor_metadata.st_ino,
+                    ),
+                )
+                os.unlink(temporary_name, dir_fd=directory_fd)
+        except (FileNotFoundError, RuntimeError):
+            pass
+        if pinned_descriptor is not None:
+            os.close(pinned_descriptor)
         if fd >= 0:
             os.close(fd)
-        try:
-            os.unlink(temporary_name, dir_fd=directory_fd)
-        except FileNotFoundError:
-            pass
         raise
 
 
@@ -2850,6 +2893,24 @@ def _pin_temporary_inode(
         raise
 
 
+def _validate_pinned_temporary(
+    path: Path,
+    directory_fd: int,
+    descriptor: int,
+    identity: tuple[int, int],
+) -> os.stat_result:
+    """Require the temporary name and retained descriptor to bind one inode."""
+    named = _secure_temporary_metadata(path, directory_fd)
+    pinned = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(pinned.st_mode)
+        or (named.st_dev, named.st_ino) != identity
+        or (pinned.st_dev, pinned.st_ino) != identity
+    ):
+        raise RuntimeError(f"mapping temporary inode changed: {path}")
+    return named
+
+
 def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:
     """Preserve rollback bytes even when the canonical parent was detached."""
     recovery_root = _mapping_lock_path(path).parent
@@ -2875,7 +2936,10 @@ def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:
         f".{hashlib.sha256(str(path).encode('utf-8')).hexdigest()}."
         f"{os.urandom(16).hex()}.recovery.json"
     )
+    recovery_path = recovery_root / name
     descriptor = -1
+    pinned_descriptor: int | None = None
+    created_identity: tuple[int, int] | None = None
     try:
         descriptor = os.open(
             name,
@@ -2886,19 +2950,45 @@ def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:
             0o600,
             dir_fd=directory_fd,
         )
-        with os.fdopen(descriptor, "wb") as stream:
-            descriptor = -1
-            stream.write(payload)
-            stream.flush()
-            os.fchmod(stream.fileno(), 0o600)
-            os.fsync(stream.fileno())
+        created = os.fstat(descriptor)
+        if not stat.S_ISREG(created.st_mode):
+            raise RuntimeError("private mapping recovery inode is unsafe")
+        created_identity = (created.st_dev, created.st_ino)
+        remaining = memoryview(payload)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("private mapping recovery write made no progress")
+            remaining = remaining[written:]
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
         metadata = os.stat(
             name,
             dir_fd=directory_fd,
             follow_symlinks=False,
         )
-        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or (metadata.st_dev, metadata.st_ino) != created_identity
+        ):
             raise RuntimeError("private mapping recovery inode is unsafe")
+        pinned_descriptor, pinned = _pin_temporary_inode(
+            recovery_path,
+            directory_fd,
+        )
+        if (pinned.st_dev, pinned.st_ino) != created_identity:
+            raise RuntimeError(
+                "private mapping recovery inode changed while being pinned"
+            )
+        os.close(descriptor)
+        descriptor = -1
+        _validate_pinned_temporary(
+            recovery_path,
+            directory_fd,
+            pinned_descriptor,
+            created_identity,
+        )
         os.fsync(directory_fd)
         current_root = recovery_root.lstat()
         if (
@@ -2910,25 +3000,40 @@ def _stage_private_mapping_recovery(path: Path, payload: bytes) -> Path:
             raise RuntimeError(
                 "private mapping recovery root changed concurrently"
             )
-        recovery_path = recovery_root / name
-        current_file = recovery_path.lstat()
-        if (
-            current_file.st_dev != metadata.st_dev
-            or current_file.st_ino != metadata.st_ino
-            or stat.S_ISLNK(current_file.st_mode)
-            or not stat.S_ISREG(current_file.st_mode)
-        ):
-            raise RuntimeError(
-                "private mapping recovery file changed concurrently"
-            )
+        _validate_pinned_temporary(
+            recovery_path,
+            directory_fd,
+            pinned_descriptor,
+            created_identity,
+        )
+        os.close(pinned_descriptor)
+        pinned_descriptor = None
         return recovery_path
     except BaseException:
+        cleanup_descriptor = (
+            pinned_descriptor
+            if pinned_descriptor is not None
+            else descriptor
+        )
+        try:
+            if (
+                cleanup_descriptor is not None
+                and cleanup_descriptor >= 0
+                and created_identity is not None
+            ):
+                _validate_pinned_temporary(
+                    recovery_path,
+                    directory_fd,
+                    cleanup_descriptor,
+                    created_identity,
+                )
+                os.unlink(name, dir_fd=directory_fd)
+        except (FileNotFoundError, RuntimeError):
+            pass
+        if pinned_descriptor is not None:
+            os.close(pinned_descriptor)
         if descriptor >= 0:
             os.close(descriptor)
-        try:
-            os.unlink(name, dir_fd=directory_fd)
-        except FileNotFoundError:
-            pass
         raise
     finally:
         os.close(directory_fd)
@@ -2949,10 +3054,12 @@ def _atomic_write_json_batch_locked(
     snapshots: dict[Path, MappingSnapshot] = {}
     installed_snapshots: dict[Path, MappingSnapshot] = {}
     staged: dict[Path, Path | None] = {}
+    staged_temporaries: dict[Path, StagedMappingTemporary] = {}
     directory_fds: dict[Path, int] = {}
     target_names: dict[Path, str] = {}
     parent_identities: dict[Path, tuple[int, int]] = {}
     parent_stack = ExitStack()
+    temporary_stack = ExitStack()
     replaced: list[Path] = []
     try:
         for path in paths:
@@ -2977,22 +3084,34 @@ def _atomic_write_json_batch_locked(
                     f"mapping parent directory changed concurrently: {path.parent}"
                 )
             payload = serialize_mapping_json(prepared[path])
-            staged[path] = _stage_bytes_for_replace(
-                path,
-                payload,
-                mode=modes[path],
-                directory_fd=descriptor,
-                parent_identity=parent_identity,
+            temporary = temporary_stack.enter_context(
+                _stage_bytes_for_replace(
+                    path,
+                    payload,
+                    mode=modes[path],
+                    directory_fd=descriptor,
+                    parent_identity=parent_identity,
+                )
             )
+            staged[path] = temporary.path
+            staged_temporaries[path] = temporary
             temporary_metadata = _secure_temporary_metadata(
                 staged[path],
                 descriptor,
             )
+            if temporary.identity != (
+                temporary_metadata.st_dev,
+                temporary_metadata.st_ino,
+            ):
+                raise RuntimeError(
+                    f"mapping staged inode identity is invalid: "
+                    f"{staged[path]}"
+                )
             installed_snapshots[path] = MappingSnapshot(
                 content=payload,
                 sha256=hashlib.sha256(payload).hexdigest(),
-                device=temporary_metadata.st_dev,
-                inode=temporary_metadata.st_ino,
+                device=temporary.identity[0],
+                inode=temporary.identity[1],
                 mode=modes[path],
                 parent_device=parent_identity[0],
                 parent_inode=parent_identity[1],
@@ -3007,20 +3126,12 @@ def _atomic_write_json_batch_locked(
             if temporary is None:
                 raise RuntimeError(f"missing staged mapping: {path}")
             _validate_mapping_snapshot(path, snapshots[path])
-            current_temporary = _secure_temporary_metadata(
+            _validate_pinned_temporary(
                 temporary,
                 directory_fds[path],
+                staged_temporaries[path].descriptor,
+                staged_temporaries[path].identity,
             )
-            if (
-                current_temporary.st_dev,
-                current_temporary.st_ino,
-            ) != (
-                installed_snapshots[path].device,
-                installed_snapshots[path].inode,
-            ):
-                raise RuntimeError(
-                    f"mapping temporary inode changed before replace: {temporary}"
-                )
             _validate_mapping_parent(path, parent_identities[path])
             os.replace(
                 temporary.name,
@@ -3048,56 +3159,82 @@ def _atomic_write_json_batch_locked(
             rollback: Path | None = None
             try:
                 _validate_mapping_snapshot(path, installed_snapshots[path])
-                rollback = _stage_bytes_for_replace(
+                with _stage_bytes_for_replace(
                     path,
                     originals[path],
                     mode=modes[path],
                     suffix=".rollback.tmp",
                     directory_fd=directory_fds[path],
                     parent_identity=parent_identities[path],
-                )
-                rollback_metadata = _secure_temporary_metadata(
-                    rollback,
-                    directory_fds[path],
-                )
-                rollback_snapshot = MappingSnapshot(
-                    content=originals[path],
-                    sha256=hashlib.sha256(originals[path]).hexdigest(),
-                    device=rollback_metadata.st_dev,
-                    inode=rollback_metadata.st_ino,
-                    mode=modes[path],
-                    parent_device=parent_identities[path][0],
-                    parent_inode=parent_identities[path][1],
-                )
-                os.replace(
-                    rollback.name,
-                    target_names[path],
-                    src_dir_fd=directory_fds[path],
-                    dst_dir_fd=directory_fds[path],
-                )
-                _validate_mapping_snapshot(path, rollback_snapshot)
-                rolled_back_snapshots[path] = rollback_snapshot
+                ) as rollback_temporary:
+                    rollback = rollback_temporary.path
+                    try:
+                        rollback_metadata = _secure_temporary_metadata(
+                            rollback,
+                            directory_fds[path],
+                        )
+                        if rollback_temporary.identity != (
+                            rollback_metadata.st_dev,
+                            rollback_metadata.st_ino,
+                        ):
+                            raise RuntimeError(
+                                "mapping rollback staged inode identity is "
+                                f"invalid: {rollback}"
+                            )
+                        rollback_snapshot = MappingSnapshot(
+                            content=originals[path],
+                            sha256=hashlib.sha256(
+                                originals[path]
+                            ).hexdigest(),
+                            device=rollback_temporary.identity[0],
+                            inode=rollback_temporary.identity[1],
+                            mode=modes[path],
+                            parent_device=parent_identities[path][0],
+                            parent_inode=parent_identities[path][1],
+                        )
+                        _validate_pinned_temporary(
+                            rollback,
+                            directory_fds[path],
+                            rollback_temporary.descriptor,
+                            rollback_temporary.identity,
+                        )
+                        os.replace(
+                            rollback.name,
+                            target_names[path],
+                            src_dir_fd=directory_fds[path],
+                            dst_dir_fd=directory_fds[path],
+                        )
+                        rollback = None
+                        _validate_mapping_snapshot(path, rollback_snapshot)
+                        rolled_back_snapshots[path] = rollback_snapshot
+                    finally:
+                        if rollback is not None:
+                            try:
+                                _validate_pinned_temporary(
+                                    rollback,
+                                    directory_fds[path],
+                                    rollback_temporary.descriptor,
+                                    rollback_temporary.identity,
+                                )
+                                os.unlink(
+                                    rollback.name,
+                                    dir_fd=directory_fds[path],
+                                )
+                            except (FileNotFoundError, RuntimeError):
+                                pass
             except BaseException as rollback_error:
                 rollback_errors.append(rollback_error)
-                if rollback is not None:
-                    try:
-                        os.unlink(
-                            rollback.name,
-                            dir_fd=directory_fds[path],
-                        )
-                    except FileNotFoundError:
-                        pass
                 try:
-                    recovery = _stage_bytes_for_replace(
+                    with _stage_bytes_for_replace(
                         path,
                         originals[path],
                         mode=0o600,
                         suffix=".recovery.json",
                         directory_fd=directory_fds[path],
                         parent_identity=parent_identities[path],
-                    )
-                    recovery_paths.append(recovery)
-                    recovery_recorded.add(path)
+                    ) as recovery_temporary:
+                        recovery_paths.append(recovery_temporary.path)
+                        recovery_recorded.add(path)
                 except BaseException as recovery_error:
                     rollback_errors.append(recovery_error)
                     try:
@@ -3122,17 +3259,16 @@ def _atomic_write_json_batch_locked(
                 if path in recovery_recorded:
                     continue
                 try:
-                    recovery_paths.append(
-                        _stage_bytes_for_replace(
-                            path,
-                            originals[path],
-                            mode=0o600,
-                            suffix=".recovery.json",
-                            directory_fd=directory_fds[path],
-                            parent_identity=parent_identities[path],
-                        )
-                    )
-                    recovery_recorded.add(path)
+                    with _stage_bytes_for_replace(
+                        path,
+                        originals[path],
+                        mode=0o600,
+                        suffix=".recovery.json",
+                        directory_fd=directory_fds[path],
+                        parent_identity=parent_identities[path],
+                    ) as recovery_temporary:
+                        recovery_paths.append(recovery_temporary.path)
+                        recovery_recorded.add(path)
                 except BaseException as recovery_error:
                     rollback_errors.append(recovery_error)
                     try:
@@ -3163,23 +3299,26 @@ def _atomic_write_json_batch_locked(
     finally:
         for path, temporary in staged.items():
             if temporary is not None:
+                staged_temporary = staged_temporaries.get(path)
+                if staged_temporary is None:
+                    continue
                 try:
-                    current = _secure_temporary_metadata(
+                    _validate_pinned_temporary(
                         temporary,
                         directory_fds[path],
+                        staged_temporary.descriptor,
+                        staged_temporary.identity,
                     )
-                    expected = installed_snapshots.get(path)
-                    if expected is not None and (
-                        current.st_dev,
-                        current.st_ino,
-                    ) == (expected.device, expected.inode):
-                        os.unlink(
-                            temporary.name,
-                            dir_fd=directory_fds[path],
-                        )
+                    os.unlink(
+                        temporary.name,
+                        dir_fd=directory_fds[path],
+                    )
                 except (FileNotFoundError, RuntimeError):
                     pass
-        parent_stack.close()
+        try:
+            temporary_stack.close()
+        finally:
+            parent_stack.close()
 
 
 def atomic_write_json_batch(
@@ -3227,10 +3366,11 @@ def atomic_write_json_batch(
 def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
     """Run full provenance and unique-claim gates without replacing mappings."""
     staged: dict[Path, Path] = {}
+    staged_temporaries: dict[Path, StagedMappingTemporary] = {}
     directory_fds: dict[Path, int] = {}
     parent_identities: dict[Path, tuple[int, int]] = {}
-    temporary_identities: dict[Path, tuple[int, int]] = {}
     parent_stack = ExitStack()
+    temporary_stack = ExitStack()
     try:
         for path, data in prepared.items():
             descriptor, _target_name, parent_identity = (
@@ -3239,26 +3379,48 @@ def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
             directory_fds[path] = descriptor
             parent_identities[path] = parent_identity
             payload = serialize_mapping_json(data)
-            staged[path] = _stage_bytes_for_replace(
-                path,
-                payload,
-                mode=0o600,
-                suffix=".validation.skills.json",
-                directory_fd=descriptor,
-                parent_identity=parent_identity,
+            temporary = temporary_stack.enter_context(
+                _stage_bytes_for_replace(
+                    path,
+                    payload,
+                    mode=0o600,
+                    suffix=".validation.skills.json",
+                    directory_fd=descriptor,
+                    parent_identity=parent_identity,
+                )
             )
+            staged[path] = temporary.path
+            staged_temporaries[path] = temporary
             temporary_metadata = _secure_temporary_metadata(
                 staged[path],
                 descriptor,
             )
-            temporary_identities[path] = (
+            if temporary.identity != (
                 temporary_metadata.st_dev,
                 temporary_metadata.st_ino,
-            )
+            ):
+                raise RuntimeError(
+                    "validation mapping staged inode identity is invalid: "
+                    f"{staged[path]}"
+                )
         errors: list[str] = []
-        for path in sorted(staged.values()):
+        for mapping_path in sorted(staged):
+            path = staged[mapping_path]
+            temporary = staged_temporaries[mapping_path]
+            _validate_pinned_temporary(
+                path,
+                directory_fds[mapping_path],
+                temporary.descriptor,
+                temporary.identity,
+            )
             errors.extend(
                 validate_provenance_mapping(path, REPO_ROOT, allow_v1=False)
+            )
+            _validate_pinned_temporary(
+                path,
+                directory_fds[mapping_path],
+                temporary.descriptor,
+                temporary.identity,
             )
         staged_paths = set(staged.values())
         original_paths = set(staged)
@@ -3269,12 +3431,28 @@ def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
             if path not in original_paths and path not in staged_paths
         ]
         repository_paths.extend(staged.values())
+        for mapping_path, temporary_path in staged.items():
+            temporary = staged_temporaries[mapping_path]
+            _validate_pinned_temporary(
+                temporary_path,
+                directory_fds[mapping_path],
+                temporary.descriptor,
+                temporary.identity,
+            )
         errors.extend(
             validate_repository_mappings(
                 sorted(repository_paths),
                 REPO_ROOT,
             )
         )
+        for mapping_path, temporary_path in staged.items():
+            temporary = staged_temporaries[mapping_path]
+            _validate_pinned_temporary(
+                temporary_path,
+                directory_fds[mapping_path],
+                temporary.descriptor,
+                temporary.identity,
+            )
         if errors:
             raise RuntimeError(
                 "candidate mapping failed full provenance validation: "
@@ -3282,7 +3460,8 @@ def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
             )
     finally:
         cleanup_errors: list[BaseException] = []
-        for mapping_path, temporary in staged.items():
+        for mapping_path, temporary_path in staged.items():
+            temporary = staged_temporaries[mapping_path]
             try:
                 _validate_mapping_parent(
                     mapping_path,
@@ -3291,29 +3470,28 @@ def _validate_candidate_mappings(prepared: dict[Path, dict]) -> None:
             except BaseException as exc:
                 cleanup_errors.append(exc)
             try:
-                metadata = _secure_temporary_metadata(
-                    temporary,
+                _validate_pinned_temporary(
+                    temporary_path,
                     directory_fds[mapping_path],
+                    temporary.descriptor,
+                    temporary.identity,
                 )
-                if (metadata.st_dev, metadata.st_ino) != temporary_identities[
-                    mapping_path
-                ]:
-                    raise RuntimeError(
-                        f"validation mapping inode changed: {temporary}"
-                    )
                 os.unlink(
-                    temporary.name,
+                    temporary_path.name,
                     dir_fd=directory_fds[mapping_path],
                 )
             except FileNotFoundError:
                 cleanup_errors.append(
                     RuntimeError(
-                        f"validation mapping disappeared: {temporary}"
+                        f"validation mapping disappeared: {temporary_path}"
                     )
                 )
             except BaseException as exc:
                 cleanup_errors.append(exc)
-        parent_stack.close()
+        try:
+            temporary_stack.close()
+        finally:
+            parent_stack.close()
         if cleanup_errors and sys.exc_info()[0] is None:
             raise RuntimeError(
                 "candidate mapping cleanup failed safely: "

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -1783,6 +1783,19 @@ def _artifact_local_bytes(skill: dict, target: str) -> bytes | None:
         return None
 
 
+def _artifact_local_mode(target: str) -> str | None:
+    if not _safe_mapping_path(target):
+        return None
+    path = REPO_ROOT / target
+    try:
+        metadata = path.lstat()
+    except OSError:
+        return None
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        return None
+    return "100755" if stat.S_IMODE(metadata.st_mode) & 0o111 else "100644"
+
+
 def _main_artifact_equal(skill: dict, local: bytes, upstream: bytes) -> bool:
     try:
         local_text = local.decode("utf-8")
@@ -1800,7 +1813,12 @@ def _main_artifact_equal(skill: dict, local: bytes, upstream: bytes) -> bool:
 def _artifact_diff(
     skill: dict,
     upstream_files: dict[str, bytes],
+    upstream_modes: dict[str, str],
 ) -> tuple[list[str], list[str], list[str]]:
+    if set(upstream_modes) != set(upstream_files) or any(
+        mode not in {"100644", "100755"} for mode in upstream_modes.values()
+    ):
+        raise RuntimeError("upstream artifact modes are incomplete or invalid")
     desired = set(upstream_files)
     previous_external_targets = _owned_targets_for_artifacts(
         skill.get("artifacts", []),
@@ -1823,10 +1841,18 @@ def _artifact_diff(
         for item in skill.get("managed_files", [])
         if isinstance(item, dict)
     }
+    manifest_modes = {
+        item.get("path"): item.get("mode")
+        for item in skill.get("managed_files", [])
+        if isinstance(item, dict)
+    }
     for path in sorted(desired & owned):
         raw = _artifact_local_bytes(skill, path)
         upstream = upstream_files[path]
         expected = manifest_hashes.get(path)
+        local_mode = _artifact_local_mode(path)
+        upstream_mode = upstream_modes[path]
+        expected_mode = manifest_modes.get(path)
         content_changed = (
             raw is None
             or (
@@ -1840,7 +1866,13 @@ def _artifact_diff(
             and isinstance(expected, str)
             and hashlib.sha256(raw).hexdigest() != expected.lower()
         )
-        if content_changed or manifest_drift:
+        mode_changed = local_mode != upstream_mode
+        mode_manifest_drift = (
+            local_mode is not None
+            and isinstance(expected_mode, str)
+            and local_mode != expected_mode
+        )
+        if content_changed or manifest_drift or mode_changed or mode_manifest_drift:
             changed.append(path)
     return changed, added, removed
 
@@ -2042,7 +2074,11 @@ def _check_v2_upstream_changes(
             "reason": str(exc),
         }
 
-    changed, added, removed = _artifact_diff(skill, inventory.files)
+    changed, added, removed = _artifact_diff(
+        skill,
+        inventory.files,
+        inventory.modes,
+    )
     artifact_changed = bool(changed or added or removed)
     checkpoint_changed = bool(
         reviewed_checkpoint
@@ -2053,6 +2089,7 @@ def _check_v2_upstream_changes(
         "upstream_path": skill.get("upstream_path"),
         "upstream_files": inventory.files,
         "source_blobs": inventory.source_blobs,
+        "upstream_modes": inventory.modes,
         "main_source_blob": inventory.source_blobs.get(
             skill.get("upstream_path")
         ),
@@ -3496,7 +3533,17 @@ def _artifact_payloads_for_engine(update: dict) -> list[dict]:
     skill = update["skill"]
     upstream_files = update.get("upstream_files")
     source_blobs = update.get("source_blobs")
-    if not isinstance(upstream_files, dict) or not isinstance(source_blobs, dict):
+    upstream_modes = update.get("upstream_modes")
+    if (
+        not isinstance(upstream_files, dict)
+        or not isinstance(source_blobs, dict)
+        or not isinstance(upstream_modes, dict)
+        or set(upstream_modes) != set(upstream_files)
+        or any(
+            mode not in {"100644", "100755"}
+            for mode in upstream_modes.values()
+        )
+    ):
         raise RuntimeError("v2 update has no materialized artifact inventory")
     payloads: list[dict] = []
     repo_skill = skill.get("repo_skill")
@@ -3535,6 +3582,7 @@ def _artifact_payloads_for_engine(update: dict) -> list[dict]:
                     "target": expanded_target,
                     "type": "file",
                     "data": raw,
+                    "mode": upstream_modes[expanded_target],
                 }
             )
     return payloads
@@ -3673,9 +3721,18 @@ def apply_v2_update(
             mapping_after = serialize_mapping_json(mapping_data)
             mapping_after_sha256 = hashlib.sha256(mapping_after).hexdigest()
             if mapping_after_sha256 == mapping_snapshot.sha256:
-                raise RuntimeError(
-                    "artifact apply produced no mapping authority transition"
-                )
+                if not sync_result.has_filesystem_changes:
+                    raise RuntimeError(
+                        "artifact apply produced neither filesystem nor "
+                        "mapping changes"
+                    )
+                # A mode-only repair can leave provenance unchanged because
+                # its managed checkpoint already declares the reviewed mode.
+                # The unchanged mapping is existing authority for the staged
+                # tree, so commit explicitly without binding an impossible
+                # same-hash mapping transition.
+                transaction.commit()
+                return sync_result
             try:
                 mapping_authority_path = (
                     mapping_path.resolve()

--- a/scripts/validate_skill_sources.py
+++ b/scripts/validate_skill_sources.py
@@ -17,6 +17,7 @@ try:
         COMMIT_RE,
         DATE_RE as V2_DATE_RE,
         EXTERNAL_KINDS,
+        GIT_FILE_MODES,
         LOCAL_CURATION_REPO,
         SCHEMA_VERSION,
         SHA256_RE,
@@ -26,6 +27,7 @@ try:
         VALID_SYNC_MODES,
         discover_source_mappings,
         github_repo,
+        git_file_mode,
         infer_channel,
         is_local_repo,
         is_local_source,
@@ -41,6 +43,7 @@ except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
         COMMIT_RE,
         DATE_RE as V2_DATE_RE,
         EXTERNAL_KINDS,
+        GIT_FILE_MODES,
         LOCAL_CURATION_REPO,
         SCHEMA_VERSION,
         SHA256_RE,
@@ -50,6 +53,7 @@ except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
         VALID_SYNC_MODES,
         discover_source_mappings,
         github_repo,
+        git_file_mode,
         infer_channel,
         is_local_repo,
         is_local_source,
@@ -936,9 +940,14 @@ def _validate_v2_entry(
             if not isinstance(managed, dict):
                 errors.append(f"{label} must be an object")
                 continue
-            missing = {"path", "sha256", "owner"} - set(managed)
+            missing = {"path", "sha256", "owner", "mode"} - set(managed)
             if missing:
                 errors.append(f"{label} missing keys: {sorted(missing)}")
+            declared_mode = managed.get("mode")
+            if declared_mode not in GIT_FILE_MODES:
+                errors.append(
+                    f"{label}.mode must be one of {sorted(GIT_FILE_MODES)}"
+                )
             path_value = managed.get("path")
             if not safe_relative_path(path_value):
                 errors.append(f"{label}.path must be a safe relative path")
@@ -962,6 +971,18 @@ def _validate_v2_entry(
                             f"{mapping}: skills[{idx}] managed file "
                             f"{path_value!r} sha256 does not match "
                             "repository content"
+                        )
+                    current_mode = git_file_mode(candidate)
+                    if current_mode is None:
+                        errors.append(
+                            f"{mapping}: skills[{idx}] managed file "
+                            f"{path_value!r} has a mode Git cannot represent"
+                        )
+                    elif declared_mode != current_mode:
+                        errors.append(
+                            f"{mapping}: skills[{idx}] managed file "
+                            f"{path_value!r} mode {declared_mode!r} does not "
+                            f"match repository mode {current_mode!r}"
                         )
             content_hash = managed.get("sha256")
             if (

--- a/scripts/validate_skill_sources.py
+++ b/scripts/validate_skill_sources.py
@@ -17,6 +17,7 @@ try:
         COMMIT_RE,
         DATE_RE as V2_DATE_RE,
         EXTERNAL_KINDS,
+        LOCAL_CURATION_REPO,
         SCHEMA_VERSION,
         SHA256_RE,
         UNKNOWN_LICENSE_VALUES,
@@ -32,6 +33,7 @@ try:
         parse_frontmatter,
         safe_relative_path,
         sha256_file,
+        valid_github_repo,
     )
 except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
     from scripts.provenance_v2 import (
@@ -39,6 +41,7 @@ except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
         COMMIT_RE,
         DATE_RE as V2_DATE_RE,
         EXTERNAL_KINDS,
+        LOCAL_CURATION_REPO,
         SCHEMA_VERSION,
         SHA256_RE,
         UNKNOWN_LICENSE_VALUES,
@@ -54,7 +57,13 @@ except ModuleNotFoundError:  # pragma: no cover - import path used by unit tests
         parse_frontmatter,
         safe_relative_path,
         sha256_file,
+        valid_github_repo,
     )
+
+try:
+    from audit_licenses import PERMISSIVE_LICENSES
+except ModuleNotFoundError:  # pragma: no cover - import path used by tests
+    from scripts.audit_licenses import PERMISSIVE_LICENSES
 
 REQUIRED_TOP = {"video", "official_references", "skills"}
 REQUIRED_SKILL_KEYS = {"video_name", "normalized_slug", "status", "repo_skill", "source", "notes"}
@@ -281,6 +290,78 @@ def _validate_tracking(
         if value and not V2_DATE_RE.fullmatch(str(value)):
             errors.append(f"{label}.{key} must be YYYY-MM-DD or null")
 
+    license_checkpoint = tracking.get("license_checkpoint")
+    if license_checkpoint is not None:
+        checkpoint_label = f"{label}.license_checkpoint"
+        if local:
+            errors.append(
+                f"{checkpoint_label} is forbidden for a local origin"
+            )
+        elif not isinstance(license_checkpoint, dict):
+            errors.append(f"{checkpoint_label} must be an object")
+        else:
+            required_checkpoint = {
+                "path",
+                "blob_sha",
+                "content_sha256",
+                "spdx",
+                "resolved_commit",
+            }
+            allowed_checkpoint = required_checkpoint | {"api_spdx"}
+            missing_checkpoint = required_checkpoint - set(license_checkpoint)
+            extra_checkpoint = set(license_checkpoint) - allowed_checkpoint
+            if missing_checkpoint:
+                errors.append(
+                    f"{checkpoint_label} missing keys: "
+                    f"{sorted(missing_checkpoint)}"
+                )
+            if extra_checkpoint:
+                errors.append(
+                    f"{checkpoint_label} unknown keys: "
+                    f"{sorted(extra_checkpoint)}"
+                )
+            if not safe_relative_path(license_checkpoint.get("path")):
+                errors.append(f"{checkpoint_label}.path must be a safe path")
+            blob_sha = license_checkpoint.get("blob_sha")
+            if not isinstance(blob_sha, str) or not COMMIT_RE.fullmatch(blob_sha):
+                errors.append(
+                    f"{checkpoint_label}.blob_sha must be a full Git object hash"
+                )
+            checkpoint_hash = license_checkpoint.get("content_sha256")
+            if (
+                not isinstance(checkpoint_hash, str)
+                or not SHA256_RE.fullmatch(checkpoint_hash)
+            ):
+                errors.append(
+                    f"{checkpoint_label}.content_sha256 must be SHA-256"
+                )
+            checkpoint_spdx = license_checkpoint.get("spdx")
+            if checkpoint_spdx not in PERMISSIVE_LICENSES:
+                errors.append(
+                    f"{checkpoint_label}.spdx must be a permitted SPDX identifier"
+                )
+            checkpoint_commit = license_checkpoint.get("resolved_commit")
+            if (
+                not isinstance(checkpoint_commit, str)
+                or not COMMIT_RE.fullmatch(checkpoint_commit)
+            ):
+                errors.append(
+                    f"{checkpoint_label}.resolved_commit must be a full commit"
+                )
+            api_spdx = license_checkpoint.get("api_spdx")
+            if api_spdx is not None and (
+                not isinstance(api_spdx, str)
+                or not api_spdx
+                or api_spdx != api_spdx.strip()
+                or len(api_spdx) > 128
+                or any(ord(character) < 0x20 for character in api_spdx)
+            ):
+                errors.append(f"{checkpoint_label}.api_spdx is invalid")
+            elif api_spdx not in {None, "NOASSERTION", checkpoint_spdx}:
+                errors.append(
+                    f"{checkpoint_label}.api_spdx conflicts with detected SPDX"
+                )
+
 
 def _validate_artifacts(
     artifacts: object,
@@ -360,15 +441,29 @@ def _validate_origin(
         local = False
     else:
         local = is_local_repo(repo)
+        if not local and not valid_github_repo(repo):
+            errors.append(
+                f"{label}.repo must be a canonical GitHub owner/repo"
+            )
 
     origin_path = origin.get("path")
     if origin_path is not None and not safe_relative_path(origin_path):
         errors.append(f"{label}.path must be a safe relative path or null")
 
-    if kind in EXTERNAL_KINDS and local:
+    curated_local = kind in {"overlay", "snapshot"} and local
+    if kind in EXTERNAL_KINDS and local and not curated_local:
         errors.append(f"{label} must be an external origin for kind {kind}")
     if kind == "in_house" and not local:
         errors.append(f"{label} must be local for kind in_house")
+    if repo == LOCAL_CURATION_REPO and kind not in {"overlay", "snapshot"}:
+        errors.append(
+            f"{label}.repo {LOCAL_CURATION_REPO!r} is only valid for "
+            "overlay or snapshot entries"
+        )
+    if curated_local and repo != LOCAL_CURATION_REPO:
+        errors.append(
+            f"{label}.repo must be {LOCAL_CURATION_REPO!r} for local curation"
+        )
 
     license_value = origin.get("license")
     if not local and (
@@ -376,17 +471,25 @@ def _validate_origin(
         or license_value.strip().lower() in UNKNOWN_LICENSE_VALUES
     ):
         errors.append(f"{label}.license must declare an external origin license")
+    if curated_local and license_value is not None:
+        errors.append(f"{label}.license must be null for local curation")
 
     sync_mode = origin.get("sync_mode")
     if sync_mode not in VALID_SYNC_MODES:
         errors.append(f"{label}.sync_mode invalid: {sync_mode!r}")
     else:
-        if sync_mode != entry_sync_mode:
+        if curated_local and sync_mode != "local-only":
+            errors.append(f"{label}.sync_mode must be 'local-only'")
+        elif not curated_local and sync_mode != entry_sync_mode:
             errors.append(
                 f"{label}.sync_mode must match entry sync_mode "
                 f"{entry_sync_mode!r}"
             )
-        if legacy_sync_mode is not None and sync_mode != legacy_sync_mode:
+        if (
+            not curated_local
+            and legacy_sync_mode is not None
+            and sync_mode != legacy_sync_mode
+        ):
             errors.append(
                 f"{label}.sync_mode must match legacy upstream.sync_mode "
                 f"{legacy_sync_mode!r}"
@@ -402,6 +505,16 @@ def _validate_origin(
         local=local,
         errors=errors,
     )
+    if (
+        not local
+        and isinstance(tracking, dict)
+        and isinstance(tracking.get("license_checkpoint"), dict)
+        and tracking["license_checkpoint"].get("spdx") != license_value
+    ):
+        errors.append(
+            f"{label}.tracking.license_checkpoint.spdx must match "
+            "origin.license"
+        )
     if not local and isinstance(tracking, dict):
         channel = tracking.get("channel")
         ref = tracking.get("ref")
@@ -573,9 +686,10 @@ def _validate_composition(
             if selector == "source_package":
                 canonical_value = value.lower()
                 source_package_ids.add(canonical_value)
-                if "/" not in value:
+                if not valid_github_repo(value):
                     errors.append(
-                        f"{dep_label}.source_package must look like owner/repo"
+                        f"{dep_label}.source_package must be a canonical "
+                        "GitHub owner/repo"
                     )
                 if value != value.strip() or value != canonical_value:
                     errors.append(
@@ -675,15 +789,24 @@ def _validate_frontmatter_semantics(
             for origin in origins
             if isinstance(origin, dict) and not is_local_repo(origin.get("repo"))
         }
-        if (
-            frontmatter_license
-            and len(origin_licenses) == 1
-            and frontmatter_license.lower() not in origin_licenses
-        ):
-            errors.append(
-                f"{label} frontmatter license {frontmatter_license!r} "
-                "does not match its origin license"
-            )
+        if frontmatter_license and origin_licenses:
+            expression = frontmatter_license.strip()
+            has_or = bool(re.search(r"\s+OR\s+", expression, re.IGNORECASE))
+            declared_licenses = {
+                part.strip().strip("()").lower()
+                for part in re.split(
+                    r"\s+(?:AND|OR)\s+",
+                    expression,
+                    flags=re.IGNORECASE,
+                )
+                if part.strip().strip("()")
+            }
+            if has_or or declared_licenses != origin_licenses:
+                errors.append(
+                    f"{label} frontmatter license {frontmatter_license!r} "
+                    "does not preserve the complete external origin license "
+                    f"lineage {sorted(origin_licenses)!r}"
+                )
 
 
 def _validate_v2_entry(
@@ -728,8 +851,16 @@ def _validate_v2_entry(
         errors.append(
             f"{mapping}: skills[{idx}].origins must not be empty for kind {kind}"
         )
+    if kind in EXTERNAL_KINDS and origins and not any(
+        isinstance(origin, dict) and not is_local_repo(origin.get("repo"))
+        for origin in origins
+    ):
+        errors.append(
+            f"{mapping}: skills[{idx}] kind {kind} requires an external origin"
+        )
     artifact_file_targets: set[str] = set()
     artifact_directory_targets: set[str] = set()
+    artifact_target_claims: dict[str, list[tuple[int, dict, dict]]] = {}
     for origin_idx, origin in enumerate(origins, 1):
         _validate_origin(
             origin,
@@ -752,6 +883,9 @@ def _validate_v2_entry(
                         artifact_directory_targets.add(target)
                     else:
                         artifact_file_targets.add(target)
+                    artifact_target_claims.setdefault(target, []).append(
+                        (origin_idx, origin, artifact)
+                    )
 
     _validate_legacy_owner_consistency(
         item,
@@ -760,6 +894,33 @@ def _validate_v2_entry(
         origins,
         errors,
     )
+
+    for target, claims in sorted(artifact_target_claims.items()):
+        origin_owners = {origin_index for origin_index, _, _ in claims}
+        if len(origin_owners) > 1:
+            errors.append(
+                f"{mapping}: skills[{idx}] artifact target {target!r} "
+                "must have exactly one origin owner; found "
+                f"{len(origin_owners)}"
+            )
+
+    repo_skill = item.get("repo_skill")
+    if kind in EXTERNAL_KINDS and isinstance(repo_skill, str):
+        repo_skill_owners = [
+            (origin, artifact)
+            for origin in origins
+            if isinstance(origin, dict)
+            for artifact in origin.get("artifacts", [])
+            if isinstance(artifact, dict)
+            and _artifact_owns_repo_skill(artifact, repo_skill)
+        ]
+        if len(repo_skill_owners) == 1 and is_local_repo(
+            repo_skill_owners[0][0].get("repo")
+        ):
+            errors.append(
+                f"{mapping}: skills[{idx}] external repo_skill must be owned "
+                "by an external origin"
+            )
 
     managed_files = item.get("managed_files")
     if not isinstance(managed_files, list):
@@ -833,19 +994,24 @@ def _validate_v2_entry(
                 "must be listed in managed_files"
             )
         for target in sorted(managed_targets):
-            if target in artifact_file_targets:
-                continue
-            target_path = PurePosixPath(target.replace("\\", "/"))
-            covered_by_directory = any(
-                PurePosixPath(directory.replace("\\", "/"))
-                in target_path.parents
-                for directory in artifact_directory_targets
-            )
-            if not covered_by_directory:
+            owners = {
+                origin_idx
+                for origin_idx, origin in enumerate(origins, 1)
+                if isinstance(origin, dict)
+                for artifact in origin.get("artifacts", [])
+                if isinstance(artifact, dict)
+                and _artifact_owns_repo_skill(artifact, target)
+            }
+            if not owners:
                 errors.append(
                     f"{mapping}: skills[{idx}] managed file {target!r} "
                     "must be covered by an exact file artifact or a parent "
                     "directory artifact"
+                )
+            elif len(owners) > 1:
+                errors.append(
+                    f"{mapping}: skills[{idx}] managed file {target!r} "
+                    f"must have exactly one artifact owner; found {len(owners)}"
                 )
 
         canonical_repo_skill = _canonical_repo_skill_path(item)
@@ -992,38 +1158,38 @@ def validate_mapping(
 
 
 def _entry_content_sha256(item: dict, repo_root: Path) -> str | None:
-    if item.get("kind") not in {"in_house", "composite"}:
-        origins = item.get("origins")
-        if isinstance(origins, list):
-            for origin in origins:
-                if not isinstance(origin, dict):
-                    continue
-                tracking = origin.get("tracking")
-                if not isinstance(tracking, dict):
-                    continue
-                content_hash = tracking.get("content_sha256")
-                if (
-                    isinstance(content_hash, str)
-                    and SHA256_RE.fullmatch(content_hash)
-                ):
-                    return content_hash.lower()
-
     repo_skill = item.get("repo_skill")
+    if not isinstance(repo_skill, str) or not safe_relative_path(repo_skill):
+        return None
+    origins = item.get("origins")
+    if not isinstance(origins, list):
+        return None
+    owner_claims = [
+        (origin, artifact)
+        for origin in origins
+        if isinstance(origin, dict)
+        and isinstance(origin.get("artifacts"), list)
+        for artifact in origin["artifacts"]
+        if _artifact_owns_repo_skill(artifact, repo_skill)
+    ]
+    if len(owner_claims) != 1:
+        return None
+    owner = owner_claims[0][0]
+
+    if item.get("kind") not in {"in_house", "composite"}:
+        tracking = owner.get("tracking")
+        content_hash = (
+            tracking.get("content_sha256")
+            if isinstance(tracking, dict)
+            else None
+        )
+        if isinstance(content_hash, str) and SHA256_RE.fullmatch(content_hash):
+            return content_hash.lower()
+
     if isinstance(repo_skill, str) and safe_relative_path(repo_skill):
         skill_path = _safe_repository_file(repo_root, repo_skill)
         if skill_path is not None:
             return sha256_file(skill_path)
-    origins = item.get("origins")
-    if isinstance(origins, list):
-        for origin in origins:
-            if not isinstance(origin, dict):
-                continue
-            tracking = origin.get("tracking")
-            if not isinstance(tracking, dict):
-                continue
-            content_hash = tracking.get("content_sha256")
-            if isinstance(content_hash, str) and SHA256_RE.fullmatch(content_hash):
-                return content_hash.lower()
     return None
 
 

--- a/skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md
+++ b/skills/ai-workflow/using-agent-skills/upstream-bundle/.claude/commands/webperf.md
@@ -1,0 +1,32 @@
+---
+description: Run a web performance audit via the web-performance-auditor persona
+---
+
+`/webperf` targets web applications specifically. Do not use it for utility libraries, CLIs, or server-only code with no browser-facing output.
+
+## Determine the mode
+
+**Deep mode** — activate when any of these is available:
+- A Lighthouse JSON report file (e.g. `npx lighthouse <url> --output json --output-path ./report.json`, or `npx -p chrome-devtools-mcp chrome-devtools lighthouse_audit --output-format=json` from the Chrome DevTools MCP CLI)
+- A PageSpeed Insights JSON response (includes Lighthouse + CrUX)
+- A CrUX API response (requires `CRUX_API_KEY` or `GOOGLE_API_KEY`)
+- A DevTools performance trace
+- A live URL plus the `chrome-devtools` MCP server configured in the harness (the agent can capture metrics directly via `lighthouse_audit` and `performance_*` tools)
+- The Chrome DevTools MCP CLI invoked locally (via `npx -p chrome-devtools-mcp chrome-devtools <tool>` or after `npm i -g chrome-devtools-mcp`) — the user runs commands like `chrome-devtools lighthouse_audit --output-format=json` and passes the JSON output to the agent
+
+**Quick mode** — default when none of the above are available. The agent scans source code for structural anti-patterns and labels every finding as `potential impact`.
+
+## Run the audit
+
+Spawn the `web-performance-auditor` subagent. Pass it explicitly:
+
+- The files, components, or diff under review
+- Any artifact paths (Lighthouse JSON, PSI JSON, CrUX response, trace) or pasted JSON content
+- The target URL or page name when known
+- A note on which mode you expect (Quick or Deep), so the agent surfaces missing inputs if Deep was intended
+
+The subagent returns a scorecard (only populated with sourced values), a ranked list of findings, positive observations, and proactive recommendations.
+
+## Output
+
+Return the full audit report to the user. No synthesis or merge step is needed — this is a single-persona command.

--- a/tests/test_artifact_set_sync.py
+++ b/tests/test_artifact_set_sync.py
@@ -1,0 +1,1694 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import artifact_set_sync as artifact_sync
+from scripts.artifact_set_sync import (
+    ArtifactApplyError,
+    ArtifactLockError,
+    ArtifactRecoveryError,
+    ArtifactValidationError,
+    ConcurrentModificationError,
+    OwnershipConflictError,
+    apply_artifact_set_sync,
+    plan_artifact_set_sync,
+    prepare_artifact_set_sync,
+    skill_advisory_lock,
+    skill_lock_identity,
+    skill_lock_path,
+    skill_transaction_journal_path,
+    sync_artifact_set,
+)
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write(root: Path, relative: str, data: bytes) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _entry(
+    files: dict[str, bytes],
+    *,
+    slug: str = "demo",
+    repo_skill: str = "skills/ai-workflow/demo/SKILL.md",
+) -> dict:
+    skill_root = Path(repo_skill).parent.as_posix()
+    return {
+        "normalized_slug": slug,
+        "repo_skill": repo_skill,
+        "kind": "mirror",
+        "origins": [
+            {
+                "artifacts": [
+                    {
+                        "source": f"upstream/{slug}",
+                        "target": skill_root,
+                        "type": "directory",
+                    }
+                ]
+            }
+        ],
+        "managed_files": [
+            {"path": path, "sha256": _digest(data), "owner": slug}
+            for path, data in sorted(files.items())
+        ],
+    }
+
+
+def _payload(source: str, target: str, data: bytes, kind: str = "file") -> dict:
+    return {"source": source, "target": target, "type": kind, "data": data}
+
+
+def _temp_artifacts(root: Path) -> list[Path]:
+    parent = root / "skills/ai-workflow"
+    return (
+        sorted(parent.glob(".demo.artifact-*")) if parent.exists() else []
+    )
+
+
+def _run_hard_exit_worker(
+    root: Path,
+    *,
+    mode: str,
+    mapping: Path | None = None,
+    before_sha256: str | None = None,
+    after_sha256: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    script = r"""
+import hashlib
+import os
+import sys
+from pathlib import Path
+from scripts import artifact_set_sync as artifact_sync
+from scripts.artifact_set_sync import plan_artifact_set_sync, prepare_artifact_set_sync
+
+root = Path(sys.argv[1])
+mode = sys.argv[2]
+skill = "skills/ai-workflow/demo/SKILL.md"
+old = (root / skill).read_bytes()
+entry = {
+    "normalized_slug": "demo",
+    "repo_skill": skill,
+    "kind": "mirror",
+    "origins": [{
+        "artifacts": [{
+            "source": "release/demo",
+            "target": "skills/ai-workflow/demo",
+            "type": "directory",
+        }],
+    }],
+    "managed_files": [{
+        "path": skill,
+        "sha256": hashlib.sha256(old).hexdigest(),
+        "owner": "demo",
+    }],
+}
+plan = plan_artifact_set_sync(
+    root,
+    entry,
+    [{"source": "release/SKILL.md", "target": skill, "type": "file", "data": b"new body"}],
+    {"ref": "v2"},
+)
+
+real_replace_tree = artifact_sync._replace_tree_and_fsync
+def replace_tree_and_hard_exit(source, destination):
+    real_replace_tree(source, destination)
+    if mode == "after-backup-before-state" and destination.name == "previous":
+        os._exit(74)
+    if (
+        mode == "after-install-before-state"
+        and destination == root / "skills/ai-workflow/demo"
+    ):
+        os._exit(75)
+
+artifact_sync._replace_tree_and_fsync = replace_tree_and_hard_exit
+
+def fault(event):
+    if mode == "after-backup" and event == "after_backup_rename":
+        os._exit(71)
+
+transaction = prepare_artifact_set_sync(plan, fault_injector=fault)
+if mode == "prepared-unbound":
+    os._exit(72)
+if mode in {"bound-before", "bound-after"}:
+    mapping = Path(sys.argv[3])
+    before_sha256 = sys.argv[4]
+    after_sha256 = sys.argv[5]
+    transaction.bind_authority(mapping, before_sha256, after_sha256)
+    if mode == "bound-before":
+        os._exit(76)
+    replacement = mapping.with_suffix(".next")
+    replacement.write_bytes(b'{"state":"after"}\n')
+    with replacement.open("rb") as handle:
+        os.fsync(handle.fileno())
+    os.replace(replacement, mapping)
+    directory_fd = os.open(mapping.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+    os._exit(73)
+raise RuntimeError(mode)
+"""
+    command = [sys.executable, "-c", script, str(root), mode]
+    if mapping is not None:
+        command.extend(
+            [
+                str(mapping),
+                str(before_sha256),
+                str(after_sha256),
+            ]
+        )
+    env = dict(os.environ)
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    )
+    return subprocess.run(
+        command,
+        cwd=repo_root,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_successful_multisidecar_sync_returns_json_ready_metadata(tmp_path: Path):
+    old = {
+        "skills/ai-workflow/demo/SKILL.md": b"old body\n",
+        "skills/ai-workflow/demo/references/guide.md": b"old guide\n",
+    }
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    checkpoint = {
+        "channel": "latest_release",
+        "ref": "v2.0.0",
+        "resolved_commit": "a" * 40,
+        "content_sha256": "0" * 64,
+    }
+    artifacts = [
+        _payload(
+            "package/skills/demo/references/guide.md",
+            "skills/ai-workflow/demo/references/guide.md",
+            b"new guide\n",
+        ),
+        _payload(
+            "package/skills/demo/templates/request.md",
+            "skills/ai-workflow/demo/templates/request.md",
+            b"template\n",
+        ),
+        _payload(
+            "package/skills/demo/scripts/check.sh",
+            "skills/ai-workflow/demo/scripts/check.sh",
+            b"#!/bin/sh\nexit 0\n",
+        ),
+        _payload(
+            "package/skills/demo/SKILL.md",
+            "skills/ai-workflow/demo/SKILL.md",
+            b"new body\n",
+        ),
+    ]
+
+    result = sync_artifact_set(tmp_path, entry, artifacts, checkpoint)
+
+    assert result.applied
+    assert not result.dry_run
+    assert result.changed == (
+        "skills/ai-workflow/demo/SKILL.md",
+        "skills/ai-workflow/demo/references/guide.md",
+        "skills/ai-workflow/demo/scripts/check.sh",
+        "skills/ai-workflow/demo/templates/request.md",
+    )
+    assert result.pruned == ()
+    assert (tmp_path / "skills/ai-workflow/demo/SKILL.md").read_bytes() == b"new body\n"
+    assert (
+        tmp_path / "skills/ai-workflow/demo/references/guide.md"
+    ).read_bytes() == b"new guide\n"
+    assert result.content_sha256 == _digest(b"new body\n")
+    assert result.checkpoint["content_sha256"] == _digest(b"new body\n")
+    assert checkpoint["content_sha256"] == "0" * 64
+    patch = result.metadata_patch()
+    assert [item["target"] for item in patch["artifacts"]] == [
+        item["path"] for item in patch["managed_files"]
+    ]
+    assert all(item["owner"] == "demo" for item in patch["managed_files"])
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_binary_bytes_and_cross_directory_source_mapping_are_exact(tmp_path: Path):
+    old = {"skills/ai-workflow/demo/SKILL.md": b"body"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    binary = b"\x00\xff\x10PNG\r\n\x1a\n"
+    artifacts = [
+        _payload(
+            "codex/SKILL.md",
+            "skills/ai-workflow/demo/SKILL.md",
+            b"new body",
+        ),
+        {
+            "source": "shared-assets/icons/logo.bin",
+            "target": "skills/ai-workflow/demo/assets/logo.bin",
+            "type": "binary",
+            "bytes": binary,
+        },
+    ]
+
+    result = sync_artifact_set(tmp_path, entry, artifacts, {"ref": "v1"})
+
+    assert (
+        tmp_path / "skills/ai-workflow/demo/assets/logo.bin"
+    ).read_bytes() == binary
+    logo = next(
+        item
+        for item in result.managed_files
+        if item["path"].endswith("logo.bin")
+    )
+    assert logo["sha256"] == _digest(binary)
+    assert all(item["type"] == "file" for item in result.artifacts)
+
+
+def test_source_and_target_rename_prunes_only_old_managed_file(tmp_path: Path):
+    old = {
+        "skills/ai-workflow/demo/SKILL.md": b"body",
+        "skills/ai-workflow/demo/references/old.md": b"owned old",
+    }
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    _write(
+        tmp_path,
+        "skills/ai-workflow/demo/notes/user.md",
+        b"keep me",
+    )
+    entry = _entry(old)
+    artifacts = [
+        _payload(
+            "relocated/codex-skill.md",
+            "skills/ai-workflow/demo/SKILL.md",
+            b"body",
+        ),
+        _payload(
+            "relocated/docs/current.md",
+            "skills/ai-workflow/demo/references/current.md",
+            b"owned old",
+        ),
+    ]
+
+    result = sync_artifact_set(tmp_path, entry, artifacts, {"ref": "v2"})
+
+    assert result.changed == (
+        "skills/ai-workflow/demo/references/current.md",
+    )
+    assert result.pruned == (
+        "skills/ai-workflow/demo/references/old.md",
+    )
+    assert not (
+        tmp_path / "skills/ai-workflow/demo/references/old.md"
+    ).exists()
+    assert (
+        tmp_path / "skills/ai-workflow/demo/references/current.md"
+    ).read_bytes() == b"owned old"
+    assert (
+        tmp_path / "skills/ai-workflow/demo/notes/user.md"
+    ).read_bytes() == b"keep me"
+    skill_artifact = next(
+        item for item in result.artifacts if item["target"].endswith("SKILL.md")
+    )
+    assert skill_artifact["source"] == "relocated/codex-skill.md"
+
+
+def test_unowned_files_are_preserved_and_not_added_to_new_manifest(tmp_path: Path):
+    old = {"skills/ai-workflow/demo/SKILL.md": b"old"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    unowned = "skills/ai-workflow/demo/local/user-notes.txt"
+    _write(tmp_path, unowned, b"user content")
+    entry = _entry(old)
+
+    result = sync_artifact_set(
+        tmp_path,
+        entry,
+        [
+            _payload(
+                "upstream/SKILL.md",
+                "skills/ai-workflow/demo/SKILL.md",
+                b"new",
+            )
+        ],
+        {"ref": "v2"},
+    )
+
+    assert unowned in result.preserved
+    assert (tmp_path / unowned).read_bytes() == b"user content"
+    assert unowned not in {item["path"] for item in result.managed_files}
+
+
+def test_unowned_target_collision_is_never_silently_adopted(tmp_path: Path):
+    old = {"skills/ai-workflow/demo/SKILL.md": b"body"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    target = "skills/ai-workflow/demo/references/existing.md"
+    _write(tmp_path, target, b"same bytes")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [
+            _payload(
+                "upstream/SKILL.md",
+                "skills/ai-workflow/demo/SKILL.md",
+                b"body",
+            ),
+            _payload("upstream/existing.md", target, b"same bytes"),
+        ],
+        {"ref": "v1"},
+    )
+
+    assert plan.unowned_conflicts == (target,)
+    with pytest.raises(OwnershipConflictError) as raised:
+        apply_artifact_set_sync(plan)
+    assert raised.value.unowned_conflicts == (target,)
+    assert (tmp_path / target).read_bytes() == b"same bytes"
+
+
+@pytest.mark.parametrize("entry_shape", ["multi_origin", "overlay"])
+def test_implicit_ownership_is_only_allowed_for_single_origin_mirror(
+    tmp_path: Path, entry_shape: str
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"body"}
+    _write(tmp_path, skill, b"body")
+    entry = _entry(old)
+    if entry_shape == "multi_origin":
+        entry["origins"].append({"artifacts": []})
+    else:
+        entry["kind"] = "overlay"
+
+    with pytest.raises(ArtifactValidationError, match="implicit ownership"):
+        plan_artifact_set_sync(
+            tmp_path,
+            entry,
+            [_payload("release/SKILL.md", skill, b"new")],
+            {"ref": "v2"},
+        )
+
+
+def test_origin_scope_prunes_selected_artifacts_and_protects_overlay_sidecars(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    external = "skills/ai-workflow/demo/references/external-old.md"
+    local = "skills/ai-workflow/demo/references/local-curation.md"
+    old = {
+        skill: b"old body",
+        external: b"external",
+        local: b"local supplement",
+    }
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    entry["origins"] = [
+        {
+            "artifacts": [
+                {"source": "upstream/SKILL.md", "target": skill, "type": "file"},
+                {
+                    "source": "upstream/external-old.md",
+                    "target": external,
+                    "type": "file",
+                },
+            ]
+        },
+        {
+            "artifacts": [
+                {"source": local, "target": local, "type": "file"},
+            ]
+        },
+    ]
+
+    result = sync_artifact_set(
+        tmp_path,
+        entry,
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+        origin_index=0,
+    )
+
+    assert result.pruned == (external,)
+    assert not (tmp_path / external).exists()
+    assert (tmp_path / local).read_bytes() == b"local supplement"
+    returned = {item["path"]: item["sha256"] for item in result.managed_files}
+    assert returned == {
+        skill: _digest(b"new body"),
+        local: _digest(b"local supplement"),
+    }
+
+
+def test_origin_scope_rejects_payload_collision_with_another_origin(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    local = "skills/ai-workflow/demo/references/local-curation.md"
+    old = {skill: b"body", local: b"curated"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    entry["origins"] = [
+        {
+            "artifacts": [
+                {"source": "upstream/SKILL.md", "target": skill, "type": "file"},
+                {
+                    "source": "upstream/references",
+                    "target": "skills/ai-workflow/demo/references",
+                    "type": "directory",
+                },
+            ]
+        },
+        {
+            "artifacts": [
+                {"source": local, "target": local, "type": "file"},
+            ]
+        },
+    ]
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [
+            _payload("release/SKILL.md", skill, b"new"),
+            _payload("release/local-curation.md", local, b"overwrite"),
+        ],
+        {"ref": "v2"},
+        origin_index=0,
+    )
+
+    assert plan.protected_targets == (local,)
+    assert plan.unowned_conflicts == (local,)
+    with pytest.raises(OwnershipConflictError):
+        apply_artifact_set_sync(plan)
+    assert (tmp_path / local).read_bytes() == b"curated"
+
+
+def test_origin_directory_claim_expands_only_across_managed_inventory(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    external = "skills/ai-workflow/demo/references/external.md"
+    local = "skills/ai-workflow/demo/local/curation.md"
+    old = {skill: b"body", external: b"external", local: b"local"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    entry["origins"] = [
+        {
+            "artifacts": [
+                {
+                    "source": "release/demo/SKILL.md",
+                    "target": skill,
+                    "type": "file",
+                },
+                {
+                    "source": "release/demo/references",
+                    "target": "skills/ai-workflow/demo/references",
+                    "type": "directory",
+                }
+            ]
+        }
+    ]
+
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [_payload("release/demo/SKILL.md", skill, b"new")],
+        {"ref": "v2"},
+        origin_index=0,
+    )
+
+    assert plan.owned_targets == (skill, external)
+    assert plan.protected_targets == (local,)
+    result = apply_artifact_set_sync(plan)
+    assert result.pruned == (external,)
+    assert (tmp_path / local).read_bytes() == b"local"
+
+
+def test_other_origin_exact_file_is_protected_from_selected_root_directory(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    external = "skills/ai-workflow/demo/references/external.md"
+    local = "skills/ai-workflow/demo/local/curation.md"
+    old = {skill: b"body", external: b"external", local: b"local"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    entry["origins"] = [
+        {
+            "artifacts": [
+                {
+                    "source": "release/demo",
+                    "target": "skills/ai-workflow/demo",
+                    "type": "directory",
+                }
+            ]
+        },
+        {
+            "artifacts": [
+                {"source": local, "target": local, "type": "file"},
+            ]
+        },
+    ]
+
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [_payload("release/demo/SKILL.md", skill, b"new")],
+        {"ref": "v2"},
+        origin_index=0,
+    )
+
+    assert plan.owned_targets == (skill, external)
+    assert plan.protected_targets == (local,)
+    result = apply_artifact_set_sync(plan)
+    assert result.pruned == (external,)
+    assert (tmp_path / local).read_bytes() == b"local"
+    assert local in {item["path"] for item in result.managed_files}
+
+
+def test_other_origin_directory_scope_protects_new_selected_payload(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"body"}
+    _write(tmp_path, skill, b"body")
+    entry = _entry(old)
+    entry["origins"] = [
+        {
+            "artifacts": [
+                {"source": "release/SKILL.md", "target": skill, "type": "file"},
+                {
+                    "source": "release/references",
+                    "target": "skills/ai-workflow/demo/references",
+                    "type": "directory",
+                },
+            ]
+        },
+        {
+            "artifacts": [
+                {
+                    "source": "curation/references",
+                    "target": "skills/ai-workflow/demo/references",
+                    "type": "directory",
+                }
+            ]
+        },
+    ]
+    target = "skills/ai-workflow/demo/references/new.md"
+
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [
+            _payload("release/SKILL.md", skill, b"new"),
+            _payload("release/references/new.md", target, b"new reference"),
+        ],
+        {"ref": "v2"},
+        origin_index=0,
+    )
+
+    assert target in plan.protected_targets
+    assert target in plan.unowned_conflicts
+    with pytest.raises(OwnershipConflictError):
+        apply_artifact_set_sync(plan)
+
+
+def test_selected_origin_must_claim_every_payload_target(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    _write(tmp_path, skill, b"body")
+    entry = _entry({skill: b"body"})
+    entry["origins"][0]["artifacts"] = [
+        {"source": "release/SKILL.md", "target": skill, "type": "file"}
+    ]
+    target = "skills/ai-workflow/demo/references/unclaimed.md"
+
+    with pytest.raises(ArtifactValidationError, match="selected origin"):
+        plan_artifact_set_sync(
+            tmp_path,
+            entry,
+            [
+                _payload("release/SKILL.md", skill, b"new"),
+                _payload("release/unclaimed.md", target, b"unclaimed"),
+            ],
+            {"ref": "v2"},
+            origin_index=0,
+        )
+
+
+@pytest.mark.parametrize("remove", [False, True])
+def test_modified_managed_overwrite_or_delete_is_blocked(
+    tmp_path: Path, remove: bool
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    sidecar = "skills/ai-workflow/demo/references/owned.md"
+    old = {skill: b"body", sidecar: b"manifest version"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    _write(tmp_path, sidecar, b"user modification")
+    artifacts = [_payload("upstream/SKILL.md", skill, b"body")]
+    if not remove:
+        artifacts.append(
+            _payload("upstream/owned.md", sidecar, b"upstream replacement")
+        )
+
+    plan = plan_artifact_set_sync(tmp_path, entry, artifacts, {"ref": "v2"})
+
+    assert plan.user_modified == (sidecar,)
+    assert any(
+        item.path == sidecar and item.kind == "hash_mismatch"
+        for item in plan.drift
+    )
+    with pytest.raises(OwnershipConflictError) as raised:
+        apply_artifact_set_sync(plan, dry_run=True)
+    assert raised.value.user_modified == (sidecar,)
+    assert (tmp_path / sidecar).read_bytes() == b"user modification"
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_modified_managed_file_equal_to_new_payload_is_safe_drift(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    sidecar = "skills/ai-workflow/demo/references/owned.md"
+    old = {skill: b"body", sidecar: b"manifest version"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    entry = _entry(old)
+    _write(tmp_path, sidecar, b"already upstream")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [
+            _payload("upstream/SKILL.md", skill, b"body"),
+            _payload("upstream/owned.md", sidecar, b"already upstream"),
+        ],
+        {"ref": "v2"},
+    )
+
+    assert not plan.blocked
+    assert plan.changed == ()
+    assert len(plan.drift) == 1
+    result = apply_artifact_set_sync(plan)
+    assert not result.applied
+    assert result.managed_files[1]["sha256"] == _digest(b"already upstream")
+
+
+def test_missing_managed_file_is_reported_as_drift_and_recreated(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    sidecar = "skills/ai-workflow/demo/references/missing.md"
+    old = {skill: b"body", sidecar: b"old"}
+    _write(tmp_path, skill, b"body")
+    entry = _entry(old)
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [
+            _payload("upstream/SKILL.md", skill, b"body"),
+            _payload("upstream/missing.md", sidecar, b"restored"),
+        ],
+        {"ref": "v2"},
+    )
+
+    assert plan.user_modified == ()
+    assert plan.drift[0].to_dict() == {
+        "path": sidecar,
+        "kind": "missing",
+        "expected_sha256": _digest(b"old"),
+        "actual_sha256": None,
+    }
+    apply_artifact_set_sync(plan)
+    assert (tmp_path / sidecar).read_bytes() == b"restored"
+
+
+def test_dry_run_performs_strictly_zero_writes(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    before = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    result = sync_artifact_set(
+        tmp_path,
+        _entry(old),
+        [_payload("upstream/SKILL.md", skill, b"new")],
+        {"ref": "v2"},
+        dry_run=True,
+    )
+
+    after = {
+        path.relative_to(tmp_path).as_posix(): path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert result.dry_run and not result.applied
+    assert before == after
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_symlink_parent_escape_is_rejected_without_touching_outside(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"body"}
+    _write(tmp_path, skill, b"body")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    references = tmp_path / "skills/ai-workflow/demo/references"
+    references.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ArtifactValidationError, match="symlink"):
+        plan_artifact_set_sync(
+            tmp_path,
+            _entry(old),
+            [
+                _payload("upstream/SKILL.md", skill, b"new body"),
+                _payload(
+                    "upstream/escape.md",
+                    "skills/ai-workflow/demo/references/escape.md",
+                    b"escape",
+                ),
+            ],
+            {"ref": "v2"},
+        )
+
+    assert list(outside.iterdir()) == []
+    assert (tmp_path / skill).read_bytes() == b"body"
+
+
+def test_symlink_introduced_during_stage_copy_is_rejected_before_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    reference = "skills/ai-workflow/demo/references/old.md"
+    old = {skill: b"body", reference: b"old"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [
+            _payload("upstream/SKILL.md", skill, b"new body"),
+            _payload(
+                "upstream/new.md",
+                "skills/ai-workflow/demo/references/new.md",
+                b"must not escape",
+            ),
+        ],
+        {"ref": "v2"},
+    )
+    real_copytree = artifact_sync.shutil.copytree
+
+    def hostile_copytree(source, destination, *args, **kwargs):
+        result = real_copytree(source, destination, *args, **kwargs)
+        if Path(destination).name == "new":
+            references = Path(destination) / "references"
+            artifact_sync.shutil.rmtree(references)
+            references.symlink_to(outside, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(artifact_sync.shutil, "copytree", hostile_copytree)
+    with pytest.raises(ArtifactValidationError, match="symlink"):
+        apply_artifact_set_sync(plan)
+
+    assert list(outside.iterdir()) == []
+    assert (tmp_path / skill).read_bytes() == b"body"
+    assert (tmp_path / reference).read_bytes() == b"old"
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_directory_payload_must_be_expanded_and_paths_must_be_canonical(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    _write(tmp_path, skill, b"body")
+    entry = _entry({skill: b"body"})
+    with pytest.raises(ArtifactValidationError, match="expanded"):
+        plan_artifact_set_sync(
+            tmp_path,
+            entry,
+            [_payload("upstream/demo", skill, b"", "directory")],
+            {},
+        )
+    with pytest.raises(ArtifactValidationError, match="canonical"):
+        plan_artifact_set_sync(
+            tmp_path,
+            entry,
+            [_payload("upstream/SKILL.md", "skills/ai-workflow/demo/../x", b"x")],
+            {},
+        )
+
+
+@pytest.mark.parametrize(
+    "event", ["after_backup_rename", "after_install_rename"]
+)
+def test_fault_after_rename_rolls_back_and_removes_all_transaction_dirs(
+    tmp_path: Path, event: str
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    sidecar = "skills/ai-workflow/demo/references/old.md"
+    old = {skill: b"old body", sidecar: b"old ref"}
+    for path, data in old.items():
+        _write(tmp_path, path, data)
+    _write(
+        tmp_path,
+        "skills/ai-workflow/demo/local.txt",
+        b"unowned",
+    )
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [
+            _payload("upstream/SKILL.md", skill, b"new body"),
+            _payload(
+                "upstream/new.md",
+                "skills/ai-workflow/demo/references/new.md",
+                b"new ref",
+            ),
+        ],
+        {"ref": "v2"},
+    )
+
+    def fail(current: str) -> None:
+        if current == event:
+            raise RuntimeError(f"injected at {event}")
+
+    with pytest.raises(ArtifactApplyError) as raised:
+        apply_artifact_set_sync(plan, fault_injector=fail)
+
+    assert raised.value.rollback_succeeded
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert (tmp_path / sidecar).read_bytes() == b"old ref"
+    assert (
+        tmp_path / "skills/ai-workflow/demo/local.txt"
+    ).read_bytes() == b"unowned"
+    assert not (
+        tmp_path / "skills/ai-workflow/demo/references/new.md"
+    ).exists()
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_mapping_finalize_failure_rolls_back_prepared_artifact_set(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "mapping.json"
+    mapping.write_bytes(b'{"checkpoint":"old"}\n')
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with (
+        pytest.raises(OSError, match="mapping replace failed"),
+        prepare_artifact_set_sync(plan) as transaction,
+    ):
+        assert (tmp_path / skill).read_bytes() == b"new body"
+        assert transaction.state == "prepared"
+        # The integration's atomic mapping writer fails before replace.
+        raise OSError("mapping replace failed")
+
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert mapping.read_bytes() == b'{"checkpoint":"old"}\n'
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_concurrent_tree_swap_in_final_scan_rename_window_is_not_lost(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = tmp_path / "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"old body"}),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+    real_replace = artifact_sync.os.replace
+    swapped = False
+
+    def hostile_replace(source, destination):
+        nonlocal swapped
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if (
+            not swapped
+            and source_path == skill_root
+            and destination_path.name == "previous"
+        ):
+            swapped = True
+            displaced = skill_root.parent / "displaced-by-concurrent-writer"
+            real_replace(skill_root, displaced)
+            skill_root.mkdir()
+            (skill_root / "SKILL.md").write_bytes(b"concurrent body")
+            (skill_root / "concurrent.txt").write_bytes(b"must survive")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(artifact_sync.os, "replace", hostile_replace)
+    with pytest.raises(ConcurrentModificationError):
+        apply_artifact_set_sync(plan)
+
+    survivors = [
+        path
+        for path in tmp_path.rglob("concurrent.txt")
+        if path.read_bytes() == b"must survive"
+    ]
+    assert survivors
+    assert (skill_root / "concurrent.txt").read_bytes() == b"must survive"
+
+
+def test_mapping_failure_after_replace_never_leaves_skill_directory_missing(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "mapping.json"
+    mapping.write_bytes(b'{"checkpoint":"old"}\n')
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with (
+        pytest.raises(OSError, match="post-replace failure"),
+        prepare_artifact_set_sync(plan),
+    ):
+        replacement = tmp_path / "mapping.json.next"
+        replacement.write_bytes(b'{"checkpoint":"new"}\n')
+        replacement.replace(mapping)
+        raise OSError("post-replace failure")
+
+    # The mapping writer owns restoration of its own post-replace failure, but
+    # the artifact transaction independently guarantees a live old directory.
+    assert mapping.read_bytes() == b'{"checkpoint":"new"}\n'
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert (tmp_path / "skills/ai-workflow/demo").is_dir()
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_prepared_transaction_commits_only_after_mapping_finalize(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with prepare_artifact_set_sync(plan) as transaction:
+        assert (tmp_path / skill).read_bytes() == b"new body"
+        result = transaction.commit()
+
+    assert result.applied
+    assert transaction.state == "committed"
+    assert (tmp_path / skill).read_bytes() == b"new body"
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_bound_authority_requires_mapping_after_hash_before_commit(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    before = b'{"state":"before"}\n'
+    after = b'{"state":"after"}\n'
+    mapping.write_bytes(before)
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with prepare_artifact_set_sync(plan) as transaction:
+        transaction.bind_authority(mapping, _digest(before), _digest(after))
+        with pytest.raises(ArtifactRecoveryError, match="before.*after hash"):
+            transaction.commit()
+        replacement = mapping.with_suffix(".next")
+        replacement.write_bytes(after)
+        replacement.replace(mapping)
+        transaction.commit()
+
+    assert mapping.read_bytes() == after
+    assert (tmp_path / skill).read_bytes() == b"new body"
+    assert not skill_transaction_journal_path(tmp_path, skill_root).exists()
+
+
+def test_bind_authority_rejects_symlink_and_non_before_digest(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    outside = tmp_path / "outside-mapping.json"
+    outside.write_bytes(b"outside")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    mapping.symlink_to(outside)
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with (
+        pytest.raises(ArtifactRecoveryError, match="unsafe path"),
+        prepare_artifact_set_sync(plan) as transaction,
+    ):
+        transaction.bind_authority(
+            mapping,
+            _digest(b"outside"),
+            _digest(b"after"),
+        )
+
+    mapping.unlink()
+    mapping.write_bytes(b"before")
+    next_plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+    with (
+        pytest.raises(ConcurrentModificationError),
+        prepare_artifact_set_sync(next_plan) as transaction,
+    ):
+        transaction.bind_authority(
+            mapping,
+            _digest(b"different"),
+            _digest(b"after"),
+        )
+
+    assert (tmp_path / skill).read_bytes() == b"old body"
+
+
+def test_bound_after_mapping_is_kept_when_context_exits_with_error(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    before = b"before\n"
+    after = b"after\n"
+    mapping.write_bytes(before)
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"old body"}),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    with pytest.raises(OSError, match="post-replace fsync"):
+        with prepare_artifact_set_sync(plan) as transaction:
+            transaction.bind_authority(
+                mapping,
+                _digest(before),
+                _digest(after),
+            )
+            replacement = mapping.with_suffix(".next")
+            replacement.write_bytes(after)
+            replacement.replace(mapping)
+            raise OSError("post-replace fsync")
+
+    assert mapping.read_bytes() == after
+    assert (tmp_path / skill).read_bytes() == b"new body"
+
+
+def test_per_skill_lock_covers_prepare_through_finalize_and_rollback(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    entry = _entry(old)
+    artifacts = [_payload("release/SKILL.md", skill, b"new")]
+    first_plan = plan_artifact_set_sync(
+        tmp_path, entry, artifacts, {"ref": "v2"}
+    )
+    first = prepare_artifact_set_sync(first_plan)
+    try:
+        with pytest.raises(ArtifactLockError):
+            prepare_artifact_set_sync(first_plan, lock_timeout=0.01)
+        with pytest.raises(ArtifactLockError):
+            apply_artifact_set_sync(first_plan, lock_timeout=0.01)
+    finally:
+        first.rollback()
+
+    second_plan = plan_artifact_set_sync(
+        tmp_path, entry, artifacts, {"ref": "v2"}
+    )
+    second = prepare_artifact_set_sync(second_plan)
+    second.rollback()
+    assert (tmp_path / skill).read_bytes() == b"old"
+    assert _temp_artifacts(tmp_path) == []
+
+
+@pytest.mark.parametrize("timeout", [-1, float("nan"), float("inf"), True])
+def test_invalid_lock_timeout_is_rejected_without_artifact_writes(
+    tmp_path: Path, timeout
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new")],
+        {"ref": "v2"},
+    )
+
+    with pytest.raises(ArtifactValidationError, match="lock_timeout"):
+        prepare_artifact_set_sync(plan, lock_timeout=timeout)
+
+    assert (tmp_path / skill).read_bytes() == b"old"
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_advisory_lock_is_released_when_lock_holder_process_crashes(
+    tmp_path: Path,
+):
+    if artifact_sync.fcntl is None:
+        pytest.skip("POSIX advisory locks are unavailable")
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    entry = _entry(old)
+    artifacts = [_payload("release/SKILL.md", skill, b"new")]
+    plan = plan_artifact_set_sync(
+        tmp_path, entry, artifacts, {"ref": "v2"}
+    )
+    initial = prepare_artifact_set_sync(plan)
+    lock_path = initial.lock_path
+    initial.rollback()
+
+    script = (
+        "import fcntl, os, sys, time\n"
+        "fd = os.open(sys.argv[1], os.O_RDWR)\n"
+        "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+        "print('locked', flush=True)\n"
+        "time.sleep(30)\n"
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(lock_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "locked"
+        with pytest.raises(ArtifactLockError):
+            prepare_artifact_set_sync(plan, lock_timeout=0.01)
+        process.kill()
+        process.wait(timeout=5)
+
+        recovered_plan = plan_artifact_set_sync(
+            tmp_path, entry, artifacts, {"ref": "v2"}
+        )
+        recovered = prepare_artifact_set_sync(recovered_plan)
+        recovered.rollback()
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+    assert (tmp_path / skill).read_bytes() == b"old"
+
+
+def test_public_skill_lock_api_reuses_engine_identity(tmp_path: Path):
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, f"{skill_root}/SKILL.md", b"body")
+
+    identity = skill_lock_identity(tmp_path, skill_root)
+    lock_path = skill_lock_path(tmp_path, skill_root)
+
+    assert lock_path.stem == identity
+    with skill_advisory_lock(tmp_path, skill_root, timeout=0.0) as lock:
+        assert lock.path == lock_path
+        with pytest.raises(ArtifactLockError):
+            with skill_advisory_lock(tmp_path, skill_root, timeout=0.01):
+                pass
+
+
+@pytest.mark.parametrize(
+    ("mode", "exit_code"),
+    [
+        ("after-backup", 71),
+        ("prepared-unbound", 72),
+        ("after-backup-before-state", 74),
+        ("after-install-before-state", 75),
+    ],
+)
+def test_hard_exit_without_mapping_authority_restores_old_tree(
+    tmp_path: Path,
+    mode: str,
+    exit_code: int,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+
+    completed = _run_hard_exit_worker(tmp_path, mode=mode)
+
+    assert completed.returncode == exit_code, completed.stderr
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    assert journal.is_file() and not journal.is_symlink()
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not journal.exists()
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_hard_exit_after_binding_before_mapping_restores_old_tree(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    before = b'{"state":"before"}\n'
+    after = b'{"state":"after"}\n'
+    mapping.write_bytes(before)
+
+    completed = _run_hard_exit_worker(
+        tmp_path,
+        mode="bound-before",
+        mapping=mapping,
+        before_sha256=_digest(before),
+        after_sha256=_digest(after),
+    )
+
+    assert completed.returncode == 76, completed.stderr
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    assert journal.exists()
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+
+    assert mapping.read_bytes() == before
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not journal.exists()
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_hard_exit_after_bound_mapping_commit_keeps_new_tree(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    before = b'{"state":"before"}\n'
+    after = b'{"state":"after"}\n'
+    mapping.write_bytes(before)
+
+    completed = _run_hard_exit_worker(
+        tmp_path,
+        mode="bound-after",
+        mapping=mapping,
+        before_sha256=_digest(before),
+        after_sha256=_digest(after),
+    )
+
+    assert completed.returncode == 73, completed.stderr
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    assert journal.exists()
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+
+    assert mapping.read_bytes() == after
+    assert (tmp_path / skill).read_bytes() == b"new body"
+    assert not journal.exists()
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_ambiguous_bound_mapping_preserves_recovery_and_fails(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    mapping = tmp_path / "docs/sources/example.skills.json"
+    mapping.parent.mkdir(parents=True)
+    before = b'{"state":"before"}\n'
+    after = b'{"state":"after"}\n'
+    mapping.write_bytes(before)
+    completed = _run_hard_exit_worker(
+        tmp_path,
+        mode="bound-after",
+        mapping=mapping,
+        before_sha256=_digest(before),
+        after_sha256=_digest(after),
+    )
+    assert completed.returncode == 73, completed.stderr
+    mapping.write_bytes(b'{"state":"ambiguous"}\n')
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+
+    with pytest.raises(ArtifactRecoveryError) as raised:
+        with skill_advisory_lock(tmp_path, skill_root):
+            pass
+
+    assert journal in raised.value.recovery_paths
+    assert journal.exists()
+    assert (tmp_path / skill).read_bytes() == b"new body"
+
+    mapping.write_bytes(before)
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not journal.exists()
+
+
+def test_tampered_journal_path_and_symlink_are_fail_closed(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    completed = _run_hard_exit_worker(tmp_path, mode="prepared-unbound")
+    assert completed.returncode == 72, completed.stderr
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    original = journal.read_bytes()
+    payload = json.loads(original)
+    payload["state"] = "rolling_back"
+    journal.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ArtifactRecoveryError, match="integrity hash mismatch"):
+        with skill_advisory_lock(tmp_path, skill_root):
+            pass
+    assert (tmp_path / skill).read_bytes() == b"new body"
+
+    payload = json.loads(original)
+    payload["stage_container"] = "../escape"
+    payload["journal_sha256"] = artifact_sync._computed_journal_integrity(
+        payload
+    )
+    journal.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ArtifactRecoveryError, match="canonical relative POSIX"):
+        with skill_advisory_lock(tmp_path, skill_root):
+            pass
+    assert (tmp_path / skill).read_bytes() == b"new body"
+
+    journal.write_bytes(original)
+    outside = tmp_path / "outside-journal.json"
+    outside.write_bytes(original)
+    journal.unlink()
+    journal.symlink_to(outside)
+    with pytest.raises(ArtifactRecoveryError, match="regular non-symlink"):
+        with skill_advisory_lock(tmp_path, skill_root):
+            pass
+
+    journal.unlink()
+    journal.write_bytes(original)
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not journal.exists()
+
+
+def test_active_transaction_journal_tamper_restores_old_and_releases_lock(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"old body"}),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    transaction = prepare_artifact_set_sync(plan)
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    original = journal.read_bytes()
+    payload = json.loads(original)
+    payload["state"] = "rolling_back"
+    journal.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ArtifactApplyError, match="failed to roll back"):
+        transaction.rollback()
+
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert journal.exists()
+    journal.write_bytes(original)
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+    assert not journal.exists()
+
+
+def test_plan_created_before_recovery_requires_retry(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    completed = _run_hard_exit_worker(tmp_path, mode="prepared-unbound")
+    assert completed.returncode == 72, completed.stderr
+    assert (tmp_path / skill).read_bytes() == b"new body"
+
+    stale_plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"new body"}),
+        [_payload("release/SKILL.md", skill, b"third body")],
+        {"ref": "v3"},
+    )
+    with pytest.raises(ConcurrentModificationError):
+        prepare_artifact_set_sync(stale_plan)
+
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not skill_transaction_journal_path(tmp_path, skill_root).exists()
+    retry_plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"old body"}),
+        [_payload("release/SKILL.md", skill, b"third body")],
+        {"ref": "v3"},
+    )
+    retried = prepare_artifact_set_sync(retry_plan)
+    retried.rollback()
+
+
+def test_journal_is_stable_before_first_rename_and_tree_parents_are_fsynced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry({skill: b"old body"}),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+    fsynced: list[Path] = []
+    real_fsync_directory = artifact_sync._fsync_directory
+
+    def record_fsync(path: Path) -> None:
+        fsynced.append(Path(path))
+        real_fsync_directory(path)
+
+    monkeypatch.setattr(artifact_sync, "_fsync_directory", record_fsync)
+    observed_state = None
+
+    def inspect_journal(event: str) -> None:
+        nonlocal observed_state
+        if event == "after_stage_built":
+            journal = skill_transaction_journal_path(tmp_path, skill_root)
+            payload = json.loads(journal.read_text(encoding="utf-8"))
+            observed_state = payload["state"]
+            assert payload["journal_sha256"]
+            assert journal.stat().st_mode & 0o777 == 0o600
+            if hasattr(os, "getuid"):
+                assert journal.stat().st_uid == os.getuid()
+
+    transaction = prepare_artifact_set_sync(plan, fault_injector=inspect_journal)
+    transaction.rollback()
+
+    skill_parent = tmp_path / "skills/ai-workflow"
+    assert observed_state == "staged"
+    assert fsynced.count(skill_parent) >= 3
+    assert skill_lock_path(tmp_path, skill_root).parent in fsynced
+
+
+def test_concurrent_rollback_occupant_is_quarantined_before_old_restore(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = tmp_path / "skills/ai-workflow/demo"
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+
+    def race(event: str) -> None:
+        if event == "after_backup_rename":
+            skill_root.mkdir()
+            (skill_root / "concurrent.txt").write_bytes(b"do not delete")
+            raise RuntimeError("force rollback after concurrent create")
+
+    with pytest.raises(ArtifactApplyError) as raised:
+        prepare_artifact_set_sync(plan, fault_injector=race)
+
+    error = raised.value
+    assert error.rollback_succeeded
+    assert error.recovery_path is not None
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    occupants = list(error.recovery_path.glob("concurrent-occupant-*"))
+    assert len(occupants) == 1
+    assert (occupants[0] / "concurrent.txt").read_bytes() == b"do not delete"
+    assert not list(
+        (tmp_path / "skills/ai-workflow").glob(".demo.artifact-stage-*")
+    )
+    artifact_sync.shutil.rmtree(error.recovery_path)
+
+
+def test_failed_old_restore_keeps_unique_backup_and_reports_recovery_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_path = tmp_path / skill
+    old = {skill: b"old body"}
+    _write(tmp_path, skill, b"old body")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("release/SKILL.md", skill, b"new body")],
+        {"ref": "v2"},
+    )
+    real_replace = artifact_sync.os.replace
+
+    def fail_restore(source, destination):
+        if (
+            Path(source).name == "previous"
+            and Path(destination) == skill_path.parent
+        ):
+            raise OSError("injected restore failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(artifact_sync.os, "replace", fail_restore)
+
+    def fail_after_backup(event: str) -> None:
+        if event == "after_backup_rename":
+            raise RuntimeError("force rollback")
+
+    with pytest.raises(ArtifactApplyError) as raised:
+        prepare_artifact_set_sync(plan, fault_injector=fail_after_backup)
+
+    error = raised.value
+    assert not error.rollback_succeeded
+    assert error.recovery_path is not None
+    backup = error.recovery_path / "previous" / "SKILL.md"
+    assert backup.read_bytes() == b"old body"
+    assert not skill_path.parent.exists()
+    # Cleanup is explicit only after the preserved backup has been observed.
+    artifact_sync.shutil.rmtree(error.recovery_path)
+    skill_transaction_journal_path(
+        tmp_path,
+        "skills/ai-workflow/demo",
+    ).unlink(missing_ok=True)
+
+
+def test_concurrent_change_after_plan_is_rejected_before_staging(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    unowned = "skills/ai-workflow/demo/local.txt"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    _write(tmp_path, unowned, b"one")
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        _entry(old),
+        [_payload("upstream/SKILL.md", skill, b"new")],
+        {"ref": "v2"},
+    )
+    _write(tmp_path, unowned, b"two")
+
+    with pytest.raises(ConcurrentModificationError) as raised:
+        apply_artifact_set_sync(plan)
+
+    assert raised.value.paths == (unowned,)
+    assert (tmp_path / skill).read_bytes() == b"old"
+    assert (tmp_path / unowned).read_bytes() == b"two"
+    assert _temp_artifacts(tmp_path) == []
+
+
+def test_second_run_with_returned_manifest_is_idempotent(tmp_path: Path):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    old = {skill: b"old"}
+    _write(tmp_path, skill, b"old")
+    artifacts = [
+        _payload("upstream/SKILL.md", skill, b"new"),
+        _payload(
+            "upstream/reference.md",
+            "skills/ai-workflow/demo/references/reference.md",
+            b"reference",
+        ),
+    ]
+    first = sync_artifact_set(
+        tmp_path, _entry(old), artifacts, {"ref": "v2"}
+    )
+    next_entry = _entry({}, slug="demo")
+    next_entry["managed_files"] = [
+        dict(item) for item in first.managed_files
+    ]
+    before = {
+        path.relative_to(tmp_path).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+
+    second = sync_artifact_set(
+        tmp_path, next_entry, artifacts, dict(first.checkpoint)
+    )
+
+    after = {
+        path.relative_to(tmp_path).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert not second.applied
+    assert second.changed == ()
+    assert second.pruned == ()
+    assert second.drift == ()
+    assert before == after
+    assert _temp_artifacts(tmp_path) == []

--- a/tests/test_artifact_set_sync.py
+++ b/tests/test_artifact_set_sync.py
@@ -61,14 +61,31 @@ def _entry(
             }
         ],
         "managed_files": [
-            {"path": path, "sha256": _digest(data), "owner": slug}
+            {
+                "path": path,
+                "sha256": _digest(data),
+                "owner": slug,
+                "mode": "100644",
+            }
             for path, data in sorted(files.items())
         ],
     }
 
 
-def _payload(source: str, target: str, data: bytes, kind: str = "file") -> dict:
-    return {"source": source, "target": target, "type": kind, "data": data}
+def _payload(
+    source: str,
+    target: str,
+    data: bytes,
+    kind: str = "file",
+    mode: str = "100644",
+) -> dict:
+    return {
+        "source": source,
+        "target": target,
+        "type": kind,
+        "data": data,
+        "mode": mode,
+    }
 
 
 def _temp_artifacts(root: Path) -> list[Path]:
@@ -113,12 +130,13 @@ entry = {
         "path": skill,
         "sha256": hashlib.sha256(old).hexdigest(),
         "owner": "demo",
+        "mode": "100644",
     }],
 }
 plan = plan_artifact_set_sync(
     root,
     entry,
-    [{"source": "release/SKILL.md", "target": skill, "type": "file", "data": b"new body"}],
+    [{"source": "release/SKILL.md", "target": skill, "type": "file", "data": b"new body", "mode": "100644"}],
     {"ref": "v2"},
 )
 
@@ -217,6 +235,7 @@ def test_successful_multisidecar_sync_returns_json_ready_metadata(tmp_path: Path
             "package/skills/demo/scripts/check.sh",
             "skills/ai-workflow/demo/scripts/check.sh",
             b"#!/bin/sh\nexit 0\n",
+            mode="100755",
         ),
         _payload(
             "package/skills/demo/SKILL.md",
@@ -248,7 +267,71 @@ def test_successful_multisidecar_sync_returns_json_ready_metadata(tmp_path: Path
         item["path"] for item in patch["managed_files"]
     ]
     assert all(item["owner"] == "demo" for item in patch["managed_files"])
+    script = tmp_path / "skills/ai-workflow/demo/scripts/check.sh"
+    assert script.stat().st_mode & 0o777 == 0o755
+    assert next(
+        item
+        for item in patch["managed_files"]
+        if item["path"].endswith("/scripts/check.sh")
+    )["mode"] == "100755"
     assert _temp_artifacts(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    ("old_mode", "new_mode"),
+    [("100644", "100755"), ("100755", "100644")],
+)
+def test_mode_only_change_is_planned_and_applied(
+    tmp_path: Path,
+    old_mode: str,
+    new_mode: str,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    body = b"same body\n"
+    _write(tmp_path, skill, body)
+    path = tmp_path / skill
+    path.chmod(0o755 if old_mode == "100755" else 0o644)
+    entry = _entry({skill: body})
+    entry["managed_files"][0]["mode"] = old_mode
+
+    plan = plan_artifact_set_sync(
+        tmp_path,
+        entry,
+        [_payload("release/SKILL.md", skill, body, mode=new_mode)],
+        {"ref": "v2"},
+    )
+
+    assert plan.changed == (skill,)
+    result = apply_artifact_set_sync(plan)
+    assert result.applied
+    assert path.read_bytes() == body
+    assert path.stat().st_mode & 0o777 == (
+        0o755 if new_mode == "100755" else 0o644
+    )
+    assert result.managed_files[0]["mode"] == new_mode
+
+
+@pytest.mark.parametrize("mode", [None, "100600", 0o755])
+def test_managed_manifest_requires_canonical_git_file_mode(
+    tmp_path: Path,
+    mode,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    body = b"body"
+    _write(tmp_path, skill, body)
+    entry = _entry({skill: body})
+    if mode is None:
+        entry["managed_files"][0].pop("mode")
+    else:
+        entry["managed_files"][0]["mode"] = mode
+
+    with pytest.raises(ArtifactValidationError, match=r"\.mode"):
+        plan_artifact_set_sync(
+            tmp_path,
+            entry,
+            [_payload("release/SKILL.md", skill, body)],
+            {"ref": "v2"},
+        )
 
 
 def test_binary_bytes_and_cross_directory_source_mapping_are_exact(tmp_path: Path):
@@ -268,6 +351,7 @@ def test_binary_bytes_and_cross_directory_source_mapping_are_exact(tmp_path: Pat
             "target": "skills/ai-workflow/demo/assets/logo.bin",
             "type": "binary",
             "bytes": binary,
+            "mode": "100644",
         },
     ]
 
@@ -882,7 +966,12 @@ def test_fault_after_rename_rolls_back_and_removes_all_transaction_dirs(
         tmp_path,
         _entry(old),
         [
-            _payload("upstream/SKILL.md", skill, b"new body"),
+            _payload(
+                "upstream/SKILL.md",
+                skill,
+                b"new body",
+                mode="100755",
+            ),
             _payload(
                 "upstream/new.md",
                 "skills/ai-workflow/demo/references/new.md",
@@ -901,6 +990,7 @@ def test_fault_after_rename_rolls_back_and_removes_all_transaction_dirs(
 
     assert raised.value.rollback_succeeded
     assert (tmp_path / skill).read_bytes() == b"old body"
+    assert (tmp_path / skill).stat().st_mode & 0o777 == 0o644
     assert (tmp_path / sidecar).read_bytes() == b"old ref"
     assert (
         tmp_path / "skills/ai-workflow/demo/local.txt"
@@ -1437,6 +1527,40 @@ def test_tampered_journal_path_and_symlink_are_fail_closed(tmp_path: Path):
             pass
 
     journal.unlink()
+    journal.write_bytes(original)
+    with skill_advisory_lock(tmp_path, skill_root):
+        pass
+    assert (tmp_path / skill).read_bytes() == b"old body"
+    assert not journal.exists()
+
+
+def test_byte_only_v1_journal_is_rejected_for_manual_recovery(
+    tmp_path: Path,
+):
+    skill = "skills/ai-workflow/demo/SKILL.md"
+    skill_root = "skills/ai-workflow/demo"
+    _write(tmp_path, skill, b"old body")
+    completed = _run_hard_exit_worker(tmp_path, mode="prepared-unbound")
+    assert completed.returncode == 72, completed.stderr
+    journal = skill_transaction_journal_path(tmp_path, skill_root)
+    original = journal.read_bytes()
+    payload = json.loads(original)
+    assert payload["version"] == 2
+    payload["version"] = 1
+    payload["journal_sha256"] = artifact_sync._computed_journal_integrity(
+        payload
+    )
+    journal.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ArtifactRecoveryError,
+        match="unsupported transaction journal version",
+    ) as raised:
+        with skill_advisory_lock(tmp_path, skill_root):
+            pass
+
+    assert journal in raised.value.recovery_paths
+    assert journal.exists()
     journal.write_bytes(original)
     with skill_advisory_lock(tmp_path, skill_root):
         pass

--- a/tests/test_bootstrap_in_house_sources.py
+++ b/tests/test_bootstrap_in_house_sources.py
@@ -1,6 +1,5 @@
 import hashlib
 import importlib.util
-import json
 import tempfile
 import textwrap
 import unittest
@@ -106,6 +105,7 @@ class BootstrapInHouseSourcesTests(unittest.TestCase):
                             (local_only_skill / "SKILL.md").read_bytes()
                         ).hexdigest(),
                         "owner": "summary-helper",
+                        "mode": "100644",
                     }
                 ],
                 skills["summary-helper"]["managed_files"],

--- a/tests/test_check_upstream_github_updates.py
+++ b/tests/test_check_upstream_github_updates.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -91,11 +92,148 @@ class CheckUpstreamGitHubUpdatesTests(unittest.TestCase):
                     "--write-json",
                     str(output),
                 ]
-                self.assertEqual(0, module.main())
-                self.assertEqual(0, json.loads(output.read_text())["total_checked"])
+                self.assertEqual(1, module.main())
+                payload = json.loads(output.read_text())
+                self.assertEqual(0, payload["total_checked"])
+                self.assertEqual("failed", payload["state"])
         finally:
             module.load_skills_with_upstream = original_load
             sys.argv = original_argv
+
+    def test_summary_is_conservative_and_reports_tri_state(self):
+        module = load_module()
+        summary, state = module.summarize_states(
+            [
+                {"change_type": "none", "check_error": None},
+                {"change_type": "artifact_changed", "check_error": None},
+                {"change_type": "monitor_review", "check_error": None},
+                {"change_type": "upstream_rollback", "check_error": None},
+                {"change_type": "expected_skipped", "check_error": None},
+            ]
+        )
+        self.assertEqual("degraded", state)
+        self.assertEqual(5, summary["total"])
+        self.assertEqual(
+            summary["total"],
+            sum(value for key, value in summary.items() if key != "total"),
+        )
+
+        _, state = module.summarize_states(
+            [{"change_type": "none", "check_error": "metadata timeout"}]
+        )
+        self.assertEqual("failed", state)
+
+    def test_offline_snapshot_is_never_reported_complete(self):
+        module = load_module()
+        summary, state = module.summarize_states(
+            [{"change_type": "expected_skipped", "check_error": None}],
+            online=False,
+        )
+        self.assertEqual("degraded", state)
+        self.assertEqual(1, summary["expected_skipped"])
+
+    def test_snapshot_returns_expected_skip_without_token_or_network(self):
+        module = load_module()
+        snapshot = {
+            "name": "archived-demo",
+            "kind": "snapshot",
+            "sync_mode": "local-only",
+            "repo": "owner/repo",
+            "last_synced_commit": None,
+            "local_path": REPO_ROOT
+            / "skills"
+            / "demo"
+            / "SKILL.md",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "upstream.json"
+            with (
+                mock.patch.object(
+                    module,
+                    "load_skills_with_upstream",
+                    return_value=[snapshot],
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_github_token",
+                    side_effect=AssertionError("token lookup must not run"),
+                ),
+                mock.patch.object(
+                    module,
+                    "check_upstream_changes",
+                    side_effect=AssertionError("network check must not run"),
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "check_upstream_github_updates.py",
+                        "--online",
+                        "--write-json",
+                        str(output),
+                    ],
+                ),
+            ):
+                self.assertEqual(0, module.main())
+            payload = json.loads(output.read_text())
+            self.assertEqual(
+                "expected_skipped",
+                payload["rows"][0]["change_type"],
+            )
+            self.assertEqual(1, payload["summary"]["expected_skipped"])
+
+    def test_per_skill_exception_becomes_unavailable_and_report_is_atomic(self):
+        module = load_module()
+        root = REPO_ROOT
+        skill = {
+            "name": "demo",
+            "repo": "owner/repo",
+            "ref": "main",
+            "sync_mode": "monitor",
+            "upstream_path": "skills/demo/SKILL.md",
+            "last_synced_commit": "a" * 40,
+            "local_path": root / "skills" / "demo" / "SKILL.md",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "upstream.json"
+            with (
+                mock.patch.object(
+                    module, "load_skills_with_upstream", return_value=[skill]
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_github_token",
+                    return_value="token",
+                ),
+                mock.patch.object(
+                    module,
+                    "online_result",
+                    side_effect=RuntimeError("network exploded"),
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "check_upstream_github_updates.py",
+                        "--online",
+                        "--write-json",
+                        str(output),
+                    ],
+                ),
+            ):
+                self.assertEqual(1, module.main())
+            payload = json.loads(output.read_text())
+            self.assertEqual("failed", payload["state"])
+            self.assertEqual(1, payload["summary"]["unavailable"])
+            self.assertIn("network exploded", payload["rows"][0]["check_error"])
+            self.assertEqual(
+                payload["summary"]["total"],
+                sum(
+                    payload["summary"][key]
+                    for key in module.BUCKETS
+                ),
+            )
+            self.assertEqual([], list(Path(tmpdir).glob("*.tmp")))
 
 
 if __name__ == "__main__":

--- a/tests/test_discover_new_skills.py
+++ b/tests/test_discover_new_skills.py
@@ -45,15 +45,45 @@ class DiscoverNewSkillsTests(unittest.TestCase):
 
         report = module.build_discovery_report(
             local_skill_count=10,
-            all_discoveries=[{"name": "alpha"}],
-            unique_discoveries=[{"name": "alpha"}],
+            all_discoveries=[
+                module.make_discovery(
+                    source_key="github",
+                    name="alpha",
+                    source="GitHub",
+                    url="https://github.com/example/alpha",
+                    repo_stars=1,
+                    description="Alpha",
+                )
+            ],
+            unique_discoveries=[
+                module.make_discovery(
+                    source_key="github",
+                    name="alpha",
+                    source="GitHub",
+                    url="https://github.com/example/alpha",
+                    repo_stars=1,
+                    description="Alpha",
+                )
+            ],
             source_health={
                 "github": {
                     "status": "degraded",
                     "errors": [{"kind": "unauthorized", "message": "401"}],
                     "queries": 2,
                     "results": 1,
-                }
+                },
+                "skills_sh": {
+                    "status": "healthy",
+                    "errors": [],
+                    "queries": 1,
+                    "results": 0,
+                },
+                "clawhub": {
+                    "status": "healthy",
+                    "errors": [],
+                    "queries": 1,
+                    "results": 0,
+                },
             },
         )
 
@@ -63,6 +93,9 @@ class DiscoverNewSkillsTests(unittest.TestCase):
         self.assertIn("source_health", report)
         self.assertEqual("degraded", report["source_health"]["github"]["status"])
         self.assertEqual("unauthorized", report["errors"][0]["kind"])
+        self.assertEqual(1, report["source_health"]["github"]["emitted"])
+        self.assertEqual(1, report["source_health"]["github"]["unique_emitted"])
+        self.assertEqual(1, report["raw_discovered"])
 
     def test_classify_fetch_error_recognizes_http_statuses(self):
         module = load_module()

--- a/tests/test_durable_file_batch.py
+++ b/tests/test_durable_file_batch.py
@@ -1,0 +1,688 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from scripts.durable_file_batch import (
+    DurableBatchError,
+    DurableBatchRecoveryError,
+    durable_batch_lock_and_recover,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def run_crashing_child(code: str, root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", code, str(root), str(SCRIPTS)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def tree_digest(root: Path) -> str:
+    digest = __import__("hashlib").sha256()
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        metadata = path.lstat()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(stat.S_IFMT(metadata.st_mode)).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(stat.S_IMODE(metadata.st_mode)).encode("ascii"))
+        digest.update(b"\0")
+        if path.is_file() and not path.is_symlink():
+            digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+class DurableFileBatchTests(unittest.TestCase):
+    def test_public_guard_preserves_explicit_after_mode(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            target = root / "mapping.json"
+            target.write_bytes(b"before")
+            target.chmod(0o600)
+
+            with durable_batch_lock_and_recover(root) as guard:
+                def apply() -> None:
+                    target.write_bytes(b"after")
+                    target.chmod(0o600)
+
+                guard.commit_batch(
+                    {target: b"after"},
+                    apply,
+                    after_modes={target: 0o600},
+                )
+
+            self.assertEqual(b"after", target.read_bytes())
+            self.assertEqual(0o600, stat.S_IMODE(target.stat().st_mode))
+            self.assertFalse((root / ".hvs-transactions/pending").exists())
+
+    def test_sync_batch_hard_exit_recovers_on_next_entry(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            first = root / "first.skills.json"
+            second = root / "second.skills.json"
+            first.write_text('{"value":"before-one"}\n', encoding="utf-8")
+            second.write_text('{"value":"before-two"}\n', encoding="utf-8")
+            before = {first: first.read_bytes(), second: second.read_bytes()}
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+import sync_upstream as sync
+root = Path(sys.argv[1])
+sync.REPO_ROOT = root
+first = root / "first.skills.json"
+second = root / "second.skills.json"
+def crash(event, path):
+    if event == "after_replace" and path == first:
+        os._exit(73)
+sync.atomic_write_json_batch(
+    {first: {"value": "after-one"}, second: {"value": "after-two"}},
+    fault_injector=crash,
+)
+"""
+            child = run_crashing_child(code, root)
+            self.assertEqual(73, child.returncode, child.stderr)
+            self.assertNotEqual(before[first], first.read_bytes())
+            self.assertEqual(before[second], second.read_bytes())
+            pending = root / ".hvs-transactions/pending"
+            self.assertTrue(pending.is_dir())
+
+            with durable_batch_lock_and_recover(root):
+                self.assertEqual(before[first], first.read_bytes())
+                self.assertEqual(before[second], second.read_bytes())
+
+            self.assertFalse(pending.exists())
+
+    def test_all_after_recovery_fsyncs_file_and_parent_before_cleanup(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            target = root / "mapping.skills.json"
+            target.write_text('{"value":"before"}\n', encoding="utf-8")
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+import sync_upstream as sync
+root = Path(sys.argv[1]); sync.REPO_ROOT = root
+target = root / "mapping.skills.json"
+def crash(event, path):
+    if event == "after_replace" and path == target:
+        os._exit(78)
+sync.atomic_write_json_batch(
+    {target: {"value": "after"}},
+    fault_injector=crash,
+)
+"""
+            child = run_crashing_child(code, root)
+            self.assertEqual(78, child.returncode, child.stderr)
+            self.assertEqual(
+                {"value": "after"},
+                json.loads(target.read_text(encoding="utf-8")),
+            )
+            pending = root / ".hvs-transactions/pending"
+            self.assertTrue(pending.is_dir())
+            target_identity = (target.stat().st_dev, target.stat().st_ino)
+            parent_identity = (
+                target.parent.stat().st_dev,
+                target.parent.stat().st_ino,
+            )
+            flushed: set[tuple[int, int]] = set()
+            real_fsync = os.fsync
+
+            def recording_fsync(descriptor: int) -> None:
+                metadata = os.fstat(descriptor)
+                flushed.add((metadata.st_dev, metadata.st_ino))
+                real_fsync(descriptor)
+
+            with mock.patch(
+                "scripts.durable_file_batch.os.fsync",
+                side_effect=recording_fsync,
+            ):
+                with durable_batch_lock_and_recover(root):
+                    pass
+
+            self.assertIn(target_identity, flushed)
+            self.assertIn(parent_identity, flushed)
+            self.assertFalse(pending.exists())
+
+    def test_all_after_shared_parent_flushes_once_after_every_file(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            first = root / "first.txt"
+            second = root / "second.txt"
+            first.write_bytes(b"before-one")
+            second.write_bytes(b"before-two")
+            apply_finished = False
+            events: list[str] = []
+            identities: dict[tuple[int, int], str] = {}
+            real_fsync = os.fsync
+
+            def apply() -> None:
+                nonlocal apply_finished
+                first.write_bytes(b"after-one")
+                second.write_bytes(b"after-two")
+                identities[
+                    (first.stat().st_dev, first.stat().st_ino)
+                ] = "first"
+                identities[
+                    (second.stat().st_dev, second.stat().st_ino)
+                ] = "second"
+                identities[
+                    (root.stat().st_dev, root.stat().st_ino)
+                ] = "parent"
+                apply_finished = True
+
+            def recording_fsync(descriptor: int) -> None:
+                metadata = os.fstat(descriptor)
+                label = identities.get((metadata.st_dev, metadata.st_ino))
+                if apply_finished and label is not None:
+                    events.append(label)
+                real_fsync(descriptor)
+
+            with mock.patch(
+                "scripts.durable_file_batch.os.fsync",
+                side_effect=recording_fsync,
+            ):
+                with durable_batch_lock_and_recover(root) as guard:
+                    guard.commit_batch(
+                        {
+                            first: b"after-one",
+                            second: b"after-two",
+                        },
+                        apply,
+                    )
+
+            self.assertEqual(["first", "second", "parent"], events)
+
+    def test_all_after_parent_detach_preserves_journal_and_third_state(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            active_parent = root / "canonical"
+            active_parent.mkdir()
+            target = active_parent / "mapping.skills.json"
+            target.write_text('{"value":"before"}\n', encoding="utf-8")
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+import sync_upstream as sync
+root = Path(sys.argv[1]); sync.REPO_ROOT = root
+target = root / "canonical/mapping.skills.json"
+def crash(event, path):
+    if event == "after_replace" and path == target:
+        os._exit(81)
+sync.atomic_write_json_batch(
+    {target: {"value": "after"}},
+    fault_injector=crash,
+)
+"""
+            child = run_crashing_child(code, root)
+            self.assertEqual(81, child.returncode, child.stderr)
+            pending = root / ".hvs-transactions/pending"
+            self.assertTrue(pending.is_dir())
+            parent_identity = (
+                active_parent.stat().st_dev,
+                active_parent.stat().st_ino,
+            )
+            detached_parent = root / "detached"
+            detached = False
+            real_fsync = os.fsync
+
+            def detach_during_parent_fsync(descriptor: int) -> None:
+                nonlocal detached
+                metadata = os.fstat(descriptor)
+                real_fsync(descriptor)
+                if (
+                    not detached
+                    and (metadata.st_dev, metadata.st_ino)
+                    == parent_identity
+                ):
+                    active_parent.rename(detached_parent)
+                    active_parent.mkdir()
+                    (active_parent / target.name).write_text(
+                        "canonical-third-state",
+                        encoding="utf-8",
+                    )
+                    detached = True
+
+            with mock.patch(
+                "scripts.durable_file_batch.os.fsync",
+                side_effect=detach_during_parent_fsync,
+            ):
+                with self.assertRaises(DurableBatchRecoveryError) as raised:
+                    with durable_batch_lock_and_recover(root):
+                        pass
+
+            self.assertTrue(detached)
+            self.assertEqual((pending,), raised.exception.recovery_paths)
+            self.assertEqual(
+                "canonical-third-state",
+                target.read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                {"value": "after"},
+                json.loads(
+                    (detached_parent / target.name).read_text(
+                        encoding="utf-8"
+                    )
+                ),
+            )
+            self.assertTrue(pending.is_dir())
+
+    def test_ingest_hard_exit_recovers_files_and_created_parents(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            existing = root / "z-existing.txt"
+            existing.write_bytes(b"before-existing")
+            new_target = root / "created" / "nested" / "first.txt"
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+import ingest_skill as ingest
+from durable_file_batch import durable_batch_lock_and_recover
+root = Path(sys.argv[1])
+new_target = root / "created" / "nested" / "first.txt"
+existing = root / "z-existing.txt"
+plans = [
+    ingest.IngestPlan(
+        skill_name="first",
+        skill_md=new_target,
+        before_skill=None,
+        after_skill=b"after-new",
+        repo_root=root,
+        before_checkpoint=ingest.capture_target_checkpoint(
+            new_target, repo_root=root
+        ),
+        before_parent_checkpoint=ingest.capture_parent_checkpoint(
+            root, new_target
+        ),
+    ),
+    ingest.IngestPlan(
+        skill_name="existing",
+        skill_md=existing,
+        before_skill=b"before-existing",
+        after_skill=b"after-existing",
+        repo_root=root,
+        before_checkpoint=ingest.capture_target_checkpoint(
+            existing, repo_root=root
+        ),
+        before_parent_checkpoint=ingest.capture_parent_checkpoint(
+            root, existing
+        ),
+    ),
+]
+def crash(event, path):
+    if event == "after_replace" and path == new_target:
+        os._exit(74)
+with durable_batch_lock_and_recover(root) as guard:
+    ingest.commit_ingest_plans(
+        plans,
+        locks_held=True,
+        durable_guard=guard,
+        fault_injector=crash,
+    )
+"""
+            child = run_crashing_child(code, root)
+            self.assertEqual(74, child.returncode, child.stderr)
+            self.assertEqual(b"after-new", new_target.read_bytes())
+            self.assertEqual(b"before-existing", existing.read_bytes())
+
+            with durable_batch_lock_and_recover(root):
+                self.assertFalse(new_target.exists())
+                self.assertEqual(b"before-existing", existing.read_bytes())
+
+            self.assertFalse((root / "created").exists())
+            self.assertFalse((root / ".hvs-transactions/pending").exists())
+
+    def test_third_state_is_never_overwritten_and_keeps_private_recovery(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            first = root / "first.skills.json"
+            second = root / "second.skills.json"
+            first.write_text('{"value":"before-one"}\n', encoding="utf-8")
+            second.write_text('{"value":"before-two"}\n', encoding="utf-8")
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+import sync_upstream as sync
+root = Path(sys.argv[1]); sync.REPO_ROOT = root
+first = root / "first.skills.json"; second = root / "second.skills.json"
+def crash(event, path):
+    if event == "after_replace" and path == first:
+        os._exit(75)
+sync.atomic_write_json_batch(
+    {first: {"value": "after-one"}, second: {"value": "after-two"}},
+    fault_injector=crash,
+)
+"""
+            self.assertEqual(75, run_crashing_child(code, root).returncode)
+            first.write_bytes(b"user-third-state")
+            second_before = second.read_bytes()
+
+            with self.assertRaises(DurableBatchRecoveryError):
+                with durable_batch_lock_and_recover(root):
+                    pass
+
+            self.assertEqual(b"user-third-state", first.read_bytes())
+            self.assertEqual(second_before, second.read_bytes())
+            pending = root / ".hvs-transactions/pending"
+            self.assertTrue(pending.is_dir())
+            for path in pending.iterdir():
+                self.assertEqual(0, stat.S_IMODE(path.stat().st_mode) & 0o077)
+
+    def test_symlink_target_recovery_fails_closed_with_recovery_path(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            target = root / "target.txt"
+            sentinel = root / "sentinel.txt"
+            target.write_bytes(b"before")
+            sentinel.write_bytes(b"sentinel")
+            code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+from durable_file_batch import durable_batch_lock_and_recover
+root = Path(sys.argv[1]); target = root / "target.txt"
+with durable_batch_lock_and_recover(root) as guard:
+    guard.commit_batch({target: b"after"}, lambda: os._exit(79))
+"""
+            self.assertEqual(79, run_crashing_child(code, root).returncode)
+            target.unlink()
+            target.symlink_to(sentinel)
+            pending = root / ".hvs-transactions/pending"
+
+            with self.assertRaises(DurableBatchRecoveryError) as raised:
+                with durable_batch_lock_and_recover(root):
+                    pass
+
+            self.assertEqual((pending,), raised.exception.recovery_paths)
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(b"sentinel", sentinel.read_bytes())
+            self.assertTrue(pending.is_dir())
+
+    def test_tampered_or_symlinked_journal_fails_closed(self):
+        for variant in ("tampered", "symlink"):
+            with self.subTest(variant=variant), tempfile.TemporaryDirectory(
+                dir=REPO_ROOT
+            ) as tmp:
+                root = Path(tmp)
+                target = root / "target.txt"
+                target.write_bytes(b"before")
+                code = r"""
+import os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+from durable_file_batch import durable_batch_lock_and_recover
+root = Path(sys.argv[1]); target = root / "target.txt"
+with durable_batch_lock_and_recover(root) as guard:
+    guard.commit_batch(
+        {target: b"after"},
+        lambda: os._exit(76),
+    )
+"""
+                self.assertEqual(76, run_crashing_child(code, root).returncode)
+                journal = root / ".hvs-transactions/pending/journal.json"
+                sentinel = root / "sentinel"
+                sentinel.write_text("do-not-read-or-change", encoding="utf-8")
+                if variant == "tampered":
+                    envelope = json.loads(journal.read_text(encoding="utf-8"))
+                    envelope["checksum"] = "0" * 64
+                    journal.write_text(json.dumps(envelope), encoding="utf-8")
+                    journal.chmod(0o600)
+                else:
+                    journal.unlink()
+                    journal.symlink_to(sentinel)
+
+                with self.assertRaises((DurableBatchRecoveryError, OSError)):
+                    with durable_batch_lock_and_recover(root):
+                        pass
+
+                self.assertEqual(b"before", target.read_bytes())
+                self.assertEqual(
+                    "do-not-read-or-change",
+                    sentinel.read_text(encoding="utf-8"),
+                )
+                self.assertTrue(
+                    (root / ".hvs-transactions/pending").exists()
+                )
+
+    def test_special_mode_is_rejected_before_journal_publication(self):
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            target = root / "executable"
+            target.write_bytes(b"before")
+            target.chmod(0o4755)
+            called = False
+
+            def apply() -> None:
+                nonlocal called
+                called = True
+                target.write_bytes(b"after")
+
+            with self.assertRaisesRegex(
+                DurableBatchError,
+                "special bits",
+            ):
+                with durable_batch_lock_and_recover(root) as guard:
+                    guard.commit_batch({target: b"after"}, apply)
+
+            self.assertFalse(called)
+            self.assertEqual(b"before", target.read_bytes())
+            self.assertEqual(0o4755, stat.S_IMODE(target.stat().st_mode))
+            self.assertFalse(
+                (root / ".hvs-transactions/pending").exists()
+            )
+
+    def test_v2_apply_dry_run_does_not_create_transaction_state(self):
+        import scripts.sync_upstream as sync
+
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            mapping = root / "mapping.skills.json"
+            mapping.write_text("{}\n", encoding="utf-8")
+            local = root / "skills/demo/SKILL.md"
+            local.parent.mkdir(parents=True)
+            local.write_text("# Demo\n", encoding="utf-8")
+            skill = {
+                "tracking": {"channel": "latest_release"},
+                "sync_mode": "replace",
+                "mapping_path": mapping,
+                "origin_index": 0,
+                "repo_skill": "skills/demo/SKILL.md",
+                "local_path": local,
+            }
+            update = {
+                "skill": skill,
+                "current_commit": "a" * 40,
+                "path_commit": "b" * 40,
+                "resolved_ref": "v1.0.0",
+            }
+            entry = {"origins": [{"tracking": {}}], "managed_files": []}
+            origin = entry["origins"][0]
+
+            @contextmanager
+            def no_op_mapping_lock(_path):
+                yield
+
+            engine = SimpleNamespace(
+                plan_artifact_set_sync=lambda *_args, **_kwargs: object(),
+                apply_artifact_set_sync=lambda _plan, *, dry_run: (
+                    "dry-result" if dry_run else None
+                ),
+            )
+            before = tree_digest(root)
+            old_root = sync.REPO_ROOT
+            sync.REPO_ROOT = root
+            try:
+                with (
+                    mock.patch.object(
+                        sync,
+                        "durable_batch_lock_and_recover",
+                        side_effect=AssertionError(
+                            "dry-run must not enter durable write recovery"
+                        ),
+                    ),
+                    mock.patch.object(
+                        sync,
+                        "mapping_advisory_lock",
+                        side_effect=no_op_mapping_lock,
+                    ),
+                    mock.patch.object(
+                        sync,
+                        "_v2_entry_and_origin",
+                        return_value=(entry, origin),
+                    ),
+                    mock.patch.object(
+                        sync,
+                        "_load_artifact_engine",
+                        return_value=engine,
+                    ),
+                    mock.patch.object(
+                        sync,
+                        "_artifact_payloads_for_engine",
+                        return_value=[],
+                    ),
+                    mock.patch.object(
+                        sync,
+                        "_other_origin_target_conflicts",
+                        return_value=[],
+                    ),
+                ):
+                    self.assertEqual(
+                        "dry-result",
+                        sync.apply_v2_update(update, dry_run=True),
+                    )
+            finally:
+                sync.REPO_ROOT = old_root
+            self.assertEqual(before, tree_digest(root))
+            self.assertFalse((root / ".hvs-transactions").exists())
+
+    def test_ingest_dry_lock_path_is_repository_read_only(self):
+        import scripts.ingest_skill as ingest
+
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            sources = root / "docs/sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "source.skills.json"
+            mapping.write_text('{"schema_version":2,"skills":[]}\n')
+            skill = root / "skills/category/demo"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("# Demo\n")
+            before = tree_digest(root)
+
+            with ingest.acquire_ingest_locks(
+                repo_root=root,
+                skill_dirs=[skill],
+                mapping_paths=[mapping],
+                durable=False,
+            ) as guard:
+                self.assertIsNone(guard)
+
+            self.assertEqual(before, tree_digest(root))
+            self.assertFalse((root / ".hvs-transactions").exists())
+
+    def test_ingest_dry_lock_does_not_recover_real_artifact_journal(self):
+        import scripts.artifact_set_sync as artifact_sync
+        import scripts.ingest_skill as ingest
+
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+            root = Path(tmp)
+            sources = root / "docs/sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "source.skills.json"
+            mapping.write_text('{"schema_version":2,"skills":[]}\n')
+            skill_root = "skills/category/demo"
+            skill_dir = root / skill_root
+            skill_dir.mkdir(parents=True)
+            skill_md = skill_dir / "SKILL.md"
+            skill_md.write_bytes(b"old body")
+            code = r"""
+import hashlib, os, sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+from artifact_set_sync import plan_artifact_set_sync, prepare_artifact_set_sync
+root = Path(sys.argv[1])
+skill = "skills/category/demo/SKILL.md"
+old = (root / skill).read_bytes()
+entry = {
+    "normalized_slug": "demo",
+    "repo_skill": skill,
+    "kind": "mirror",
+    "origins": [{"artifacts": [{
+        "source": "release/demo",
+        "target": "skills/category/demo",
+        "type": "directory",
+    }]}],
+    "managed_files": [{
+        "path": skill,
+        "sha256": hashlib.sha256(old).hexdigest(),
+        "owner": "demo",
+    }],
+}
+plan = plan_artifact_set_sync(
+    root,
+    entry,
+    [{
+        "source": "release/SKILL.md",
+        "target": skill,
+        "type": "file",
+        "data": b"new body",
+    }],
+    {"ref": "v2"},
+)
+prepare_artifact_set_sync(plan)
+os._exit(80)
+"""
+            child = run_crashing_child(code, root)
+            self.assertEqual(80, child.returncode, child.stderr)
+            journal = artifact_sync.skill_transaction_journal_path(
+                root,
+                skill_root,
+            )
+            self.assertTrue(journal.exists())
+            before = tree_digest(root)
+
+            with self.assertRaises(Exception) as raised:
+                with ingest.acquire_ingest_locks(
+                    repo_root=root,
+                    skill_dirs=[skill_dir],
+                    mapping_paths=[mapping],
+                    durable=False,
+                ):
+                    pass
+
+            self.assertEqual(
+                "ArtifactRecoveryError",
+                type(raised.exception).__name__,
+            )
+            self.assertEqual((journal,), raised.exception.recovery_paths)
+            self.assertEqual(before, tree_digest(root))
+            self.assertTrue(journal.exists())
+
+            # Explicit writable entry recovers the fixture for test cleanup.
+            with artifact_sync.skill_advisory_lock(root, skill_root):
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_durable_file_batch.py
+++ b/tests/test_durable_file_batch.py
@@ -633,21 +633,23 @@ entry = {
         "target": "skills/category/demo",
         "type": "directory",
     }]}],
-    "managed_files": [{
-        "path": skill,
-        "sha256": hashlib.sha256(old).hexdigest(),
-        "owner": "demo",
-    }],
+        "managed_files": [{
+            "path": skill,
+            "sha256": hashlib.sha256(old).hexdigest(),
+            "owner": "demo",
+            "mode": "100644",
+        }],
 }
 plan = plan_artifact_set_sync(
     root,
     entry,
     [{
         "source": "release/SKILL.md",
-        "target": skill,
-        "type": "file",
-        "data": b"new body",
-    }],
+            "target": skill,
+            "type": "file",
+            "data": b"new body",
+            "mode": "100644",
+        }],
     {"ref": "v2"},
 )
 prepare_artifact_set_sync(plan)

--- a/tests/test_export_openclaw_skills.py
+++ b/tests/test_export_openclaw_skills.py
@@ -1,4 +1,6 @@
 import importlib.util
+import stat
+import subprocess
 import tempfile
 import textwrap
 import unittest
@@ -19,6 +21,30 @@ def load_export_module():
 
 
 class ExportOpenClawSkillsTests(unittest.TestCase):
+    @staticmethod
+    def git_index_modes(*paths: str) -> dict[str, str]:
+        output = subprocess.check_output(
+            [
+                "git",
+                "ls-files",
+                "--stage",
+                "-z",
+                "--",
+                *paths,
+            ],
+            cwd=REPO_ROOT,
+        )
+        modes: dict[str, str] = {}
+        for record in output.split(b"\0"):
+            if not record:
+                continue
+            metadata, separator, raw_path = record.partition(b"\t")
+            fields = metadata.split()
+            if not separator or len(fields) != 3 or fields[2] != b"0":
+                raise AssertionError(f"malformed Git index record: {record!r}")
+            modes[raw_path.decode("utf-8")] = fields[0].decode("ascii")
+        return modes
+
     def test_export_flattens_skill_tree_and_synthesizes_frontmatter(self):
         module = load_export_module()
 
@@ -56,6 +82,65 @@ class ExportOpenClawSkillsTests(unittest.TestCase):
             self.assertIn("name: demo-skill", exported_skill_md)
             self.assertIn("description: Automates demo workflow for local testing.", exported_skill_md)
             self.assertIn("# Demo Skill", exported_skill_md)
+
+    def test_export_preserves_executable_mode(self):
+        module = load_export_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            source_root = tmp / "skills"
+            output_root = tmp / "openclaw-skills"
+            skill_dir = source_root / "developer-engineering" / "demo-skill"
+            scripts = skill_dir / "scripts"
+            scripts.mkdir(parents=True)
+            skill_md = skill_dir / "SKILL.md"
+            skill_md.write_text(
+                "---\nname: demo-skill\ndescription: Demo.\n---\n# Demo\n",
+                encoding="utf-8",
+            )
+            skill_md.chmod(0o755)
+            executable = scripts / "check.sh"
+            executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            executable.chmod(0o755)
+
+            module.export_openclaw_skills(source_root, output_root)
+
+            exported = output_root / "demo-skill" / "scripts" / "check.sh"
+            self.assertEqual(executable.read_bytes(), exported.read_bytes())
+            self.assertEqual(0o755, stat.S_IMODE(exported.stat().st_mode))
+            exported_skill = output_root / "demo-skill" / "SKILL.md"
+            self.assertEqual(0o755, stat.S_IMODE(exported_skill.stat().st_mode))
+
+    def test_tracked_openclaw_export_modes_match_canonical_index(self):
+        module = load_export_module()
+        canonical_modes = self.git_index_modes("skills")
+        exported_modes = self.git_index_modes("openclaw-skills")
+        mismatches: list[str] = []
+
+        for canonical, mode in sorted(canonical_modes.items()):
+            parts = Path(canonical).parts
+            if len(parts) < 4:
+                continue
+            skill_root = Path(*parts[:3])
+            if f"{skill_root.as_posix()}/SKILL.md" not in canonical_modes:
+                continue
+            relative = Path(*parts[3:])
+            if any(part in module.IGNORED_NAMES for part in relative.parts):
+                continue
+            exported = (
+                Path("openclaw-skills") / parts[2] / relative
+            ).as_posix()
+            exported_mode = exported_modes.get(exported)
+            if exported_mode != mode:
+                mismatches.append(
+                    f"{canonical} -> {exported}: {mode} != {exported_mode}"
+                )
+
+        self.assertEqual(
+            [],
+            mismatches,
+            "Tracked OpenClaw artifacts must preserve canonical Git modes.",
+        )
 
     def test_export_preserves_extra_frontmatter_blocks(self):
         module = load_export_module()

--- a/tests/test_export_openclaw_skills.py
+++ b/tests/test_export_openclaw_skills.py
@@ -1,10 +1,12 @@
 import importlib.util
+import json
 import stat
 import subprocess
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -23,6 +25,21 @@ def load_export_module():
 class ExportOpenClawSkillsTests(unittest.TestCase):
     @staticmethod
     def git_index_modes(*paths: str) -> dict[str, str]:
+        snapshot = REPO_ROOT / ".hvs-stage-index-modes.json"
+        if snapshot.is_file() and not (REPO_ROOT / ".git").exists():
+            payload = json.loads(snapshot.read_text(encoding="utf-8"))
+            if (
+                payload.get("schema_version") != 1
+                or payload.get("source") != "trusted-git-index"
+                or not isinstance(payload.get("modes"), dict)
+            ):
+                raise AssertionError("malformed trusted Git index snapshot")
+            prefixes = tuple(path.rstrip("/") + "/" for path in paths)
+            return {
+                relative: mode
+                for relative, mode in payload["modes"].items()
+                if relative in paths or relative.startswith(prefixes)
+            }
         output = subprocess.check_output(
             [
                 "git",
@@ -141,6 +158,32 @@ class ExportOpenClawSkillsTests(unittest.TestCase):
             mismatches,
             "Tracked OpenClaw artifacts must preserve canonical Git modes.",
         )
+
+    def test_index_mode_gate_consumes_trusted_snapshot_without_git_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".hvs-stage-index-modes.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "source": "trusted-git-index",
+                        "modes": {
+                            "skills/category/demo/SKILL.md": "100755",
+                            "openclaw-skills/demo/SKILL.md": "100755",
+                            "README.md": "100644",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch(
+                f"{__name__}.REPO_ROOT",
+                root,
+            ):
+                self.assertEqual(
+                    {"skills/category/demo/SKILL.md": "100755"},
+                    self.git_index_modes("skills"),
+                )
 
     def test_export_preserves_extra_frontmatter_blocks(self):
         module = load_export_module()

--- a/tests/test_generate_sync_report.py
+++ b/tests/test_generate_sync_report.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -22,6 +23,55 @@ def load_module():
 
 
 class GenerateSyncReportTests(unittest.TestCase):
+    def valid_discovery(self) -> dict:
+        return {
+            "local_skill_count": 1,
+            "raw_discovered": 0,
+            "total_discovered": 0,
+            "unique_discovered": 0,
+            "discoveries": [],
+            "source_health": {
+                source: {
+                    "status": "healthy",
+                    "queries": 1,
+                    "results": 0,
+                    "raw_results": 0,
+                    "emitted": 0,
+                    "unique_emitted": 0,
+                    "errors": [],
+                }
+                for source in ("github", "skills_sh", "clawhub")
+            },
+            "errors": [],
+        }
+
+    def valid_upstream(self) -> dict:
+        return {
+            "mode": "online",
+            "state": "complete",
+            "summary": {
+                "total": 1,
+                "equal": 1,
+                "changed": 0,
+                "monitor_review": 0,
+                "unavailable": 0,
+                "rollback": 0,
+                "expected_skipped": 0,
+            },
+            "total_checked": 1,
+            "needs_update_count": 0,
+            "needs_review_count": 0,
+            "check_error_count": 0,
+            "rows": [
+                {
+                    "change_type": "none",
+                    "check_error": None,
+                    "needs_update": False,
+                    "needs_review": False,
+                }
+            ],
+        }
+
     def test_source_label_uses_discovery_url_without_blank_github_repo(self) -> None:
         module = load_module()
 
@@ -42,6 +92,28 @@ class GenerateSyncReportTests(unittest.TestCase):
             module.upstream_skill_name({"video_name": "supabase-postgres-best-practices"}),
         )
 
+    def test_tri_state_combines_source_health_and_upstream_state(self) -> None:
+        module = load_module()
+        self.assertEqual(
+            "complete",
+            module.discovery_state(
+                self.valid_discovery(),
+                exists=True,
+            ),
+        )
+        self.assertEqual(
+            "degraded",
+            module.combine_state("complete", "degraded"),
+        )
+        self.assertEqual(
+            "failed",
+            module.combine_state("degraded", "failed"),
+        )
+        self.assertEqual(
+            "failed",
+            module.upstream_report_state({"state": "complete"}, exists=True),
+        )
+
     def test_main_generates_non_empty_skill_and_source_fields(self) -> None:
         with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
             tmp_dir = Path(tmp)
@@ -52,8 +124,27 @@ class GenerateSyncReportTests(unittest.TestCase):
                 json.dumps(
                     {
                         "local_skill_count": 1,
+                        "raw_discovered": 1,
+                        "total_discovered": 1,
+                        "unique_discovered": 1,
+                        "source_health": {
+                            source: {
+                                "status": "healthy",
+                                "queries": 1,
+                                "results": 1 if source == "skills_sh" else 0,
+                                "raw_results": 1 if source == "skills_sh" else 0,
+                                "emitted": 1 if source == "skills_sh" else 0,
+                                "unique_emitted": (
+                                    1 if source == "skills_sh" else 0
+                                ),
+                                "errors": [],
+                            }
+                            for source in ("github", "skills_sh", "clawhub")
+                        },
+                        "errors": [],
                         "discoveries": [
                             {
+                                "source_key": "skills_sh",
                                 "name": "supabase",
                                 "source": "skills.sh (supabase/agent-skills)",
                                 "url": "https://skills.sh/supabase/agent-skills/supabase",
@@ -68,10 +159,28 @@ class GenerateSyncReportTests(unittest.TestCase):
             upstream.write_text(
                 json.dumps(
                     {
+                        "mode": "online",
+                        "state": "complete",
+                        "summary": {
+                            "total": 1,
+                            "equal": 0,
+                            "changed": 1,
+                            "monitor_review": 0,
+                            "unavailable": 0,
+                            "rollback": 0,
+                            "expected_skipped": 0,
+                        },
+                        "total_checked": 1,
+                        "needs_update_count": 1,
+                        "needs_review_count": 0,
+                        "check_error_count": 0,
                         "rows": [
                             {
                                 "video_name": "graphify",
+                                "change_type": "artifact_changed",
+                                "check_error": None,
                                 "needs_update": True,
+                                "needs_review": False,
                                 "latest_commit": "1234567890abcdef",
                             }
                         ]
@@ -97,16 +206,222 @@ class GenerateSyncReportTests(unittest.TestCase):
                     "--output",
                     str(output.relative_to(REPO_ROOT)),
                 ]
-                module.main()
+                self.assertEqual(0, module.main())
             finally:
                 sys.argv = old_argv
                 os.chdir(old_cwd)
 
             report = output.read_text(encoding="utf-8")
+            self.assertIn("**Automation state**: `complete`", report)
             self.assertIn("[supabase/agent-skills](https://skills.sh/supabase/agent-skills/supabase)", report)
             self.assertIn("**graphify**", report)
             self.assertNotIn("https://github.com/)", report)
             self.assertNotIn("****", report)
+
+    def test_discovery_requires_exact_three_sources_and_consistent_status(self):
+        module = load_module()
+        payload = self.valid_discovery()
+        payload["source_health"].pop("clawhub")
+        with self.assertRaisesRegex(ValueError, "exactly"):
+            module.validate_discovery(payload)
+
+        payload = self.valid_discovery()
+        payload["source_health"]["github"]["queries"] = True
+        with self.assertRaisesRegex(ValueError, "non-negative integers"):
+            module.validate_discovery(payload)
+
+        payload = self.valid_discovery()
+        payload["source_health"]["github"].update(
+            {
+                "status": "healthy",
+                "errors": [
+                    {
+                        "kind": "network_error",
+                        "status_code": None,
+                        "message": "timeout",
+                    }
+                ],
+            }
+        )
+        payload["errors"] = [
+            {
+                "kind": "network_error",
+                "status_code": None,
+                "message": "timeout",
+                "source": "github",
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, "disagrees"):
+            module.validate_discovery(payload)
+
+    def test_upstream_recomputes_rows_and_rejects_declared_mismatch(self):
+        module = load_module()
+        payload = self.valid_upstream()
+        payload["summary"]["equal"] = True
+        with self.assertRaisesRegex(ValueError, "disagrees"):
+            module.validate_upstream(payload)
+
+        payload = self.valid_upstream()
+        payload["state"] = "degraded"
+        with self.assertRaisesRegex(ValueError, "declared state"):
+            module.validate_upstream(payload)
+
+        payload = self.valid_upstream()
+        payload["rows"][0]["needs_update"] = True
+        with self.assertRaisesRegex(ValueError, "needs_update"):
+            module.validate_upstream(payload)
+
+    def test_invalid_inputs_still_write_failed_github_outputs(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            discovery = root / "discovery.json"
+            upstream = root / "upstream.json"
+            output = root / "report.md"
+            github_output = root / "github-output"
+            discovery.write_text("{}", encoding="utf-8")
+            upstream.write_text("{}", encoding="utf-8")
+            with mock.patch.dict(
+                os.environ,
+                {"GITHUB_OUTPUT": str(github_output)},
+                clear=False,
+            ):
+                result = module.main(
+                    [
+                        "--discovery",
+                        str(discovery),
+                        "--upstream",
+                        str(upstream),
+                        "--output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(1, result)
+            self.assertIn("sync_state=failed", github_output.read_text())
+            self.assertIn("needs_attention=true", github_output.read_text())
+            self.assertIn("Report Validation Failures", output.read_text())
+
+    def test_outputs_are_not_published_before_report_write_succeeds(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            discovery = root / "discovery.json"
+            upstream = root / "upstream.json"
+            github_output = root / "github-output"
+            discovery.write_text(
+                json.dumps(self.valid_discovery()),
+                encoding="utf-8",
+            )
+            upstream.write_text(
+                json.dumps(self.valid_upstream()),
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.dict(
+                    os.environ,
+                    {"GITHUB_OUTPUT": str(github_output)},
+                    clear=False,
+                ),
+                mock.patch.object(
+                    module,
+                    "_atomic_write_text",
+                    side_effect=OSError("disk full"),
+                ),
+            ):
+                with self.assertRaisesRegex(OSError, "disk full"):
+                    module.main(
+                        [
+                            "--discovery",
+                            str(discovery),
+                            "--upstream",
+                            str(upstream),
+                            "--output",
+                            str(root / "report.md"),
+                        ]
+                    )
+            self.assertFalse(github_output.exists())
+
+    def test_discovery_rows_and_source_conservation_are_strict(self):
+        module = load_module()
+        payload = self.valid_discovery()
+        payload["source_health"]["github"].update(
+            {
+                "results": 1,
+                "raw_results": 1,
+                "emitted": 1,
+                "unique_emitted": 1,
+            }
+        )
+        payload.update(
+            {
+                "raw_discovered": 1,
+                "total_discovered": 1,
+                "unique_discovered": 1,
+                "discoveries": [
+                    {
+                        "source_key": "github",
+                        "name": "demo",
+                        "source": "GitHub",
+                        "url": "https://github.com/example/demo",
+                        "repo_stars": 1,
+                        "description": "Demo",
+                    }
+                ],
+            }
+        )
+        self.assertEqual("complete", module.validate_discovery(payload))
+        payload["discoveries"][0].pop("source_key")
+        with self.assertRaisesRegex(ValueError, "source_key"):
+            module.validate_discovery(payload)
+
+    def test_discovery_errors_are_rendered_in_stable_source_order(self):
+        module = load_module()
+        discovery = self.valid_discovery()
+        discovery["source_health"]["skills_sh"].update(
+            {
+                "status": "unavailable",
+                "errors": [
+                    {
+                        "kind": "network_error",
+                        "status_code": None,
+                        "message": "timeout",
+                    }
+                ],
+            }
+        )
+        discovery["errors"] = [
+            {
+                "kind": "network_error",
+                "status_code": None,
+                "message": "timeout",
+                "source": "skills_sh",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            discovery_path = root / "discovery.json"
+            upstream_path = root / "upstream.json"
+            output = root / "report.md"
+            discovery_path.write_text(json.dumps(discovery), encoding="utf-8")
+            upstream_path.write_text(
+                json.dumps(self.valid_upstream()), encoding="utf-8"
+            )
+            self.assertEqual(
+                0,
+                module.main(
+                    [
+                        "--discovery",
+                        str(discovery_path),
+                        "--upstream",
+                        str(upstream_path),
+                        "--output",
+                        str(output),
+                    ]
+                ),
+            )
+            report = output.read_text(encoding="utf-8")
+            self.assertIn("Discovery Source Errors (1)", report)
+            self.assertIn("**skills_sh** (`network_error`)", report)
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest_skill.py
+++ b/tests/test_ingest_skill.py
@@ -1,5 +1,9 @@
 import importlib.util
+import contextlib
+import json
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -18,8 +22,27 @@ def load_module():
     return module
 
 
+def mock_license_checkpoint(
+    commit: str = "a" * 40,
+    *,
+    spdx: str = "MIT",
+    api_spdx: str | None = "MIT",
+) -> dict[str, str]:
+    checkpoint = {
+        "path": "LICENSE",
+        "blob_sha": "e" * 40,
+        "content_sha256": "f" * 64,
+        "spdx": spdx,
+        "resolved_commit": commit,
+    }
+    if api_spdx is not None:
+        checkpoint["api_spdx"] = api_spdx
+    return checkpoint
+
+
 class IngestSkillTests(unittest.TestCase):
     def write_skill(self, root: Path, frontmatter: str) -> Path:
+        (root / "docs" / "sources").mkdir(parents=True, exist_ok=True)
         skill_dir = root / "skills" / "developer-engineering" / "sample-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(frontmatter + "\n# Sample\n", encoding="utf-8")
@@ -27,34 +50,84 @@ class IngestSkillTests(unittest.TestCase):
 
     def test_external_ingest_rejects_missing_license(self):
         module = load_module()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
             skill_dir = self.write_skill(
                 Path(tmpdir),
                 "---\nname: sample-skill\ndescription: Sample\n---",
             )
-            with mock.patch.object(module, "fetch_github_repo_license", return_value=None):
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=("a" * 40, "b" * 40),
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_commit_bound_github_license",
+                    return_value=(
+                        None,
+                        None,
+                        "immutable license evidence is unavailable",
+                    ),
+                ),
+            ):
                 ok = module.ingest_one(
                     skill_dir,
                     source="github:owner/repo",
                     source_url="https://github.com/owner/repo",
                     dry_run=True,
+                    run_full_validation=False,
                 )
 
             self.assertFalse(ok)
 
     def test_external_ingest_adds_detected_permissive_license(self):
         module = load_module()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
             skill_dir = self.write_skill(
-                Path(tmpdir),
+                root,
                 "---\nname: sample-skill\ndescription: Sample\n---",
             )
-            with mock.patch.object(module, "fetch_github_repo_license", return_value="MIT"):
+            mapping = root / "docs" / "sources" / "ingested-external.skills.json"
+            license_checkpoint = mock_license_checkpoint()
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_commit_bound_github_license",
+                    return_value=("MIT", license_checkpoint, None),
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=("a" * 40, "b" * 40),
+                ),
+                mock.patch.object(
+                    module,
+                    "classify_github_artifacts",
+                    return_value=(
+                        [
+                            {
+                                "source": "skills/sample-skill/SKILL.md",
+                                "target": (
+                                    "skills/developer-engineering/"
+                                    "sample-skill/SKILL.md"
+                                ),
+                                "type": "file",
+                            }
+                        ],
+                        [],
+                    ),
+                ),
+            ):
                 ok = module.ingest_one(
                     skill_dir,
                     source="github:owner/repo",
                     source_url="https://github.com/owner/repo",
                     dry_run=False,
+                    external_mapping=mapping,
+                    repo_root=root,
+                    run_full_validation=False,
                 )
 
             content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
@@ -64,9 +137,10 @@ class IngestSkillTests(unittest.TestCase):
 
     def test_in_house_ingest_does_not_require_license(self):
         module = load_module()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
             skill_dir = self.write_skill(
-                Path(tmpdir),
+                root,
                 "---\nname: sample-skill\ndescription: Sample\n---",
             )
             ok = module.ingest_one(
@@ -74,9 +148,1124 @@ class IngestSkillTests(unittest.TestCase):
                 source="in-house",
                 source_url="",
                 dry_run=True,
+                run_full_validation=False,
+                repo_root=root,
             )
 
             self.assertTrue(ok)
+
+    def test_ingest_one_defaults_to_isolated_full_validation(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            before = (skill_dir / "SKILL.md").read_bytes()
+            with mock.patch.object(
+                module,
+                "execute_validated_ingest",
+                return_value=True,
+            ) as validate:
+                self.assertTrue(
+                    module.ingest_one(
+                        skill_dir,
+                        "in-house",
+                        "",
+                        True,
+                        repo_root=root,
+                    )
+                )
+            self.assertTrue(validate.called)
+            self.assertTrue(validate.call_args.kwargs["dry_run"])
+            self.assertTrue(validate.call_args.kwargs["locks_held"])
+            self.assertEqual(before, (skill_dir / "SKILL.md").read_bytes())
+
+    def test_external_ingest_registers_v2_mapping_before_bootstrap(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            (skill_dir / "template.txt").write_text("local supplement\n", encoding="utf-8")
+            mapping = root / "docs" / "sources" / "ingested-external.skills.json"
+            checkpoint = ("a" * 40, "b" * 40)
+            license_checkpoint = mock_license_checkpoint()
+            artifacts = (
+                [
+                    {
+                        "source": "skills/sample-skill/SKILL.md",
+                        "target": (
+                            "skills/developer-engineering/sample-skill/SKILL.md"
+                        ),
+                        "type": "file",
+                    }
+                ],
+                [
+                    {
+                        "source": (
+                            "skills/developer-engineering/sample-skill/"
+                            "template.txt"
+                        ),
+                        "target": (
+                            "skills/developer-engineering/sample-skill/"
+                            "template.txt"
+                        ),
+                        "type": "file",
+                    }
+                ],
+            )
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_commit_bound_github_license",
+                    return_value=("MIT", license_checkpoint, None),
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=checkpoint,
+                ),
+                mock.patch.object(
+                    module,
+                    "classify_github_artifacts",
+                    return_value=artifacts,
+                ),
+            ):
+                ok = module.ingest_one(
+                    skill_dir,
+                    source="github:owner/repo",
+                    source_url=(
+                        "https://github.com/owner/repo/tree/main/"
+                        "skills/sample-skill"
+                    ),
+                    dry_run=False,
+                    external_mapping=mapping,
+                    repo_root=root,
+                    run_full_validation=False,
+                )
+
+            self.assertTrue(ok)
+            payload = json.loads(mapping.read_text(encoding="utf-8"))
+            self.assertEqual(2, payload["schema_version"])
+            self.assertEqual(1, len(payload["skills"]))
+            entry = payload["skills"][0]
+            self.assertEqual("overlay", entry["kind"])
+            self.assertEqual("monitor", entry["sync_mode"])
+            self.assertEqual("owner/repo", entry["origins"][0]["repo"])
+            self.assertEqual("local-repo/curation", entry["origins"][1]["repo"])
+            self.assertEqual(2, len(entry["managed_files"]))
+            self.assertEqual("a" * 40, entry["origins"][0]["tracking"]["resolved_commit"])
+            self.assertEqual(
+                license_checkpoint,
+                entry["origins"][0]["tracking"]["license_checkpoint"],
+            )
+            self.assertEqual("b" * 40, entry["origins"][0]["tracking"]["path_commit"])
+            self.assertEqual(
+                "skills/sample-skill/SKILL.md",
+                entry["origins"][0]["artifacts"][0]["source"],
+            )
+            self.assertEqual(
+                "skills/developer-engineering/sample-skill/SKILL.md",
+                entry["repo_skill"],
+            )
+
+            validator_path = REPO_ROOT / "scripts" / "validate_skill_sources.py"
+            validator_spec = importlib.util.spec_from_file_location(
+                "validate_skill_sources_for_ingest_test",
+                validator_path,
+            )
+            self.assertIsNotNone(validator_spec)
+            self.assertIsNotNone(validator_spec.loader)
+            validator = importlib.util.module_from_spec(validator_spec)
+            validator_spec.loader.exec_module(validator)
+            self.assertEqual([], validator.validate_mapping(mapping, root))
+
+            bootstrap_path = REPO_ROOT / "scripts" / "bootstrap_in_house_sources.py"
+            spec = importlib.util.spec_from_file_location(
+                "bootstrap_in_house_sources_for_ingest_test",
+                bootstrap_path,
+            )
+            self.assertIsNotNone(spec)
+            self.assertIsNotNone(spec.loader)
+            bootstrap = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(bootstrap)
+            in_house_path = root / "docs" / "sources" / "in-house.skills.json"
+            in_house = bootstrap.build_in_house_mapping(
+                repo_root=root,
+                repo_url="https://github.com/local/repo",
+                target_mapping=in_house_path,
+                existing_payload=None,
+                today="2026-08-20",
+            )
+            self.assertEqual([], in_house["skills"])
+
+    def test_external_ingest_dry_run_never_creates_mapping(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\nlicense: MIT\n---",
+            )
+            mapping = root / "docs" / "sources" / "ingested-external.skills.json"
+            before = (skill_dir / "SKILL.md").read_bytes()
+            license_checkpoint = mock_license_checkpoint()
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_commit_bound_github_license",
+                    return_value=("MIT", license_checkpoint, None),
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=("a" * 40, "b" * 40),
+                ),
+                mock.patch.object(
+                    module,
+                    "classify_github_artifacts",
+                    return_value=(
+                        [
+                            {
+                                "source": "skills/sample-skill/SKILL.md",
+                                "target": (
+                                    "skills/developer-engineering/"
+                                    "sample-skill/SKILL.md"
+                                ),
+                                "type": "file",
+                            }
+                        ],
+                        [],
+                    ),
+                ),
+            ):
+                ok = module.ingest_one(
+                    skill_dir,
+                    source="github:owner/repo",
+                    source_url="https://github.com/owner/repo",
+                    dry_run=True,
+                    external_mapping=mapping,
+                    repo_root=root,
+                    run_full_validation=False,
+                )
+            self.assertTrue(ok)
+            self.assertFalse(mapping.exists())
+            self.assertEqual(before, (skill_dir / "SKILL.md").read_bytes())
+
+    def test_github_artifact_classification_rejects_unreviewed_body_drift(self):
+        module = load_module()
+
+        class FakeProvider:
+            def __init__(self, _token):
+                pass
+
+            def tree(self, _repo, _commit):
+                return {
+                    "upstream/SKILL.md": {"type": "blob", "sha": "skill-blob"},
+                    "upstream/data.bin": {"type": "blob", "sha": "data-blob"},
+                }
+
+            def blob(self, _repo, blob_sha):
+                return {
+                    "skill-blob": b"---\nname: sample-skill\n---\n# Upstream\n",
+                    "data-blob": b"\x00\x01",
+                }[blob_sha]
+
+        fake_module = types.SimpleNamespace(
+            GitHubArtifactProvider=FakeProvider,
+            GitHubProviderError=RuntimeError,
+        )
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            (skill_dir / "data.bin").write_bytes(b"\x00\x01")
+            (skill_dir / "local.txt").write_text("local\n", encoding="utf-8")
+            with mock.patch.dict(
+                sys.modules,
+                {"github_artifact_provider": fake_module},
+            ):
+                with self.assertRaisesRegex(ValueError, "does not match"):
+                    module.classify_github_artifacts(
+                        skill_dir=skill_dir,
+                        repo_root=root,
+                        repo="owner/repo",
+                        resolved_commit="a" * 40,
+                        upstream_skill_path="upstream/SKILL.md",
+                    )
+                (skill_dir / "SKILL.md").write_text(
+                    "---\nname: sample-skill\ndescription: Local\n---\n"
+                    "# Upstream\n",
+                    encoding="utf-8",
+                )
+                external, local = module.classify_github_artifacts(
+                    skill_dir=skill_dir,
+                    repo_root=root,
+                    repo="owner/repo",
+                    resolved_commit="a" * 40,
+                    upstream_skill_path="upstream/SKILL.md",
+                    artifact_maps=[
+                        (
+                            "upstream/data.bin",
+                            (
+                                "skills/developer-engineering/"
+                                "sample-skill/data.bin"
+                            ),
+                        )
+                    ],
+                )
+
+            self.assertEqual(
+                {"upstream/SKILL.md", "upstream/data.bin"},
+                {artifact["source"] for artifact in external},
+            )
+            self.assertEqual(
+                [
+                    "skills/developer-engineering/sample-skill/local.txt",
+                ],
+                [artifact["target"] for artifact in local],
+            )
+
+    def test_commit_license_overrides_default_branch_and_must_match_frontmatter(self):
+        module = load_module()
+        evidence = types.SimpleNamespace(
+            path="LICENSE",
+            blob_sha="e" * 40,
+            content_sha256="f" * 64,
+            resolved_commit="a" * 40,
+            spdx_candidates=("Apache-2.0",),
+            api_spdx="NOASSERTION",
+        )
+        provider = mock.Mock()
+        provider.license_evidence.return_value = evidence
+        with mock.patch.object(
+            module,
+            "GitHubArtifactProvider",
+            return_value=provider,
+        ):
+            detected, checkpoint, error = (
+                module.resolve_commit_bound_github_license(
+                    {"license": "MIT"},
+                    "github:owner/repo",
+                    "https://github.com/owner/repo",
+                    repo="owner/repo",
+                    resolved_commit="a" * 40,
+                )
+            )
+        self.assertIsNone(detected)
+        self.assertIsNone(checkpoint)
+        self.assertIn("does not match", error)
+        provider.license_evidence.assert_called_once_with(
+            "owner/repo",
+            "a" * 40,
+        )
+
+    def test_graphify_noassertion_canonical_apache_license_is_accepted(self):
+        module = load_module()
+        apache = (
+            REPO_ROOT
+            / "skills"
+            / "developer-engineering"
+            / "mcp-builder"
+            / "LICENSE.txt"
+        ).read_bytes()
+        evidence = types.SimpleNamespace(
+            path="LICENSE",
+            blob_sha="e" * 40,
+            content_sha256="f" * 64,
+            resolved_commit="a" * 40,
+            spdx_candidates=(
+                module.GitHubArtifactProvider._detect_license_spdx(apache)
+            ),
+            api_spdx="NOASSERTION",
+        )
+        provider = mock.Mock()
+        provider.license_evidence.return_value = evidence
+        with mock.patch.object(
+            module,
+            "GitHubArtifactProvider",
+            return_value=provider,
+        ):
+            detected, checkpoint, error = (
+                module.resolve_commit_bound_github_license(
+                    {"license": "Apache-2.0"},
+                    "github:Graphify-Labs/graphify",
+                    "https://github.com/Graphify-Labs/graphify",
+                    repo="Graphify-Labs/graphify",
+                    resolved_commit="a" * 40,
+                )
+            )
+
+        self.assertIsNone(error)
+        self.assertEqual("Apache-2.0", detected)
+        self.assertEqual("Apache-2.0", checkpoint["spdx"])
+        self.assertEqual("NOASSERTION", checkpoint["api_spdx"])
+        self.assertEqual("a" * 40, checkpoint["resolved_commit"])
+
+    def test_legacy_external_registration_cannot_bypass_license_check(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                (
+                    "---\nname: sample-skill\ndescription: Sample\n"
+                    "license: MIT\n---"
+                ),
+            )
+            mapping = (
+                root / "docs" / "sources" / "external.skills.json"
+            )
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=("a" * 40, "b" * 40),
+                ),
+                mock.patch.object(
+                    module,
+                    "resolve_commit_bound_github_license",
+                    return_value=(
+                        None,
+                        None,
+                        "detected SPDX 'Apache-2.0' does not match "
+                        "origin.license 'MIT'",
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(ValueError, "does not match"):
+                    module.register_external_provenance(
+                        skill_dir=skill_dir,
+                        source="github:owner/repo",
+                        source_url="https://github.com/owner/repo",
+                        license_value="MIT",
+                        mapping_path=mapping,
+                        repo_root=root,
+                    )
+            self.assertFalse(mapping.exists())
+
+    def test_strict_github_source_rejects_hostname_and_repo_mismatch(self):
+        module = load_module()
+        self.assertIsNone(
+            module.github_repo_from_source(
+                "github:owner/repo",
+                "https://github.com.evil.example/owner/repo",
+            )
+        )
+        detected, error = module.resolve_external_license(
+            {"license": "MIT"},
+            "github:owner/repo",
+            "https://github.com/other/repo",
+        )
+        self.assertIsNone(detected)
+        self.assertIn("disagree", error)
+
+    def test_supplied_checkpoint_mismatch_fails_before_any_write(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            skill_path = skill_dir / "SKILL.md"
+            before = skill_path.read_bytes()
+            mapping = root / "docs" / "sources" / "external.skills.json"
+            with (
+                mock.patch.object(
+                    module,
+                    "resolve_github_checkpoint",
+                    return_value=("a" * 40, "b" * 40),
+                ),
+            ):
+                ok = module.ingest_one(
+                    skill_dir,
+                    "github:owner/repo",
+                    "https://github.com/owner/repo",
+                    False,
+                    repo_root=root,
+                    external_mapping=mapping,
+                    resolved_commit="c" * 40,
+                    run_full_validation=False,
+                )
+            self.assertFalse(ok)
+            self.assertEqual(before, skill_path.read_bytes())
+            self.assertFalse(mapping.exists())
+
+    def test_non_github_license_string_without_evidence_is_rejected(self):
+        module = load_module()
+        detected, error = module.resolve_external_license(
+            {"license": "MIT"},
+            "skills.sh",
+            "https://skills.sh/example/skill",
+        )
+        self.assertIsNone(detected)
+        self.assertIn("cannot prove immutable content lineage", error)
+
+    def test_batch_claim_inventory_scans_all_v2_mappings(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            sources = Path(tmpdir)
+            for index, name in enumerate(("alpha", "beta")):
+                (sources / f"{index}.skills.json").write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 2,
+                            "skills": [
+                                {
+                                    "normalized_slug": name,
+                                    "status": "verified_in_repo",
+                                }
+                            ],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+            self.assertEqual(
+                {"alpha", "beta"},
+                module.get_tracked_skills(sources),
+            )
+
+    def test_artifact_manifest_requires_explicit_cross_directory_targets(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            manifest = Path(tmpdir) / "artifacts.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "artifacts": [
+                            {
+                                "source": "packages/docs/reference.md",
+                                "target": (
+                                    "skills/developer-engineering/"
+                                    "sample-skill/references/reference.md"
+                                ),
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                [
+                    (
+                        "packages/docs/reference.md",
+                        (
+                            "skills/developer-engineering/"
+                            "sample-skill/references/reference.md"
+                        ),
+                    )
+                ],
+                module.load_artifact_manifest(manifest),
+            )
+
+    def test_atomic_ingest_restores_frontmatter_when_mapping_replace_fails(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            skill_path = skill_dir / "SKILL.md"
+            mapping = root / "docs" / "sources" / "external.skills.json"
+            plan = module.IngestPlan(
+                skill_name="sample-skill",
+                skill_md=skill_path,
+                before_skill=skill_path.read_bytes(),
+                after_skill=skill_path.read_bytes() + b"\nsource: test\n",
+                mapping_path=mapping,
+                before_mapping=None,
+                after_mapping=b"{}\n",
+            )
+            original_write = module._write_atomic_bytes
+            calls = 0
+
+            def flaky_write(path, content, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("mapping replace failed")
+                return original_write(path, content, **kwargs)
+
+            with mock.patch.object(
+                module, "_write_atomic_bytes", side_effect=flaky_write
+            ):
+                with self.assertRaisesRegex(OSError, "mapping replace failed"):
+                    module.commit_ingest_plans([plan])
+            self.assertEqual(plan.before_skill, skill_path.read_bytes())
+            self.assertFalse(mapping.exists())
+            self.assertTrue((root / "docs" / "sources").is_dir())
+
+    def test_post_replace_directory_fsync_failure_restores_current_file(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_path = root / "SKILL.md"
+            skill_path.write_bytes(b"before")
+            plan = module.IngestPlan(
+                skill_name="demo",
+                skill_md=skill_path,
+                before_skill=b"before",
+                after_skill=b"after",
+                repo_root=root,
+                before_checkpoint=module.capture_target_checkpoint(
+                    skill_path,
+                    repo_root=root,
+                ),
+            )
+            real_fsync = module.os.fsync
+            calls = 0
+
+            def fail_first_directory_sync(descriptor):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("directory fsync failed")
+                return real_fsync(descriptor)
+
+            with mock.patch.object(
+                module.os,
+                "fsync",
+                side_effect=fail_first_directory_sync,
+            ):
+                with self.assertRaisesRegex(
+                    OSError, "directory fsync failed"
+                ):
+                    module.commit_ingest_plans(
+                        [plan],
+                        locks_held=True,
+                    )
+            self.assertEqual(b"before", skill_path.read_bytes())
+
+    def test_sidecar_or_claim_race_rejects_stale_ingest_plan(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            sidecar = skill_dir / "template.txt"
+            sidecar.write_text("before", encoding="utf-8")
+            plan = module.prepare_ingest(
+                skill_dir,
+                "in-house",
+                "",
+                repo_root=root,
+            )
+            sidecar.write_text("after", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "race detected"):
+                module.commit_ingest_plans([plan])
+            self.assertEqual(
+                plan.before_skill,
+                (skill_dir / "SKILL.md").read_bytes(),
+            )
+
+    def test_post_ingest_pipeline_is_fail_fast(self):
+        module = load_module()
+        failed = types.SimpleNamespace(
+            returncode=7,
+            stdout="gate failed",
+            stderr="details",
+        )
+        with mock.patch.object(
+            module.subprocess,
+            "run",
+            return_value=failed,
+        ) as run:
+            self.assertFalse(module.run_pipeline(False))
+        self.assertEqual(1, run.call_count)
+        inventory_command = [
+            module.sys.executable,
+            "scripts/reconcile_artifact_inventory.py",
+            "--offline",
+            "--check-clean",
+            "--quiet",
+        ]
+        self.assertIn(inventory_command, module.pipeline_commands())
+
+    def test_dry_run_validates_staged_diff_without_repository_writes(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            (root / "docs" / "sources").mkdir(parents=True)
+            target = root / "SKILL.md"
+            target.write_bytes(b"before")
+            mutation = module.IngestPlan(
+                skill_name="staged:SKILL.md",
+                skill_md=target,
+                before_skill=b"before",
+                after_skill=b"after",
+            )
+            baseline = module.repository_bytes_snapshot(root)
+            baseline_checkpoints = module.repository_checkpoint_snapshot(
+                root,
+                set(baseline),
+            )
+            tracked_reports = module.tracked_report_paths(root)
+            with mock.patch.object(
+                module,
+                "validate_ingest_plans",
+                return_value=(
+                    [mutation],
+                    baseline,
+                    baseline_checkpoints,
+                    tracked_reports,
+                ),
+            ):
+                self.assertTrue(
+                    module.execute_validated_ingest(
+                        [mutation],
+                        repo_root=root,
+                        dry_run=True,
+                        locks_held=True,
+                    )
+                )
+            self.assertEqual(b"before", target.read_bytes())
+
+    def test_staged_mutation_keeps_original_target_checkpoint(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            (root / "docs" / "sources").mkdir(parents=True)
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.mkdir(parents=True)
+            target = skill_dir / "SKILL.md"
+            target.write_bytes(b"before")
+            checkpoint = module.capture_target_checkpoint(
+                target,
+                repo_root=root,
+            )
+            plan = module.IngestPlan(
+                skill_name="demo",
+                skill_md=target,
+                before_skill=b"before",
+                after_skill=b"after",
+                repo_root=root,
+                before_checkpoint=checkpoint,
+            )
+
+            with mock.patch.object(module, "run_pipeline", return_value=True):
+                validated = module.validate_ingest_plans(
+                    [plan],
+                    repo_root=root,
+                )
+
+            self.assertIsNotNone(validated)
+            mutations, _baseline, _checkpoints, _tracked_reports = validated
+            mutation = next(
+                item for item in mutations if item.skill_md == target
+            )
+            self.assertEqual(checkpoint, mutation.before_checkpoint)
+            self.assertEqual(
+                {"exists", "dev", "ino", "mode", "size", "sha256"},
+                set(mutation.before_checkpoint),
+            )
+            self.assertEqual(b"before", target.read_bytes())
+
+    def test_noop_validation_ignores_generated_reports_but_copies_them(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            reports = root / "docs" / "sources" / "reports"
+            reports.mkdir(parents=True)
+            generated_json = reports / "skill-quality-audit.json"
+            generated_markdown = reports / "skill-quality-audit.md"
+            historic = reports / "skill-curation-2026-04-25.md"
+            generated_json.write_text('{"before":true}\n', encoding="utf-8")
+            generated_markdown.write_text("# Before\n", encoding="utf-8")
+            historic.write_text("# Historic\n", encoding="utf-8")
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.mkdir(parents=True)
+            target = skill_dir / "SKILL.md"
+            target.write_bytes(b"before")
+            tracked = {
+                "docs/sources/reports/skill-curation-2026-04-25.md"
+            }
+            plan = module.IngestPlan(
+                skill_name="demo",
+                skill_md=target,
+                before_skill=b"before",
+                after_skill=b"before",
+                repo_root=root,
+                before_checkpoint=module.capture_target_checkpoint(
+                    target,
+                    repo_root=root,
+                ),
+                before_parent_checkpoint=module.capture_parent_checkpoint(
+                    root,
+                    target,
+                ),
+            )
+
+            def mutate_generated_reports(_dry_run, *, repo_root):
+                staged_reports = repo_root / "docs" / "sources" / "reports"
+                self.assertEqual(
+                    '{"before":true}\n',
+                    (staged_reports / generated_json.name).read_text(),
+                )
+                self.assertEqual(
+                    "# Historic\n",
+                    (staged_reports / historic.name).read_text(),
+                )
+                (staged_reports / generated_json.name).write_text(
+                    '{"after":true}\n',
+                    encoding="utf-8",
+                )
+                (staged_reports / generated_markdown.name).write_text(
+                    "# After\n",
+                    encoding="utf-8",
+                )
+                return True
+
+            with (
+                mock.patch.object(
+                    module,
+                    "tracked_report_paths",
+                    return_value=tracked,
+                ),
+                mock.patch.object(
+                    module,
+                    "run_pipeline",
+                    side_effect=mutate_generated_reports,
+                ),
+            ):
+                validated = module.validate_ingest_plans(
+                    [plan],
+                    repo_root=root,
+                )
+
+            self.assertIsNotNone(validated)
+            mutations, baseline, _checkpoints, reported_tracked = validated
+            self.assertEqual([], mutations)
+            self.assertEqual(tracked, reported_tracked)
+            self.assertIn(
+                "docs/sources/reports/skill-curation-2026-04-25.md",
+                baseline,
+            )
+            self.assertNotIn(
+                "docs/sources/reports/skill-quality-audit.json",
+                baseline,
+            )
+            self.assertNotIn(
+                "docs/sources/reports/skill-quality-audit.md",
+                baseline,
+            )
+            self.assertEqual('{"before":true}\n', generated_json.read_text())
+            self.assertEqual("# Before\n", generated_markdown.read_text())
+
+    def test_stage_copy_rejects_symlink_without_touching_external_sentinel(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            base = Path(tmpdir)
+            root = base / "repo"
+            root.mkdir()
+            (root / "docs" / "sources").mkdir(parents=True)
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo\n---\n# Demo\n",
+                encoding="utf-8",
+            )
+            sentinel = base / "outside.txt"
+            sentinel.write_text("do-not-touch", encoding="utf-8")
+            (skill_dir / "escape").symlink_to(sentinel)
+            destination = base / "stage"
+
+            with self.assertRaisesRegex(ValueError, "contains a symlink"):
+                module._copy_stage_repository(root, destination)
+
+            self.assertEqual("do-not-touch", sentinel.read_text())
+            self.assertFalse(destination.exists())
+
+    def test_repo_root_ancestor_symlink_is_rejected_nofollow(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            base = Path(tmpdir)
+            real_root = base / "real"
+            real_root.mkdir()
+            alias = base / "alias"
+            alias.symlink_to(real_root, target_is_directory=True)
+            with self.assertRaises(OSError):
+                module.open_directory_nofollow(alias)
+
+    def test_ingest_and_sync_share_mapping_and_skill_lock_identities(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "source.skills.json"
+            mapping.write_text(
+                '{"schema_version":2,"skills":[]}\n',
+                encoding="utf-8",
+            )
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo\n---\n# Demo\n",
+                encoding="utf-8",
+            )
+
+            with module.acquire_ingest_locks(
+                repo_root=root,
+                skill_dirs=[skill_dir],
+                mapping_paths=[mapping],
+                timeout=0,
+            ):
+                with self.assertRaisesRegex(Exception, "already active"):
+                    with module.mapping_advisory_lock(mapping, timeout=0):
+                        pass
+                with self.assertRaisesRegex(
+                    Exception, "already active"
+                ):
+                    with module.skill_advisory_lock(
+                        root,
+                        "skills/category/demo",
+                        timeout=0,
+                    ):
+                        pass
+
+            with module.mapping_advisory_lock(mapping, timeout=0):
+                with self.assertRaisesRegex(Exception, "already active"):
+                    with module.acquire_ingest_locks(
+                        repo_root=root,
+                        skill_dirs=[skill_dir],
+                        mapping_paths=[mapping],
+                        timeout=0,
+                    ):
+                        pass
+
+    def test_ingest_skill_lock_allows_engine_recovery_before_revalidation(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "source.skills.json"
+            mapping.write_text(
+                '{"schema_version":2,"skills":[]}\n',
+                encoding="utf-8",
+            )
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.parent.mkdir(parents=True)
+            entered = []
+
+            @contextlib.contextmanager
+            def recovering_skill_lock(
+                repo_root,
+                skill_root,
+                *,
+                timeout,
+                recover_pending,
+            ):
+                entered.append(
+                    (
+                        Path(repo_root),
+                        skill_root,
+                        timeout,
+                        recover_pending,
+                    )
+                )
+                skill_dir.mkdir()
+                (skill_dir / "SKILL.md").write_text(
+                    "---\nname: demo\n---\n# Demo\n",
+                    encoding="utf-8",
+                )
+                yield
+
+            with mock.patch.object(
+                module,
+                "skill_advisory_lock",
+                side_effect=recovering_skill_lock,
+            ):
+                with module.acquire_ingest_locks(
+                    repo_root=root,
+                    skill_dirs=[skill_dir],
+                    mapping_paths=[mapping],
+                    timeout=0,
+                ):
+                    self.assertTrue(skill_dir.is_dir())
+
+            self.assertEqual(
+                [(root, "skills/category/demo", 0, True)],
+                entered,
+            )
+
+    def test_batch_checkpoint_race_is_rejected_before_first_write(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.txt"
+            second = root / "second.txt"
+            first.write_bytes(b"first-before")
+            second.write_bytes(b"second-before")
+            plans = []
+            for path, after in (
+                (first, b"first-after"),
+                (second, b"second-after"),
+            ):
+                plans.append(
+                    module.IngestPlan(
+                        skill_name=path.name,
+                        skill_md=path,
+                        before_skill=path.read_bytes(),
+                        after_skill=after,
+                        repo_root=root,
+                        before_checkpoint=module.capture_target_checkpoint(
+                            path,
+                            repo_root=root,
+                        ),
+                    )
+                )
+            replacement = root / "replacement"
+            replacement.write_bytes(b"second-before")
+            replacement.replace(second)
+
+            with self.assertRaisesRegex(
+                RuntimeError, "changed after staging"
+            ):
+                module.commit_ingest_plans(plans, locks_held=True)
+
+            self.assertEqual(b"first-before", first.read_bytes())
+            self.assertEqual(b"second-before", second.read_bytes())
+
+    def test_atomic_commit_securely_creates_missing_target_parents(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            target = root / "generated" / "nested" / "artifact.txt"
+            plan = module.IngestPlan(
+                skill_name="generated",
+                skill_md=target,
+                before_skill=None,
+                after_skill=b"generated",
+                repo_root=root,
+                before_checkpoint=module.capture_target_checkpoint(
+                    target,
+                    repo_root=root,
+                ),
+                before_parent_checkpoint=module.capture_parent_checkpoint(
+                    root,
+                    target,
+                ),
+            )
+
+            module.commit_ingest_plans([plan], locks_held=True)
+
+            self.assertEqual(b"generated", target.read_bytes())
+            self.assertFalse(target.is_symlink())
+
+    def test_failed_batch_removes_new_target_and_created_parents(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            generated = root / "generated" / "nested" / "artifact.txt"
+            existing = root / "existing.txt"
+            existing.write_bytes(b"before")
+            plans = [
+                module.IngestPlan(
+                    skill_name="generated",
+                    skill_md=generated,
+                    before_skill=None,
+                    after_skill=b"generated",
+                    repo_root=root,
+                    before_checkpoint=module.capture_target_checkpoint(
+                        generated,
+                        repo_root=root,
+                    ),
+                    before_parent_checkpoint=(
+                        module.capture_parent_checkpoint(root, generated)
+                    ),
+                ),
+                module.IngestPlan(
+                    skill_name="existing",
+                    skill_md=existing,
+                    before_skill=b"before",
+                    after_skill=b"after",
+                    repo_root=root,
+                    before_checkpoint=module.capture_target_checkpoint(
+                        existing,
+                        repo_root=root,
+                    ),
+                    before_parent_checkpoint=(
+                        module.capture_parent_checkpoint(root, existing)
+                    ),
+                ),
+            ]
+            real_write = module._write_atomic_bytes
+            calls = 0
+
+            def fail_second(path, content, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("second target failed")
+                return real_write(path, content, **kwargs)
+
+            with mock.patch.object(
+                module,
+                "_write_atomic_bytes",
+                side_effect=fail_second,
+            ):
+                with self.assertRaisesRegex(OSError, "second target failed"):
+                    module.commit_ingest_plans(
+                        plans,
+                        locks_held=True,
+                    )
+
+            self.assertFalse(generated.exists())
+            self.assertFalse((root / "generated").exists())
+            self.assertEqual(b"before", existing.read_bytes())
+
+    def test_secure_writer_rechecks_destination_inode_before_replace(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            target = root / "target.txt"
+            target.write_bytes(b"before")
+            checkpoint = module.capture_target_checkpoint(
+                target,
+                repo_root=root,
+            )
+            real_capture = module._capture_target_at
+            target_captures = 0
+
+            def replace_at_boundary(parent_fd, leaf, path):
+                nonlocal target_captures
+                if path == target:
+                    target_captures += 1
+                    if target_captures == 3:
+                        replacement = root / "replacement.txt"
+                        replacement.write_bytes(b"before")
+                        replacement.replace(target)
+                return real_capture(parent_fd, leaf, path)
+
+            with mock.patch.object(
+                module,
+                "_capture_target_at",
+                side_effect=replace_at_boundary,
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "changed immediately before replace",
+                ):
+                    module._write_atomic_bytes_secure(
+                        target,
+                        b"after",
+                        repo_root=root,
+                        expected_checkpoint=checkpoint,
+                    )
+
+            self.assertEqual(b"before", target.read_bytes())
+            self.assertEqual([], list(root.glob(".*.tmp")))
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest_skill.py
+++ b/tests/test_ingest_skill.py
@@ -1267,6 +1267,48 @@ class IngestSkillTests(unittest.TestCase):
             self.assertEqual("do-not-touch", sentinel.read_text())
             self.assertFalse(destination.exists())
 
+    def test_stage_copy_exports_trusted_index_modes_without_git_directory(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            base = Path(tmpdir)
+            root = base / "repo"
+            root.mkdir()
+            subprocess.run(
+                ["git", "init", "-q", str(root)],
+                check=True,
+            )
+            canonical = root / "skills" / "category" / "demo" / "SKILL.md"
+            exported = root / "openclaw-skills" / "demo" / "SKILL.md"
+            canonical.parent.mkdir(parents=True)
+            exported.parent.mkdir(parents=True)
+            canonical.write_text("---\nname: demo\n---\n", encoding="utf-8")
+            exported.write_bytes(canonical.read_bytes())
+            canonical.chmod(0o755)
+            exported.chmod(0o755)
+            subprocess.run(
+                ["git", "-C", str(root), "add", "skills", "openclaw-skills"],
+                check=True,
+            )
+
+            destination = base / "stage"
+            module._copy_stage_repository(root, destination)
+
+            self.assertFalse((destination / ".git").exists())
+            snapshot_path = (
+                destination / module.STAGE_INDEX_MODES_NAME
+            )
+            self.assertEqual(0o600, stat.S_IMODE(snapshot_path.stat().st_mode))
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            self.assertEqual("trusted-git-index", snapshot["source"])
+            self.assertEqual(
+                "100755",
+                snapshot["modes"]["skills/category/demo/SKILL.md"],
+            )
+            self.assertEqual(
+                "100755",
+                snapshot["modes"]["openclaw-skills/demo/SKILL.md"],
+            )
+
     def test_repo_root_ancestor_symlink_is_rejected_nofollow(self):
         module = load_module()
         with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:

--- a/tests/test_ingest_skill.py
+++ b/tests/test_ingest_skill.py
@@ -1,6 +1,8 @@
 import importlib.util
 import contextlib
 import json
+import stat
+import subprocess
 import sys
 import tempfile
 import types
@@ -89,6 +91,7 @@ class IngestSkillTests(unittest.TestCase):
                 root,
                 "---\nname: sample-skill\ndescription: Sample\n---",
             )
+            (skill_dir / "SKILL.md").chmod(0o755)
             mapping = root / "docs" / "sources" / "ingested-external.skills.json"
             license_checkpoint = mock_license_checkpoint()
             with (
@@ -134,6 +137,75 @@ class IngestSkillTests(unittest.TestCase):
             self.assertTrue(ok)
             self.assertIn("license: MIT", content)
             self.assertIn('source: "github:owner/repo"', content)
+            self.assertEqual(
+                0o755,
+                stat.S_IMODE((skill_dir / "SKILL.md").stat().st_mode),
+            )
+            payload = json.loads(mapping.read_text(encoding="utf-8"))
+            managed = payload["skills"][0]["managed_files"]
+            self.assertEqual(
+                "100755",
+                next(
+                    item["mode"]
+                    for item in managed
+                    if item["path"].endswith("/SKILL.md")
+                ),
+            )
+
+    def test_dry_run_rejects_dirty_tracked_executable_mode(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir="/private/tmp") as tmpdir:
+            root = Path(tmpdir)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            skill_md = skill_dir / "SKILL.md"
+            skill_md.chmod(0o644)
+            subprocess.run(
+                ["git", "-C", str(root), "add", "skills"],
+                check=True,
+            )
+            skill_md.chmod(0o755)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "dirty executable-mode changes",
+            ):
+                module.prepare_ingest(
+                    skill_dir,
+                    "in-house",
+                    "",
+                    repo_root=root,
+                )
+
+            self.assertEqual(
+                0o755,
+                stat.S_IMODE(skill_md.stat().st_mode),
+            )
+
+    def test_ingest_fingerprint_changes_on_mode_only_mutation(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            skill_dir = self.write_skill(
+                root,
+                "---\nname: sample-skill\ndescription: Sample\n---",
+            )
+            mapping = root / "docs" / "sources" / "external.skills.json"
+            before = module.capture_ingest_fingerprint(
+                skill_dir=skill_dir,
+                mapping_path=mapping,
+                repo_root=root,
+            )
+            (skill_dir / "SKILL.md").chmod(0o755)
+            after = module.capture_ingest_fingerprint(
+                skill_dir=skill_dir,
+                mapping_path=mapping,
+                repo_root=root,
+            )
+            self.assertNotEqual(before, after)
 
     def test_in_house_ingest_does_not_require_license(self):
         module = load_module()
@@ -365,8 +437,16 @@ class IngestSkillTests(unittest.TestCase):
 
             def tree(self, _repo, _commit):
                 return {
-                    "upstream/SKILL.md": {"type": "blob", "sha": "skill-blob"},
-                    "upstream/data.bin": {"type": "blob", "sha": "data-blob"},
+                    "upstream/SKILL.md": {
+                        "type": "blob",
+                        "mode": "100644",
+                        "sha": "skill-blob",
+                    },
+                    "upstream/data.bin": {
+                        "type": "blob",
+                        "mode": "100644",
+                        "sha": "data-blob",
+                    },
                 }
 
             def blob(self, _repo, blob_sha):
@@ -431,6 +511,98 @@ class IngestSkillTests(unittest.TestCase):
                 ],
                 [artifact["target"] for artifact in local],
             )
+
+    def test_github_artifact_classification_requires_exact_regular_git_mode(self):
+        module = load_module()
+        cases = (
+            ("skill-644-vs-755", "skill", 0o644, "100755"),
+            ("skill-755-vs-644", "skill", 0o755, "100644"),
+            ("sidecar-644-vs-755", "sidecar", 0o644, "100755"),
+            ("sidecar-755-vs-644", "sidecar", 0o755, "100644"),
+            ("skill-symlink-mode", "skill", 0o644, "120000"),
+            ("sidecar-symlink-mode", "sidecar", 0o644, "120000"),
+        )
+
+        for label, mismatched_target, local_mode, upstream_mode in cases:
+            with self.subTest(label=label):
+                with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+                    root = Path(tmpdir)
+                    skill_dir = self.write_skill(
+                        root,
+                        "---\nname: sample-skill\ndescription: Sample\n---",
+                    )
+                    skill_path = skill_dir / "SKILL.md"
+                    sidecar_path = skill_dir / "data.bin"
+                    sidecar_path.write_bytes(b"\x00\x01")
+                    skill_path.chmod(
+                        local_mode if mismatched_target == "skill" else 0o644
+                    )
+                    sidecar_path.chmod(
+                        local_mode if mismatched_target == "sidecar" else 0o644
+                    )
+                    skill_bytes = skill_path.read_bytes()
+                    tree = {
+                        "upstream/SKILL.md": {
+                            "type": "blob",
+                            "mode": (
+                                upstream_mode
+                                if mismatched_target == "skill"
+                                else "100644"
+                            ),
+                            "sha": "skill-blob",
+                        },
+                        "upstream/data.bin": {
+                            "type": "blob",
+                            "mode": (
+                                upstream_mode
+                                if mismatched_target == "sidecar"
+                                else "100644"
+                            ),
+                            "sha": "data-blob",
+                        },
+                    }
+
+                    class FakeProvider:
+                        def __init__(self, _token):
+                            pass
+
+                        def tree(self, _repo, _commit):
+                            return tree
+
+                        def blob(self, _repo, blob_sha):
+                            return {
+                                "skill-blob": skill_bytes,
+                                "data-blob": b"\x00\x01",
+                            }[blob_sha]
+
+                    fake_module = types.SimpleNamespace(
+                        GitHubArtifactProvider=FakeProvider,
+                        GitHubProviderError=RuntimeError,
+                    )
+                    with mock.patch.dict(
+                        sys.modules,
+                        {"github_artifact_provider": fake_module},
+                    ):
+                        with self.assertRaisesRegex(
+                            ValueError,
+                            "regular Git blob|mode does not match",
+                        ):
+                            module.classify_github_artifacts(
+                                skill_dir=skill_dir,
+                                repo_root=root,
+                                repo="owner/repo",
+                                resolved_commit="a" * 40,
+                                upstream_skill_path="upstream/SKILL.md",
+                                artifact_maps=[
+                                    (
+                                        "upstream/data.bin",
+                                        (
+                                            "skills/developer-engineering/"
+                                            "sample-skill/data.bin"
+                                        ),
+                                    )
+                                ],
+                            )
 
     def test_commit_license_overrides_default_branch_and_must_match_frontmatter(self):
         module = load_module()
@@ -870,6 +1042,116 @@ class IngestSkillTests(unittest.TestCase):
             )
             self.assertEqual(b"before", target.read_bytes())
 
+    def test_staged_mode_only_mutation_is_materialized_and_applied(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            (root / "docs" / "sources").mkdir(parents=True)
+            skill_dir = root / "skills" / "category" / "demo"
+            skill_dir.mkdir(parents=True)
+            target = skill_dir / "SKILL.md"
+            target.write_bytes(b"same bytes")
+            target.chmod(0o644)
+            checkpoint = module.capture_target_checkpoint(
+                target,
+                repo_root=root,
+            )
+            plan = module.IngestPlan(
+                skill_name="demo",
+                skill_md=target,
+                before_skill=b"same bytes",
+                after_skill=b"same bytes",
+                repo_root=root,
+                before_checkpoint=checkpoint,
+            )
+
+            def chmod_in_stage(_dry_run, *, repo_root):
+                staged_target = (
+                    repo_root / "skills" / "category" / "demo" / "SKILL.md"
+                )
+                staged_target.chmod(0o755)
+                return True
+
+            with mock.patch.object(
+                module,
+                "run_pipeline",
+                side_effect=chmod_in_stage,
+            ):
+                validated = module.validate_ingest_plans(
+                    [plan],
+                    repo_root=root,
+                )
+
+            self.assertIsNotNone(validated)
+            mutations, _baseline, _checkpoints, _tracked_reports = validated
+            mutation = next(
+                item for item in mutations if item.skill_md == target
+            )
+            self.assertEqual(b"same bytes", mutation.before_skill)
+            self.assertEqual(b"same bytes", mutation.after_skill)
+            self.assertEqual(0o755, mutation.after_mode)
+            self.assertEqual(0o644, stat.S_IMODE(target.stat().st_mode))
+
+            module.commit_ingest_plans(mutations, locks_held=True)
+            self.assertEqual(b"same bytes", target.read_bytes())
+            self.assertEqual(0o755, stat.S_IMODE(target.stat().st_mode))
+
+    def test_failed_mode_only_batch_restores_original_mode(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.txt"
+            second = root / "second.txt"
+            first.write_bytes(b"same")
+            second.write_bytes(b"before")
+            first.chmod(0o644)
+            plans = [
+                module.IngestPlan(
+                    skill_name="first",
+                    skill_md=first,
+                    before_skill=b"same",
+                    after_skill=b"same",
+                    after_mode=0o755,
+                    repo_root=root,
+                    before_checkpoint=module.capture_target_checkpoint(
+                        first,
+                        repo_root=root,
+                    ),
+                ),
+                module.IngestPlan(
+                    skill_name="second",
+                    skill_md=second,
+                    before_skill=b"before",
+                    after_skill=b"after",
+                    repo_root=root,
+                    before_checkpoint=module.capture_target_checkpoint(
+                        second,
+                        repo_root=root,
+                    ),
+                ),
+            ]
+            real_write = module._write_atomic_bytes
+            calls = 0
+
+            def fail_second(path, content, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise OSError("second target failed")
+                return real_write(path, content, **kwargs)
+
+            with mock.patch.object(
+                module,
+                "_write_atomic_bytes",
+                side_effect=fail_second,
+            ):
+                with self.assertRaisesRegex(OSError, "second target failed"):
+                    module.commit_ingest_plans(plans, locks_held=True)
+
+            self.assertEqual(b"same", first.read_bytes())
+            self.assertEqual(0o644, stat.S_IMODE(first.stat().st_mode))
+            self.assertEqual(b"before", second.read_bytes())
+
     def test_noop_validation_ignores_generated_reports_but_copies_them(self):
         module = load_module()
         with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
@@ -1136,6 +1418,35 @@ class IngestSkillTests(unittest.TestCase):
 
             self.assertEqual(b"first-before", first.read_bytes())
             self.assertEqual(b"second-before", second.read_bytes())
+
+    def test_mode_race_is_rejected_before_first_write(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmpdir:
+            root = Path(tmpdir)
+            target = root / "target.txt"
+            target.write_bytes(b"before")
+            target.chmod(0o644)
+            plan = module.IngestPlan(
+                skill_name="target",
+                skill_md=target,
+                before_skill=b"before",
+                after_skill=b"after",
+                repo_root=root,
+                before_checkpoint=module.capture_target_checkpoint(
+                    target,
+                    repo_root=root,
+                ),
+            )
+            target.chmod(0o755)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "changed after staging",
+            ):
+                module.commit_ingest_plans([plan], locks_held=True)
+
+            self.assertEqual(b"before", target.read_bytes())
+            self.assertEqual(0o755, stat.S_IMODE(target.stat().st_mode))
 
     def test_atomic_commit_securely_creates_missing_target_parents(self):
         module = load_module()

--- a/tests/test_ingest_skill.py
+++ b/tests/test_ingest_skill.py
@@ -154,7 +154,7 @@ class IngestSkillTests(unittest.TestCase):
 
     def test_dry_run_rejects_dirty_tracked_executable_mode(self):
         module = load_module()
-        with tempfile.TemporaryDirectory(dir="/private/tmp") as tmpdir:
+        with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             subprocess.run(["git", "init", "-q", str(root)], check=True)
             skill_dir = self.write_skill(

--- a/tests/test_provenance_pipeline.py
+++ b/tests/test_provenance_pipeline.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 class ProvenancePipelineTests(unittest.TestCase):
@@ -79,6 +80,20 @@ class ProvenancePipelineTests(unittest.TestCase):
         cmd = module.resolve_python_cmd()
         self.assertTrue(cmd)
         self.assertEqual(Path(sys.executable).name.lower(), Path(cmd[0]).name.lower())
+
+    def test_run_is_fail_fast_but_can_accept_explicit_report_state(self):
+        module = self.load_module()
+        degraded = subprocess.CompletedProcess(["checker"], 2)
+        with mock.patch.object(
+            module.subprocess, "run", return_value=degraded
+        ):
+            module.run(
+                ["checker"],
+                self.root,
+                accepted_codes=frozenset({0, 2}),
+            )
+            with self.assertRaises(subprocess.CalledProcessError):
+                module.run(["checker"], self.root)
 
 
 if __name__ == "__main__":

--- a/tests/test_provenance_v2.py
+++ b/tests/test_provenance_v2.py
@@ -344,12 +344,7 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
             hostile_temporary = root / f".{mapping.name}.hostile.tmp"
             hostile_temporary.symlink_to(external)
 
-            with mock.patch.object(
-                provenance.tempfile,
-                "_get_candidate_names",
-                return_value=iter(("hostile", "safe")),
-            ):
-                provenance.atomic_write_json(mapping, {"schema_version": 2})
+            provenance.atomic_write_json(mapping, {"schema_version": 2})
 
             self.assertEqual(
                 {"schema_version": 2},
@@ -357,8 +352,79 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
             )
             self.assertEqual("do not overwrite\n", external.read_text(encoding="utf-8"))
             self.assertTrue(hostile_temporary.is_symlink())
-            self.assertFalse((root / f".{mapping.name}.safe.tmp").exists())
             self.assertEqual(0o640, os.stat(mapping).st_mode & 0o777)
+
+    def test_atomic_writer_rejects_temp_aba_and_preserves_foreign_occupant(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    fd_root = Path("/dev/fd")
+                    before_fds = (
+                        len(list(fd_root.iterdir()))
+                        if fd_root.exists()
+                        else None
+                    )
+                    mapping = root / "example.skills.json"
+                    original = b'{"old":true}\n'
+                    mapping.write_bytes(original)
+                    sentinel = root / "sentinel"
+                    sentinel.write_bytes(b"sentinel")
+                    real_validate = provenance._validate_atomic_temporary
+                    calls = 0
+                    foreign: Path | None = None
+
+                    def attack(directory_fd, name, descriptors, identity):
+                        nonlocal calls, foreign
+                        calls += 1
+                        if calls == 2:
+                            foreign = root / name
+                            foreign.unlink()
+                            if replacement_kind == "regular":
+                                foreign.write_bytes(b"foreign")
+                            else:
+                                foreign.symlink_to(sentinel)
+                        return real_validate(
+                            directory_fd,
+                            name,
+                            descriptors,
+                            identity,
+                        )
+
+                    with (
+                        mock.patch.object(
+                            provenance,
+                            "_validate_atomic_temporary",
+                            side_effect=attack,
+                        ),
+                        self.assertRaisesRegex(
+                            RuntimeError,
+                            "temporary inode changed|unsafe JSON temporary",
+                        ),
+                    ):
+                        provenance.atomic_write_json(
+                            mapping,
+                            {"schema_version": 2},
+                        )
+
+                    self.assertEqual(original, mapping.read_bytes())
+                    self.assertIsNotNone(foreign)
+                    assert foreign is not None
+                    self.assertTrue(
+                        foreign.exists() or foreign.is_symlink(),
+                        "cleanup must not delete a foreign temporary occupant",
+                    )
+                    if replacement_kind == "regular":
+                        self.assertEqual(b"foreign", foreign.read_bytes())
+                    else:
+                        self.assertTrue(foreign.is_symlink())
+                    self.assertEqual(b"sentinel", sentinel.read_bytes())
+                    if before_fds is not None:
+                        self.assertEqual(
+                            before_fds,
+                            len(list(fd_root.iterdir())),
+                            "atomic JSON writer leaked a descriptor",
+                        )
 
     def test_managed_digest_refresh_is_explicit_and_updates_matching_origin_only(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_provenance_v2.py
+++ b/tests/test_provenance_v2.py
@@ -125,6 +125,11 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
             schema["$defs"]["managedFile"]["properties"]["sha256"]["$ref"],
         )
         self.assertEqual(
+            ["100644", "100755"],
+            schema["$defs"]["managedFile"]["properties"]["mode"]["enum"],
+        )
+        self.assertIn("mode", schema["$defs"]["managedFile"]["required"])
+        self.assertEqual(
             "#/$defs/sha256",
             schema["$defs"]["composition"]["properties"]["dependency_lock"][
                 "additionalProperties"
@@ -191,6 +196,7 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
                         "path": rel,
                         "sha256": provenance.sha256_file(root / rel),
                         "owner": "example",
+                        "mode": "100644",
                     }
                 ],
                 entry["managed_files"],
@@ -525,6 +531,7 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
                     "path": rel,
                     "sha256": provenance.sha256_file(root / rel),
                     "owner": "example",
+                    "mode": "100644",
                 },
                 migrated["skills"][0]["managed_files"][0],
             )
@@ -785,6 +792,7 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
                     "path": sidecar,
                     "sha256": provenance.sha256_file(root / sidecar),
                     "owner": "example",
+                    "mode": "100644",
                 }
             )
             skill_path = root / entry["repo_skill"]
@@ -1120,6 +1128,36 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
                 any("owner must match normalized_slug" in error for error in errors)
             )
 
+    def test_managed_file_mode_must_match_repository_executable_bit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping, data = self.make_migrated_mapping(root)
+            entry = data["skills"][0]
+            skill_path = root / entry["repo_skill"]
+
+            skill_path.chmod(0o755)
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+            errors = validator.validate_mapping(mapping, root)
+            self.assertTrue(
+                any(
+                    "mode '100644' does not match repository mode '100755'"
+                    in error
+                    for error in errors
+                ),
+                errors,
+            )
+
+            entry["managed_files"][0]["mode"] = "100755"
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+            self.assertEqual([], validator.validate_mapping(mapping, root))
+
+            skill_path.chmod(0o4755)
+            errors = validator.validate_mapping(mapping, root)
+            self.assertTrue(
+                any("mode Git cannot represent" in error for error in errors),
+                errors,
+            )
+
     def test_directory_artifact_covers_only_explicit_managed_descendants(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -1142,6 +1180,7 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
                     "path": guide,
                     "sha256": provenance.sha256_file(guide_path),
                     "owner": "example",
+                    "mode": "100644",
                 }
             )
             mapping.write_text(json.dumps(data), encoding="utf-8")

--- a/tests/test_provenance_v2.py
+++ b/tests/test_provenance_v2.py
@@ -2,6 +2,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -129,10 +130,31 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
                 "additionalProperties"
             ]["$ref"],
         )
+        local_tracking_contract = (
+            schema["$defs"]["origin"]["allOf"][0]["then"]["properties"][
+                "tracking"
+            ]["allOf"][1]
+        )
+        self.assertEqual(
+            ["license_checkpoint"],
+            local_tracking_contract["not"]["required"],
+        )
         self.assertEqual(
             "#/$defs/nullableSha256",
             schema["$defs"]["tracking"]["properties"]["content_sha256"]["$ref"],
         )
+        relative_pattern = schema["$defs"]["relativePath"]["pattern"]
+        self.assertIsNotNone(re.fullmatch(relative_pattern, "references/guide.md"))
+        for invalid_path in (
+            "references\\guide.md",
+            "references//guide.md",
+            "references/./guide.md",
+            "references/guide.md/",
+        ):
+            self.assertIsNone(
+                re.fullmatch(relative_pattern, invalid_path),
+                invalid_path,
+            )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             sources = Path(tmpdir)
@@ -527,6 +549,29 @@ class ProvenanceV2MigrationTests(unittest.TestCase):
             with self.subTest(invalid=invalid):
                 self.assertFalse(provenance.safe_relative_path(invalid))
 
+    def test_github_repo_parser_requires_exact_host_and_canonical_repo(self):
+        self.assertEqual(
+            "owner/upstream",
+            provenance.github_repo("github:Owner/Upstream"),
+        )
+        self.assertEqual(
+            "owner/upstream",
+            provenance.github_repo(
+                "https://github.com/Owner/Upstream/blob/main/SKILL.md"
+            ),
+        )
+        for invalid in (
+            "https://evilgithub.com/owner/upstream",
+            "https://github.com.evil.test/owner/upstream",
+            "https://github.com//owner/upstream",
+            "https://user@github.com/owner/upstream",
+            "github:owner/upstream/extra",
+            "github:-owner/upstream",
+            "github:owner/..",
+        ):
+            with self.subTest(invalid=invalid):
+                self.assertIsNone(provenance.github_repo(invalid))
+
 
 class ProvenanceV2ValidationTests(unittest.TestCase):
     def make_migrated_mapping(
@@ -685,6 +730,96 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
                 any("external origin license" in error for error in errors)
             )
             self.assertTrue(any("sync_mode invalid" in error for error in errors))
+
+    def test_license_checkpoint_rejects_conflicting_github_spdx(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping, data = self.make_migrated_mapping(root)
+            tracking = data["skills"][0]["origins"][0]["tracking"]
+            tracking["license_checkpoint"] = {
+                "path": "LICENSE",
+                "blob_sha": "b" * 40,
+                "content_sha256": "c" * 64,
+                "spdx": "MIT",
+                "resolved_commit": "a" * 40,
+                "api_spdx": "Apache-2.0",
+            }
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+
+            errors = validator.validate_mapping(mapping, root)
+
+            self.assertTrue(
+                any(
+                    "api_spdx conflicts with detected SPDX" in error
+                    for error in errors
+                ),
+                errors,
+            )
+
+            tracking["license_checkpoint"]["api_spdx"] = "NOASSERTION"
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+            self.assertEqual([], validator.validate_mapping(mapping, root))
+
+    def test_frontmatter_license_must_cover_every_external_origin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping, data = self.make_migrated_mapping(root)
+            entry = data["skills"][0]
+            sidecar = "skills/category/example/references/apache.md"
+            (root / sidecar).parent.mkdir(parents=True)
+            (root / sidecar).write_text("apache origin\n", encoding="utf-8")
+            second = deepcopy(entry["origins"][0])
+            second["repo"] = "other/apache-source"
+            second["license"] = "Apache-2.0"
+            second["path"] = "docs/apache.md"
+            second["artifacts"] = [
+                {
+                    "source": "docs/apache.md",
+                    "target": sidecar,
+                    "type": "file",
+                }
+            ]
+            entry["origins"].append(second)
+            entry["managed_files"].append(
+                {
+                    "path": sidecar,
+                    "sha256": provenance.sha256_file(root / sidecar),
+                    "owner": "example",
+                }
+            )
+            skill_path = root / entry["repo_skill"]
+            skill_path.write_text(
+                skill_path.read_text(encoding="utf-8").replace(
+                    "license: MIT",
+                    "license: BSD-3-Clause",
+                ),
+                encoding="utf-8",
+            )
+            entry["managed_files"][0]["sha256"] = provenance.sha256_file(skill_path)
+            entry["origins"][0]["tracking"]["content_sha256"] = (
+                entry["managed_files"][0]["sha256"]
+            )
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+
+            errors = validator.validate_mapping(mapping, root)
+            self.assertTrue(
+                any("license lineage" in error for error in errors),
+                errors,
+            )
+
+            skill_path.write_text(
+                skill_path.read_text(encoding="utf-8").replace(
+                    "license: BSD-3-Clause",
+                    "license: MIT AND Apache-2.0",
+                ),
+                encoding="utf-8",
+            )
+            entry["managed_files"][0]["sha256"] = provenance.sha256_file(skill_path)
+            entry["origins"][0]["tracking"]["content_sha256"] = (
+                entry["managed_files"][0]["sha256"]
+            )
+            mapping.write_text(json.dumps(data), encoding="utf-8")
+            self.assertEqual([], validator.validate_mapping(mapping, root))
 
     def test_default_and_canary_channels_reject_replace(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -850,7 +985,6 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             mapping, data = self.make_migrated_mapping(root)
-            entry = data["skills"][0]
 
             mutations = (
                 ("repo", "different/upstream", "upstream.repo"),
@@ -1664,6 +1798,54 @@ class ProvenanceV2ValidationTests(unittest.TestCase):
                 ),
                 errors,
             )
+
+    def test_dependency_hash_uses_unique_repo_skill_owner_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _, data = self.make_migrated_mapping(root, "dependency")
+            entry = data["skills"][0]
+            owner_hash = entry["origins"][0]["tracking"]["content_sha256"]
+            unrelated = deepcopy(entry["origins"][0])
+            unrelated["repo"] = "other/unrelated"
+            unrelated["license"] = "Apache-2.0"
+            unrelated["path"] = "docs/other.md"
+            unrelated["artifacts"] = [
+                {
+                    "source": "docs/other.md",
+                    "target": "skills/category/dependency/references/other.md",
+                    "type": "file",
+                }
+            ]
+            unrelated["tracking"]["content_sha256"] = "f" * 64
+            entry["origins"].insert(0, unrelated)
+
+            self.assertEqual(
+                owner_hash,
+                validator._entry_content_sha256(entry, root),
+            )
+
+            duplicate_in_owner = deepcopy(entry)
+            duplicate_in_owner["origins"][1]["artifacts"].append(
+                deepcopy(duplicate_in_owner["origins"][1]["artifacts"][0])
+            )
+            self.assertIsNone(
+                validator._entry_content_sha256(duplicate_in_owner, root)
+            )
+
+            duplicate_owner = deepcopy(unrelated)
+            duplicate_owner["artifacts"] = [
+                {
+                    "source": "other/SKILL.md",
+                    "target": entry["repo_skill"],
+                    "type": "file",
+                }
+            ]
+            entry["origins"].append(duplicate_owner)
+            self.assertIsNone(validator._entry_content_sha256(entry, root))
+
+            for origin in entry["origins"]:
+                origin["artifacts"] = []
+            self.assertIsNone(validator._entry_content_sha256(entry, root))
 
     def test_dependency_lock_detects_stale_composite(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_reconcile_artifact_inventory.py
+++ b/tests/test_reconcile_artifact_inventory.py
@@ -1,0 +1,1824 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+provenance = load_script("provenance_v2")
+validator = load_script("validate_skill_sources")
+inventory = load_script("reconcile_artifact_inventory")
+openclaw_export = load_script("export_openclaw_skills")
+
+COMMIT = "a" * 40
+ROOT_TREE = "b" * 40
+MAIN_BLOB = "1" * 40
+EXACT_BLOB = "2" * 40
+UNAVAILABLE_BLOB = "3" * 40
+
+
+def write_skill(root: Path, slug: str = "demo") -> str:
+    relative = f"skills/category/{slug}/SKILL.md"
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        f"name: {slug}\n"
+        "description: Test skill\n"
+        "zh_description: 测试技能\n"
+        "version: 1.0.0\n"
+        "author: tester\n"
+        "source: github:owner/upstream\n"
+        'source_url: "https://github.com/owner/upstream"\n'
+        "license: MIT\n"
+        "tags: [test]\n"
+        'created_at: "2026-08-20"\n'
+        'updated_at: "2026-08-20"\n'
+        "quality: 2\n"
+        "complexity: beginner\n"
+        "---\n"
+        "# Demo\n",
+        encoding="utf-8",
+    )
+    return relative
+
+
+def make_entry(root: Path, slug: str = "demo") -> dict:
+    repo_skill = f"skills/category/{slug}/SKILL.md"
+    content_hash = provenance.sha256_file(root / repo_skill)
+    return {
+        "video_name": slug,
+        "normalized_slug": slug,
+        "status": "verified_in_repo",
+        "repo_skill": repo_skill,
+        "source": "https://github.com/owner/upstream/tree/main/upstream/demo",
+        "notes": "External test mirror.",
+        "kind": "mirror",
+        "sync_mode": "monitor",
+        "upstream": {
+            "repo": "owner/upstream",
+            "path": "upstream/demo/SKILL.md",
+            "ref": "main",
+            "sync_mode": "monitor",
+            "last_checked_at": "2026-08-20",
+            "last_synced_at": "2026-08-20",
+            "last_synced_commit": COMMIT,
+        },
+        "origins": [
+            {
+                "repo": "owner/upstream",
+                "path": "upstream/demo/SKILL.md",
+                "license": "MIT",
+                "sync_mode": "monitor",
+                "artifacts": [
+                    {
+                        "source": "upstream/demo/SKILL.md",
+                        "target": repo_skill,
+                        "type": "file",
+                    }
+                ],
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": COMMIT,
+                    "path_commit": COMMIT,
+                    "content_sha256": content_hash,
+                    "last_checked_at": "2026-08-20",
+                    "last_synced_at": "2026-08-20",
+                },
+            }
+        ],
+        "managed_files": [
+            {
+                "path": repo_skill,
+                "sha256": content_hash,
+                "owner": slug,
+            }
+        ],
+    }
+
+
+def make_payload(entry: dict) -> dict:
+    return {
+        "schema_version": 2,
+        "video": {"url": "https://example.com", "checked_at": "2026-08-20"},
+        "official_references": [],
+        "skills": [entry],
+    }
+
+
+def write_tree_fixture(
+    cache: inventory.GitHubObjectCache,
+    entries: list[dict],
+) -> None:
+    path = cache.tree_cache_path("owner/upstream", COMMIT)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "sha": COMMIT,
+                "truncated": False,
+                "tree": entries,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_blob_fixture(
+    cache: inventory.GitHubObjectCache,
+    object_sha: str,
+    content: bytes,
+) -> None:
+    path = cache.blob_cache_path("owner/upstream", object_sha)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def online_tree_responder(entries: list[dict]):
+    def respond(endpoint: str, *, fields: dict[str, str] | None = None):
+        if endpoint == f"repos/owner/upstream/git/commits/{COMMIT}":
+            return {"sha": COMMIT, "tree": {"sha": ROOT_TREE}}
+        if endpoint == f"repos/owner/upstream/git/trees/{ROOT_TREE}":
+            if fields != {"recursive": "1"}:
+                raise AssertionError(f"missing recursive tree request: {fields!r}")
+            return {
+                "sha": ROOT_TREE,
+                "truncated": False,
+                "tree": entries,
+            }
+        raise AssertionError(f"unexpected GitHub endpoint: {endpoint}")
+
+    return respond
+
+
+class ArtifactInventoryTests(unittest.TestCase):
+    def test_repository_managed_files_are_present_in_git_index(self):
+        try:
+            tracked_output = subprocess.check_output(
+                ["git", "ls-files", "--cached", "-z", "--", "skills"],
+                cwd=REPO_ROOT,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("repository Git index is unavailable")
+
+        tracked = {
+            value.decode("utf-8")
+            for value in tracked_output.split(b"\0")
+            if value
+        }
+        managed: set[str] = set()
+        source_root = REPO_ROOT / "docs" / "sources"
+        mapping_paths = sorted(source_root.glob("*.skills.json"))
+        mapping_paths.extend(sorted(source_root.glob("*.bundle.json")))
+        for mapping_path in mapping_paths:
+            payload = json.loads(mapping_path.read_text(encoding="utf-8"))
+            for entry in payload.get("skills", []):
+                if not isinstance(entry, dict):
+                    continue
+                for record in entry.get("managed_files", []):
+                    if isinstance(record, dict) and isinstance(
+                        record.get("path"), str
+                    ):
+                        managed.add(record["path"])
+
+        missing = sorted(managed - tracked)
+        self.assertEqual(
+            [],
+            missing,
+            "Every managed artifact must be committed to the Git index; "
+            "fresh checkouts cannot rely on ignored or untracked files.",
+        )
+
+    def test_openclaw_export_contains_every_canonical_skill_file_in_git_index(
+        self,
+    ):
+        try:
+            tracked_output = subprocess.check_output(
+                [
+                    "git",
+                    "ls-files",
+                    "--cached",
+                    "-z",
+                    "--",
+                    "openclaw-skills",
+                ],
+                cwd=REPO_ROOT,
+            )
+            canonical_output = subprocess.check_output(
+                ["git", "ls-files", "--cached", "-z", "--", "skills"],
+                cwd=REPO_ROOT,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("repository Git index is unavailable")
+
+        tracked = {
+            value.decode("utf-8")
+            for value in tracked_output.split(b"\0")
+            if value
+        }
+        missing: list[str] = []
+        mismatched: list[str] = []
+        canonical_paths = sorted(
+            value.decode("utf-8")
+            for value in canonical_output.split(b"\0")
+            if value
+        )
+        for canonical_relative in canonical_paths:
+            parts = Path(canonical_relative).parts
+            if len(parts) < 4:
+                continue
+            skill_root = Path(*parts[:3])
+            if not (REPO_ROOT / skill_root / "SKILL.md").is_file():
+                continue
+            relative = Path(*parts[3:])
+            if any(part in openclaw_export.IGNORED_NAMES for part in relative.parts):
+                continue
+            export_relative = (
+                Path("openclaw-skills") / parts[2] / relative
+            ).as_posix()
+            canonical = REPO_ROOT / canonical_relative
+            exported = REPO_ROOT / export_relative
+            if (
+                canonical.is_symlink()
+                or export_relative not in tracked
+                or not exported.is_file()
+            ):
+                missing.append(export_relative)
+                continue
+            expected = canonical.read_bytes()
+            if canonical.name == openclaw_export.SKILL_FILENAME:
+                expected = openclaw_export.normalize_skill_markdown(
+                    canonical.parent.name,
+                    canonical.read_text(encoding="utf-8"),
+                ).encode("utf-8")
+            if expected != exported.read_bytes():
+                mismatched.append(export_relative)
+
+        self.assertEqual(
+            [],
+            missing,
+            "Every canonical skill artifact must exist in the tracked "
+            "OpenClaw export.",
+        )
+        self.assertEqual(
+            [],
+            mismatched,
+            "Tracked OpenClaw sidecars must be byte-identical and SKILL.md "
+            "files must match the canonical OpenClaw normalization.",
+        )
+
+    def test_cached_blob_must_match_declared_git_oid_and_size(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/forged.bin"
+            content = b"locally exact but cache key is forged"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(content)
+            forged_oid = "2" * 40
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/forged.bin",
+                        "type": "blob",
+                        "sha": forged_oid,
+                        "size": len(content),
+                    }
+                ],
+            )
+            write_blob_fixture(cache, forged_oid, content)
+
+            inspection = inventory.inspect_entry(
+                entry,
+                repo_root=root,
+                cache=cache,
+            )
+            proposal = next(
+                item for item in inspection["unowned"] if item["target"] == target
+            )
+            self.assertEqual("unavailable", proposal["classification"])
+            self.assertIn("object id", proposal["reason"])
+
+    def test_forged_offline_tree_with_valid_blob_oid_cannot_authorize_external(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/forged.md"
+            content = b"local bytes with a valid Git object id\n"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(content)
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/forged.md",
+                        "type": "blob",
+                        "sha": object_sha,
+                        "size": len(content),
+                    }
+                ],
+            )
+
+            inspection = inventory.inspect_entry(
+                entry,
+                repo_root=root,
+                cache=cache,
+            )
+            proposal = next(
+                item for item in inspection["unowned"] if item["target"] == target
+            )
+
+            self.assertEqual("unavailable", proposal["classification"])
+            self.assertIn("cannot authorize", proposal["reason"])
+            self.assertEqual(
+                "offline_authority_forbidden",
+                proposal["checked_sources"][0]["result"],
+            )
+
+    def test_online_tree_ignores_forged_disk_cache_and_binds_commit_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/forged.md"
+            content = b"forged cached lineage\n"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(content)
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/forged.md",
+                        "type": "blob",
+                        "sha": object_sha,
+                        "size": len(content),
+                    }
+                ],
+            )
+
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                side_effect=online_tree_responder([]),
+            ) as fetch:
+                inspection = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=cache,
+                )
+
+            proposal = next(
+                item for item in inspection["unowned"] if item["target"] == target
+            )
+            self.assertEqual("local_overlay", proposal["classification"])
+            self.assertEqual(2, fetch.call_count)
+            self.assertEqual(
+                f"repos/owner/upstream/git/commits/{COMMIT}",
+                fetch.call_args_list[0].args[0],
+            )
+            self.assertEqual(
+                f"repos/owner/upstream/git/trees/{ROOT_TREE}",
+                fetch.call_args_list[1].args[0],
+            )
+
+    def test_online_tree_commit_binding_mismatch_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/untrusted.md"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(b"local\n")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                return_value={
+                    "sha": "c" * 40,
+                    "tree": {"sha": ROOT_TREE},
+                },
+            ):
+                inspection = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=cache,
+                )
+
+            proposal = next(
+                item for item in inspection["unowned"] if item["target"] == target
+            )
+            self.assertEqual("unavailable", proposal["classification"])
+            self.assertIn("commit/root-tree binding", proposal["reason"])
+
+    def test_api_blob_requires_strict_base64_oid_and_size(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = b"valid bytes"
+            oid = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(Path(tmpdir))
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                return_value={
+                    "sha": oid,
+                    "size": len(content),
+                    "encoding": "base64",
+                    "content": "%%%not-base64%%%",
+                },
+            ):
+                with self.assertRaisesRegex(
+                    inventory.SourceUnavailable,
+                    "base64",
+                ):
+                    cache.get_blob("owner/upstream", oid, expected_size=len(content))
+
+            bad_oid = "3" * 40
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                return_value={
+                    "sha": bad_oid,
+                    "size": len(content),
+                    "encoding": "base64",
+                    "content": "dmFsaWQgYnl0ZXM=",
+                },
+            ):
+                with self.assertRaisesRegex(
+                    inventory.SourceUnavailable,
+                    "object id",
+                ):
+                    cache.get_blob(
+                        "owner/upstream",
+                        bad_oid,
+                        expected_size=len(content),
+                    )
+
+    def test_cache_ancestor_symlink_is_never_followed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_root = root / "cache"
+            outside = root / "outside"
+            outside.mkdir()
+            content = b"outside cache bytes"
+            oid = inventory._git_blob_oid(content, "sha1")
+            outside_blob_dir = outside / "owner__upstream"
+            outside_blob_dir.mkdir()
+            (outside_blob_dir / f"{oid}.bin").write_bytes(content)
+            (cache_root / "blobs").mkdir(parents=True)
+            (cache_root / "blobs/owner__upstream").symlink_to(
+                outside_blob_dir,
+                target_is_directory=True,
+            )
+            cache = inventory.GitHubObjectCache(cache_root, offline=True)
+
+            with self.assertRaisesRegex(inventory.SourceUnavailable, "symlink"):
+                cache.get_blob(
+                    "owner/upstream",
+                    oid,
+                    expected_size=len(content),
+                )
+
+    def test_exact_binary_and_local_overlay_are_classified_by_expected_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            exact_target = "skills/category/demo/references/exact.bin"
+            overlay_target = "skills/category/demo/src/runtime.py"
+            exact_bytes = b"\x00\xffbinary\n"
+            overlay_bytes = b"same bytes elsewhere"
+            exact_blob = inventory._git_blob_oid(exact_bytes, "sha1")
+            (root / exact_target).parent.mkdir(parents=True)
+            (root / exact_target).write_bytes(exact_bytes)
+            (root / overlay_target).parent.mkdir(parents=True)
+            (root / overlay_target).write_bytes(overlay_bytes)
+
+            cache = inventory.GitHubObjectCache(
+                root / "cache",
+                offline=False,
+            )
+            trusted_entries = [
+                {
+                    "path": "upstream/demo/SKILL.md",
+                    "type": "blob",
+                    "sha": MAIN_BLOB,
+                    "size": 0,
+                },
+                {
+                    "path": "upstream/demo/references/exact.bin",
+                    "type": "blob",
+                    "sha": exact_blob,
+                    "size": len(exact_bytes),
+                },
+                # A repository-wide hash match outside the declared official
+                # skill root must not be attributed to that origin.
+                {
+                    "path": "src/runtime.py",
+                    "type": "blob",
+                    "sha": UNAVAILABLE_BLOB,
+                    "size": len(overlay_bytes),
+                },
+            ]
+
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                side_effect=online_tree_responder(trusted_entries),
+            ):
+                report = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=cache,
+                )
+            by_target = {item["target"]: item for item in report["unowned"]}
+
+            self.assertEqual(
+                "external_exact",
+                by_target[exact_target]["classification"],
+            )
+            self.assertEqual(
+                "upstream/demo/references/exact.bin",
+                by_target[exact_target]["source"],
+            )
+            self.assertEqual(
+                "local_overlay",
+                by_target[overlay_target]["classification"],
+            )
+            self.assertEqual(overlay_target, by_target[overlay_target]["source"])
+            self.assertIn(repo_skill, report["actual_files"])
+
+    def test_blob_404_is_unavailable_instead_of_becoming_local_overlay(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/missing.bin"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(b"local")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/missing.bin",
+                        "type": "blob",
+                        "sha": UNAVAILABLE_BLOB,
+                        "size": len(b"local"),
+                    }
+                ],
+            )
+
+            report = inventory.inspect_entry(entry, repo_root=root, cache=cache)
+
+            self.assertEqual("unavailable", report["unowned"][0]["classification"])
+            self.assertIn("offline cache miss", report["unowned"][0]["reason"])
+
+    def test_transformed_standalone_entrypoint_does_not_claim_package_siblings(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            origin = entry["origins"][0]
+            origin["path"] = "graphify/skill-codex.md"
+            origin["artifacts"][0]["source"] = "graphify/skill-codex.md"
+            entry["upstream"]["path"] = "graphify/skill-codex.md"
+            target = "skills/category/demo/runtime.py"
+            content = b"package snapshot"
+            (root / target).write_bytes(content)
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "graphify/runtime.py",
+                        "type": "blob",
+                        "sha": object_sha,
+                        "size": len(content),
+                    }
+                ],
+            )
+
+            report = inventory.inspect_entry(entry, repo_root=root, cache=cache)
+
+            self.assertEqual("local_overlay", report["unowned"][0]["classification"])
+            self.assertEqual(target, report["unowned"][0]["source"])
+
+    def test_live_tree_404_is_reported_as_source_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = inventory.GitHubObjectCache(Path(tmpdir))
+            completed = mock.Mock(
+                returncode=1,
+                stdout=b"",
+                stderr=b"gh: Not Found (HTTP 404)",
+            )
+            with mock.patch.object(inventory.subprocess, "run", return_value=completed):
+                with self.assertRaisesRegex(inventory.SourceUnavailable, "404"):
+                    cache.get_tree("owner/upstream", COMMIT)
+
+    def test_symlinks_and_cache_artifacts_are_never_scanned(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            skill_root = (root / repo_skill).parent
+            (skill_root / ".DS_Store").write_bytes(b"ignored")
+            cache_dir = skill_root / "__pycache__"
+            cache_dir.mkdir()
+            (cache_dir / "module.pyc").write_bytes(b"ignored")
+            external = root / "outside.txt"
+            external.write_text("outside", encoding="utf-8")
+            (skill_root / "linked.txt").symlink_to(external)
+            linked_dir = skill_root / "linked-dir"
+            linked_dir.symlink_to(root, target_is_directory=True)
+
+            actual, issues = inventory._iter_regular_skill_files(root, repo_skill)
+
+            self.assertEqual([repo_skill], actual)
+            self.assertEqual(2, len(issues))
+            self.assertEqual({"symlink"}, {issue["issue"] for issue in issues})
+
+            entry = make_entry(root)
+            entry["managed_files"].append(
+                {
+                    "path": "skills/category/demo/linked.txt",
+                    "sha256": "f" * 64,
+                    "owner": "demo",
+                }
+            )
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+            report = inventory.reconcile_mappings(
+                [mapping],
+                repo_root=root,
+                cache=inventory.GitHubObjectCache(root / "cache", offline=True),
+                write=True,
+            )
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(2, report["summary"]["scan_errors"])
+            self.assertEqual(1, report["summary"]["stale_managed"])
+            self.assertEqual(1, report["summary"]["write_blocked_entries"])
+
+    def test_skill_ancestor_symlink_is_rejected_without_scanning_outside(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "repo"
+            root.mkdir()
+            outside = Path(tmpdir) / "outside"
+            repo_skill = write_skill(outside)
+            secret = outside / "skills/category/demo/secret.txt"
+            secret.write_text("must not be scanned", encoding="utf-8")
+            (root / "skills").symlink_to(
+                outside / "skills",
+                target_is_directory=True,
+            )
+
+            actual, issues = inventory._iter_regular_skill_files(root, repo_skill)
+
+            self.assertEqual([], actual)
+            self.assertTrue(issues)
+            self.assertIn("symlink", {item["issue"] for item in issues})
+            self.assertNotIn(
+                "secret.txt",
+                json.dumps(issues, ensure_ascii=False),
+            )
+
+    def test_directory_artifact_missing_managed_is_still_exactly_classified(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            entry["origins"][0]["artifacts"] = [
+                {
+                    "source": "upstream/demo",
+                    "target": "skills/category/demo",
+                    "type": "directory",
+                },
+                {
+                    "source": "upstream/demo/SKILL.md",
+                    "target": "skills/category/demo/SKILL.md",
+                    "type": "file",
+                }
+            ]
+            target = "skills/category/demo/references/exact.bin"
+            content = b"\x00directory sidecar\xff"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(content)
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+            trusted_entries = [
+                {
+                    "path": "upstream/demo/references/exact.bin",
+                    "type": "blob",
+                    "sha": object_sha,
+                    "size": len(content),
+                }
+            ]
+
+            with mock.patch.object(
+                cache,
+                "_gh_json",
+                side_effect=online_tree_responder(trusted_entries),
+            ):
+                inspection = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=cache,
+                )
+            by_target = {
+                item["target"]: item for item in inspection["unowned"]
+            }
+
+            self.assertIn(target, inspection["missing_managed"])
+            self.assertEqual([], inspection["ownership_conflicts"])
+            self.assertEqual("external_exact", by_target[target]["classification"])
+            self.assertEqual(
+                "owner/upstream",
+                by_target[target]["declared_owner"]["repo"],
+            )
+            updated, changed, blocked = inventory.apply_entry_reconciliation(
+                entry,
+                inspection,
+                repo_root=root,
+                today="2026-08-20",
+            )
+            self.assertTrue(changed)
+            self.assertIsNone(blocked)
+            self.assertEqual(
+                entry["origins"][0]["artifacts"],
+                updated["origins"][0]["artifacts"],
+            )
+            self.assertIn(
+                target,
+                {managed["path"] for managed in updated["managed_files"]},
+            )
+
+    def test_directory_artifact_content_mismatch_blocks_owner_reassignment(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            entry["origins"][0]["artifacts"] = [
+                {
+                    "source": "upstream/demo",
+                    "target": "skills/category/demo",
+                    "type": "directory",
+                }
+            ]
+            target = "skills/category/demo/references/drifted.bin"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(b"local bytes")
+            upstream_bytes = b"different upstream bytes"
+            upstream_oid = inventory._git_blob_oid(upstream_bytes, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/drifted.bin",
+                        "type": "blob",
+                        "sha": upstream_oid,
+                        "size": len(upstream_bytes),
+                    }
+                ],
+            )
+            write_blob_fixture(cache, upstream_oid, upstream_bytes)
+
+            inspection = inventory.inspect_entry(entry, repo_root=root, cache=cache)
+            proposal = next(
+                item for item in inspection["unowned"] if item["target"] == target
+            )
+            self.assertEqual("local_overlay", proposal["classification"])
+            self.assertFalse(proposal["declared_owner"]["local"])
+
+            updated, changed, blocked = inventory.apply_entry_reconciliation(
+                entry,
+                inspection,
+                repo_root=root,
+                today="2026-08-20",
+            )
+            self.assertFalse(changed)
+            self.assertEqual(entry, updated)
+            self.assertIn("declared owner mismatch", blocked)
+
+    def test_managed_hash_mismatch_and_stale_record_block_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            (root / repo_skill).write_text("changed after checkpoint\n", encoding="utf-8")
+            entry["managed_files"].append(
+                {
+                    "path": "skills/category/demo/removed.txt",
+                    "sha256": "e" * 64,
+                    "owner": "demo",
+                }
+            )
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            report = inventory.reconcile_mappings(
+                [mapping],
+                repo_root=root,
+                cache=inventory.GitHubObjectCache(root / "cache", offline=True),
+                write=True,
+            )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(1, report["summary"]["hash_mismatches"])
+            self.assertEqual(1, report["summary"]["stale_managed"])
+            self.assertEqual(1, report["summary"]["write_blocked_entries"])
+            reason = report["entries"][0]["write_blocked_reason"]
+            self.assertIn("managed hash mismatch", reason)
+            self.assertIn("stale managed file", reason)
+
+    def test_scandir_error_is_reported_and_blocks_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            with mock.patch.object(
+                inventory.os,
+                "scandir",
+                side_effect=PermissionError("denied"),
+            ):
+                report = inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=inventory.GitHubObjectCache(root / "cache", offline=True),
+                    write=True,
+                )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(1, report["summary"]["scan_errors"])
+            issue = report["entries"][0]["scan_errors"][0]
+            self.assertEqual("io_error", issue["issue"])
+            self.assertEqual("scandir", issue["operation"])
+            self.assertIn("scan/read error", report["entries"][0]["write_blocked_reason"])
+
+    def test_managed_file_read_error_is_reported_and_blocks_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            with mock.patch.object(
+                inventory,
+                "_sha256_regular_file",
+                side_effect=PermissionError("read denied"),
+            ):
+                report = inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=inventory.GitHubObjectCache(root / "cache", offline=True),
+                    write=True,
+                )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(1, report["summary"]["scan_errors"])
+            issue = report["entries"][0]["scan_errors"][0]
+            self.assertEqual("hash_managed_file", issue["operation"])
+            self.assertIn("read denied", issue["detail"])
+            self.assertEqual(1, report["summary"]["write_blocked_entries"])
+
+    def test_dry_run_is_read_only_and_write_is_atomic_and_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            exact_target = "skills/category/demo/references/exact.bin"
+            overlay_target = "skills/category/demo/LOCAL.md"
+            exact_bytes = b"\x00exact\xff"
+            exact_blob = inventory._git_blob_oid(exact_bytes, "sha1")
+            (root / exact_target).parent.mkdir(parents=True)
+            (root / exact_target).write_bytes(exact_bytes)
+            (root / overlay_target).write_text("local supplement\n", encoding="utf-8")
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            cache_dir = root / "cache"
+            cache = inventory.GitHubObjectCache(cache_dir, offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/references/exact.bin",
+                        "type": "blob",
+                        "sha": exact_blob,
+                        "size": len(exact_bytes),
+                    }
+                ],
+            )
+            write_blob_fixture(cache, exact_blob, exact_bytes)
+            report_path = root / "dry-run.json"
+
+            self.assertEqual(
+                0,
+                inventory.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--mapping",
+                        "docs/sources/example.skills.json",
+                        "--cache-dir",
+                        str(cache_dir),
+                        "--offline",
+                        "--output",
+                        str(report_path),
+                    ]
+                ),
+            )
+            self.assertEqual(before, mapping.read_bytes())
+            dry_report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(0, dry_report["summary"]["external_exact"])
+            self.assertEqual(1, dry_report["summary"]["local_overlay"])
+            self.assertEqual(1, dry_report["summary"]["unavailable"])
+            self.assertEqual(
+                1,
+                inventory.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--mapping",
+                        "docs/sources/example.skills.json",
+                        "--cache-dir",
+                        str(cache_dir),
+                        "--offline",
+                        "--check-clean",
+                        "--output",
+                        str(root / "dirty-check.json"),
+                    ]
+                ),
+            )
+
+            self.assertEqual(
+                1,
+                inventory.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--mapping",
+                        "docs/sources/example.skills.json",
+                        "--cache-dir",
+                        str(cache_dir),
+                        "--offline",
+                        "--write",
+                        "--output",
+                        str(root / "write.json"),
+                    ]
+                ),
+            )
+            self.assertEqual(before, mapping.read_bytes())
+
+            online_cache = inventory.GitHubObjectCache(
+                cache_dir,
+                offline=False,
+            )
+            trusted_entries = [
+                {
+                    "path": "upstream/demo/references/exact.bin",
+                    "type": "blob",
+                    "sha": exact_blob,
+                    "size": len(exact_bytes),
+                }
+            ]
+            with mock.patch.object(
+                online_cache,
+                "_gh_json",
+                side_effect=online_tree_responder(trusted_entries),
+            ):
+                online_report = inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=online_cache,
+                    write=True,
+                    today="2026-08-20",
+                )
+            self.assertEqual(1, online_report["summary"]["mappings_changed"])
+
+            written = json.loads(mapping.read_text(encoding="utf-8"))
+            written_entry = written["skills"][0]
+            self.assertEqual("overlay", written_entry["kind"])
+            self.assertEqual("monitor", written_entry["sync_mode"])
+            local_origin = next(
+                origin
+                for origin in written_entry["origins"]
+                if origin["repo"] == inventory.LOCAL_OVERLAY_REPO
+            )
+            self.assertIsNone(local_origin["license"])
+            self.assertEqual("local-only", local_origin["sync_mode"])
+            self.assertEqual(
+                [{"source": overlay_target, "target": overlay_target, "type": "file"}],
+                local_origin["artifacts"],
+            )
+            self.assertEqual(
+                {repo_skill, exact_target, overlay_target},
+                {
+                    managed["path"]
+                    for managed in written_entry["managed_files"]
+                },
+            )
+            self.assertEqual([], validator.validate_mapping(mapping, root))
+            self.assertEqual(
+                0,
+                inventory.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--mapping",
+                        "docs/sources/example.skills.json",
+                        "--cache-dir",
+                        str(cache_dir),
+                        "--offline",
+                        "--check-clean",
+                        "--output",
+                        str(root / "clean-check.json"),
+                    ]
+                ),
+            )
+
+            once = mapping.read_bytes()
+            second_report = inventory.reconcile_mappings(
+                [mapping],
+                repo_root=root,
+                cache=inventory.GitHubObjectCache(cache_dir, offline=True),
+                write=True,
+                today="2026-08-20",
+            )
+            self.assertEqual(once, mapping.read_bytes())
+            self.assertEqual(0, second_report["summary"]["mappings_changed"])
+
+    def test_unavailable_entry_blocks_write_without_partial_managed_claims(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/unavailable.txt"
+            (root / target).write_text("local", encoding="utf-8")
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+
+            report = inventory.reconcile_mappings(
+                [mapping],
+                repo_root=root,
+                cache=cache,
+                write=True,
+            )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(1, report["summary"]["unavailable"])
+            self.assertEqual(1, report["summary"]["write_blocked_entries"])
+            report_path = root / "blocked-write-report.json"
+            self.assertEqual(
+                1,
+                inventory.main(
+                    [
+                        "--repo-root",
+                        str(root),
+                        "--mapping",
+                        "docs/sources/example.skills.json",
+                        "--cache-dir",
+                        str(root / "cache"),
+                        "--offline",
+                        "--write",
+                        "--output",
+                        str(report_path),
+                    ]
+                ),
+            )
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertGreater(
+                json.loads(report_path.read_text(encoding="utf-8"))["summary"][
+                    "write_blocked_entries"
+                ],
+                0,
+            )
+
+    def test_write_honors_shared_mapping_lock_before_first_snapshot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+            worker = r"""
+import sys
+from pathlib import Path
+from scripts.reconcile_artifact_inventory import (
+    GitHubObjectCache,
+    reconcile_mappings,
+)
+
+root = Path(sys.argv[1])
+mapping = Path(sys.argv[2])
+reconcile_mappings(
+    [mapping],
+    repo_root=root,
+    cache=GitHubObjectCache(root / "cache", offline=True),
+    write=True,
+    lock_timeout=0.0,
+)
+"""
+            from scripts.sync_upstream import mapping_advisory_lock
+
+            with mapping_advisory_lock(mapping, timeout=0.0):
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        worker,
+                        str(root),
+                        str(mapping),
+                    ],
+                    cwd=REPO_ROOT,
+                    env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=10,
+                )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("already active", completed.stderr)
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(
+                [],
+                [
+                    path.name
+                    for path in mapping.parent.iterdir()
+                    if path.name.startswith(".example.skills.json.")
+                ],
+            )
+
+    def test_write_rejects_symlinked_mapping_ancestor_without_outside_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "repo"
+            outside = Path(tmpdir) / "outside"
+            root.mkdir()
+            outside_sources = outside / "sources"
+            outside_sources.mkdir(parents=True)
+            mapping = root / "docs/sources/example.skills.json"
+            (root / "docs").mkdir()
+            (root / "docs/sources").symlink_to(
+                outside_sources,
+                target_is_directory=True,
+            )
+            outside_mapping = outside_sources / mapping.name
+            outside_mapping.write_text(
+                json.dumps(make_payload({}), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = outside_mapping.read_bytes()
+
+            with self.assertRaises(inventory.ReconciliationWriteError):
+                inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=inventory.GitHubObjectCache(
+                        root / "cache",
+                        offline=True,
+                    ),
+                    write=True,
+                    lock_timeout=0.0,
+                )
+
+            self.assertEqual(before, outside_mapping.read_bytes())
+            self.assertEqual(
+                [mapping.name],
+                sorted(path.name for path in outside_sources.iterdir()),
+            )
+
+    def test_write_is_all_or_none_when_any_entry_has_debt(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root, "safe")
+            safe = make_entry(root, "safe")
+            safe_sidecar = "skills/category/safe/LOCAL.md"
+            (root / safe_sidecar).write_text("safe overlay\n", encoding="utf-8")
+            safe_mapping = root / "docs/sources/safe.skills.json"
+            safe_mapping.parent.mkdir(parents=True)
+            safe_mapping.write_text(
+                json.dumps(make_payload(safe), indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+            write_skill(root, "blocked")
+            blocked = make_entry(root, "blocked")
+            blocked_sidecar = "skills/category/blocked/unavailable.txt"
+            (root / blocked_sidecar).write_text("blocked\n", encoding="utf-8")
+            blocked_mapping = root / "docs/sources/blocked.skills.json"
+            blocked_mapping.write_text(
+                json.dumps(make_payload(blocked), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = {
+                safe_mapping: safe_mapping.read_bytes(),
+                blocked_mapping: blocked_mapping.read_bytes(),
+            }
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+
+            report = inventory.reconcile_mappings(
+                [safe_mapping, blocked_mapping],
+                repo_root=root,
+                cache=cache,
+                write=True,
+            )
+
+            self.assertEqual(before[safe_mapping], safe_mapping.read_bytes())
+            self.assertEqual(before[blocked_mapping], blocked_mapping.read_bytes())
+            self.assertEqual(0, report["summary"]["mappings_changed"])
+            self.assertGreater(report["summary"]["write_blocked_entries"], 0)
+
+    def test_classification_checkpoint_blocks_toctou_adoption(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/exact.bin"
+            original = b"upstream exact"
+            (root / target).parent.mkdir(parents=True)
+            (root / target).write_bytes(original)
+            object_sha = inventory._git_blob_oid(original, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+            trusted_entries = [
+                {
+                    "path": "upstream/demo/references/exact.bin",
+                    "type": "blob",
+                    "sha": object_sha,
+                    "size": len(original),
+                }
+            ]
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+            original_apply = inventory.apply_entry_reconciliation
+            mutated = False
+
+            def mutate_after_classification(*args, **kwargs):
+                nonlocal mutated
+                result = original_apply(*args, **kwargs)
+                if not mutated:
+                    mutated = True
+                    replacement = root / f"{target}.replacement"
+                    replacement.write_bytes(b"user bytes after classification")
+                    os.replace(replacement, root / target)
+                return result
+
+            with (
+                mock.patch.object(
+                    cache,
+                    "_gh_json",
+                    side_effect=online_tree_responder(trusted_entries),
+                ),
+                mock.patch.object(
+                    inventory,
+                    "apply_entry_reconciliation",
+                    side_effect=mutate_after_classification,
+                ),
+            ):
+                report = inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=cache,
+                    write=True,
+                )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual(
+                b"user bytes after classification",
+                (root / target).read_bytes(),
+            )
+            self.assertEqual(0, report["summary"]["mappings_changed"])
+            self.assertGreater(report["summary"]["write_blocked_entries"], 0)
+
+    def test_cross_mapping_commit_failure_rolls_back_every_mapping(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mappings = []
+            for slug in ("one", "two"):
+                write_skill(root, slug)
+                entry = make_entry(root, slug)
+                sidecar = f"skills/category/{slug}/LOCAL.md"
+                (root / sidecar).write_text(
+                    f"{slug} overlay\n",
+                    encoding="utf-8",
+                )
+                mapping = root / f"docs/sources/{slug}.skills.json"
+                mapping.parent.mkdir(parents=True, exist_ok=True)
+                mapping.write_text(
+                    json.dumps(make_payload(entry), indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                mappings.append(mapping)
+            before = {path: path.read_bytes() for path in mappings}
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+            real_replace = inventory.os.replace
+            failed = False
+
+            def fail_second_stage(source, destination, *args, **kwargs):
+                nonlocal failed
+                source_path = Path(source)
+                destination_path = Path(destination)
+                if (
+                    not failed
+                    and destination_path.name == mappings[1].name
+                    and ".inventory-stage-" in source_path.name
+                ):
+                    failed = True
+                    raise OSError("injected second mapping replace failure")
+                return real_replace(source, destination, *args, **kwargs)
+
+            with (
+                mock.patch.object(
+                    cache,
+                    "_gh_json",
+                    side_effect=online_tree_responder([]),
+                ),
+                mock.patch.object(
+                    inventory.os,
+                    "replace",
+                    side_effect=fail_second_stage,
+                ),
+            ):
+                report = inventory.reconcile_mappings(
+                    mappings,
+                    repo_root=root,
+                    cache=cache,
+                    write=True,
+                )
+
+            self.assertEqual(0, report["summary"]["mappings_changed"])
+            self.assertIn("injected", report["summary"]["write_error"])
+            for path in mappings:
+                self.assertEqual(before[path], path.read_bytes())
+
+    def test_cross_mapping_hard_exit_recovers_all_before_on_next_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mappings = []
+            for slug in ("one", "two"):
+                write_skill(root, slug)
+                entry = make_entry(root, slug)
+                sidecar = f"skills/category/{slug}/LOCAL.md"
+                (root / sidecar).write_text(
+                    f"{slug} overlay\n",
+                    encoding="utf-8",
+                )
+                mapping = root / f"docs/sources/{slug}.skills.json"
+                mapping.parent.mkdir(parents=True, exist_ok=True)
+                mapping.write_text(
+                    json.dumps(make_payload(entry), indent=2) + "\n",
+                    encoding="utf-8",
+                )
+                mappings.append(mapping)
+            before = {path: path.read_bytes() for path in mappings}
+            worker = r"""
+import os
+import sys
+from pathlib import Path
+from scripts import reconcile_artifact_inventory as inventory
+
+root = Path(sys.argv[1])
+mappings = [Path(value) for value in sys.argv[2:]]
+commit = "a" * 40
+root_tree = "b" * 40
+cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+
+def respond(endpoint, *, fields=None):
+    if endpoint == f"repos/owner/upstream/git/commits/{commit}":
+        return {"sha": commit, "tree": {"sha": root_tree}}
+    if endpoint == f"repos/owner/upstream/git/trees/{root_tree}":
+        return {"sha": root_tree, "truncated": False, "tree": []}
+    raise AssertionError(endpoint)
+
+cache._gh_json = respond
+real_replace = inventory.os.replace
+
+def hard_exit_after_first_install(source, destination, *args, **kwargs):
+    real_replace(source, destination, *args, **kwargs)
+    if (
+        Path(destination).name == mappings[0].name
+        and ".inventory-stage-" in Path(source).name
+    ):
+        os._exit(73)
+
+inventory.os.replace = hard_exit_after_first_install
+inventory.reconcile_mappings(
+    mappings,
+    repo_root=root,
+    cache=cache,
+    write=True,
+    lock_timeout=0.0,
+)
+"""
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    worker,
+                    str(root),
+                    *(str(path) for path in mappings),
+                ],
+                cwd=REPO_ROOT,
+                env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+            self.assertEqual(73, completed.returncode, completed.stderr)
+            self.assertNotEqual(before[mappings[0]], mappings[0].read_bytes())
+            self.assertEqual(before[mappings[1]], mappings[1].read_bytes())
+            self.assertTrue(
+                (root / ".hvs-transactions/pending/journal.json").is_file()
+            )
+
+            report = inventory.reconcile_mappings(
+                mappings,
+                repo_root=root,
+                cache=inventory.GitHubObjectCache(
+                    root / "cache",
+                    offline=True,
+                ),
+                write=True,
+                lock_timeout=0.0,
+            )
+
+            self.assertGreater(report["summary"]["write_blocked_entries"], 0)
+            for path in mappings:
+                self.assertEqual(before[path], path.read_bytes())
+            self.assertFalse((root / ".hvs-transactions/pending").exists())
+            self.assertEqual(
+                [],
+                [
+                    path.name
+                    for path in mappings[0].parent.iterdir()
+                    if ".inventory-stage-" in path.name
+                ],
+            )
+
+    def test_detached_mapping_parent_never_overwrites_concurrent_active_tree(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            sidecar = "skills/category/demo/LOCAL.md"
+            (root / sidecar).write_text("local overlay\n", encoding="utf-8")
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+            detached = root / "docs/sources-detached"
+            cache = inventory.GitHubObjectCache(root / "cache", offline=False)
+            original_assert = inventory._assert_active_mapping_parent
+            detached_once = False
+
+            def detach_after_identity_check(*args, **kwargs):
+                nonlocal detached_once
+                original_assert(*args, **kwargs)
+                if detached_once:
+                    return
+                detached_once = True
+                mapping.parent.rename(detached)
+                mapping.parent.mkdir()
+                mapping.write_bytes(before)
+
+            with (
+                mock.patch.object(
+                    cache,
+                    "_gh_json",
+                    side_effect=online_tree_responder([]),
+                ),
+                mock.patch.object(
+                    inventory,
+                    "_assert_active_mapping_parent",
+                    side_effect=detach_after_identity_check,
+                ),
+            ):
+                report = inventory.reconcile_mappings(
+                    [mapping],
+                    repo_root=root,
+                    cache=cache,
+                    write=True,
+                    lock_timeout=0.0,
+                )
+
+            self.assertEqual(0, report["summary"]["mappings_changed"])
+            self.assertIn(
+                "parent changed concurrently",
+                report["summary"]["write_error"],
+            )
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertNotEqual(
+                before,
+                (detached / mapping.name).read_bytes(),
+            )
+            self.assertFalse((root / ".hvs-transactions/pending").exists())
+
+    def test_snapshot_local_supplement_keeps_snapshot_update_policy(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            entry["kind"] = "snapshot"
+            entry["sync_mode"] = "local-only"
+            entry["upstream"]["sync_mode"] = "local-only"
+            entry["origins"][0]["sync_mode"] = "local-only"
+            target = "skills/category/demo/LOCAL.md"
+            (root / target).write_text("snapshot supplement\n", encoding="utf-8")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(cache, [])
+            inspection = inventory.inspect_entry(entry, repo_root=root, cache=cache)
+
+            updated, changed, blocked = inventory.apply_entry_reconciliation(
+                entry,
+                inspection,
+                repo_root=root,
+                today="2026-08-20",
+            )
+
+            self.assertTrue(changed)
+            self.assertIsNone(blocked)
+            self.assertEqual("snapshot", updated["kind"])
+            self.assertEqual("local-only", updated["sync_mode"])
+            self.assertEqual("local-only", updated["origins"][0]["sync_mode"])
+            self.assertEqual(
+                inventory.LOCAL_OVERLAY_REPO,
+                updated["origins"][1]["repo"],
+            )
+            self.assertEqual("local-only", updated["origins"][1]["sync_mode"])
+
+    def test_validator_accepts_curated_overlay_and_rejects_duplicate_origin_owner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            overlay_target = "skills/category/demo/LOCAL.md"
+            (root / overlay_target).write_text("local\n", encoding="utf-8")
+            entry["kind"] = "overlay"
+            entry["origins"].append(
+                inventory._local_overlay_origin(
+                    entry,
+                    [
+                        {
+                            "source": overlay_target,
+                            "target": overlay_target,
+                            "type": "file",
+                        }
+                    ],
+                    today="2026-08-20",
+                )
+            )
+            entry["managed_files"].append(
+                {
+                    "path": overlay_target,
+                    "sha256": provenance.sha256_file(root / overlay_target),
+                    "owner": "demo",
+                }
+            )
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            self.assertEqual([], validator.validate_mapping(mapping, root))
+
+            duplicated = deepcopy(entry)
+            duplicated["origins"][1]["artifacts"].append(
+                {
+                    "source": repo_skill,
+                    "target": repo_skill,
+                    "type": "file",
+                }
+            )
+            mapping.write_text(
+                json.dumps(make_payload(duplicated), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            errors = validator.validate_mapping(mapping, root)
+            self.assertTrue(
+                any("repo_skill must have exactly one" in error for error in errors),
+                errors,
+            )
+
+            local_only_owner = deepcopy(entry)
+            local_only_owner["origins"][0]["artifacts"] = []
+            local_only_owner["origins"][1]["artifacts"].append(
+                {
+                    "source": repo_skill,
+                    "target": repo_skill,
+                    "type": "file",
+                }
+            )
+            mapping.write_text(
+                json.dumps(make_payload(local_only_owner), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            errors = validator.validate_mapping(mapping, root)
+            self.assertTrue(
+                any("external repo_skill must be owned" in error for error in errors),
+                errors,
+            )
+
+    def test_schema_pins_local_overlay_contract(self):
+        schema = json.loads(
+            (REPO_ROOT / "scripts/provenance_v2.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        conditional = schema["$defs"]["origin"]["allOf"][0]
+        self.assertEqual(
+            "local-repo/curation",
+            conditional["if"]["properties"]["repo"]["const"],
+        )
+        properties = conditional["then"]["properties"]
+        self.assertEqual("null", properties["license"]["type"])
+        self.assertEqual("local-only", properties["sync_mode"]["const"])
+        tracking = properties["tracking"]["allOf"][1]["properties"]
+        self.assertEqual("local", tracking["channel"]["const"])
+        self.assertEqual("local", tracking["ref"]["const"])
+
+    def test_migration_preserves_mixed_origin_ownership_and_modes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            overlay_target = "skills/category/demo/LOCAL.md"
+            (root / overlay_target).write_text("local\n", encoding="utf-8")
+            entry["kind"] = "overlay"
+            entry["origins"].append(
+                inventory._local_overlay_origin(
+                    entry,
+                    [
+                        {
+                            "source": overlay_target,
+                            "target": overlay_target,
+                            "type": "file",
+                        }
+                    ],
+                    today="2026-08-20",
+                )
+            )
+            entry["managed_files"].append(
+                {
+                    "path": overlay_target,
+                    "sha256": provenance.sha256_file(root / overlay_target),
+                    "owner": "demo",
+                }
+            )
+
+            migrated = provenance.migrate_payload(
+                make_payload(entry),
+                root,
+                local_tracking_date="2026-08-21",
+                refresh_managed_digests=True,
+            )
+            migrated_entry = migrated["skills"][0]
+            external_origin, local_origin = migrated_entry["origins"]
+
+            self.assertEqual("monitor", migrated_entry["sync_mode"])
+            self.assertEqual("monitor", external_origin["sync_mode"])
+            self.assertEqual("local-only", local_origin["sync_mode"])
+            self.assertEqual(
+                [
+                    {
+                        "source": overlay_target,
+                        "target": overlay_target,
+                        "type": "file",
+                    }
+                ],
+                local_origin["artifacts"],
+            )
+            self.assertEqual("local", local_origin["tracking"]["ref"])
+            self.assertIsNone(local_origin["tracking"]["resolved_commit"])
+            self.assertIsNone(local_origin["tracking"]["path_commit"])
+            self.assertIsNone(local_origin["tracking"]["content_sha256"])
+            self.assertEqual(
+                {repo_skill, overlay_target},
+                {
+                    managed["path"]
+                    for managed in migrated_entry["managed_files"]
+                },
+            )
+
+    def test_migration_never_drops_missing_external_evidence_from_overlay(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            missing_target = "skills/category/demo/references/missing.md"
+            entry["kind"] = "overlay"
+            entry["origins"][0]["artifacts"].append(
+                {
+                    "source": "skills/demo/references/missing.md",
+                    "target": missing_target,
+                    "type": "file",
+                }
+            )
+            entry["managed_files"].append(
+                {
+                    "path": missing_target,
+                    "sha256": "f" * 64,
+                    "owner": "demo",
+                }
+            )
+            entry["origins"].append(
+                inventory._local_overlay_origin(
+                    entry,
+                    [],
+                    today="2026-08-20",
+                )
+            )
+
+            migrated = provenance.migrate_payload(
+                make_payload(entry),
+                root,
+                local_tracking_date="2026-08-21",
+                refresh_managed_digests=True,
+            )
+
+            managed = {
+                item["path"]: item
+                for item in migrated["skills"][0]["managed_files"]
+            }
+            self.assertIn(missing_target, managed)
+            self.assertEqual("f" * 64, managed[missing_target]["sha256"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_artifact_inventory.py
+++ b/tests/test_reconcile_artifact_inventory.py
@@ -112,6 +112,7 @@ def make_entry(root: Path, slug: str = "demo") -> dict:
                 "path": repo_skill,
                 "sha256": content_hash,
                 "owner": slug,
+                "mode": "100644",
             }
         ],
     }
@@ -130,6 +131,14 @@ def write_tree_fixture(
     cache: inventory.GitHubObjectCache,
     entries: list[dict],
 ) -> None:
+    normalized_entries = [
+        (
+            {**entry, "mode": entry.get("mode", "100644")}
+            if entry.get("type") == "blob"
+            else dict(entry)
+        )
+        for entry in entries
+    ]
     path = cache.tree_cache_path("owner/upstream", COMMIT)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -137,7 +146,7 @@ def write_tree_fixture(
             {
                 "sha": COMMIT,
                 "truncated": False,
-                "tree": entries,
+                "tree": normalized_entries,
             }
         ),
         encoding="utf-8",
@@ -155,6 +164,15 @@ def write_blob_fixture(
 
 
 def online_tree_responder(entries: list[dict]):
+    normalized_entries = [
+        (
+            {**entry, "mode": entry.get("mode", "100644")}
+            if entry.get("type") == "blob"
+            else dict(entry)
+        )
+        for entry in entries
+    ]
+
     def respond(endpoint: str, *, fields: dict[str, str] | None = None):
         if endpoint == f"repos/owner/upstream/git/commits/{COMMIT}":
             return {"sha": COMMIT, "tree": {"sha": ROOT_TREE}}
@@ -164,7 +182,7 @@ def online_tree_responder(entries: list[dict]):
             return {
                 "sha": ROOT_TREE,
                 "truncated": False,
-                "tree": entries,
+                "tree": normalized_entries,
             }
         raise AssertionError(f"unexpected GitHub endpoint: {endpoint}")
 
@@ -360,6 +378,31 @@ class ArtifactInventoryTests(unittest.TestCase):
                 "offline_authority_forbidden",
                 proposal["checked_sources"][0]["result"],
             )
+
+    def test_tree_rejects_symlink_git_mode_120000(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            content = b"references/outside.md"
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            cache = inventory.GitHubObjectCache(root / "cache", offline=True)
+            write_tree_fixture(
+                cache,
+                [
+                    {
+                        "path": "upstream/demo/link.md",
+                        "type": "blob",
+                        "mode": "120000",
+                        "sha": object_sha,
+                        "size": len(content),
+                    }
+                ],
+            )
+
+            with self.assertRaisesRegex(
+                inventory.SourceUnavailable,
+                "non-regular.*120000",
+            ):
+                cache.get_tree("owner/upstream", COMMIT)
 
     def test_online_tree_ignores_forged_disk_cache_and_binds_commit_root(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -564,6 +607,7 @@ class ArtifactInventoryTests(unittest.TestCase):
                 "external_exact",
                 by_target[exact_target]["classification"],
             )
+            self.assertEqual("100644", by_target[exact_target]["mode"])
             self.assertEqual(
                 "upstream/demo/references/exact.bin",
                 by_target[exact_target]["source"],
@@ -572,8 +616,87 @@ class ArtifactInventoryTests(unittest.TestCase):
                 "local_overlay",
                 by_target[overlay_target]["classification"],
             )
+            self.assertEqual("100644", by_target[overlay_target]["mode"])
             self.assertEqual(overlay_target, by_target[overlay_target]["source"])
             self.assertIn(repo_skill, report["actual_files"])
+
+    def test_external_exact_requires_matching_blob_bytes_and_tree_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_skill(root)
+            entry = make_entry(root)
+            target = "skills/category/demo/references/executable.sh"
+            content = b"#!/bin/sh\nexit 0\n"
+            target_path = root / target
+            target_path.parent.mkdir(parents=True)
+            target_path.write_bytes(content)
+            target_path.chmod(0o755)
+            object_sha = inventory._git_blob_oid(content, "sha1")
+            source = "upstream/demo/references/executable.sh"
+
+            mismatched_cache = inventory.GitHubObjectCache(
+                root / "mismatch-cache",
+                offline=False,
+            )
+            with mock.patch.object(
+                mismatched_cache,
+                "_gh_json",
+                side_effect=online_tree_responder(
+                    [
+                        {
+                            "path": source,
+                            "type": "blob",
+                            "mode": "100644",
+                            "sha": object_sha,
+                            "size": len(content),
+                        }
+                    ]
+                ),
+            ):
+                mismatched = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=mismatched_cache,
+                )
+            proposal = next(
+                item for item in mismatched["unowned"] if item["target"] == target
+            )
+            self.assertEqual("local_overlay", proposal["classification"])
+            self.assertEqual("100755", proposal["mode"])
+            self.assertEqual(
+                "mode_mismatch",
+                proposal["checked_sources"][0]["result"],
+            )
+
+            matching_cache = inventory.GitHubObjectCache(
+                root / "matching-cache",
+                offline=False,
+            )
+            with mock.patch.object(
+                matching_cache,
+                "_gh_json",
+                side_effect=online_tree_responder(
+                    [
+                        {
+                            "path": source,
+                            "type": "blob",
+                            "mode": "100755",
+                            "sha": object_sha,
+                            "size": len(content),
+                        }
+                    ]
+                ),
+            ):
+                matching = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=matching_cache,
+                )
+            proposal = next(
+                item for item in matching["unowned"] if item["target"] == target
+            )
+            self.assertEqual("external_exact", proposal["classification"])
+            self.assertEqual("100755", proposal["mode"])
 
     def test_blob_404_is_unavailable_instead_of_becoming_local_overlay(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -671,6 +794,7 @@ class ArtifactInventoryTests(unittest.TestCase):
                     "path": "skills/category/demo/linked.txt",
                     "sha256": "f" * 64,
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
             mapping = root / "docs/sources/example.skills.json"
@@ -843,6 +967,7 @@ class ArtifactInventoryTests(unittest.TestCase):
                     "path": "skills/category/demo/removed.txt",
                     "sha256": "e" * 64,
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
             mapping = root / "docs/sources/example.skills.json"
@@ -915,7 +1040,7 @@ class ArtifactInventoryTests(unittest.TestCase):
 
             with mock.patch.object(
                 inventory,
-                "_sha256_regular_file",
+                "_regular_file_snapshot",
                 side_effect=PermissionError("read denied"),
             ):
                 report = inventory.reconcile_mappings(
@@ -931,6 +1056,77 @@ class ArtifactInventoryTests(unittest.TestCase):
             self.assertEqual("hash_managed_file", issue["operation"])
             self.assertIn("read denied", issue["detail"])
             self.assertEqual(1, report["summary"]["write_blocked_entries"])
+
+    def test_managed_mode_drift_is_reported_and_blocks_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            (root / repo_skill).chmod(0o755)
+            mapping = root / "docs/sources/example.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(make_payload(entry), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            report = inventory.reconcile_mappings(
+                [mapping],
+                repo_root=root,
+                cache=inventory.GitHubObjectCache(
+                    root / "cache",
+                    offline=True,
+                ),
+                write=True,
+            )
+
+            self.assertEqual(before, mapping.read_bytes())
+            self.assertEqual([repo_skill], report["entries"][0]["mode_mismatches"])
+            self.assertEqual(1, report["summary"]["mode_mismatches"])
+            self.assertEqual(1, report["summary"]["write_blocked_entries"])
+            self.assertIn(
+                "managed mode mismatch",
+                report["entries"][0]["write_blocked_reason"],
+            )
+
+    def test_mode_change_during_secure_read_is_a_toctou_scan_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_skill = write_skill(root)
+            entry = make_entry(root)
+            skill_path = root / repo_skill
+            changed = False
+            real_read = inventory.os.read
+
+            def chmod_during_read(descriptor: int, size: int) -> bytes:
+                nonlocal changed
+                chunk = real_read(descriptor, size)
+                if chunk and not changed:
+                    skill_path.chmod(0o755)
+                    changed = True
+                return chunk
+
+            with mock.patch.object(
+                inventory.os,
+                "read",
+                side_effect=chmod_during_read,
+            ):
+                inspection = inventory.inspect_entry(
+                    entry,
+                    repo_root=root,
+                    cache=inventory.GitHubObjectCache(
+                        root / "cache",
+                        offline=True,
+                    ),
+                )
+
+            self.assertTrue(changed)
+            self.assertTrue(inspection["scan_errors"])
+            self.assertIn(
+                "changed while reading",
+                inspection["scan_errors"][0]["detail"],
+            )
 
     def test_dry_run_is_read_only_and_write_is_atomic_and_idempotent(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1071,6 +1267,13 @@ class ArtifactInventoryTests(unittest.TestCase):
                 {repo_skill, exact_target, overlay_target},
                 {
                     managed["path"]
+                    for managed in written_entry["managed_files"]
+                },
+            )
+            self.assertEqual(
+                {"100644"},
+                {
+                    managed["mode"]
                     for managed in written_entry["managed_files"]
                 },
             )
@@ -1648,6 +1851,7 @@ inventory.reconcile_mappings(
                     "path": overlay_target,
                     "sha256": provenance.sha256_file(root / overlay_target),
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
             mapping = root / "docs/sources/example.skills.json"
@@ -1739,6 +1943,7 @@ inventory.reconcile_mappings(
                     "path": overlay_target,
                     "sha256": provenance.sha256_file(root / overlay_target),
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
 
@@ -1795,6 +2000,7 @@ inventory.reconcile_mappings(
                     "path": missing_target,
                     "sha256": "f" * 64,
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
             entry["origins"].append(

--- a/tests/test_repo_validation_workflow.py
+++ b/tests/test_repo_validation_workflow.py
@@ -38,6 +38,11 @@ class RepoValidationWorkflowTests(unittest.TestCase):
         self.assertIn("python scripts/audit_licenses.py", commands)
         self.assertIn("python scripts/validate_skill_sources.py", commands)
         self.assertIn(
+            "python scripts/reconcile_artifact_inventory.py "
+            "--offline --check-clean --quiet",
+            commands,
+        )
+        self.assertIn(
             "python scripts/check_source_coverage.py --min-percent 100",
             commands,
         )

--- a/tests/test_sync_all_upstream_skills.py
+++ b/tests/test_sync_all_upstream_skills.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sync_all_upstream_skills.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "sync_all_upstream_skills",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_uses_only_governed_v2_sync_entrypoint():
+    module = load_module()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with mock.patch.object(module, "run", return_value=0) as run:
+            assert module.main(["--repo-root", tmpdir]) == 0
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert commands == [
+        (module.PYTHON, "scripts/sync_upstream.py", "--check-only"),
+    ]
+
+
+def test_apply_pipeline_uses_full_pytest_and_no_legacy_importers():
+    module = load_module()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with mock.patch.object(module, "run", return_value=0) as run:
+            assert (
+                module.main(
+                    [
+                        "--repo-root",
+                        tmpdir,
+                        "--apply",
+                        "--run-pipeline",
+                    ]
+                )
+                == 0
+            )
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert commands[0] == (module.PYTHON, "scripts/sync_upstream.py", "--apply")
+    assert (module.PYTHON, "-m", "pytest", "-q", "tests") in commands
+    assert (
+        module.PYTHON,
+        "scripts/reconcile_artifact_inventory.py",
+        "--offline",
+        "--check-clean",
+        "--quiet",
+    ) in commands
+    flattened = "\n".join(" ".join(command) for command in commands)
+    assert "sync_addyosmani_agent_skills.py" not in flattened
+    assert "sync_simota_agent_skills.py" not in flattened
+    assert "sync_codex_skills.py" not in flattened
+
+
+def test_apply_preserves_degraded_state_and_runs_pipeline_after_writes():
+    module = load_module()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            mock.patch.object(
+                module,
+                "repository_digest",
+                side_effect=["before", "after"],
+            ),
+            mock.patch.object(
+                module,
+                "run",
+                side_effect=[2] + [0] * len(module.POST_SYNC_PIPELINE),
+            ) as run,
+        ):
+            assert (
+                module.main(
+                    [
+                        "--repo-root",
+                        tmpdir,
+                        "--apply",
+                        "--run-pipeline",
+                    ]
+                )
+                == 2
+            )
+    assert len(run.call_args_list) == 1 + len(module.POST_SYNC_PIPELINE)
+
+
+def test_apply_preserves_failed_state_without_install_or_unwritten_pipeline():
+    module = load_module()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            mock.patch.object(
+                module,
+                "repository_digest",
+                side_effect=["same", "same"],
+            ),
+            mock.patch.object(module, "run", return_value=1) as run,
+        ):
+            assert (
+                module.main(
+                    [
+                        "--repo-root",
+                        tmpdir,
+                        "--apply",
+                        "--run-pipeline",
+                    ]
+                )
+                == 1
+            )
+    assert len(run.call_args_list) == 1

--- a/tests/test_sync_upstream.py
+++ b/tests/test_sync_upstream.py
@@ -98,6 +98,7 @@ def complete_v2_entry(entry: dict, content: bytes) -> dict:
                 "path": entry["repo_skill"],
                 "sha256": hashlib.sha256(content).hexdigest(),
                 "owner": slug,
+                "mode": "100644",
             }
         ],
     )
@@ -2188,6 +2189,13 @@ class SyncUpstreamTests(unittest.TestCase):
             b"\x00\xff\x10",
             first.files["skills/ai/demo/static/logo.bin"],
         )
+        self.assertEqual(
+            {
+                "skills/ai/demo/SKILL.md": "100644",
+                "skills/ai/demo/static/logo.bin": "100755",
+            },
+            first.modes,
+        )
         self.assertEqual(first, second)
         self.assertTrue(all(count == 1 for count in calls.values()), calls)
 
@@ -2414,6 +2422,9 @@ class SyncUpstreamTests(unittest.TestCase):
 
         self.assertEqual(
             b"# Skill\n", inventory.files["skills/ai/demo/SKILL.md"]
+        )
+        self.assertEqual(
+            "100644", inventory.modes["skills/ai/demo/SKILL.md"]
         )
 
     def test_github_provider_truncated_walk_preserves_but_does_not_descend_special_objects(self):
@@ -2864,6 +2875,12 @@ class SyncUpstreamTests(unittest.TestCase):
                                 ): upstream
                             },
                             {"upstream/SKILL.md": "1" * 40},
+                            {
+                                (
+                                    "skills/ai-workflow/curated-demo/"
+                                    "SKILL.md"
+                                ): "100644"
+                            },
                             ResolvedRef(
                                 channel, "reviewed-ref", checkpoint
                             ),
@@ -3090,6 +3107,7 @@ class SyncUpstreamTests(unittest.TestCase):
                         return ArtifactInventory(
                             {target: local},
                             {"upstream/SKILL.md": "1" * 40},
+                            {target: "100644"},
                             ResolvedRef(
                                 "default_branch", "main", "b" * 40
                             ),
@@ -3178,6 +3196,10 @@ class SyncUpstreamTests(unittest.TestCase):
                             side_target: b"\x00new",
                         },
                         {"upstream/SKILL.md": "1" * 40, "upstream/guide.bin": "2" * 40},
+                        {
+                            main_target: "100644",
+                            side_target: "100644",
+                        },
                         ResolvedRef("default_branch", "main", "b" * 40),
                     )
 
@@ -3325,6 +3347,7 @@ class SyncUpstreamTests(unittest.TestCase):
                     return ArtifactInventory(
                         {repo_skill: upstream},
                         {upstream_path: "f" * 40},
+                        {repo_skill: "100644"},
                         ResolvedRef(
                             "latest_release", "v2.0.0", "b" * 40
                         ),
@@ -3409,6 +3432,10 @@ class SyncUpstreamTests(unittest.TestCase):
                             binary_target: b"\x00\xffnew",
                         },
                         {"src/SKILL.md": "1" * 40, "src/data.bin": "2" * 40},
+                        {
+                            main_target: "100644",
+                            binary_target: "100644",
+                        },
                         ResolvedRef("latest_release", "v2", "a" * 40),
                     )
 
@@ -3488,6 +3515,7 @@ class SyncUpstreamTests(unittest.TestCase):
             changed, added, removed = module._artifact_diff(
                 skill,
                 {main_target: b"# Same\n"},
+                {main_target: "100644"},
             )
 
             self.assertEqual([], changed)
@@ -3543,12 +3571,56 @@ class SyncUpstreamTests(unittest.TestCase):
                     main_target: b"# Same\n",
                     newly_desired: b"# Existing identical bytes\n",
                 },
+                {
+                    main_target: "100644",
+                    newly_desired: "100644",
+                },
             )
 
             self.assertEqual([], changed)
             self.assertEqual([newly_desired], added)
             # Removed remains an inventory delta even though disk is missing.
             self.assertEqual([formerly_owned], removed)
+
+    def test_artifact_diff_reports_mode_only_change(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            target = "skills/ai-workflow/demo/SKILL.md"
+            body = b"# Same\n"
+            path = root / target
+            path.parent.mkdir(parents=True)
+            path.write_bytes(body)
+            path.chmod(0o644)
+            skill = {
+                "repo_skill": target,
+                "artifacts": [
+                    {
+                        "source": "upstream/SKILL.md",
+                        "target": target,
+                        "type": "file",
+                    }
+                ],
+                "other_origin_artifacts": [],
+                "managed_files": [
+                    {
+                        "path": target,
+                        "sha256": hashlib.sha256(body).hexdigest(),
+                        "mode": "100644",
+                    }
+                ],
+            }
+
+            changed, added, removed = module._artifact_diff(
+                skill,
+                {target: body},
+                {target: "100755"},
+            )
+
+            self.assertEqual([target], changed)
+            self.assertEqual([], added)
+            self.assertEqual([], removed)
 
     def test_v2_missing_source_reports_exact_blob_move_candidates_without_guessing(self):
         module = load_module()
@@ -4069,6 +4141,7 @@ entry = {
         "path": skill,
         "sha256": hashlib.sha256(old).hexdigest(),
         "owner": "demo",
+        "mode": "100644",
     }],
 }
 plan = plan_artifact_set_sync(
@@ -4079,6 +4152,7 @@ plan = plan_artifact_set_sync(
         "target": skill,
         "type": "file",
         "data": new,
+        "mode": "100644",
     }],
     {"resolved_commit": "c" * 40},
 )
@@ -4514,6 +4588,11 @@ os._exit(73)
                     "package/references/curated.md": "2" * 40,
                     "package/templates/nested/config.bin": "3" * 40,
                 },
+                "upstream_modes": {
+                    main_target: "100644",
+                    exact_target: "100644",
+                    nested_target: "100644",
+                },
             }
             plan_calls = []
             original_engine_loader = module._load_artifact_engine
@@ -4674,6 +4753,7 @@ os._exit(73)
                     "path": side_target,
                     "sha256": hashlib.sha256(old_side).hexdigest(),
                     "owner": "demo",
+                    "mode": "100644",
                 }
             )
             mapping.write_text(
@@ -4721,6 +4801,10 @@ os._exit(73)
                     "package/SKILL.md": "1" * 40,
                     "package/assets/data.bin": "2" * 40,
                 },
+                "upstream_modes": {
+                    main_target: "100644",
+                    side_target: "100755",
+                },
             }
 
             result = module.apply_v2_update(update)
@@ -4728,6 +4812,7 @@ os._exit(73)
             self.assertTrue(result.applied)
             self.assertIn("# New", main_path.read_text(encoding="utf-8"))
             self.assertEqual(b"\x00\xffnew", side_path.read_bytes())
+            self.assertEqual(0o755, side_path.stat().st_mode & 0o777)
             recorded = json.loads(mapping.read_text(encoding="utf-8"))
             entry = recorded["skills"][0]
             tracking = entry["origins"][0]["tracking"]
@@ -4746,8 +4831,131 @@ os._exit(73)
                 {main_target, side_target},
                 {item["path"] for item in entry["managed_files"]},
             )
+            self.assertEqual(
+                "100755",
+                next(
+                    item
+                    for item in entry["managed_files"]
+                    if item["path"] == side_target
+                )["mode"],
+            )
             self.assertEqual(artifacts, entry["origins"][0]["artifacts"])
             self.assertEqual("v2.0.0", entry["upstream"]["ref"])
+
+    def test_v2_apply_commits_mode_repair_when_mapping_is_already_authoritative(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+            target = "skills/ai-workflow/demo/SKILL.md"
+            local = root / target
+            local.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            local.write_bytes(content)
+            local.chmod(0o644)
+            commit = "a" * 40
+            today = module.date.today().isoformat()
+            artifacts = [
+                {
+                    "source": "package/SKILL.md",
+                    "target": target,
+                    "type": "file",
+                }
+            ]
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": target,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "package/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": artifacts,
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                                "resolved_commit": commit,
+                                "path_commit": commit,
+                                "content_sha256": hashlib.sha256(
+                                    content
+                                ).hexdigest(),
+                                "last_checked_at": today,
+                                "last_synced_at": today,
+                                "license_checkpoint": (
+                                    mock_license_checkpoint(commit)
+                                ),
+                            },
+                        }
+                    ],
+                },
+                content,
+            )
+            entry["managed_files"][0]["mode"] = "100755"
+            entry["upstream"].update(
+                {
+                    "ref": "v1.0.0",
+                    "path_commit": commit,
+                    "last_checked_at": today,
+                    "last_synced_at": today,
+                    "last_synced_commit": commit,
+                }
+            )
+            payload = {
+                "schema_version": 2,
+                "video": {"checked_at": today},
+                "official_references": [],
+                "skills": [entry],
+            }
+            mapping = module.SOURCE_MAPPINGS_DIR / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_bytes(module.serialize_mapping_json(payload))
+            before = mapping.read_bytes()
+            skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": target,
+                "sync_mode": "replace",
+                "tracking": {
+                    "channel": "latest_release",
+                    "ref": "v1.0.0",
+                },
+                "artifacts": artifacts,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "local_path": local,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            update = {
+                "skill": skill,
+                "changes": "artifact_changed",
+                "current_commit": commit,
+                "path_commit": commit,
+                "resolved_ref": "v1.0.0",
+                "license_evidence": mock_license_checkpoint(commit),
+                "upstream_files": {target: content},
+                "source_blobs": {"package/SKILL.md": "1" * 40},
+                "upstream_modes": {target: "100755"},
+            }
+            original_merge = module.merge_frontmatter
+            module.merge_frontmatter = lambda local_text, _upstream: local_text
+            try:
+                result = module.apply_v2_update(update)
+            finally:
+                module.merge_frontmatter = original_merge
+
+            self.assertTrue(result.applied)
+            self.assertEqual(0o755, local.stat().st_mode & 0o777)
+            self.assertEqual(before, mapping.read_bytes())
 
     def test_v2_mapping_write_failure_rolls_back_prepared_artifact_tree(self):
         module = load_module()
@@ -4839,6 +5047,7 @@ os._exit(73)
                     main_target: b"---\nname: demo\n---\n# New\n"
                 },
                 "source_blobs": {"package/SKILL.md": "1" * 40},
+                "upstream_modes": {main_target: "100644"},
             }
             original_writer = module.atomic_write_json
             def fail_before_replace(path, data, **kwargs):

--- a/tests/test_sync_upstream.py
+++ b/tests/test_sync_upstream.py
@@ -1,15 +1,153 @@
+import base64
+import hashlib
 import importlib.util
 import io
 import json
 import tempfile
 import textwrap
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
 
+from scripts.github_artifact_provider import (
+    ArtifactInventory,
+    GitHubArtifactProvider,
+    GitHubUnavailable,
+    LicenseEvidence,
+    ResolvedRef,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "sync_upstream.py"
+
+
+def git_blob_sha(data: bytes) -> str:
+    return hashlib.sha1(
+        f"blob {len(data)}\0".encode("ascii") + data
+    ).hexdigest()
+
+
+def external_skill_content(slug: str, repo: str) -> bytes:
+    return (
+        "---\n"
+        f"name: {slug}\n"
+        f"source: github:{repo}\n"
+        f"source_url: https://github.com/{repo}\n"
+        "license: MIT\n"
+        "---\n"
+        f"# {slug}\n"
+    ).encode("utf-8")
+
+
+def mock_license_evidence(
+    commit: str = "b" * 40,
+    *,
+    spdx: str = "MIT",
+    api_spdx: str | None = None,
+) -> LicenseEvidence:
+    return LicenseEvidence(
+        path="LICENSE",
+        blob_sha="e" * 40,
+        content_sha256=hashlib.sha256(spdx.encode("utf-8")).hexdigest(),
+        resolved_commit=commit,
+        spdx_candidates=(spdx,),
+        api_spdx=spdx if api_spdx is None else api_spdx,
+    )
+
+
+def mock_license_checkpoint(
+    commit: str = "b" * 40,
+    *,
+    spdx: str = "MIT",
+    api_spdx: str | None = None,
+) -> dict:
+    evidence = mock_license_evidence(
+        commit,
+        spdx=spdx,
+        api_spdx=api_spdx,
+    )
+    return {
+        "path": evidence.path,
+        "blob_sha": evidence.blob_sha,
+        "content_sha256": evidence.content_sha256,
+        "spdx": spdx,
+        "resolved_commit": commit,
+        "api_spdx": evidence.api_spdx,
+    }
+
+
+def complete_v2_entry(entry: dict, content: bytes) -> dict:
+    """Fill strict v2 sync fields for focused loader fixtures."""
+    entry = json.loads(json.dumps(entry))
+    slug = entry["normalized_slug"]
+    external_repo = next(
+        str(origin["repo"])
+        for origin in entry["origins"]
+        if not str(origin.get("repo", "")).startswith("local-repo/")
+    )
+    entry.setdefault("video_name", slug)
+    entry.setdefault("status", "verified_in_repo")
+    entry.setdefault("source", f"https://github.com/{external_repo}")
+    entry.setdefault("notes", "Strict v2 synchronization fixture.")
+    entry.setdefault("sync_mode", entry["origins"][0]["sync_mode"])
+    entry.setdefault(
+        "managed_files",
+        [
+            {
+                "path": entry["repo_skill"],
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "owner": slug,
+            }
+        ],
+    )
+    for origin in entry["origins"]:
+        origin.setdefault("path", origin.get("artifacts", [{}])[0].get("source"))
+        origin.setdefault(
+            "license",
+            None if str(origin.get("repo", "")).startswith("local-repo/") else "MIT",
+        )
+        tracking = origin.setdefault("tracking", {})
+        tracking.setdefault(
+            "channel",
+            "local"
+            if str(origin.get("repo", "")).startswith("local-repo/")
+            else "default_branch",
+        )
+        tracking.setdefault("ref", "local" if tracking["channel"] == "local" else "main")
+        if not isinstance(tracking.get("resolved_commit"), str) or len(
+            tracking["resolved_commit"]
+        ) not in {40, 64}:
+            tracking["resolved_commit"] = "a" * 40
+        if not isinstance(tracking.get("path_commit"), str) or len(
+            tracking["path_commit"]
+        ) not in {40, 64}:
+            tracking["path_commit"] = "b" * 40
+        tracking.setdefault(
+            "content_sha256", hashlib.sha256(content).hexdigest()
+        )
+        tracking.setdefault("last_checked_at", "2026-01-01")
+        tracking.setdefault("last_synced_at", "2026-01-01")
+    external = next(
+        origin
+        for origin in entry["origins"]
+        if not str(origin.get("repo", "")).startswith("local-repo/")
+    )
+    tracking = external["tracking"]
+    entry.setdefault(
+        "upstream",
+        {
+            "repo": external["repo"],
+            "path": external["path"],
+            "ref": tracking["ref"],
+            "sync_mode": external["sync_mode"],
+            "last_checked_at": tracking["last_checked_at"],
+            "last_synced_at": tracking["last_synced_at"],
+            "last_synced_commit": tracking["resolved_commit"],
+            "path_commit": tracking["path_commit"],
+        },
+    )
+    return entry
 
 
 def load_module():
@@ -90,7 +228,9 @@ class SyncUpstreamTests(unittest.TestCase):
     def test_check_only_is_strictly_read_only_by_default(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
-            mapping = Path(tmpdir) / "source.skills.json"
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            mapping = root / "source.skills.json"
             skill = self._mapping_fixture(mapping)
             before = mapping.read_bytes()
             calls = []
@@ -112,7 +252,9 @@ class SyncUpstreamTests(unittest.TestCase):
     def test_check_only_record_check_explicitly_updates_mapping(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
-            mapping = Path(tmpdir) / "source.skills.json"
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            mapping = root / "source.skills.json"
             skill = self._mapping_fixture(mapping)
             before = mapping.read_bytes()
 
@@ -176,6 +318,7 @@ class SyncUpstreamTests(unittest.TestCase):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
+            module.REPO_ROOT = root
             mapping = root / "source.skills.json"
             skill = self._mapping_fixture(mapping)
             local_path = root / "SKILL.md"
@@ -226,6 +369,94 @@ class SyncUpstreamTests(unittest.TestCase):
                 today,
                 recorded["skills"][0]["upstream"]["last_synced_at"],
             )
+
+    def test_legacy_apply_uses_global_mapping_skill_lock_order(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            mapping = root / "source.skills.json"
+            skill = self._mapping_fixture(mapping)
+            local_path = (
+                root
+                / "skills"
+                / "ai-workflow"
+                / "demo-skill"
+                / "SKILL.md"
+            )
+            local_path.parent.mkdir(parents=True)
+            local_path.write_text("# Old\n", encoding="utf-8")
+            skill.update(
+                {
+                    "local_path": local_path,
+                    "local_content": "# Old\n",
+                    "sync_mode": "replace",
+                }
+            )
+            update = {
+                "skill": skill,
+                "upstream_path": "SKILL.md",
+                "upstream_content": "# New\n",
+                "changes": "body_changed",
+            }
+            events: list[str] = []
+
+            @contextmanager
+            def global_guard(path):
+                self.assertEqual(root, path)
+                events.append("global-enter")
+                yield object()
+                events.append("global-exit")
+
+            @contextmanager
+            def mapping_lock(path):
+                self.assertEqual(mapping, path)
+                events.append("mapping-enter")
+                yield
+                events.append("mapping-exit")
+
+            @contextmanager
+            def skill_lock(repo_root, skill_root, *, timeout):
+                self.assertEqual(root, repo_root)
+                self.assertEqual(
+                    "skills/ai-workflow/demo-skill",
+                    skill_root,
+                )
+                self.assertEqual(10.0, timeout)
+                events.append("skill-enter")
+                yield
+                events.append("skill-exit")
+
+            original_global = module.durable_batch_lock_and_recover
+            original_mapping = module.mapping_advisory_lock
+            original_engine = module._load_artifact_engine
+            original_aux = module.sync_github_auxiliary_files
+            module.durable_batch_lock_and_recover = global_guard
+            module.mapping_advisory_lock = mapping_lock
+            module._load_artifact_engine = lambda: SimpleNamespace(
+                skill_advisory_lock=skill_lock
+            )
+            module.sync_github_auxiliary_files = lambda *_args: 0
+            try:
+                self.assertEqual(0, module.apply_legacy_update(update, None))
+            finally:
+                module.durable_batch_lock_and_recover = original_global
+                module.mapping_advisory_lock = original_mapping
+                module._load_artifact_engine = original_engine
+                module.sync_github_auxiliary_files = original_aux
+
+            self.assertEqual(
+                [
+                    "global-enter",
+                    "mapping-enter",
+                    "skill-enter",
+                    "skill-exit",
+                    "mapping-exit",
+                    "global-exit",
+                ],
+                events,
+            )
+            self.assertIn("# New", local_path.read_text(encoding="utf-8"))
 
     def test_apply_dry_run_leaves_skill_and_mapping_unchanged(self):
         module = load_module()
@@ -412,7 +643,7 @@ class SyncUpstreamTests(unittest.TestCase):
         self.assertEqual(expected, observed)
         self.assertEqual(observed["total"], sum(value for key, value in observed.items() if key != "total"))
 
-    def test_v2_apply_update_is_blocked_without_any_write(self):
+    def test_v2_apply_rejects_incomplete_mapping_without_any_write(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -458,12 +689,12 @@ class SyncUpstreamTests(unittest.TestCase):
                 module.update_mapping_after_sync = original_sync_write
                 module.sync_github_auxiliary_files = original_aux
 
-            self.assertEqual(2, exit_code)
-            self.assertIn("legacy single-file/sibling writer", output)
+            self.assertEqual(1, exit_code)
+            self.assertIn("FAILED", output)
             self.assertEqual(mapping_before, mapping.read_bytes())
             self.assertEqual(skill_before, local_path.read_bytes())
 
-    def test_v2_record_check_is_blocked_without_legacy_timestamp_write(self):
+    def test_v2_record_check_rejects_incomplete_observation_without_write(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
             mapping = Path(tmpdir) / "source.skills.json"
@@ -490,8 +721,8 @@ class SyncUpstreamTests(unittest.TestCase):
             finally:
                 module.update_mapping_after_check = original_update
 
-            self.assertEqual(2, exit_code)
-            self.assertIn("origin-aware artifact-set writer", output)
+            self.assertEqual(1, exit_code)
+            self.assertIn("Failed to record check atomically", output)
             self.assertEqual(before, mapping.read_bytes())
 
     def test_v1_apply_requires_explicit_allow_v1_and_writes_nothing_by_default(self):
@@ -687,6 +918,70 @@ class SyncUpstreamTests(unittest.TestCase):
                 self.assertIn("strict integer 2 is required", loaded[0]["load_error"])
                 self.assertNotIn("attacker/legacy", json.dumps(loaded[0], default=str))
 
+    def test_real_v2_mapping_scope_includes_active_external_snapshots(self):
+        module = load_module()
+
+        loaded = module.load_skills_with_upstream()
+        snapshots = [
+            skill for skill in loaded if skill.get("kind") == "snapshot"
+        ]
+
+        self.assertEqual(151, len(loaded))
+        self.assertEqual(12, len(snapshots))
+        self.assertTrue(
+            all(skill.get("expected_skip_reason") for skill in snapshots)
+        )
+
+    def test_snapshot_is_expected_skipped_without_network(self):
+        module = load_module()
+        module._ACTIVE_ARTIFACT_PROVIDER = SimpleNamespace(
+            resolve_tracking=lambda *_args: self.fail(
+                "snapshot must not resolve a network ref"
+            )
+        )
+        skill = {
+            "name": "archived-value",
+            "schema_version": 2,
+            "kind": "snapshot",
+            "repo": "owner/repo",
+            "expected_skip_reason": "licensed snapshot",
+        }
+
+        result = module.check_upstream_changes(skill, None)
+
+        self.assertEqual("expected_skipped", result["changes"])
+        self.assertEqual("licensed snapshot", result["reason"])
+
+    def test_snapshot_only_main_keeps_token_and_provider_fully_lazy(self):
+        module = load_module()
+        skill = {
+            "name": "archived-value",
+            "schema_version": 2,
+            "kind": "snapshot",
+            "repo": "owner/repo",
+            "source": "github:owner/repo",
+            "expected_skip_reason": "licensed snapshot",
+        }
+        original_load = module.load_skills_with_upstream
+        original_resolve = module.resolve_github_token
+        original_provider = module.GitHubArtifactProvider
+        module.load_skills_with_upstream = lambda **_kwargs: [skill]
+        module.resolve_github_token = lambda: self.fail(
+            "snapshot-only run must not resolve credentials"
+        )
+        module.GitHubArtifactProvider = lambda *_args, **_kwargs: self.fail(
+            "snapshot-only run must not construct a provider"
+        )
+        try:
+            with redirect_stdout(io.StringIO()):
+                exit_code = module.main(["--check-only"])
+        finally:
+            module.load_skills_with_upstream = original_load
+            module.resolve_github_token = original_resolve
+            module.GitHubArtifactProvider = original_provider
+
+        self.assertEqual(0, exit_code)
+
     def test_explicit_allow_v1_loads_headerless_legacy_mapping(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -749,11 +1044,13 @@ class SyncUpstreamTests(unittest.TestCase):
                                 "normalized_slug": "demo-skill",
                                 "status": "verified_in_repo",
                                 "kind": "mirror",
+                                "sync_mode": "monitor",
                                 "repo_skill": repo_skill,
                                 "origins": [
                                     {
                                         "repo": "trusted/owner",
                                         "path": None,
+                                        "license": "MIT",
                                         "sync_mode": "monitor",
                                         "artifacts": [
                                             {
@@ -763,10 +1060,25 @@ class SyncUpstreamTests(unittest.TestCase):
                                             }
                                         ],
                                         "tracking": {
+                                            "channel": "default_branch",
                                             "ref": "main",
-                                            "resolved_commit": "reviewed",
-                                            "path_commit": "reviewed-path",
+                                            "resolved_commit": "a" * 40,
+                                            "path_commit": "b" * 40,
+                                            "content_sha256": hashlib.sha256(
+                                                local_path.read_bytes()
+                                            ).hexdigest(),
+                                            "last_checked_at": "2026-01-01",
+                                            "last_synced_at": "2026-01-01",
                                         },
+                                    }
+                                ],
+                                "managed_files": [
+                                    {
+                                        "path": repo_skill,
+                                        "sha256": hashlib.sha256(
+                                            local_path.read_bytes()
+                                        ).hexdigest(),
+                                        "owner": "demo-skill",
                                     }
                                 ],
                             }
@@ -834,6 +1146,7 @@ class SyncUpstreamTests(unittest.TestCase):
                                 "normalized_slug": "demo-skill",
                                 "status": "verified_in_repo",
                                 "kind": "mirror",
+                                "sync_mode": "monitor",
                                 "repo_skill": "skills/ai-workflow/demo-skill/SKILL.md",
                                 "source": "https://github.com/attacker/legacy",
                                 "upstream": {
@@ -847,6 +1160,7 @@ class SyncUpstreamTests(unittest.TestCase):
                                     {
                                         "repo": "trusted/owner",
                                         "path": "canonical/SKILL.md",
+                                        "license": "MIT",
                                         "sync_mode": "monitor",
                                         "artifacts": [
                                             {
@@ -855,10 +1169,25 @@ class SyncUpstreamTests(unittest.TestCase):
                                             }
                                         ],
                                         "tracking": {
+                                            "channel": "default_branch",
                                             "ref": "main",
-                                            "resolved_commit": "trusted-checkpoint",
-                                            "path_commit": "trusted-path-checkpoint",
+                                            "resolved_commit": "a" * 40,
+                                            "path_commit": "b" * 40,
+                                            "content_sha256": hashlib.sha256(
+                                                local_path.read_bytes()
+                                            ).hexdigest(),
+                                            "last_checked_at": "2026-01-01",
+                                            "last_synced_at": "2026-01-01",
                                         },
+                                    }
+                                ],
+                                "managed_files": [
+                                    {
+                                        "path": "skills/ai-workflow/demo-skill/SKILL.md",
+                                        "sha256": hashlib.sha256(
+                                            local_path.read_bytes()
+                                        ).hexdigest(),
+                                        "owner": "demo-skill",
                                     }
                                 ],
                             }
@@ -881,8 +1210,8 @@ class SyncUpstreamTests(unittest.TestCase):
             self.assertEqual("canonical/SKILL.md", loaded[0]["upstream_path"])
             self.assertEqual("main", loaded[0]["ref"])
             self.assertEqual("monitor", loaded[0]["sync_mode"])
-            self.assertEqual("trusted-checkpoint", loaded[0]["last_synced_commit"])
-            self.assertEqual("trusted-path-checkpoint", loaded[0]["path_commit"])
+            self.assertEqual("a" * 40, loaded[0]["last_synced_commit"])
+            self.assertEqual("b" * 40, loaded[0]["path_commit"])
             self.assertNotIn("attacker", json.dumps(loaded[0], default=str))
 
     def test_v2_loader_fails_closed_when_target_has_no_owner(self):
@@ -905,6 +1234,7 @@ class SyncUpstreamTests(unittest.TestCase):
                                 "normalized_slug": "demo-skill",
                                 "status": "verified_in_repo",
                                 "kind": "mirror",
+                                "sync_mode": "replace",
                                 "repo_skill": "skills/ai-workflow/demo-skill/SKILL.md",
                                 "upstream": {
                                     "repo": "attacker/legacy",
@@ -914,6 +1244,7 @@ class SyncUpstreamTests(unittest.TestCase):
                                     {
                                         "repo": "trusted/owner",
                                         "path": "other/SKILL.md",
+                                        "license": "MIT",
                                         "sync_mode": "replace",
                                         "artifacts": [
                                             {
@@ -921,7 +1252,26 @@ class SyncUpstreamTests(unittest.TestCase):
                                                 "target": "skills/ai-workflow/other/SKILL.md",
                                             }
                                         ],
-                                        "tracking": {"ref": "v1.0.0"},
+                                        "tracking": {
+                                            "channel": "latest_release",
+                                            "ref": "v1.0.0",
+                                            "resolved_commit": "a" * 40,
+                                            "path_commit": "b" * 40,
+                                            "content_sha256": hashlib.sha256(
+                                                local_path.read_bytes()
+                                            ).hexdigest(),
+                                            "last_checked_at": "2026-01-01",
+                                            "last_synced_at": "2026-01-01",
+                                        },
+                                    }
+                                ],
+                                "managed_files": [
+                                    {
+                                        "path": "skills/ai-workflow/demo-skill/SKILL.md",
+                                        "sha256": hashlib.sha256(
+                                            local_path.read_bytes()
+                                        ).hexdigest(),
+                                        "owner": "demo-skill",
                                     }
                                 ],
                             }
@@ -939,7 +1289,7 @@ class SyncUpstreamTests(unittest.TestCase):
 
             self.assertEqual(1, len(loaded))
             self.assertEqual("", loaded[0]["repo"])
-            self.assertIn("exactly one origin/artifact owner", loaded[0]["load_error"])
+            self.assertIn("exactly one artifact owner", loaded[0]["load_error"])
             self.assertNotIn("attacker/legacy", json.dumps(loaded[0], default=str))
 
     def test_v2_loader_fails_closed_when_target_has_multiple_owners(self):
@@ -954,11 +1304,22 @@ class SyncUpstreamTests(unittest.TestCase):
             owner = lambda name: {
                 "repo": f"trusted/{name}",
                 "path": f"{name}/SKILL.md",
+                "license": "MIT",
                 "sync_mode": "replace",
                 "artifacts": [
                     {"source": f"{name}/SKILL.md", "target": repo_skill}
                 ],
-                "tracking": {"ref": "v1.0.0"},
+                "tracking": {
+                    "channel": "latest_release",
+                    "ref": "v1.0.0",
+                    "resolved_commit": "a" * 40,
+                    "path_commit": "b" * 40,
+                    "content_sha256": hashlib.sha256(
+                        local_path.read_bytes()
+                    ).hexdigest(),
+                    "last_checked_at": "2026-01-01",
+                    "last_synced_at": "2026-01-01",
+                },
             }
             mapping = repo / "docs" / "sources" / "owners.skills.json"
             mapping.parent.mkdir(parents=True)
@@ -972,8 +1333,18 @@ class SyncUpstreamTests(unittest.TestCase):
                                 "normalized_slug": "demo-skill",
                                 "status": "verified_in_repo",
                                 "kind": "mirror",
+                                "sync_mode": "replace",
                                 "repo_skill": repo_skill,
                                 "origins": [owner("one"), owner("two")],
+                                "managed_files": [
+                                    {
+                                        "path": repo_skill,
+                                        "sha256": hashlib.sha256(
+                                            local_path.read_bytes()
+                                        ).hexdigest(),
+                                        "owner": "demo-skill",
+                                    }
+                                ],
                             }
                         ],
                     }
@@ -1024,13 +1395,85 @@ class SyncUpstreamTests(unittest.TestCase):
 
         merged = module.merge_frontmatter(local, upstream)
 
-        self.assertIn('description: "New upstream description."', merged)
+        self.assertIn("description: New upstream description.", merged)
         self.assertIn('version: "1.2.4"', merged)
         self.assertIn("upstream_slug: demo-skill", merged)
         self.assertIn("# New Body", merged)
         self.assertNotIn("# Old Body", merged)
         self.assertIn("LOCAL-QUALITY-SUPPLEMENT:START", merged)
         self.assertIn("Preserve this reviewed local rule.", merged)
+
+    def test_frontmatter_authority_detects_and_applies_permission_revocation(self):
+        module = load_module()
+        local = textwrap.dedent(
+            """\
+            ---
+            name: demo
+            description: Upstream-owned description.
+            zh_description: 本地中文说明
+            version: "1.2.3"
+            author: local-curator
+            source: github:owner/repo
+            source_url: https://github.com/owner/repo
+            license: MIT
+            tags: [demo]
+            created_at: "2026-01-01"
+            updated_at: "2026-01-01"
+            quality: 4
+            complexity: advanced
+            upstream_slug: upstream-demo
+            allowed-tools: Bash Read
+            compatibility: old-runtime
+            disable-model-invocation: true
+            user-invocable: true
+            argument-hint: old-argument
+            ---
+            # Same body
+            """
+        )
+        upstream = textwrap.dedent(
+            """\
+            ---
+            name: demo
+            description: Upstream-owned description.
+            source: github:attacker/ignored
+            version: "99.0.0"
+            compatibility: new-runtime
+            disable-model-invocation: false
+            user-invocable: false
+            argument-hint: new-argument
+            ---
+            # Same body
+            """
+        )
+
+        self.assertFalse(
+            module._main_artifact_equal({}, local.encode(), upstream.encode())
+        )
+        merged = module.merge_frontmatter(local, upstream)
+
+        self.assertNotIn("allowed-tools:", merged)
+        self.assertIn("compatibility: new-runtime", merged)
+        self.assertIn("disable-model-invocation: false", merged)
+        self.assertIn("user-invocable: false", merged)
+        self.assertIn("argument-hint: new-argument", merged)
+        self.assertIn("source: github:owner/repo", merged)
+        self.assertNotIn("github:attacker/ignored", merged)
+        self.assertIn("zh_description: 本地中文说明", merged)
+        self.assertIn("upstream_slug: upstream-demo", merged)
+        self.assertIn('version: "1.2.4"', merged)
+
+        local_authority_only = local.replace(
+            "source: github:owner/repo",
+            "source: github:local/changed",
+        ).replace('version: "1.2.3"', 'version: "7.8.9"')
+        self.assertTrue(
+            module._main_artifact_equal(
+                {},
+                local.encode(),
+                local_authority_only.encode(),
+            )
+        )
 
     def test_repository_adaptation_rewrites_addyosmani_shared_references(self):
         module = load_module()
@@ -1383,7 +1826,9 @@ class SyncUpstreamTests(unittest.TestCase):
     def test_update_mapping_after_check_only_syncs_equal_body(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
-            mapping = Path(tmpdir) / "source.skills.json"
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            mapping = root / "source.skills.json"
             mapping.write_text(
                 json.dumps(
                     {
@@ -1668,6 +2113,3259 @@ class SyncUpstreamTests(unittest.TestCase):
                 "# Identity\n",
                 (local_dir / "references" / "identity.md").read_text(encoding="utf-8"),
             )
+
+    def test_github_provider_resolves_stable_release_and_fetches_binary_directory_once(self):
+        commit = "c" * 40
+        skill_data = b"# Skill\n"
+        binary_data = b"\x00\xff\x10"
+        skill_blob = git_blob_sha(skill_data)
+        binary_blob = git_blob_sha(binary_data)
+        calls = {}
+
+        def fake_api(url):
+            calls[url] = calls.get(url, 0) + 1
+            if url.endswith("/releases/latest"):
+                return {
+                    "tag_name": "v2.0.0",
+                    "draft": False,
+                    "prerelease": False,
+                }
+            if url.endswith("/commits/v2.0.0"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "package/SKILL.md",
+                            "type": "blob",
+                            "mode": "100644",
+                            "sha": skill_blob,
+                        },
+                        {
+                            "path": "package/assets/logo.bin",
+                            "type": "blob",
+                            "mode": "100755",
+                            "sha": binary_blob,
+                        },
+                    ],
+                }
+            if url.endswith(f"/git/blobs/{skill_blob}"):
+                return {
+                    "encoding": "base64",
+                    "content": base64.b64encode(skill_data).decode(),
+                    "size": len(skill_data),
+                }
+            if url.endswith(f"/git/blobs/{binary_blob}"):
+                return {
+                    "encoding": "base64",
+                    "content": base64.b64encode(binary_data).decode(),
+                    "size": len(binary_data),
+                }
+            raise AssertionError(url)
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        tracking = {"channel": "latest_release", "ref": "latest"}
+        artifacts = [
+            {
+                "type": "file",
+                "source": "package/SKILL.md",
+                "target": "skills/ai/demo/SKILL.md",
+            },
+            {
+                "type": "directory",
+                "source": "package/assets",
+                "target": "skills/ai/demo/static",
+            },
+        ]
+
+        first = provider.fetch_artifacts("owner/repo", tracking, artifacts)
+        second = provider.fetch_artifacts("owner/repo", tracking, artifacts)
+
+        self.assertEqual("v2.0.0", first.resolved.ref)
+        self.assertEqual(commit, first.resolved.commit)
+        self.assertEqual(
+            b"\x00\xff\x10",
+            first.files["skills/ai/demo/static/logo.bin"],
+        )
+        self.assertEqual(first, second)
+        self.assertTrue(all(count == 1 for count in calls.values()), calls)
+
+    def test_github_provider_rejects_symlink_mode_for_file_artifact(self):
+        commit = "c" * 40
+        symlink_payload = b"../outside"
+        symlink_blob = git_blob_sha(symlink_payload)
+
+        def fake_api(url):
+            if url.endswith(f"/commits/{commit}"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "package/SKILL.md",
+                            "type": "blob",
+                            "mode": "120000",
+                            "sha": symlink_blob,
+                            "size": len(symlink_payload),
+                        }
+                    ],
+                }
+            raise AssertionError(url)
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        with self.assertRaisesRegex(
+            GitHubUnavailable,
+            "requires manual review.*120000",
+        ):
+            provider.fetch_artifacts(
+                "owner/repo",
+                {"channel": "fixed_ref", "ref": commit},
+                [
+                    {
+                        "source": "package/SKILL.md",
+                        "target": "skills/ai/demo/SKILL.md",
+                    }
+                ],
+            )
+
+    def test_github_provider_allows_unrelated_symlink_outside_declared_source(self):
+        commit = "c" * 40
+        skill_payload = b"# Security Pen Testing\n"
+        skill_blob = git_blob_sha(skill_payload)
+        unrelated_symlink_payload = b"../../../engineering-team/skills/a11y-audit"
+        unrelated_symlink_blob = git_blob_sha(unrelated_symlink_payload)
+        source = "engineering-team/skills/security-pen-testing/SKILL.md"
+
+        def fake_api(url):
+            if url.endswith(f"/commits/{commit}"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": source,
+                            "type": "blob",
+                            "mode": "100644",
+                            "sha": skill_blob,
+                            "size": len(skill_payload),
+                        },
+                        {
+                            "path": ".codex/skills/a11y-audit",
+                            "type": "blob",
+                            "mode": "120000",
+                            "sha": unrelated_symlink_blob,
+                            "size": len(unrelated_symlink_payload),
+                        },
+                    ],
+                }
+            if url.endswith(f"/git/blobs/{skill_blob}"):
+                return {
+                    "encoding": "base64",
+                    "content": base64.b64encode(skill_payload).decode(),
+                    "size": len(skill_payload),
+                }
+            raise AssertionError(url)
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        inventory = provider.fetch_artifacts(
+            "alirezarezvani/claude-skills",
+            {"channel": "fixed_ref", "ref": commit},
+            [
+                {
+                    "source": source,
+                    "target": (
+                        "skills/security-and-reliability/"
+                        "security-pen-testing/SKILL.md"
+                    ),
+                }
+            ],
+        )
+
+        self.assertEqual(
+            skill_payload,
+            inventory.files[
+                "skills/security-and-reliability/"
+                "security-pen-testing/SKILL.md"
+            ],
+        )
+
+    def test_github_provider_directory_fails_closed_on_special_or_unknown_entry(self):
+        commit = "c" * 40
+        regular_payload = b"regular"
+        regular_blob = git_blob_sha(regular_payload)
+        cases = (
+            ("symlink", "blob", "120000"),
+            ("gitlink", "commit", "160000"),
+            ("unknown-mode", "blob", "100600"),
+            ("missing-mode", "blob", None),
+            ("unknown-type", "mystery", "100644"),
+        )
+
+        for name, item_type, mode in cases:
+            with self.subTest(name=name):
+                def fake_api(url):
+                    if url.endswith(f"/commits/{commit}"):
+                        return {"sha": commit}
+                    if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                        return {
+                            "truncated": False,
+                            "tree": [
+                                {
+                                    "path": "package/assets/regular.bin",
+                                    "type": "blob",
+                                    "mode": "100644",
+                                    "sha": regular_blob,
+                                    "size": len(regular_payload),
+                                },
+                                {
+                                    "path": f"package/assets/{name}",
+                                    "type": item_type,
+                                    "mode": mode,
+                                    "sha": "d" * 40,
+                                },
+                            ],
+                        }
+                    raise AssertionError(url)
+
+                provider = GitHubArtifactProvider(api_get=fake_api)
+                with self.assertRaisesRegex(
+                    GitHubUnavailable,
+                    "requires manual review",
+                ):
+                    provider.fetch_artifacts(
+                        "owner/repo",
+                        {"channel": "fixed_ref", "ref": commit},
+                        [
+                            {
+                                "type": "directory",
+                                "source": "package/assets",
+                                "target": "skills/ai/demo/assets",
+                            }
+                        ],
+                    )
+
+    def test_github_provider_fixed_ref_requires_full_commit(self):
+        provider = GitHubArtifactProvider(
+            api_get=lambda _url: self.fail("short fixed ref must not hit network")
+        )
+        with self.assertRaises(GitHubUnavailable):
+            provider.resolve_tracking(
+                "owner/repo",
+                {"channel": "fixed_ref", "ref": "v1.0.0"},
+            )
+
+    def test_github_provider_truncated_tree_falls_back_to_nonrecursive_git_trees(self):
+        commit = "c" * 40
+        blob_data = b"# Skill\n"
+        blob = git_blob_sha(blob_data)
+
+        def fake_api(url):
+            if url.endswith(f"/commits/{commit}"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {"truncated": True, "tree": []}
+            if url.endswith(f"/git/trees/{commit}"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "package",
+                            "type": "tree",
+                            "mode": "040000",
+                            "sha": "d" * 40,
+                        }
+                    ],
+                }
+            if url.endswith(f"/git/trees/{'d' * 40}"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "SKILL.md",
+                            "type": "blob",
+                            "mode": "100644",
+                            "sha": blob,
+                            "size": len(blob_data),
+                        }
+                    ],
+                }
+            if url.endswith(f"/git/blobs/{blob}"):
+                return {
+                    "encoding": "base64",
+                    "content": base64.b64encode(blob_data).decode(),
+                    "size": len(blob_data),
+                }
+            raise AssertionError(url)
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        inventory = provider.fetch_artifacts(
+            "owner/repo",
+            {"channel": "fixed_ref", "ref": commit},
+            [
+                {
+                    "source": "package/SKILL.md",
+                    "target": "skills/ai/demo/SKILL.md",
+                }
+            ],
+        )
+
+        self.assertEqual(
+            b"# Skill\n", inventory.files["skills/ai/demo/SKILL.md"]
+        )
+
+    def test_github_provider_truncated_walk_preserves_but_does_not_descend_special_objects(self):
+        commit = "c" * 40
+        package_tree = "d" * 40
+        blob_data = b"# Skill\n"
+        blob = git_blob_sha(blob_data)
+
+        def fake_api(url):
+            if url.endswith(f"/commits/{commit}"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {"truncated": True, "tree": []}
+            if url.endswith(f"/git/trees/{commit}"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "package",
+                            "type": "tree",
+                            "mode": "040000",
+                            "sha": package_tree,
+                        },
+                        {
+                            "path": "unrelated-symlink",
+                            "type": "blob",
+                            "mode": "120000",
+                            "sha": "e" * 40,
+                        },
+                        {
+                            "path": "unrelated-submodule",
+                            "type": "commit",
+                            "mode": "160000",
+                            "sha": "f" * 40,
+                        },
+                    ],
+                }
+            if url.endswith(f"/git/trees/{package_tree}"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "SKILL.md",
+                            "type": "blob",
+                            "mode": "100644",
+                            "sha": blob,
+                            "size": len(blob_data),
+                        }
+                    ],
+                }
+            if url.endswith(f"/git/blobs/{blob}"):
+                return {
+                    "encoding": "base64",
+                    "content": base64.b64encode(blob_data).decode(),
+                    "size": len(blob_data),
+                }
+            raise AssertionError(
+                f"special Git objects must not be traversed or fetched: {url}"
+            )
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        inventory = provider.fetch_artifacts(
+            "owner/repo",
+            {"channel": "fixed_ref", "ref": commit},
+            [
+                {
+                    "source": "package/SKILL.md",
+                    "target": "skills/ai/demo/SKILL.md",
+                }
+            ],
+        )
+
+        self.assertEqual(
+            b"# Skill\n", inventory.files["skills/ai/demo/SKILL.md"]
+        )
+        tree = provider.tree("owner/repo", commit)
+        self.assertEqual("120000", tree["unrelated-symlink"]["mode"])
+        self.assertEqual("160000", tree["unrelated-submodule"]["mode"])
+
+    def test_github_provider_nested_truncated_tree_fails_closed(self):
+        commit = "c" * 40
+        child = "d" * 40
+
+        def fake_api(url):
+            if url.endswith(f"/commits/{commit}"):
+                return {"sha": commit}
+            if url.endswith(f"/git/trees/{commit}?recursive=1"):
+                return {"truncated": True, "tree": []}
+            if url.endswith(f"/git/trees/{commit}"):
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "path": "package",
+                            "type": "tree",
+                            "mode": "040000",
+                            "sha": child,
+                        }
+                    ],
+                }
+            if url.endswith(f"/git/trees/{child}"):
+                return {"truncated": True, "tree": []}
+            raise AssertionError(url)
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        with self.assertRaisesRegex(
+            GitHubUnavailable, "complete non-recursive Git tree unavailable"
+        ):
+            provider.tree("owner/repo", commit)
+
+    def test_github_provider_rejects_unsafe_identifiers_and_encodes_path_query(self):
+        seen = []
+
+        def fake_api(url):
+            seen.append(url)
+            if "/commits?" in url:
+                return [{"sha": "c" * 40}]
+            return {
+                "status": "ahead",
+                "ahead_by": 1,
+                "behind_by": 0,
+            }
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        with self.assertRaisesRegex(GitHubUnavailable, "repository slug"):
+            provider.resolve_commit("owner/repo/extra", "main")
+        with self.assertRaisesRegex(GitHubUnavailable, "safe paths"):
+            provider.fetch_artifacts(
+                "owner/repo",
+                {"channel": "fixed_ref", "ref": "a" * 40},
+                [{"source": "../SKILL.md", "target": "skills/demo/SKILL.md"}],
+            )
+
+        with self.assertRaisesRegex(
+            GitHubUnavailable, "base and head must be full commit"
+        ):
+            provider.compare("owner/repo", "base/branch", "head?value")
+        provider.compare("owner/repo", "a" * 40, "b" * 40)
+        self.assertTrue(
+            seen[-1].endswith(
+                f"/compare/{'a' * 40}...{'b' * 40}"
+            ),
+            seen[-1],
+        )
+        with self.assertRaisesRegex(
+            GitHubUnavailable, "query ref must be a full commit"
+        ):
+            provider.path_commit("owner/repo", "main", "path/SKILL.md")
+        self.assertEqual(
+            "c" * 40,
+            provider.path_commit(
+                "owner/repo",
+                "d" * 40,
+                "dir/space name.md?x",
+            ),
+        )
+        self.assertIn(
+            f"sha={'d' * 40}&path=dir%2Fspace+name.md%3Fx&per_page=1",
+            seen[-1],
+        )
+
+    def test_github_provider_strict_blob_base64_size_and_hash_validation(self):
+        valid = b"binary\x00payload"
+        valid_sha = git_blob_sha(valid)
+        cases = (
+            (
+                "base64",
+                valid_sha,
+                {
+                    "encoding": "base64",
+                    "content": "@@@=",
+                    "size": len(valid),
+                },
+                "invalid base64",
+            ),
+            (
+                "size",
+                valid_sha,
+                {
+                    "encoding": "base64",
+                    "content": base64.b64encode(valid).decode(),
+                    "size": len(valid) + 1,
+                },
+                "size mismatch",
+            ),
+            (
+                "hash",
+                "a" * 40,
+                {
+                    "encoding": "base64",
+                    "content": base64.b64encode(valid).decode(),
+                    "size": len(valid),
+                },
+                "hash mismatch",
+            ),
+        )
+        for label, sha, response, message in cases:
+            with self.subTest(case=label):
+                provider = GitHubArtifactProvider(
+                    api_get=lambda _url, response=response: response
+                )
+                with self.assertRaisesRegex(GitHubUnavailable, message):
+                    provider.blob("owner/repo", sha)
+
+        whitespace_content = "\n ".join(
+            [
+                base64.b64encode(valid).decode()[:8],
+                base64.b64encode(valid).decode()[8:],
+            ]
+        )
+        provider = GitHubArtifactProvider(
+            api_get=lambda _url: {
+                "encoding": "base64",
+                "content": whitespace_content,
+                "size": len(valid),
+            }
+        )
+        self.assertEqual(valid, provider.blob("owner/repo", valid_sha))
+
+    def test_commit_bound_license_evidence_is_binary_strict_and_text_classified(self):
+        # Graphify's NOASSERTION license bytes normalize exactly to GitHub's
+        # canonical Apache-2.0 template.
+        apache = (
+            REPO_ROOT
+            / "skills"
+            / "developer-engineering"
+            / "mcp-builder"
+            / "LICENSE.txt"
+        ).read_bytes()
+        apache_sha = git_blob_sha(apache)
+        commit = "a" * 40
+        seen = []
+
+        def response(**overrides):
+            value = {
+                "path": "LICENSE",
+                "sha": apache_sha,
+                "size": len(apache),
+                "encoding": "base64",
+                "content": base64.b64encode(apache).decode("ascii"),
+                "license": {"spdx_id": "NOASSERTION"},
+            }
+            value.update(overrides)
+            return value
+
+        def fake_api(url):
+            seen.append(url)
+            return response()
+
+        provider = GitHubArtifactProvider(api_get=fake_api)
+        evidence = provider.license_evidence("owner/repo", commit)
+
+        self.assertTrue(
+            seen[-1].endswith(f"/license?ref={commit}"),
+            seen[-1],
+        )
+        self.assertEqual("LICENSE", evidence.path)
+        self.assertEqual(apache_sha, evidence.blob_sha)
+        self.assertEqual(hashlib.sha256(apache).hexdigest(), evidence.content_sha256)
+        self.assertEqual(("Apache-2.0",), evidence.spdx_candidates)
+        self.assertEqual("NOASSERTION", evidence.api_spdx)
+        self.assertEqual(evidence, provider.license_evidence("owner/repo", commit))
+        self.assertEqual(1, len(seen))
+
+        invalid_cases = (
+            ("path", response(path="../LICENSE"), "license path"),
+            ("base64", response(content="@@@="), "base64 license"),
+            ("size", response(size=len(apache) + 1), "size mismatch"),
+            ("hash", response(sha="b" * 40), "blob hash mismatch"),
+        )
+        for label, payload, expected in invalid_cases:
+            with self.subTest(case=label):
+                strict_provider = GitHubArtifactProvider(
+                    api_get=lambda _url, payload=payload: payload
+                )
+                with self.assertRaisesRegex(GitHubUnavailable, expected):
+                    strict_provider.license_evidence("owner/repo", commit)
+
+        with self.assertRaisesRegex(
+            GitHubUnavailable, "full immutable commit"
+        ):
+            provider.license_evidence("owner/repo", "main")
+
+        spoofed = (
+            b"This work is not licensed under Apache License Version 2.0.",
+            (
+                b"Permission is hereby granted, free of charge, to any person "
+                b"obtaining a copy"
+            ),
+            (
+                b"Redistribution and use in source and binary forms are "
+                b"permitted, including the forbidden advertising clause."
+            ),
+        )
+        for raw in spoofed:
+            with self.subTest(spoof=raw[:24]):
+                self.assertEqual(
+                    (),
+                    GitHubArtifactProvider._detect_license_spdx(raw),
+                )
+
+    def test_license_evidence_requires_unique_stable_declared_spdx(self):
+        module = load_module()
+        evidence = mock_license_evidence(
+            spdx="Apache-2.0",
+            api_spdx="NOASSERTION",
+        )
+        checkpoint, error = module._validate_license_evidence(
+            {"license": "Apache-2.0", "tracking": {}},
+            evidence,
+        )
+        self.assertIsNone(error)
+        self.assertEqual("Apache-2.0", checkpoint["spdx"])
+        public_checkpoint, public_error = module.validate_license_evidence(
+            "Apache-2.0",
+            evidence,
+        )
+        self.assertIsNone(public_error)
+        self.assertEqual(
+            module.license_checkpoint(evidence),
+            public_checkpoint,
+        )
+
+        _checkpoint, mismatch = module._validate_license_evidence(
+            {"license": "MIT", "tracking": {}},
+            evidence,
+        )
+        self.assertIn("does not match origin.license", mismatch)
+
+        ambiguous = LicenseEvidence(
+            path="LICENSE",
+            blob_sha="e" * 40,
+            content_sha256="f" * 64,
+            resolved_commit="b" * 40,
+            spdx_candidates=("Apache-2.0", "MIT"),
+            api_spdx="NOASSERTION",
+        )
+        _checkpoint, ambiguity = module._validate_license_evidence(
+            {"license": "Apache-2.0", "tracking": {}},
+            ambiguous,
+        )
+        self.assertIn("2 canonical SPDX matches", ambiguity)
+
+        explicit_api = LicenseEvidence(
+            path="LICENSE",
+            blob_sha="e" * 40,
+            content_sha256="f" * 64,
+            resolved_commit="b" * 40,
+            spdx_candidates=(),
+            api_spdx="MIT",
+        )
+        explicit_checkpoint, explicit_error = (
+            module.validate_license_evidence("MIT", explicit_api)
+        )
+        self.assertIsNone(explicit_error)
+        self.assertEqual("MIT", explicit_checkpoint["spdx"])
+
+        previous = mock_license_checkpoint(
+            spdx="Apache-2.0",
+            api_spdx="NOASSERTION",
+        )
+        previous["content_sha256"] = "0" * 64
+        _checkpoint, changed = module._validate_license_evidence(
+            {
+                "license": "Apache-2.0",
+                "tracking": {"license_checkpoint": previous},
+            },
+            evidence,
+        )
+        self.assertIn("evidence changed", changed)
+
+    def test_v2_license_checkpoint_rejects_api_spdx_conflict(self):
+        module = load_module()
+        content = external_skill_content("demo", "owner/repo")
+        entry = complete_v2_entry(
+            {
+                "normalized_slug": "demo",
+                "kind": "overlay",
+                "sync_mode": "monitor",
+                "repo_skill": "skills/ai-workflow/demo/SKILL.md",
+                "origins": [
+                    {
+                        "repo": "owner/repo",
+                        "path": "upstream/SKILL.md",
+                        "license": "MIT",
+                        "sync_mode": "monitor",
+                        "artifacts": [
+                            {
+                                "source": "upstream/SKILL.md",
+                                "target": (
+                                    "skills/ai-workflow/demo/SKILL.md"
+                                ),
+                                "type": "file",
+                            }
+                        ],
+                    }
+                ],
+            },
+            content,
+        )
+        tracking = entry["origins"][0]["tracking"]
+        tracking["license_checkpoint"] = mock_license_checkpoint(
+            tracking["resolved_commit"],
+            spdx="MIT",
+            api_spdx="Apache-2.0",
+        )
+
+        errors = module._v2_sync_entry_errors(entry)
+
+        self.assertTrue(
+            any("api_spdx conflicts" in error for error in errors),
+            errors,
+        )
+
+    def test_v2_monitor_same_reviewed_checkpoint_ignores_curated_divergence(self):
+        for channel, sync_mode in (
+            ("default_branch", "replace"),
+            ("canary", "replace"),
+            ("fixed_ref", "monitor"),
+            ("latest_release", "monitor"),
+        ):
+            with self.subTest(channel=channel, sync_mode=sync_mode):
+                module = load_module()
+                checkpoint = "a" * 40
+                path_checkpoint = "c" * 40
+                refreshed_path_checkpoint = "d" * 40
+                upstream = b"# Upstream body intentionally differs\n"
+
+                class Provider:
+                    def resolve_tracking(self, _repo, _tracking):
+                        return ResolvedRef(channel, "reviewed-ref", checkpoint)
+
+                    def license_evidence(self, _repo, commit):
+                        self.assertEqual(checkpoint, commit)
+                        return mock_license_evidence(commit)
+
+                    def compare(self, *_args):
+                        self.fail(
+                            "an exact reviewed checkpoint must not be compared"
+                        )
+
+                    def fetch_artifacts(self, _repo, _tracking, _artifacts):
+                        return ArtifactInventory(
+                            {
+                                (
+                                    "skills/ai-workflow/curated-demo/"
+                                    "SKILL.md"
+                                ): upstream
+                            },
+                            {"upstream/SKILL.md": "1" * 40},
+                            ResolvedRef(
+                                channel, "reviewed-ref", checkpoint
+                            ),
+                        )
+
+                    def path_commit(self, _repo, ref, path):
+                        self.assertEqual(checkpoint, ref)
+                        self.assertEqual("upstream", path)
+                        return refreshed_path_checkpoint
+
+                provider = Provider()
+                provider.assertEqual = self.assertEqual
+                provider.fail = self.fail
+                module._ACTIVE_ARTIFACT_PROVIDER = provider
+                skill = {
+                    "schema_version": 2,
+                    "name": "curated-demo",
+                    "repo": "owner/repo",
+                    "license": "MIT",
+                    "repo_skill": "skills/ai-workflow/curated-demo/SKILL.md",
+                    "upstream_path": "upstream/SKILL.md",
+                    "origin_path": "upstream",
+                    "tracking": {
+                        "channel": channel,
+                        "ref": "reviewed-ref",
+                        "resolved_commit": checkpoint,
+                        "path_commit": path_checkpoint,
+                        "content_sha256": "1" * 64,
+                        "license_checkpoint": mock_license_checkpoint(
+                            checkpoint
+                        ),
+                    },
+                    "sync_mode": sync_mode,
+                    "last_synced_commit": checkpoint,
+                    "artifacts": [
+                        {
+                            "source": "upstream/SKILL.md",
+                            "target": (
+                                "skills/ai-workflow/curated-demo/SKILL.md"
+                            ),
+                            "type": "file",
+                        }
+                    ],
+                    "managed_files": [
+                        {
+                            "path": (
+                                "skills/ai-workflow/curated-demo/SKILL.md"
+                            ),
+                            # This intentionally describes locally curated
+                            # bytes rather than an upstream mirror.
+                            "sha256": "2" * 64,
+                        }
+                    ],
+                }
+
+                result = module.check_upstream_changes(skill, None)
+
+                self.assertEqual("none", result["changes"])
+                self.assertEqual(checkpoint, result["current_commit"])
+                self.assertEqual(
+                    refreshed_path_checkpoint, result["path_commit"]
+                )
+                self.assertEqual("identical", result["relation"])
+                self.assertEqual(
+                    ["skills/ai-workflow/curated-demo/SKILL.md"],
+                    result["changed_files"],
+                )
+                self.assertEqual(
+                    mock_license_checkpoint(checkpoint),
+                    result["license_evidence"],
+                )
+                self.assertIn("upstream_files", result)
+
+    def test_v2_monitor_same_checkpoint_missing_artifact_is_unavailable(self):
+        module = load_module()
+        checkpoint = "a" * 40
+
+        class Provider:
+            def resolve_tracking(self, _repo, _tracking):
+                return ResolvedRef("default_branch", "main", checkpoint)
+
+            def license_evidence(self, _repo, commit):
+                return mock_license_evidence(commit)
+
+            def fetch_artifacts(self, *_args):
+                raise module.ArtifactNotFound(["missing/SKILL.md"])
+
+            def moved_candidates(self, *_args, **_kwargs):
+                return {}
+
+            def path_commit(self, *_args):
+                self.fail("a missing artifact has no valid path checkpoint")
+
+        provider = Provider()
+        provider.fail = self.fail
+        module._ACTIVE_ARTIFACT_PROVIDER = provider
+        result = module.check_upstream_changes(
+            {
+                "schema_version": 2,
+                "name": "curated-demo",
+                "repo": "owner/repo",
+                "license": "MIT",
+                "repo_skill": (
+                    "skills/ai-workflow/curated-demo/SKILL.md"
+                ),
+                "upstream_path": "missing/SKILL.md",
+                "origin_path": "missing",
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": checkpoint,
+                    "path_commit": "c" * 40,
+                    "content_sha256": "1" * 64,
+                },
+                "sync_mode": "monitor",
+                "last_synced_commit": checkpoint,
+                "artifacts": [
+                    {
+                        "source": "missing/SKILL.md",
+                        "target": (
+                            "skills/ai-workflow/curated-demo/SKILL.md"
+                        ),
+                        "type": "file",
+                    }
+                ],
+            },
+            None,
+        )
+
+        self.assertEqual("unavailable", result["changes"])
+        self.assertIn("missing/SKILL.md", result["reason"])
+        self.assertEqual({}, result["moved_candidates"])
+
+    def test_v2_monitor_same_checkpoint_still_rejects_license_drift(self):
+        module = load_module()
+        checkpoint = "a" * 40
+
+        class Provider:
+            def resolve_tracking(self, _repo, _tracking):
+                return ResolvedRef("default_branch", "main", checkpoint)
+
+            def license_evidence(self, _repo, commit):
+                evidence = mock_license_evidence(commit)
+                return LicenseEvidence(
+                    path=evidence.path,
+                    blob_sha=evidence.blob_sha,
+                    content_sha256="0" * 64,
+                    resolved_commit=evidence.resolved_commit,
+                    spdx_candidates=evidence.spdx_candidates,
+                    api_spdx=evidence.api_spdx,
+                )
+
+            def fetch_artifacts(self, *_args):
+                self.fail("license drift must fail before artifact fetch")
+
+        provider = Provider()
+        provider.fail = self.fail
+        module._ACTIVE_ARTIFACT_PROVIDER = provider
+        result = module.check_upstream_changes(
+            {
+                "schema_version": 2,
+                "name": "curated-demo",
+                "repo": "owner/repo",
+                "license": "MIT",
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": checkpoint,
+                    "path_commit": "c" * 40,
+                    "content_sha256": "1" * 64,
+                    "license_checkpoint": mock_license_checkpoint(
+                        checkpoint
+                    ),
+                },
+                "sync_mode": "monitor",
+                "last_synced_commit": checkpoint,
+                "artifacts": [
+                    {
+                        "source": "upstream/SKILL.md",
+                        "target": (
+                            "skills/ai-workflow/curated-demo/SKILL.md"
+                        ),
+                        "type": "file",
+                    }
+                ],
+            },
+            None,
+        )
+
+        self.assertEqual("unavailable", result["changes"])
+        self.assertIn("license evidence changed", result["reason"])
+
+    def test_v2_monitor_different_checkpoint_always_requires_review(self):
+        for relation_status in ("ahead", "diverged", "identical"):
+            with self.subTest(relation=relation_status), tempfile.TemporaryDirectory() as tmpdir:
+                module = load_module()
+                root = Path(tmpdir)
+                module.REPO_ROOT = root
+                target = "skills/ai-workflow/curated-demo/SKILL.md"
+                local = b"---\nname: curated-demo\n---\n# Same body\n"
+                local_path = root / target
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                local_path.write_bytes(local)
+
+                class Provider:
+                    def resolve_tracking(self, _repo, _tracking):
+                        return ResolvedRef(
+                            "default_branch", "main", "b" * 40
+                        )
+
+                    def license_evidence(self, _repo, commit):
+                        return mock_license_evidence(commit)
+
+                    def compare(self, _repo, base, head):
+                        self.assertEqual("a" * 40, base)
+                        self.assertEqual("b" * 40, head)
+                        return {
+                            "status": relation_status,
+                            "ahead_by": 1,
+                            "behind_by": 0,
+                        }
+
+                    def fetch_artifacts(self, _repo, _tracking, _artifacts):
+                        return ArtifactInventory(
+                            {target: local},
+                            {"upstream/SKILL.md": "1" * 40},
+                            ResolvedRef(
+                                "default_branch", "main", "b" * 40
+                            ),
+                        )
+
+                    def path_commit(self, _repo, ref, _path):
+                        self.assertEqual("b" * 40, ref)
+                        return "d" * 40
+
+                provider = Provider()
+                provider.assertEqual = self.assertEqual
+                module._ACTIVE_ARTIFACT_PROVIDER = provider
+                result = module.check_upstream_changes(
+                    {
+                        "schema_version": 2,
+                        "name": "curated-demo",
+                        "repo": "owner/repo",
+                        "license": "MIT",
+                        "repo_skill": target,
+                        "upstream_path": "upstream/SKILL.md",
+                        "origin_path": "upstream",
+                        "tracking": {
+                            "channel": "default_branch",
+                            "ref": "main",
+                            "resolved_commit": "a" * 40,
+                            "path_commit": "c" * 40,
+                            "content_sha256": hashlib.sha256(local).hexdigest(),
+                            "license_checkpoint": mock_license_checkpoint(
+                                "a" * 40
+                            ),
+                        },
+                        "sync_mode": "monitor",
+                        "last_synced_commit": "a" * 40,
+                        "artifacts": [
+                            {
+                                "source": "upstream/SKILL.md",
+                                "target": target,
+                                "type": "file",
+                            }
+                        ],
+                        "managed_files": [
+                            {
+                                "path": target,
+                                "sha256": hashlib.sha256(local).hexdigest(),
+                            }
+                        ],
+                    },
+                    None,
+                )
+
+                self.assertEqual("monitor_review", result["changes"])
+                self.assertEqual(relation_status, result["relation"])
+                self.assertEqual([], result["changed_files"])
+                self.assertEqual("d" * 40, result["path_commit"])
+
+    def test_v2_sidecar_only_change_on_default_branch_requires_monitor_review(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            side_target = "skills/ai-workflow/demo/references/guide.bin"
+            for relative, raw in (
+                (main_target, b"---\nname: demo\n---\n# Same\n"),
+                (side_target, b"\x00old"),
+            ):
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(raw)
+
+            class Provider:
+                def resolve_tracking(self, _repo, _tracking):
+                    return ResolvedRef("default_branch", "main", "b" * 40)
+
+                def license_evidence(self, _repo, commit):
+                    return mock_license_evidence(commit)
+
+                def compare(self, *_args):
+                    return {"status": "ahead", "ahead_by": 1, "behind_by": 0}
+
+                def fetch_artifacts(self, _repo, _tracking, _artifacts):
+                    return ArtifactInventory(
+                        {
+                            main_target: b"---\nname: demo\n---\n# Same\n",
+                            side_target: b"\x00new",
+                        },
+                        {"upstream/SKILL.md": "1" * 40, "upstream/guide.bin": "2" * 40},
+                        ResolvedRef("default_branch", "main", "b" * 40),
+                    )
+
+                def path_commit(self, _repo, ref, _path):
+                    if ref != "b" * 40:
+                        raise AssertionError("path query was not commit-pinned")
+                    return "d" * 40
+
+            module._ACTIVE_ARTIFACT_PROVIDER = Provider()
+            skill = {
+                "schema_version": 2,
+                "name": "demo",
+                "repo": "owner/repo",
+                "license": "MIT",
+                "repo_skill": main_target,
+                "origin_path": "upstream",
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": "a" * 40,
+                    "path_commit": "a" * 40,
+                    "content_sha256": "1" * 64,
+                },
+                "sync_mode": "monitor",
+                "last_synced_commit": "a" * 40,
+                "artifacts": [
+                    {
+                        "source": "upstream",
+                        "target": "skills/ai-workflow/demo",
+                        "type": "directory",
+                    }
+                ],
+                "managed_files": [
+                    {"path": main_target},
+                    {"path": side_target},
+                ],
+            }
+
+            result = module.check_upstream_changes(skill, None)
+
+            self.assertEqual("monitor_review", result["changes"])
+            self.assertEqual([side_target], result["changed_files"])
+            self.assertEqual([], result["added_files"])
+            self.assertEqual("d" * 40, result["path_commit"])
+
+    def test_stable_frontmatter_only_change_is_not_equal_or_recorded_as_synced(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            upstream_path = "upstream/SKILL.md"
+            local = (
+                "---\n"
+                "name: demo\n"
+                "description: A sufficiently detailed original description.\n"
+                "source: github:owner/repo\n"
+                "source_url: https://github.com/owner/repo\n"
+                "license: MIT\n"
+                'version: "1.0.0"\n'
+                'updated_at: "2026-01-01"\n'
+                "---\n"
+                "# Same body\n"
+            ).encode("utf-8")
+            upstream = (
+                "---\n"
+                "name: demo\n"
+                "description: A materially revised upstream description.\n"
+                'version: "9.9.9"\n'
+                'updated_at: "2099-01-01"\n'
+                "---\n"
+                "# Same body\n"
+            ).encode("utf-8")
+            local_path = root / repo_skill
+            local_path.parent.mkdir(parents=True)
+            local_path.write_bytes(local)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": upstream_path,
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": [
+                                {
+                                    "source": upstream_path,
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                                "resolved_commit": "a" * 40,
+                                "path_commit": "c" * 40,
+                                "content_sha256": hashlib.sha256(
+                                    local
+                                ).hexdigest(),
+                            },
+                        }
+                    ],
+                },
+                local,
+            )
+            mapping = (
+                module.SOURCE_MAPPINGS_DIR / "frontmatter.skills.json"
+            )
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {},
+                        "official_references": [],
+                        "skills": [entry],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            class Provider:
+                def resolve_tracking(self, _repo, _tracking):
+                    return ResolvedRef(
+                        "latest_release", "v2.0.0", "b" * 40
+                    )
+
+                def license_evidence(self, _repo, commit):
+                    return mock_license_evidence(commit)
+
+                def compare(self, *_args):
+                    return {
+                        "status": "ahead",
+                        "ahead_by": 1,
+                        "behind_by": 0,
+                    }
+
+                def fetch_artifacts(self, _repo, _tracking, _artifacts):
+                    return ArtifactInventory(
+                        {repo_skill: upstream},
+                        {upstream_path: "f" * 40},
+                        ResolvedRef(
+                            "latest_release", "v2.0.0", "b" * 40
+                        ),
+                    )
+
+                def path_commit(self, _repo, ref, _path):
+                    if ref != "b" * 40:
+                        raise AssertionError(
+                            "path query was not pinned to the resolved commit"
+                        )
+                    return "d" * 40
+
+            module._ACTIVE_ARTIFACT_PROVIDER = Provider()
+            skill = module._v2_loaded_skill(entry, mapping, 0)
+            self.assertIsNotNone(skill)
+
+            result = module.check_upstream_changes(skill, None)
+
+            self.assertEqual("artifact_changed", result["changes"])
+            self.assertEqual([repo_skill], result["changed_files"])
+            self.assertEqual("f" * 40, result["main_source_blob"])
+            module.record_v2_checks([result])
+            recorded = json.loads(mapping.read_text(encoding="utf-8"))
+            tracking = recorded["skills"][0]["origins"][0]["tracking"]
+            self.assertEqual("v1.0.0", tracking["ref"])
+            self.assertEqual("a" * 40, tracking["resolved_commit"])
+            self.assertEqual("c" * 40, tracking["path_commit"])
+            self.assertEqual(
+                hashlib.sha256(local).hexdigest(),
+                tracking["content_sha256"],
+            )
+            self.assertEqual(
+                module.date.today().isoformat(),
+                tracking["last_checked_at"],
+            )
+            self.assertEqual(
+                mock_license_checkpoint(),
+                tracking["license_checkpoint"],
+            )
+
+            metadata_noise = upstream.replace(
+                b"A materially revised upstream description.",
+                b"A sufficiently detailed original description.",
+            )
+            self.assertTrue(
+                module._main_artifact_equal(skill, local, metadata_noise)
+            )
+            self.assertFalse(
+                module._main_artifact_equal(
+                    skill,
+                    local,
+                    upstream.replace(b"name: demo", b"name: renamed-demo"),
+                )
+            )
+
+    def test_v2_binary_change_on_stable_release_is_auto_syncable(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            binary_target = "skills/ai-workflow/demo/assets/data.bin"
+            for relative, raw in (
+                (main_target, b"# Same\n"),
+                (binary_target, b"\x00old"),
+            ):
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(raw)
+
+            class Provider:
+                def resolve_tracking(self, _repo, _tracking):
+                    return ResolvedRef("latest_release", "v2", "a" * 40)
+
+                def license_evidence(self, _repo, commit):
+                    return mock_license_evidence(commit)
+
+                def fetch_artifacts(self, _repo, _tracking, _artifacts):
+                    return ArtifactInventory(
+                        {
+                            main_target: b"# Same\n",
+                            binary_target: b"\x00\xffnew",
+                        },
+                        {"src/SKILL.md": "1" * 40, "src/data.bin": "2" * 40},
+                        ResolvedRef("latest_release", "v2", "a" * 40),
+                    )
+
+                def path_commit(self, _repo, ref, _path):
+                    if ref != "a" * 40:
+                        raise AssertionError("path query was not commit-pinned")
+                    return "b" * 40
+
+            module._ACTIVE_ARTIFACT_PROVIDER = Provider()
+            skill = {
+                "schema_version": 2,
+                "name": "demo",
+                "repo": "owner/repo",
+                "license": "MIT",
+                "repo_skill": main_target,
+                "origin_path": "src",
+                "tracking": {"channel": "latest_release", "ref": "latest"},
+                "sync_mode": "replace",
+                "last_synced_commit": "a" * 40,
+                "artifacts": [
+                    {
+                        "source": "src",
+                        "target": "skills/ai-workflow/demo",
+                        "type": "directory",
+                    }
+                ],
+                "managed_files": [
+                    {"path": main_target},
+                    {"path": binary_target},
+                ],
+            }
+
+            result = module.check_upstream_changes(skill, None)
+
+            self.assertEqual("artifact_changed", result["changes"])
+            self.assertEqual([binary_target], result["changed_files"])
+            self.assertEqual(b"\x00\xffnew", result["upstream_files"][binary_target])
+            self.assertEqual("b" * 40, result["path_commit"])
+
+    def test_overlay_local_origin_sidecar_is_never_classified_for_external_prune(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            local_overlay = "skills/ai-workflow/demo/references/local-policy.md"
+            for relative, raw in (
+                (main_target, b"# Same\n"),
+                (local_overlay, b"# Local policy\n"),
+            ):
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(raw)
+            managed = [
+                {"path": main_target},
+                {"path": local_overlay},
+            ]
+            skill = {
+                "repo_skill": main_target,
+                "artifacts": [
+                    {
+                        "source": "upstream",
+                        "target": "skills/ai-workflow/demo",
+                        "type": "directory",
+                    }
+                ],
+                "other_origin_artifacts": [
+                    {
+                        "source": "curation/local-policy.md",
+                        "target": local_overlay,
+                        "type": "file",
+                    }
+                ],
+                "managed_files": managed,
+            }
+
+            changed, added, removed = module._artifact_diff(
+                skill,
+                {main_target: b"# Same\n"},
+            )
+
+            self.assertEqual([], changed)
+            self.assertEqual([], added)
+            self.assertEqual([], removed)
+
+    def test_artifact_diff_uses_external_ownership_not_incidental_disk_state(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            newly_desired = "skills/ai-workflow/demo/references/new.md"
+            formerly_owned = "skills/ai-workflow/demo/references/old.md"
+            for relative, raw in (
+                (main_target, b"# Same\n"),
+                # Same bytes must not silently grant ownership.
+                (newly_desired, b"# Existing identical bytes\n"),
+            ):
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(raw)
+            skill = {
+                "repo_skill": main_target,
+                "artifacts": [
+                    {
+                        "source": "upstream/SKILL.md",
+                        "target": main_target,
+                        "type": "file",
+                    },
+                    {
+                        "source": "upstream/old.md",
+                        "target": formerly_owned,
+                        "type": "file",
+                    },
+                ],
+                "other_origin_artifacts": [],
+                "managed_files": [
+                    {
+                        "path": main_target,
+                        "sha256": hashlib.sha256(b"# Same\n").hexdigest(),
+                    },
+                    {
+                        "path": formerly_owned,
+                        "sha256": hashlib.sha256(b"# Old\n").hexdigest(),
+                    },
+                ],
+            }
+
+            changed, added, removed = module._artifact_diff(
+                skill,
+                {
+                    main_target: b"# Same\n",
+                    newly_desired: b"# Existing identical bytes\n",
+                },
+            )
+
+            self.assertEqual([], changed)
+            self.assertEqual([newly_desired], added)
+            # Removed remains an inventory delta even though disk is missing.
+            self.assertEqual([formerly_owned], removed)
+
+    def test_v2_missing_source_reports_exact_blob_move_candidates_without_guessing(self):
+        module = load_module()
+
+        class Provider:
+            def resolve_tracking(self, _repo, _tracking):
+                return ResolvedRef("default_branch", "main", "b" * 40)
+
+            def license_evidence(self, _repo, commit):
+                return mock_license_evidence(commit)
+
+            def compare(self, *_args):
+                return {"status": "ahead", "ahead_by": 1, "behind_by": 0}
+
+            def fetch_artifacts(self, *_args):
+                raise module.ArtifactNotFound(["old/SKILL.md"])
+
+            def moved_candidates(self, *_args, **_kwargs):
+                return {"old/SKILL.md": ["new/location/SKILL.md"]}
+
+        module._ACTIVE_ARTIFACT_PROVIDER = Provider()
+        result = module.check_upstream_changes(
+            {
+                "schema_version": 2,
+                "name": "demo",
+                "repo": "owner/repo",
+                "license": "MIT",
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": "a" * 40,
+                    "path_commit": "a" * 40,
+                    "content_sha256": "1" * 64,
+                },
+                "sync_mode": "monitor",
+                "last_synced_commit": "a" * 40,
+                "artifacts": [
+                    {
+                        "source": "old/SKILL.md",
+                        "target": "skills/ai/demo/SKILL.md",
+                    }
+                ],
+            },
+            None,
+        )
+
+        self.assertEqual("unavailable", result["changes"])
+        self.assertEqual(
+            {"old/SKILL.md": ["new/location/SKILL.md"]},
+            result["moved_candidates"],
+        )
+        self.assertNotIn("upstream_files", result)
+
+    def test_v2_monitor_without_complete_checkpoint_is_unavailable_fail_closed(self):
+        module = load_module()
+        module._ACTIVE_ARTIFACT_PROVIDER = SimpleNamespace(
+            resolve_tracking=lambda *_args: self.fail(
+                "incomplete monitor checkpoint must not hit network"
+            )
+        )
+
+        result = module.check_upstream_changes(
+            {
+                "schema_version": 2,
+                "name": "demo",
+                "repo": "owner/repo",
+                "tracking": {
+                    "channel": "default_branch",
+                    "ref": "main",
+                    "resolved_commit": None,
+                    "path_commit": None,
+                    "content_sha256": None,
+                },
+                "sync_mode": "monitor",
+            },
+            None,
+        )
+
+        self.assertEqual("unavailable", result["changes"])
+        self.assertIn("complete reviewed checkpoint", result["reason"])
+        self.assertIn("resolved_commit", result["reason"])
+
+    def test_manual_and_snapshot_policy_skip_only_after_v2_structure_validation(self):
+        for kind, mode, damage in (
+            ("overlay", "manual", "tracking"),
+            ("snapshot", "local-only", "license"),
+        ):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as tmpdir:
+                module = load_module()
+                root = Path(tmpdir)
+                repo_skill = "skills/ai-workflow/demo/SKILL.md"
+                local_path = root / repo_skill
+                local_path.parent.mkdir(parents=True)
+                local_path.write_text(
+                    "---\nname: demo\n---\n# Demo\n", encoding="utf-8"
+                )
+                entry = complete_v2_entry(
+                    {
+                        "video_name": "demo",
+                        "normalized_slug": "demo",
+                        "status": "verified_in_repo",
+                        "kind": kind,
+                        "sync_mode": mode,
+                        "repo_skill": repo_skill,
+                        "origins": [
+                            {
+                                "repo": "owner/repo",
+                                "path": "upstream/SKILL.md",
+                                "sync_mode": mode,
+                                "artifacts": [
+                                    {
+                                        "source": "upstream/SKILL.md",
+                                        "target": repo_skill,
+                                        "type": "file",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    local_path.read_bytes(),
+                )
+                if damage == "tracking":
+                    del entry["origins"][0]["tracking"]["content_sha256"]
+                else:
+                    del entry["origins"][0]["license"]
+                mapping = root / "docs" / "sources" / "invalid.skills.json"
+                mapping.parent.mkdir(parents=True)
+                mapping.write_text(
+                    json.dumps({"schema_version": 2, "skills": [entry]}),
+                    encoding="utf-8",
+                )
+                module.REPO_ROOT = root
+                module.SKILLS_DIR = root / "skills"
+                module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+
+                loaded = module.load_skills_with_upstream()
+
+                self.assertEqual(1, len(loaded))
+                self.assertIn("invalid v2 sync entry", loaded[0]["load_error"])
+                self.assertNotIn("expected_skip_reason", loaded[0])
+
+    def test_record_v2_check_updates_observation_but_not_managed_content(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = mapping.parent
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            local = root / repo_skill
+            local.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            local.write_bytes(content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "overlay",
+                    "sync_mode": "monitor",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "upstream/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "monitor",
+                            "artifacts": [
+                                {
+                                    "source": "upstream/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                content,
+            )
+            old_content = hashlib.sha256(content).hexdigest()
+            old_managed = json.loads(json.dumps(entry["managed_files"]))
+            old_path_commit = entry["origins"][0]["tracking"]["path_commit"]
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {"checked_at": "2026-01-01"},
+                        "official_references": [],
+                        "skills": [entry],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            skill = {
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": repo_skill,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            module.record_v2_checks(
+                [
+                    {
+                        "skill": skill,
+                        "changes": "monitor_review",
+                        "resolved_ref": "main",
+                        "current_commit": "b" * 40,
+                        "path_commit": "b" * 40,
+                        "license_evidence": mock_license_checkpoint(),
+                    }
+                ]
+            )
+
+            recorded = json.loads(mapping.read_text(encoding="utf-8"))
+            entry = recorded["skills"][0]
+            tracking = entry["origins"][0]["tracking"]
+            self.assertEqual("a" * 40, tracking["resolved_commit"])
+            self.assertEqual(old_path_commit, tracking["path_commit"])
+            self.assertEqual("2026-01-01", tracking["last_synced_at"])
+            self.assertEqual("a" * 40, entry["upstream"]["last_synced_commit"])
+            self.assertEqual(old_content, tracking["content_sha256"])
+            self.assertEqual(old_managed, entry["managed_files"])
+
+    def test_record_batch_locks_mapping_and_preserves_other_skill_updates(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+
+            def entry(slug):
+                repo_skill = f"skills/ai-workflow/{slug}/SKILL.md"
+                local = root / repo_skill
+                local.parent.mkdir(parents=True)
+                content = external_skill_content(slug, f"owner/{slug}")
+                local.write_bytes(content)
+                value = complete_v2_entry(
+                    {
+                        "normalized_slug": slug,
+                        "kind": "overlay",
+                        "sync_mode": "monitor",
+                        "repo_skill": repo_skill,
+                        "notes": f"initial-{slug}",
+                        "origins": [
+                            {
+                                "repo": f"owner/{slug}",
+                                "path": f"{slug}/SKILL.md",
+                                "license": "MIT",
+                                "sync_mode": "monitor",
+                                "artifacts": [
+                                    {
+                                        "source": f"{slug}/SKILL.md",
+                                        "target": repo_skill,
+                                        "type": "file",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    content,
+                )
+                value["source"] = f"https://github.com/owner/{slug}"
+                return value
+
+            entries = [entry("one"), entry("two")]
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {},
+                        "official_references": [],
+                        "skills": entries,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            skills = [
+                {
+                    "name": value["normalized_slug"],
+                    "schema_version": 2,
+                    "repo": value["origins"][0]["repo"],
+                    "repo_skill": value["repo_skill"],
+                    "mapping_path": mapping,
+                    "mapping_entry_index": index,
+                    "origin_index": 0,
+                    "mapping_fingerprint": module._entry_origin_fingerprint(
+                        value, 0
+                    ),
+                }
+                for index, value in enumerate(entries)
+            ]
+            # An unrelated field change made after checking must survive.
+            current = json.loads(mapping.read_text(encoding="utf-8"))
+            current["skills"][1]["notes"] = "concurrent-unrelated-update"
+            mapping.write_text(json.dumps(current), encoding="utf-8")
+
+            module.record_v2_checks(
+                [
+                    {
+                        "skill": skill,
+                        "changes": "monitor_review",
+                        "resolved_ref": "main",
+                        "current_commit": "b" * 40,
+                        "path_commit": "b" * 40,
+                        "license_evidence": mock_license_checkpoint(),
+                    }
+                    for skill in skills
+                ]
+            )
+
+            recorded = json.loads(mapping.read_text(encoding="utf-8"))
+            self.assertEqual(
+                "concurrent-unrelated-update",
+                recorded["skills"][1]["notes"],
+            )
+            self.assertTrue(
+                all(
+                    value["origins"][0]["tracking"]["last_checked_at"]
+                    == module.date.today().isoformat()
+                    for value in recorded["skills"]
+                )
+            )
+
+    def test_record_batch_rejects_stale_selected_origin_fingerprint(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = mapping.parent
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            local = root / repo_skill
+            local.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            local.write_bytes(content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "overlay",
+                    "sync_mode": "monitor",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "old/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "monitor",
+                            "artifacts": [
+                                {
+                                    "source": "old/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                content,
+            )
+            skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": repo_skill,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            entry["origins"][0]["path"] = "new/SKILL.md"
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {},
+                        "official_references": [],
+                        "skills": [entry],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            before = mapping.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError, "changed after upstream check"
+            ):
+                module.record_v2_checks(
+                    [
+                        {
+                            "skill": skill,
+                            "changes": "monitor_review",
+                            "resolved_ref": "main",
+                            "current_commit": "b" * 40,
+                            "path_commit": "b" * 40,
+                        }
+                    ]
+                )
+
+            self.assertEqual(before, mapping.read_bytes())
+
+    def test_record_check_recovers_post_mapping_hard_exit_before_reread(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            skill_path = root / repo_skill
+            skill_path.parent.mkdir(parents=True)
+            old_content = external_skill_content("demo", "owner/repo")
+            new_content = old_content.replace(b"# demo", b"# updated demo")
+            skill_path.write_bytes(old_content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "upstream/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": [
+                                {
+                                    "source": "upstream/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                            },
+                        }
+                    ],
+                },
+                old_content,
+            )
+            before_data = {
+                "schema_version": 2,
+                "video": {},
+                "official_references": [],
+                "skills": [entry],
+            }
+            mapping = (
+                root / "docs" / "sources" / "source.skills.json"
+            )
+            mapping.parent.mkdir(parents=True)
+            mapping.write_bytes(module.serialize_mapping_json(before_data))
+            checked_skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": repo_skill,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+
+            after_data = json.loads(json.dumps(before_data))
+            after_entry = after_data["skills"][0]
+            new_digest = hashlib.sha256(new_content).hexdigest()
+            after_entry["managed_files"][0]["sha256"] = new_digest
+            after_tracking = after_entry["origins"][0]["tracking"]
+            after_tracking["content_sha256"] = new_digest
+            after_tracking["resolved_commit"] = "c" * 40
+            after_tracking["path_commit"] = "d" * 40
+            after_tracking["ref"] = "v2.0.0"
+            after_path = mapping.with_suffix(".after")
+            after_bytes = module.serialize_mapping_json(after_data)
+            after_path.write_bytes(after_bytes)
+
+            worker = r"""
+import hashlib
+import os
+import sys
+from pathlib import Path
+from scripts.artifact_set_sync import (
+    plan_artifact_set_sync,
+    prepare_artifact_set_sync,
+)
+
+root = Path(sys.argv[1])
+mapping = Path(sys.argv[2])
+after_path = Path(sys.argv[3])
+skill = "skills/ai-workflow/demo/SKILL.md"
+old = (root / skill).read_bytes()
+new = old.replace(b"# demo", b"# updated demo")
+entry = {
+    "normalized_slug": "demo",
+    "repo_skill": skill,
+    "kind": "mirror",
+    "origins": [{
+        "artifacts": [{
+            "source": "upstream/SKILL.md",
+            "target": skill,
+            "type": "file",
+        }],
+    }],
+    "managed_files": [{
+        "path": skill,
+        "sha256": hashlib.sha256(old).hexdigest(),
+        "owner": "demo",
+    }],
+}
+plan = plan_artifact_set_sync(
+    root,
+    entry,
+    [{
+        "source": "upstream/SKILL.md",
+        "target": skill,
+        "type": "file",
+        "data": new,
+    }],
+    {"resolved_commit": "c" * 40},
+)
+transaction = prepare_artifact_set_sync(plan)
+before_sha = hashlib.sha256(mapping.read_bytes()).hexdigest()
+after_sha = hashlib.sha256(after_path.read_bytes()).hexdigest()
+transaction.bind_authority(
+    mapping.relative_to(root).as_posix(),
+    before_sha,
+    after_sha,
+)
+os.replace(after_path, mapping)
+directory_fd = os.open(
+    mapping.parent,
+    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+)
+os.fsync(directory_fd)
+os.close(directory_fd)
+os._exit(73)
+"""
+            import subprocess
+            import sys
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    worker,
+                    str(root),
+                    str(mapping),
+                    str(after_path),
+                ],
+                cwd=REPO_ROOT,
+                env={
+                    **__import__("os").environ,
+                    "PYTHONPATH": str(REPO_ROOT),
+                },
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(73, completed.returncode, completed.stderr)
+
+            from scripts.artifact_set_sync import (
+                skill_transaction_journal_path,
+            )
+
+            journal = skill_transaction_journal_path(
+                root,
+                "skills/ai-workflow/demo",
+            )
+            self.assertTrue(journal.exists())
+            with self.assertRaisesRegex(
+                RuntimeError, "changed after upstream check"
+            ):
+                module.record_v2_checks(
+                    [
+                        {
+                            "skill": checked_skill,
+                            "changes": "none",
+                            "resolved_ref": "v1.0.0",
+                            "current_commit": "b" * 40,
+                            "path_commit": "b" * 40,
+                            "license_evidence": mock_license_checkpoint(),
+                        }
+                    ]
+                )
+
+            self.assertEqual(after_bytes, mapping.read_bytes())
+            self.assertEqual(new_content, skill_path.read_bytes())
+            self.assertFalse(journal.exists())
+
+    def test_record_check_rejects_symlinked_mapping_ancestor(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            skill_path = root / repo_skill
+            skill_path.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            skill_path.write_bytes(content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "overlay",
+                    "sync_mode": "monitor",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "upstream/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "monitor",
+                            "artifacts": [
+                                {
+                                    "source": "upstream/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                content,
+            )
+            outside = root / "outside"
+            sources = outside / "sources"
+            sources.mkdir(parents=True)
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            (root / "docs").symlink_to(outside, target_is_directory=True)
+            outside_mapping = sources / mapping.name
+            outside_mapping.write_text(
+                json.dumps({"schema_version": 2, "skills": [entry]}),
+                encoding="utf-8",
+            )
+            before = outside_mapping.read_bytes()
+            checked_skill = {
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": repo_skill,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+
+            with self.assertRaises((OSError, RuntimeError)):
+                module.record_v2_checks(
+                    [
+                        {
+                            "skill": checked_skill,
+                            "changes": "monitor_review",
+                            "current_commit": "b" * 40,
+                            "path_commit": "b" * 40,
+                            "license_evidence": mock_license_checkpoint(),
+                        }
+                    ]
+                )
+
+            self.assertEqual(before, outside_mapping.read_bytes())
+            self.assertEqual([], list(sources.glob(".*.tmp")))
+
+    def test_v2_authority_fingerprint_and_revalidation_cover_revocation_fields(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            local = root / repo_skill
+            local.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            local.write_bytes(content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "upstream/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": [
+                                {
+                                    "source": "upstream/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                            },
+                        }
+                    ],
+                },
+                content,
+            )
+            fingerprint = module._entry_origin_fingerprint(entry, 0)
+
+            mutations = (
+                ("kind", lambda value: value.__setitem__("kind", "snapshot")),
+                ("status", lambda value: value.__setitem__("status", "retired")),
+                (
+                    "entry sync mode",
+                    lambda value: value.__setitem__("sync_mode", "monitor"),
+                ),
+                (
+                    "origin repo",
+                    lambda value: value["origins"][0].__setitem__(
+                        "repo", "owner/revoked"
+                    ),
+                ),
+                (
+                    "origin path",
+                    lambda value: value["origins"][0].__setitem__(
+                        "path", "moved/SKILL.md"
+                    ),
+                ),
+                (
+                    "origin license",
+                    lambda value: value["origins"][0].__setitem__(
+                        "license", None
+                    ),
+                ),
+                (
+                    "origin sync mode",
+                    lambda value: value["origins"][0].__setitem__(
+                        "sync_mode", "archived"
+                    ),
+                ),
+                (
+                    "artifact authority",
+                    lambda value: value["origins"][0]["artifacts"][0].__setitem__(
+                        "source", "replacement/SKILL.md"
+                    ),
+                ),
+                (
+                    "tracking channel",
+                    lambda value: value["origins"][0]["tracking"].__setitem__(
+                        "channel", "default_branch"
+                    ),
+                ),
+                (
+                    "tracking ref",
+                    lambda value: value["origins"][0]["tracking"].__setitem__(
+                        "ref", "v2.0.0"
+                    ),
+                ),
+                (
+                    "managed ownership",
+                    lambda value: value["managed_files"][0].__setitem__(
+                        "owner", "revoked"
+                    ),
+                ),
+            )
+            for label, mutate in mutations:
+                with self.subTest(field=label):
+                    candidate = json.loads(json.dumps(entry))
+                    mutate(candidate)
+                    self.assertNotEqual(
+                        fingerprint,
+                        module._entry_origin_fingerprint(candidate, 0),
+                    )
+
+            checked_skill = {
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "mapping_fingerprint": fingerprint,
+            }
+            revoked = json.loads(json.dumps(entry))
+            revoked["status"] = "retired"
+            with self.assertRaisesRegex(
+                RuntimeError, "authority is no longer valid|no longer active"
+            ):
+                module._v2_entry_and_origin(
+                    {"skills": [revoked]},
+                    checked_skill,
+                    for_apply=True,
+                )
+
+            without_fingerprint = dict(checked_skill)
+            without_fingerprint.pop("mapping_fingerprint")
+            with self.assertRaisesRegex(RuntimeError, "fingerprint"):
+                module._v2_entry_and_origin(
+                    {"skills": [entry]},
+                    without_fingerprint,
+                    for_apply=True,
+                )
+
+            monitor = json.loads(json.dumps(entry))
+            monitor["kind"] = "overlay"
+            monitor["sync_mode"] = "monitor"
+            monitor["origins"][0]["sync_mode"] = "monitor"
+            monitor["origins"][0]["tracking"]["channel"] = "default_branch"
+            monitor["origins"][0]["tracking"]["ref"] = "main"
+            monitor_skill = {
+                **checked_skill,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    monitor, 0
+                ),
+            }
+            with self.assertRaisesRegex(
+                RuntimeError, "no longer permits automatic stable apply"
+            ):
+                module._v2_entry_and_origin(
+                    {"skills": [monitor]},
+                    monitor_skill,
+                    for_apply=True,
+                )
+
+    def test_mapping_advisory_lock_rejects_second_writer(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mapping = Path(tmpdir) / "source.skills.json"
+            mapping.write_text("{}\n", encoding="utf-8")
+            with module.mapping_advisory_lock(mapping):
+                with self.assertRaises(module.MappingLockError):
+                    with module.mapping_advisory_lock(mapping, timeout=0):
+                        self.fail("second mapping writer acquired the lock")
+            for invalid in (True, -1, float("nan"), float("inf")):
+                with self.subTest(timeout=invalid), self.assertRaises(
+                    ValueError
+                ):
+                    with module.mapping_advisory_lock(
+                        mapping, timeout=invalid
+                    ):
+                        self.fail("invalid timeout acquired mapping lock")
+
+    def test_apply_rejects_payload_targets_claimed_by_other_origin_scopes(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            exact_target = (
+                "skills/ai-workflow/demo/references/curated.md"
+            )
+            nested_target = (
+                "skills/ai-workflow/demo/templates/nested/config.bin"
+            )
+            main_path = root / main_target
+            main_path.parent.mkdir(parents=True)
+            old_main = external_skill_content("demo", "owner/repo")
+            main_path.write_bytes(old_main)
+            selected_artifacts = [
+                {
+                    "source": "package",
+                    "target": "skills/ai-workflow/demo",
+                    "type": "directory",
+                }
+            ]
+            other_artifacts = [
+                {
+                    "source": exact_target,
+                    "target": exact_target,
+                    "type": "file",
+                },
+                {
+                    "source": "skills/ai-workflow/demo/templates",
+                    "target": "skills/ai-workflow/demo/templates",
+                    "type": "directory",
+                },
+            ]
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "overlay",
+                    "sync_mode": "replace",
+                    "repo_skill": main_target,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "package",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": selected_artifacts,
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                            },
+                        },
+                        {
+                            "repo": "local-repo/curation",
+                            "path": (
+                                "skills/ai-workflow/demo/references"
+                            ),
+                            "license": None,
+                            "sync_mode": "manual",
+                            "artifacts": other_artifacts,
+                            "tracking": {
+                                "channel": "local",
+                                "ref": "local",
+                            },
+                        },
+                    ],
+                },
+                old_main,
+            )
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {},
+                        "official_references": [],
+                        "skills": [entry],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": main_target,
+                "sync_mode": "replace",
+                "tracking": {
+                    "channel": "latest_release",
+                    "ref": "v1.0.0",
+                },
+                "artifacts": selected_artifacts,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "local_path": main_path,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            update = {
+                "skill": skill,
+                "changes": "artifact_changed",
+                "current_commit": "b" * 40,
+                "path_commit": "c" * 40,
+                "resolved_ref": "v2.0.0",
+                "license_evidence": mock_license_checkpoint(),
+                "upstream_files": {
+                    main_target: b"---\nname: demo\n---\n# New\n",
+                    exact_target: b"upstream exact",
+                    nested_target: b"\x00upstream nested",
+                },
+                "source_blobs": {
+                    "package/SKILL.md": "1" * 40,
+                    "package/references/curated.md": "2" * 40,
+                    "package/templates/nested/config.bin": "3" * 40,
+                },
+            }
+            plan_calls = []
+            original_engine_loader = module._load_artifact_engine
+            module._load_artifact_engine = lambda: SimpleNamespace(
+                plan_artifact_set_sync=lambda *_args, **_kwargs: plan_calls.append(
+                    True
+                )
+            )
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "collide with another origin scope"
+                ) as raised:
+                    module.apply_v2_update(update)
+            finally:
+                module._load_artifact_engine = original_engine_loader
+
+            self.assertIn(exact_target, str(raised.exception))
+            self.assertIn(nested_target, str(raised.exception))
+            self.assertEqual([], plan_calls)
+            self.assertEqual(
+                [exact_target, nested_target],
+                module._other_origin_target_conflicts(
+                    entry,
+                    selected_origin_index=0,
+                    desired_targets={
+                        exact_target,
+                        nested_target,
+                        "skills/ai-workflow/demo/other.txt",
+                    },
+                ),
+            )
+
+    def test_candidate_mapping_gate_rejects_repository_unique_claim_conflict(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            module.SOURCE_MAPPINGS_DIR = root / "docs" / "sources"
+            repo_skill = "skills/ai-workflow/demo/SKILL.md"
+            local = root / repo_skill
+            local.parent.mkdir(parents=True)
+            content = external_skill_content("demo", "owner/repo")
+            local.write_bytes(content)
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": repo_skill,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "upstream/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": [
+                                {
+                                    "source": "upstream/SKILL.md",
+                                    "target": repo_skill,
+                                    "type": "file",
+                                }
+                            ],
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                            },
+                        }
+                    ],
+                },
+                content,
+            )
+            data = {
+                "schema_version": 2,
+                "video": {},
+                "official_references": [],
+                "skills": [entry],
+            }
+            module.SOURCE_MAPPINGS_DIR.mkdir(parents=True)
+            candidate = module.SOURCE_MAPPINGS_DIR / "candidate.skills.json"
+            duplicate = module.SOURCE_MAPPINGS_DIR / "duplicate.skills.json"
+            candidate.write_text(json.dumps(data), encoding="utf-8")
+            duplicate.write_text(json.dumps(data), encoding="utf-8")
+            before = candidate.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "candidate mapping failed full provenance validation.*"
+                "duplicate|unique|claimed",
+            ):
+                module._validate_candidate_mappings({candidate: data})
+
+            self.assertEqual(before, candidate.read_bytes())
+            self.assertEqual(
+                [],
+                list(module.SOURCE_MAPPINGS_DIR.glob(".*.validation.skills.json")),
+            )
+
+    def test_v2_apply_commits_artifact_set_and_mapping_in_one_transaction(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            side_target = "skills/ai-workflow/demo/assets/data.bin"
+            main_path = root / main_target
+            side_path = root / side_target
+            main_path.parent.mkdir(parents=True, exist_ok=True)
+            side_path.parent.mkdir(parents=True, exist_ok=True)
+            old_main = (
+                "---\nname: demo\nsource: github:owner/repo\n"
+                "source_url: https://github.com/owner/repo\n"
+                "license: MIT\nversion: \"1.0.0\"\n"
+                "updated_at: \"2026-01-01\"\n---\n# Old\n"
+            ).encode()
+            old_side = b"\x00old"
+            main_path.write_bytes(old_main)
+            side_path.write_bytes(old_side)
+            artifacts = [
+                {
+                    "source": "package",
+                    "target": "skills/ai-workflow/demo",
+                    "type": "directory",
+                },
+            ]
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            module.SOURCE_MAPPINGS_DIR = mapping.parent
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": main_target,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "package",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": artifacts,
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                                "resolved_commit": "a" * 40,
+                                "path_commit": "a" * 40,
+                                "content_sha256": hashlib.sha256(
+                                    old_main
+                                ).hexdigest(),
+                            },
+                        }
+                    ],
+                },
+                old_main,
+            )
+            entry["managed_files"].append(
+                {
+                    "path": side_target,
+                    "sha256": hashlib.sha256(old_side).hexdigest(),
+                    "owner": "demo",
+                }
+            )
+            mapping.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "video": {},
+                        "official_references": [],
+                        "skills": [entry],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": main_target,
+                "sync_mode": "replace",
+                "tracking": {
+                    "channel": "latest_release",
+                    "ref": "v1.0.0",
+                },
+                "artifacts": artifacts,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "local_path": main_path,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            update = {
+                "skill": skill,
+                "changes": "artifact_changed",
+                "current_commit": "b" * 40,
+                "path_commit": "a" * 40,
+                "resolved_ref": "v2.0.0",
+                "license_evidence": mock_license_checkpoint(),
+                "upstream_files": {
+                    main_target: b"---\nname: demo\n---\n# New\n",
+                    side_target: b"\x00\xffnew",
+                },
+                "source_blobs": {
+                    "package/SKILL.md": "1" * 40,
+                    "package/assets/data.bin": "2" * 40,
+                },
+            }
+
+            result = module.apply_v2_update(update)
+
+            self.assertTrue(result.applied)
+            self.assertIn("# New", main_path.read_text(encoding="utf-8"))
+            self.assertEqual(b"\x00\xffnew", side_path.read_bytes())
+            recorded = json.loads(mapping.read_text(encoding="utf-8"))
+            entry = recorded["skills"][0]
+            tracking = entry["origins"][0]["tracking"]
+            self.assertEqual("v2.0.0", tracking["ref"])
+            self.assertEqual("b" * 40, tracking["resolved_commit"])
+            self.assertEqual("a" * 40, tracking["path_commit"])
+            self.assertEqual(
+                hashlib.sha256(main_path.read_bytes()).hexdigest(),
+                tracking["content_sha256"],
+            )
+            self.assertEqual(
+                mock_license_checkpoint(),
+                tracking["license_checkpoint"],
+            )
+            self.assertEqual(
+                {main_target, side_target},
+                {item["path"] for item in entry["managed_files"]},
+            )
+            self.assertEqual(artifacts, entry["origins"][0]["artifacts"])
+            self.assertEqual("v2.0.0", entry["upstream"]["ref"])
+
+    def test_v2_mapping_write_failure_rolls_back_prepared_artifact_tree(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            module.SKILLS_DIR = root / "skills"
+            main_target = "skills/ai-workflow/demo/SKILL.md"
+            main_path = root / main_target
+            main_path.parent.mkdir(parents=True)
+            old_main = (
+                b"---\nname: demo\nsource: github:owner/repo\n"
+                b"source_url: https://github.com/owner/repo\nlicense: MIT\n"
+                b"version: \"1.0.0\"\n---\n# Old\n"
+            )
+            main_path.write_bytes(old_main)
+            artifacts = [
+                {
+                    "source": "package/SKILL.md",
+                    "target": main_target,
+                    "type": "file",
+                }
+            ]
+            mapping = root / "docs" / "sources" / "source.skills.json"
+            mapping.parent.mkdir(parents=True)
+            module.SOURCE_MAPPINGS_DIR = mapping.parent
+            entry = complete_v2_entry(
+                {
+                    "normalized_slug": "demo",
+                    "kind": "mirror",
+                    "sync_mode": "replace",
+                    "repo_skill": main_target,
+                    "origins": [
+                        {
+                            "repo": "owner/repo",
+                            "path": "package/SKILL.md",
+                            "license": "MIT",
+                            "sync_mode": "replace",
+                            "artifacts": artifacts,
+                            "tracking": {
+                                "channel": "latest_release",
+                                "ref": "v1.0.0",
+                                "resolved_commit": "a" * 40,
+                                "path_commit": "a" * 40,
+                                "content_sha256": hashlib.sha256(
+                                    old_main
+                                ).hexdigest(),
+                            },
+                        }
+                    ],
+                },
+                old_main,
+            )
+            payload = {
+                "schema_version": 2,
+                "video": {},
+                "official_references": [],
+                "skills": [entry],
+            }
+            mapping.write_text(json.dumps(payload), encoding="utf-8")
+            mapping_before = mapping.read_bytes()
+            skill = {
+                "name": "demo",
+                "schema_version": 2,
+                "repo": "owner/repo",
+                "repo_skill": main_target,
+                "sync_mode": "replace",
+                "tracking": {
+                    "channel": "latest_release",
+                    "ref": "v1.0.0",
+                },
+                "artifacts": artifacts,
+                "mapping_path": mapping,
+                "mapping_entry_index": 0,
+                "origin_index": 0,
+                "local_path": main_path,
+                "mapping_fingerprint": module._entry_origin_fingerprint(
+                    entry, 0
+                ),
+            }
+            update = {
+                "skill": skill,
+                "changes": "artifact_changed",
+                "current_commit": "b" * 40,
+                "path_commit": "a" * 40,
+                "resolved_ref": "v2.0.0",
+                "license_evidence": mock_license_checkpoint(),
+                "upstream_files": {
+                    main_target: b"---\nname: demo\n---\n# New\n"
+                },
+                "source_blobs": {"package/SKILL.md": "1" * 40},
+            }
+            original_writer = module.atomic_write_json
+            def fail_before_replace(path, data, **kwargs):
+                return original_writer(
+                    path,
+                    data,
+                    **kwargs,
+                    fault_injector=lambda event: (
+                        (_ for _ in ()).throw(OSError("mapping disk full"))
+                        if event == "after_temp_fsync"
+                        else None
+                    ),
+                )
+
+            module.atomic_write_json = fail_before_replace
+            try:
+                with self.assertRaises(module.AtomicMappingWriteError) as raised:
+                    module.apply_v2_update(update)
+            finally:
+                module.atomic_write_json = original_writer
+
+            self.assertFalse(raised.exception.replaced)
+            self.assertEqual(old_main, main_path.read_bytes())
+            self.assertEqual(mapping_before, mapping.read_bytes())
+
+            def fail_after_replace(path, data, **kwargs):
+                return original_writer(
+                    path,
+                    data,
+                    **kwargs,
+                    fault_injector=lambda event: (
+                        (_ for _ in ()).throw(
+                            OSError("mapping directory fsync failed")
+                        )
+                        if event == "after_replace"
+                        else None
+                    ),
+                )
+
+            module.atomic_write_json = fail_after_replace
+            try:
+                with self.assertRaises(
+                    module.AtomicMappingWriteError
+                ) as raised_after:
+                    module.apply_v2_update(update)
+            finally:
+                module.atomic_write_json = original_writer
+
+            self.assertTrue(raised_after.exception.replaced)
+            self.assertIn("# New", main_path.read_text(encoding="utf-8"))
+            recorded = json.loads(mapping.read_text(encoding="utf-8"))
+            self.assertEqual(
+                "b" * 40,
+                recorded["skills"][0]["origins"][0]["tracking"][
+                    "resolved_commit"
+                ],
+            )
+
+    def test_atomic_mapping_writer_rejects_symlink_and_nonregular_targets(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            real = root / "real.json"
+            real.write_text("{}\n", encoding="utf-8")
+            symlink = root / "mapping.json"
+            symlink.symlink_to(real)
+            with self.assertRaises(module.AtomicMappingWriteError) as symlink_error:
+                module.atomic_write_json(symlink, {"safe": True})
+            self.assertFalse(symlink_error.exception.replaced)
+            self.assertEqual("{}\n", real.read_text(encoding="utf-8"))
+
+            symlink.unlink()
+            symlink.symlink_to(root / "missing.json")
+            with self.assertRaises(
+                module.AtomicMappingWriteError
+            ) as broken_symlink_error:
+                module.atomic_write_json(symlink, {"safe": True})
+            self.assertFalse(broken_symlink_error.exception.replaced)
+
+            symlink.unlink()
+            symlink.mkdir()
+            with self.assertRaises(module.AtomicMappingWriteError) as dir_error:
+                module.atomic_write_json(symlink, {"safe": True})
+            self.assertFalse(dir_error.exception.replaced)
+
+            symlink.rmdir()
+            symlink.write_text('{"old": true}\n', encoding="utf-8")
+
+            def swap_temp_inode(event):
+                if event != "after_temp_fsync":
+                    return
+                candidates = list(root.glob(".mapping.json.*.tmp"))
+                self.assertEqual(1, len(candidates))
+                candidates[0].unlink()
+                candidates[0].symlink_to(real)
+
+            with self.assertRaises(module.AtomicMappingWriteError) as inode_error:
+                module.atomic_write_json(
+                    symlink,
+                    {"safe": True},
+                    fault_injector=swap_temp_inode,
+                )
+            self.assertFalse(inode_error.exception.replaced)
+            self.assertEqual(
+                '{"old": true}\n', symlink.read_text(encoding="utf-8")
+            )
+            foreign = list(root.glob(".mapping.json.*.tmp"))
+            self.assertEqual(1, len(foreign))
+            self.assertTrue(foreign[0].is_symlink())
+            foreign[0].unlink()
+
+            sentinel = b"concurrent-regular-occupant"
+
+            def swap_temp_for_regular(event):
+                if event != "after_temp_fsync":
+                    return
+                candidates = list(root.glob(".mapping.json.*.tmp"))
+                self.assertEqual(1, len(candidates))
+                candidates[0].unlink()
+                candidates[0].write_bytes(sentinel)
+
+            with self.assertRaises(module.AtomicMappingWriteError):
+                module.atomic_write_json(
+                    symlink,
+                    {"safe": True},
+                    fault_injector=swap_temp_for_regular,
+                )
+            foreign = list(root.glob(".mapping.json.*.tmp"))
+            self.assertEqual(1, len(foreign))
+            self.assertEqual(sentinel, foreign[0].read_bytes())
+            foreign[0].unlink()
+
+    def test_atomic_mapping_writer_cas_preserves_concurrent_mapping_change(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            mapping = root / "mapping.skills.json"
+            mapping.write_text('{"value": "old"}\n', encoding="utf-8")
+            snapshot = module.capture_mapping_snapshot(mapping)
+            concurrent = b'{"value": "concurrent"}\n'
+
+            def modify_mapping(event):
+                if event == "after_temp_fsync":
+                    mapping.write_bytes(concurrent)
+
+            with self.assertRaises(
+                module.AtomicMappingWriteError
+            ) as raised:
+                module.atomic_write_json(
+                    mapping,
+                    {"value": "new"},
+                    expected_snapshot=snapshot,
+                    fault_injector=modify_mapping,
+                )
+
+            self.assertFalse(raised.exception.replaced)
+            self.assertEqual(concurrent, mapping.read_bytes())
+
+    def test_atomic_mapping_writer_rejects_detached_parent_after_replace(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "mapping.skills.json"
+            before = b'{"value": "old"}\n'
+            racer = b'{"value": "racer"}\n'
+            mapping.write_bytes(before)
+            detached = root / "detached-sources"
+
+            def detach_parent(event):
+                if event != "after_replace":
+                    return
+                sources.rename(detached)
+                sources.mkdir()
+                (sources / mapping.name).write_bytes(racer)
+
+            with self.assertRaises(
+                module.AtomicMappingWriteError
+            ) as raised:
+                module.atomic_write_json(
+                    mapping,
+                    {"value": "new"},
+                    fault_injector=detach_parent,
+                )
+
+            self.assertTrue(raised.exception.replaced)
+            self.assertEqual(racer, mapping.read_bytes())
+            self.assertEqual(
+                module.serialize_mapping_json({"value": "new"}),
+                (detached / mapping.name).read_bytes(),
+            )
+            self.assertEqual([], list(detached.glob(".*.tmp")))
+
+    def test_mapping_batch_rollback_never_overwrites_concurrent_occupant(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            first = root / "first.skills.json"
+            second = root / "second.skills.json"
+            first.write_text('{"value": "old-one"}\n', encoding="utf-8")
+            second.write_text('{"value": "old-two"}\n', encoding="utf-8")
+            concurrent = b'{"value": "concurrent"}\n'
+
+            def replace_then_modify(event, path):
+                if event == "after_replace" and path == first:
+                    first.write_bytes(concurrent)
+                    raise OSError("concurrent writer occupied first mapping")
+
+            with self.assertRaises(
+                module.AtomicMappingBatchError
+            ) as raised:
+                module.atomic_write_json_batch(
+                    {
+                        first: {"value": "new-one"},
+                        second: {"value": "new-two"},
+                    },
+                    fault_injector=replace_then_modify,
+                )
+
+            self.assertFalse(raised.exception.rollback_succeeded)
+            self.assertEqual(concurrent, first.read_bytes())
+            self.assertEqual(
+                b'{"value": "old-two"}\n',
+                second.read_bytes(),
+            )
+            self.assertTrue(raised.exception.recovery_paths)
+            self.assertTrue(
+                any(
+                    b'{"value": "old-one"}' in recovery.read_bytes()
+                    for recovery in raised.exception.recovery_paths
+                )
+            )
+
+    def test_atomic_mapping_batch_rolls_back_first_when_second_replace_fails(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            first = root / "first.skills.json"
+            second = root / "second.skills.json"
+            first.write_text('{"value": "old-one"}\n', encoding="utf-8")
+            second.write_text('{"value": "old-two"}\n', encoding="utf-8")
+            originals = {first: first.read_bytes(), second: second.read_bytes()}
+
+            def fail_second(event, path):
+                if event == "after_replace" and path == second:
+                    raise OSError("second mapping replace fault")
+
+            with self.assertRaises(
+                module.AtomicMappingBatchError
+            ) as raised:
+                module.atomic_write_json_batch(
+                    {
+                        first: {"value": "new-one"},
+                        second: {"value": "new-two"},
+                    },
+                    fault_injector=fail_second,
+                )
+
+            self.assertTrue(raised.exception.rollback_succeeded)
+            self.assertEqual(originals[first], first.read_bytes())
+            self.assertEqual(originals[second], second.read_bytes())
+
+    def test_atomic_mapping_batch_surfaces_recovery_files_when_rollback_fails(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            first = root / "first.skills.json"
+            second = root / "second.skills.json"
+            first.write_text('{"value": "old-one"}\n', encoding="utf-8")
+            second.write_text('{"value": "old-two"}\n', encoding="utf-8")
+
+            def fail_second(event, path):
+                if event == "after_replace" and path == second:
+                    raise OSError("forward fault")
+
+            real_replace = module.os.replace
+
+            def fail_rollback(source, target, **kwargs):
+                if str(source).endswith(".rollback.tmp"):
+                    raise OSError("rollback fault")
+                return real_replace(source, target, **kwargs)
+
+            module.os.replace = fail_rollback
+            try:
+                with self.assertRaises(
+                    module.AtomicMappingBatchError
+                ) as raised:
+                    module.atomic_write_json_batch(
+                        {
+                            first: {"value": "new-one"},
+                            second: {"value": "new-two"},
+                        },
+                        fault_injector=fail_second,
+                    )
+            finally:
+                module.os.replace = real_replace
+
+            self.assertFalse(raised.exception.rollback_succeeded)
+            self.assertTrue(raised.exception.recovery_paths)
+            self.assertTrue(
+                all(path.is_file() for path in raised.exception.recovery_paths)
+            )
+
+    def test_mapping_batch_rejects_detached_parent_after_replace(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "mapping.skills.json"
+            mapping.write_text('{"value": "old"}\n', encoding="utf-8")
+            detached = root / "detached-sources"
+            racer = b'{"value": "racer"}\n'
+
+            def detach_parent(event, path):
+                if event != "after_replace" or path != mapping:
+                    return
+                sources.rename(detached)
+                sources.mkdir()
+                (sources / mapping.name).write_bytes(racer)
+
+            with self.assertRaises(
+                module.AtomicMappingBatchError
+            ) as raised:
+                module.atomic_write_json_batch(
+                    {mapping: {"value": "new"}},
+                    fault_injector=detach_parent,
+                )
+
+            self.assertFalse(raised.exception.rollback_succeeded)
+            self.assertEqual(racer, mapping.read_bytes())
+            self.assertTrue(raised.exception.recovery_paths)
+
+    def test_mapping_batch_rollback_rejects_detached_parent_and_recovers(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            mapping = sources / "mapping.skills.json"
+            original = b'{"value": "old"}\n'
+            racer = b'{"value": "racer"}\n'
+            mapping.write_bytes(original)
+            detached = root / "detached-sources"
+
+            def fail_forward(event, path):
+                if event == "after_replace" and path == mapping:
+                    raise OSError("force rollback")
+
+            real_replace = module.os.replace
+
+            def detach_after_rollback(source, target, **kwargs):
+                result = real_replace(source, target, **kwargs)
+                if str(source).endswith(".rollback.tmp"):
+                    sources.rename(detached)
+                    sources.mkdir()
+                    (sources / mapping.name).write_bytes(racer)
+                return result
+
+            module.os.replace = detach_after_rollback
+            try:
+                with self.assertRaises(
+                    module.AtomicMappingBatchError
+                ) as raised:
+                    module.atomic_write_json_batch(
+                        {mapping: {"value": "new"}},
+                        fault_injector=fail_forward,
+                    )
+            finally:
+                module.os.replace = real_replace
+
+            self.assertFalse(raised.exception.rollback_succeeded)
+            self.assertEqual(racer, mapping.read_bytes())
+            self.assertEqual(original, (detached / mapping.name).read_bytes())
+            self.assertTrue(raised.exception.recovery_paths)
+            self.assertTrue(
+                all(path.is_file() for path in raised.exception.recovery_paths)
+            )
+            self.assertTrue(
+                any(
+                    path.read_bytes() == original
+                    for path in raised.exception.recovery_paths
+                )
+            )
+
+    def test_candidate_validation_cleanup_uses_pinned_parent_inode(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            module.REPO_ROOT = root
+            sources = root / "docs" / "sources"
+            sources.mkdir(parents=True)
+            module.SOURCE_MAPPINGS_DIR = sources
+            mapping = sources / "mapping.skills.json"
+            mapping.write_text('{"schema_version": 2}\n', encoding="utf-8")
+            detached = root / "detached-sources"
+            sentinel = b"do-not-delete"
+
+            original_validate = module.validate_provenance_mapping
+            original_repository_validate = module.validate_repository_mappings
+            module.validate_provenance_mapping = lambda *_args, **_kwargs: []
+
+            def detach_during_validation(paths, _root):
+                staged = next(
+                    path
+                    for path in paths
+                    if path.name.endswith(".validation.skills.json")
+                )
+                sources.rename(detached)
+                sources.mkdir()
+                (sources / staged.name).write_bytes(sentinel)
+                return []
+
+            module.validate_repository_mappings = detach_during_validation
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "cleanup failed safely"
+                ):
+                    module._validate_candidate_mappings(
+                        {mapping: {"schema_version": 2}}
+                    )
+            finally:
+                module.validate_provenance_mapping = original_validate
+                module.validate_repository_mappings = (
+                    original_repository_validate
+                )
+
+            self.assertEqual(
+                [sentinel],
+                [
+                    path.read_bytes()
+                    for path in sources.glob(
+                        ".*.validation.skills.json"
+                    )
+                ],
+            )
+            self.assertEqual(
+                [],
+                list(detached.glob(".*.validation.skills.json")),
+            )
+
+    def test_report_json_exposes_degraded_state_and_conserved_counts(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.json"
+            skill = {
+                "name": "demo",
+                "category": "ai-workflow",
+                "source": "github:owner/repo",
+                "repo": "owner/repo",
+                "schema_version": 2,
+            }
+            exit_code, _output = self._run_main(
+                module,
+                ["--check-only", "--report-json", str(report_path)],
+                [skill],
+                lambda checked, _token: {
+                    "skill": checked,
+                    "changes": "monitor_review",
+                    "current_commit": "a" * 40,
+                },
+            )
+
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(2, exit_code)
+            self.assertEqual("degraded", report["state"])
+            self.assertEqual(
+                report["summary"]["total"],
+                sum(
+                    report["summary"][key]
+                    for key in (
+                        "equal",
+                        "changed",
+                        "monitor_review",
+                        "unavailable",
+                        "rollback",
+                        "expected_skipped",
+                    )
+                ),
+            )
+
+    def test_report_json_exposes_complete_and_failed_states(self):
+        for label, checker, expected_code, expected_state in (
+            (
+                "complete",
+                lambda checked, _token: {
+                    "skill": checked,
+                    "changes": "none",
+                },
+                0,
+                "complete",
+            ),
+            (
+                "failed",
+                lambda _checked, _token: None,
+                1,
+                "failed",
+            ),
+        ):
+            with self.subTest(state=label), tempfile.TemporaryDirectory() as tmpdir:
+                module = load_module()
+                report_path = Path(tmpdir) / "report.json"
+                skill = {
+                    "name": "demo",
+                    "category": "ai-workflow",
+                    "source": "github:owner/repo",
+                    "repo": "owner/repo",
+                    "schema_version": 2,
+                }
+                exit_code, _output = self._run_main(
+                    module,
+                    ["--check-only", "--report-json", str(report_path)],
+                    [skill],
+                    checker,
+                )
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+                self.assertEqual(expected_code, exit_code)
+                self.assertEqual(expected_state, report["state"])
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_upstream.py
+++ b/tests/test_sync_upstream.py
@@ -162,6 +162,70 @@ def load_module():
 
 class SyncUpstreamTests(unittest.TestCase):
     @staticmethod
+    def _open_fd_count() -> int:
+        fd_root = Path("/dev/fd")
+        if not fd_root.exists():
+            raise unittest.SkipTest("/dev/fd is unavailable")
+        return len(list(fd_root.iterdir()))
+
+    @staticmethod
+    def _install_post_stage_metadata_attack(
+        module,
+        *,
+        root: Path,
+        replacement_kind: str,
+        selector,
+    ):
+        """Replace a staged name on its first caller-side metadata check."""
+        real_secure = module._secure_temporary_metadata
+        call_counts: dict[Path, int] = {}
+        foreign: list[Path] = []
+        sentinel = b"foreign-post-stage-occupant"
+        symlink_target = root / "foreign-target"
+        symlink_target.write_bytes(sentinel)
+
+        def attack(path, directory_fd):
+            candidate = Path(path)
+            if selector(candidate):
+                call_counts[candidate] = call_counts.get(candidate, 0) + 1
+                # The stage helper performs two pinned checks.  The third call
+                # is the first fallible caller-side check after it returns.
+                if call_counts[candidate] == 3:
+                    candidate.unlink()
+                    if replacement_kind == "regular":
+                        candidate.write_bytes(sentinel)
+                    elif replacement_kind == "symlink":
+                        candidate.symlink_to(symlink_target)
+                    elif replacement_kind != "missing":
+                        raise AssertionError(
+                            f"unknown replacement kind: {replacement_kind}"
+                        )
+                    foreign.append(candidate)
+            return real_secure(path, directory_fd)
+
+        module._secure_temporary_metadata = attack
+        return real_secure, foreign, sentinel
+
+    def _assert_foreign_stage_state(
+        self,
+        foreign: list[Path],
+        replacement_kind: str,
+        sentinel: bytes,
+    ) -> None:
+        self.assertEqual(1, len(foreign))
+        path = foreign[0]
+        if replacement_kind == "missing":
+            self.assertFalse(path.exists())
+            self.assertFalse(path.is_symlink())
+            return
+        self.assertTrue(path.exists())
+        if replacement_kind == "symlink":
+            self.assertTrue(path.is_symlink())
+        else:
+            self.assertEqual(sentinel, path.read_bytes())
+        path.unlink()
+
+    @staticmethod
     def _mapping_fixture(path: Path) -> dict:
         path.write_text(
             json.dumps(
@@ -5181,6 +5245,114 @@ os._exit(73)
             self.assertEqual(sentinel, foreign[0].read_bytes())
             foreign[0].unlink()
 
+    def test_stage_helper_pins_created_inode_before_parent_validation(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                module = load_module()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    module.REPO_ROOT = root
+                    mapping = root / "mapping.json"
+                    mapping.write_text(
+                        '{"value": "old"}\n',
+                        encoding="utf-8",
+                    )
+                    sentinel = b"foreign-pre-pin-occupant"
+                    symlink_target = root / "foreign-target"
+                    symlink_target.write_bytes(sentinel)
+                    foreign: list[Path] = []
+                    real_validate_parent = module._validate_mapping_parent
+
+                    def replace_during_parent_validation(path, identity):
+                        real_validate_parent(path, identity)
+                        if foreign:
+                            return
+                        candidates = list(
+                            root.glob(".mapping.json.*.tmp")
+                        )
+                        if not candidates:
+                            return
+                        self.assertEqual(1, len(candidates))
+                        candidate = candidates[0]
+                        candidate.unlink()
+                        if replacement_kind == "symlink":
+                            candidate.symlink_to(symlink_target)
+                        else:
+                            candidate.write_bytes(sentinel)
+                        foreign.append(candidate)
+
+                    module._validate_mapping_parent = (
+                        replace_during_parent_validation
+                    )
+                    try:
+                        with self.assertRaises(
+                            module.AtomicMappingWriteError
+                        ) as raised:
+                            module.atomic_write_json(
+                                mapping,
+                                {"value": "new"},
+                            )
+                    finally:
+                        module._validate_mapping_parent = real_validate_parent
+
+                    self.assertFalse(raised.exception.replaced)
+                    self.assertEqual(
+                        b'{"value": "old"}\n',
+                        mapping.read_bytes(),
+                    )
+                    self.assertEqual(1, len(foreign))
+                    self.assertTrue(foreign[0].exists())
+                    if replacement_kind == "symlink":
+                        self.assertTrue(foreign[0].is_symlink())
+                    else:
+                        self.assertEqual(sentinel, foreign[0].read_bytes())
+                    foreign[0].unlink()
+
+    def test_atomic_mapping_post_stage_failures_do_not_leak_fds(self):
+        module = load_module()
+        for replacement_kind in ("regular", "symlink", "missing"):
+            with self.subTest(replacement_kind=replacement_kind):
+                baseline_fds = self._open_fd_count()
+                for _iteration in range(12):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        root = Path(tmpdir)
+                        module.REPO_ROOT = root
+                        mapping = root / "mapping.json"
+                        original = b'{"value": "old"}\n'
+                        mapping.write_bytes(original)
+                        real_secure, foreign, sentinel = (
+                            self._install_post_stage_metadata_attack(
+                                module,
+                                root=root,
+                                replacement_kind=replacement_kind,
+                                selector=lambda path: path.name.endswith(
+                                    ".tmp"
+                                ),
+                            )
+                        )
+                        try:
+                            with self.assertRaises(
+                                module.AtomicMappingWriteError
+                            ) as raised:
+                                module.atomic_write_json(
+                                    mapping,
+                                    {"value": "new"},
+                                )
+                        finally:
+                            module._secure_temporary_metadata = real_secure
+
+                        self.assertFalse(raised.exception.replaced)
+                        self.assertEqual(original, mapping.read_bytes())
+                        self._assert_foreign_stage_state(
+                            foreign,
+                            replacement_kind,
+                            sentinel,
+                        )
+                    self.assertEqual(
+                        baseline_fds,
+                        self._open_fd_count(),
+                    )
+
     def test_atomic_mapping_writer_cas_preserves_concurrent_mapping_change(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -5316,6 +5488,117 @@ os._exit(73)
             self.assertEqual(originals[first], first.read_bytes())
             self.assertEqual(originals[second], second.read_bytes())
 
+    def test_mapping_batch_pins_staged_inode_and_preserves_foreign_occupant(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                module = load_module()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    module.REPO_ROOT = root
+                    first = root / "first.skills.json"
+                    second = root / "second.skills.json"
+                    first.write_text(
+                        '{"value": "old-one"}\n', encoding="utf-8"
+                    )
+                    second.write_text(
+                        '{"value": "old-two"}\n', encoding="utf-8"
+                    )
+                    originals = {
+                        first: first.read_bytes(),
+                        second: second.read_bytes(),
+                    }
+                    sentinel = b"foreign-batch-temporary"
+                    symlink_target = root / "foreign-target"
+                    symlink_target.write_bytes(sentinel)
+                    foreign: list[Path] = []
+
+                    def replace_staged_name(event, path):
+                        if (
+                            event != "after_stage"
+                            or path != first
+                            or foreign
+                        ):
+                            return
+                        candidates = list(
+                            root.glob(".first.skills.json.*.tmp")
+                        )
+                        self.assertEqual(1, len(candidates))
+                        candidate = candidates[0]
+                        candidate.unlink()
+                        if replacement_kind == "symlink":
+                            candidate.symlink_to(symlink_target)
+                        else:
+                            candidate.write_bytes(sentinel)
+                        foreign.append(candidate)
+
+                    with self.assertRaises(
+                        module.AtomicMappingBatchError
+                    ) as raised:
+                        module.atomic_write_json_batch(
+                            {
+                                first: {"value": "new-one"},
+                                second: {"value": "new-two"},
+                            },
+                            fault_injector=replace_staged_name,
+                        )
+
+                    self.assertTrue(raised.exception.rollback_succeeded)
+                    self.assertEqual(originals[first], first.read_bytes())
+                    self.assertEqual(originals[second], second.read_bytes())
+                    self.assertEqual(1, len(foreign))
+                    self.assertTrue(foreign[0].exists())
+                    if replacement_kind == "symlink":
+                        self.assertTrue(foreign[0].is_symlink())
+                    else:
+                        self.assertEqual(sentinel, foreign[0].read_bytes())
+                    foreign[0].unlink()
+
+    def test_mapping_batch_post_stage_failures_do_not_leak_fds(self):
+        module = load_module()
+        for replacement_kind in ("regular", "symlink", "missing"):
+            with self.subTest(replacement_kind=replacement_kind):
+                baseline_fds = self._open_fd_count()
+                for _iteration in range(12):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        root = Path(tmpdir)
+                        module.REPO_ROOT = root
+                        mapping = root / "mapping.skills.json"
+                        original = b'{"value": "old"}\n'
+                        mapping.write_bytes(original)
+                        real_secure, foreign, sentinel = (
+                            self._install_post_stage_metadata_attack(
+                                module,
+                                root=root,
+                                replacement_kind=replacement_kind,
+                                selector=lambda path: path.name.endswith(
+                                    ".tmp"
+                                ),
+                            )
+                        )
+                        try:
+                            with self.assertRaises(
+                                module.AtomicMappingBatchError
+                            ) as raised:
+                                module._atomic_write_json_batch_locked(
+                                    {mapping: {"value": "new"}},
+                                )
+                        finally:
+                            module._secure_temporary_metadata = real_secure
+
+                        self.assertTrue(
+                            raised.exception.rollback_succeeded
+                        )
+                        self.assertEqual(original, mapping.read_bytes())
+                        self._assert_foreign_stage_state(
+                            foreign,
+                            replacement_kind,
+                            sentinel,
+                        )
+                    self.assertEqual(
+                        baseline_fds,
+                        self._open_fd_count(),
+                    )
+
     def test_atomic_mapping_batch_surfaces_recovery_files_when_rollback_fails(self):
         module = load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -5357,6 +5640,188 @@ os._exit(73)
             self.assertTrue(
                 all(path.is_file() for path in raised.exception.recovery_paths)
             )
+
+    def test_batch_rollback_temp_pin_preserves_foreign_occupant(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                module = load_module()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    module.REPO_ROOT = root
+                    first = root / "first.skills.json"
+                    second = root / "second.skills.json"
+                    first.write_text(
+                        '{"value": "old-one"}\n', encoding="utf-8"
+                    )
+                    second.write_text(
+                        '{"value": "old-two"}\n', encoding="utf-8"
+                    )
+                    sentinel = b"foreign-rollback-temporary"
+                    symlink_target = root / "foreign-target"
+                    symlink_target.write_bytes(sentinel)
+                    foreign: list[Path] = []
+
+                    def fail_second(event, path):
+                        if event == "after_replace" and path == second:
+                            raise OSError("force rollback")
+
+                    real_pin = module._pin_temporary_inode
+
+                    def replace_after_pin(path, directory_fd):
+                        descriptor, metadata = real_pin(path, directory_fd)
+                        candidate = Path(path)
+                        if (
+                            candidate.name.endswith(".rollback.tmp")
+                            and not foreign
+                        ):
+                            candidate.unlink()
+                            if replacement_kind == "symlink":
+                                candidate.symlink_to(symlink_target)
+                            else:
+                                candidate.write_bytes(sentinel)
+                            foreign.append(candidate)
+                        return descriptor, metadata
+
+                    module._pin_temporary_inode = replace_after_pin
+                    try:
+                        with self.assertRaises(
+                            module.AtomicMappingBatchError
+                        ) as raised:
+                            module.atomic_write_json_batch(
+                                {
+                                    first: {"value": "new-one"},
+                                    second: {"value": "new-two"},
+                                },
+                                fault_injector=fail_second,
+                            )
+                    finally:
+                        module._pin_temporary_inode = real_pin
+
+                    self.assertFalse(raised.exception.rollback_succeeded)
+                    self.assertTrue(raised.exception.recovery_paths)
+                    self.assertEqual(1, len(foreign))
+                    self.assertTrue(foreign[0].exists())
+                    if replacement_kind == "symlink":
+                        self.assertTrue(foreign[0].is_symlink())
+                    else:
+                        self.assertEqual(sentinel, foreign[0].read_bytes())
+                    foreign[0].unlink()
+
+    def test_batch_rollback_post_stage_failures_do_not_leak_fds(self):
+        module = load_module()
+        for replacement_kind in ("regular", "symlink", "missing"):
+            with self.subTest(replacement_kind=replacement_kind):
+                baseline_fds = self._open_fd_count()
+                for _iteration in range(12):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        root = Path(tmpdir)
+                        module.REPO_ROOT = root
+                        first = root / "first.skills.json"
+                        second = root / "second.skills.json"
+                        first_original = b'{"value": "old-one"}\n'
+                        second_original = b'{"value": "old-two"}\n'
+                        first.write_bytes(first_original)
+                        second.write_bytes(second_original)
+
+                        def fail_after_second_replace(event, path):
+                            if event == "after_replace" and path == second:
+                                raise OSError("force rollback")
+
+                        real_secure, foreign, sentinel = (
+                            self._install_post_stage_metadata_attack(
+                                module,
+                                root=root,
+                                replacement_kind=replacement_kind,
+                                selector=lambda path: (
+                                    path.name.startswith(
+                                        ".second.skills.json."
+                                    )
+                                    and path.name.endswith(".rollback.tmp")
+                                ),
+                            )
+                        )
+                        try:
+                            with self.assertRaises(
+                                module.AtomicMappingBatchError
+                            ) as raised:
+                                module._atomic_write_json_batch_locked(
+                                    {
+                                        first: {"value": "new-one"},
+                                        second: {"value": "new-two"},
+                                    },
+                                    fault_injector=fail_after_second_replace,
+                                )
+                        finally:
+                            module._secure_temporary_metadata = real_secure
+
+                        self.assertFalse(
+                            raised.exception.rollback_succeeded
+                        )
+                        self.assertEqual(first_original, first.read_bytes())
+                        self.assertFalse(second.is_symlink())
+                        self.assertNotEqual(sentinel, second.read_bytes())
+                        self._assert_foreign_stage_state(
+                            foreign,
+                            replacement_kind,
+                            sentinel,
+                        )
+                    self.assertEqual(
+                        baseline_fds,
+                        self._open_fd_count(),
+                    )
+
+    def test_private_recovery_pin_preserves_foreign_occupant(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                module = load_module()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    module.REPO_ROOT = root
+                    mapping = root / "mapping.skills.json"
+                    mapping.write_text(
+                        '{"value": "old"}\n', encoding="utf-8"
+                    )
+                    sentinel = b"foreign-private-recovery"
+                    symlink_target = root / "foreign-target"
+                    symlink_target.write_bytes(sentinel)
+                    foreign: list[Path] = []
+                    real_pin = module._pin_temporary_inode
+
+                    def replace_after_pin(path, directory_fd):
+                        descriptor, metadata = real_pin(path, directory_fd)
+                        candidate = Path(path)
+                        if (
+                            candidate.name.endswith(".recovery.json")
+                            and not foreign
+                        ):
+                            candidate.unlink()
+                            if replacement_kind == "symlink":
+                                candidate.symlink_to(symlink_target)
+                            else:
+                                candidate.write_bytes(sentinel)
+                            foreign.append(candidate)
+                        return descriptor, metadata
+
+                    module._pin_temporary_inode = replace_after_pin
+                    try:
+                        with self.assertRaisesRegex(
+                            RuntimeError,
+                            "temporary inode changed|temporary is unsafe",
+                        ):
+                            module._stage_private_mapping_recovery(
+                                mapping,
+                                b'{"value": "recovery"}\n',
+                            )
+                    finally:
+                        module._pin_temporary_inode = real_pin
+
+                    self.assertEqual(1, len(foreign))
+                    self.assertTrue(foreign[0].exists())
+                    if replacement_kind == "symlink":
+                        self.assertTrue(foreign[0].is_symlink())
+                    else:
+                        self.assertEqual(sentinel, foreign[0].read_bytes())
+                    foreign[0].unlink()
 
     def test_mapping_batch_rejects_detached_parent_after_replace(self):
         module = load_module()
@@ -5497,6 +5962,124 @@ os._exit(73)
                 [],
                 list(detached.glob(".*.validation.skills.json")),
             )
+
+    def test_candidate_validation_pins_temp_and_preserves_foreign_occupant(self):
+        for replacement_kind in ("regular", "symlink"):
+            with self.subTest(replacement_kind=replacement_kind):
+                module = load_module()
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    module.REPO_ROOT = root
+                    sources = root / "docs" / "sources"
+                    sources.mkdir(parents=True)
+                    module.SOURCE_MAPPINGS_DIR = sources
+                    mapping = sources / "mapping.skills.json"
+                    mapping.write_text(
+                        '{"schema_version": 2}\n',
+                        encoding="utf-8",
+                    )
+                    sentinel = b"foreign-validation-temporary"
+                    symlink_target = root / "foreign-target"
+                    symlink_target.write_bytes(sentinel)
+                    foreign: list[Path] = []
+                    original_validate = module.validate_provenance_mapping
+                    original_repository_validate = (
+                        module.validate_repository_mappings
+                    )
+
+                    def replace_validation_temp(path, *_args, **_kwargs):
+                        candidate = Path(path)
+                        candidate.unlink()
+                        if replacement_kind == "symlink":
+                            candidate.symlink_to(symlink_target)
+                        else:
+                            candidate.write_bytes(sentinel)
+                        foreign.append(candidate)
+                        return []
+
+                    module.validate_provenance_mapping = (
+                        replace_validation_temp
+                    )
+                    module.validate_repository_mappings = (
+                        lambda *_args, **_kwargs: []
+                    )
+                    try:
+                        with self.assertRaisesRegex(
+                            RuntimeError,
+                            "temporary inode changed|temporary is unsafe",
+                        ):
+                            module._validate_candidate_mappings(
+                                {mapping: {"schema_version": 2}}
+                            )
+                    finally:
+                        module.validate_provenance_mapping = original_validate
+                        module.validate_repository_mappings = (
+                            original_repository_validate
+                        )
+
+                    self.assertEqual(1, len(foreign))
+                    self.assertTrue(foreign[0].exists())
+                    if replacement_kind == "symlink":
+                        self.assertTrue(foreign[0].is_symlink())
+                    else:
+                        self.assertEqual(sentinel, foreign[0].read_bytes())
+                    foreign[0].unlink()
+
+    def test_candidate_post_stage_failures_do_not_leak_fds(self):
+        module = load_module()
+        original_validate = module.validate_provenance_mapping
+        original_repository_validate = module.validate_repository_mappings
+        module.validate_provenance_mapping = lambda *_args, **_kwargs: []
+        module.validate_repository_mappings = lambda *_args, **_kwargs: []
+        try:
+            for replacement_kind in ("regular", "symlink", "missing"):
+                with self.subTest(replacement_kind=replacement_kind):
+                    baseline_fds = self._open_fd_count()
+                    for _iteration in range(12):
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            root = Path(tmpdir)
+                            module.REPO_ROOT = root
+                            sources = root / "docs" / "sources"
+                            sources.mkdir(parents=True)
+                            module.SOURCE_MAPPINGS_DIR = sources
+                            mapping = sources / "mapping.skills.json"
+                            original = b'{"schema_version": 2}\n'
+                            mapping.write_bytes(original)
+                            real_secure, foreign, sentinel = (
+                                self._install_post_stage_metadata_attack(
+                                    module,
+                                    root=root,
+                                    replacement_kind=replacement_kind,
+                                    selector=lambda path: path.name.endswith(
+                                        ".validation.skills.json"
+                                    ),
+                                )
+                            )
+                            try:
+                                with self.assertRaises(
+                                    (RuntimeError, FileNotFoundError)
+                                ):
+                                    module._validate_candidate_mappings(
+                                        {mapping: {"schema_version": 2}}
+                                    )
+                            finally:
+                                module._secure_temporary_metadata = (
+                                    real_secure
+                                )
+
+                            self.assertEqual(original, mapping.read_bytes())
+                            self._assert_foreign_stage_state(
+                                foreign,
+                                replacement_kind,
+                                sentinel,
+                            )
+                        self.assertEqual(
+                            baseline_fds,
+                            self._open_fd_count(),
+                        )
+        finally:
+            module.validate_provenance_mapping = original_validate
+            module.validate_repository_mappings = original_repository_validate
 
     def test_report_json_exposes_degraded_state_and_conserved_counts(self):
         module = load_module()

--- a/tests/test_upstream_sync_workflow.py
+++ b/tests/test_upstream_sync_workflow.py
@@ -14,6 +14,17 @@ class UpstreamSyncWorkflowTests(unittest.TestCase):
         job = data["jobs"]["discover-and-sync"]
         steps = job["steps"]
 
+        discovery = next(
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("name") == "Discover new skills from external sources"
+        )
+        self.assertEqual(
+            "${{ secrets.GITHUB_TOKEN }}",
+            discovery["env"]["GITHUB_TOKEN"],
+        )
+
         reconcile = next(
             step
             for step in steps
@@ -21,19 +32,65 @@ class UpstreamSyncWorkflowTests(unittest.TestCase):
         )
         self.assertEqual("actions/github-script@v7", reconcile["uses"])
         self.assertEqual(
-            "steps.discovery.outcome == 'success' && steps.upstream.outcome == 'success'",
+            "always()",
             reconcile["if"],
+        )
+        self.assertEqual(
+            "${{ steps.report.outputs.needs_attention }}",
+            reconcile["env"]["NEEDS_ATTENTION"],
+        )
+        self.assertEqual(
+            "${{ steps.report.outputs.sync_state }}",
+            reconcile["env"]["SYNC_STATE"],
+        )
+        self.assertEqual(
+            "${{ steps.report.outcome }}",
+            reconcile["env"]["REPORT_OUTCOME"],
         )
 
         script = reconcile["with"]["script"]
         self.assertIn("github.rest.issues.create", script)
         self.assertIn("github.rest.issues.update", script)
         self.assertIn("state_reason: 'completed'", script)
-        self.assertIn("latest weekly scan found no meaningful", script)
+        self.assertIn("latest weekly scan completed with state", script)
+        self.assertIn("issue.title === title", script)
+        self.assertNotIn("issue.title.startsWith(title)", script)
+        self.assertIn("if (syncState !== 'complete')", script)
+        self.assertIn(
+            "process.env.REPORT_OUTCOME === 'success'",
+            script,
+        )
+        self.assertIn("const reportExists = fs.existsSync", script)
+        self.assertIn("const report = reportExists", script)
+        self.assertNotIn(
+            "reportSucceeded && fs.existsSync(process.env.REPORT_PATH)",
+            script,
+        )
+        self.assertIn(": 'failed'", script)
+        degraded_branch, complete_branches = script.split(
+            "} else if (needsAttention) {", 1
+        )
+        self.assertNotIn("state: 'closed'", degraded_branch)
+        self.assertIn("state: 'closed'", complete_branches)
         self.assertNotIn(
             "peter-evans/create-issue-from-file",
             WORKFLOW_PATH.read_text(encoding="utf-8"),
         )
+
+        enforce = next(
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("name") == "Enforce sync automation state"
+        )
+        self.assertEqual("always()", enforce["if"])
+        self.assertEqual(
+            "${{ steps.report.outcome }}",
+            enforce["env"]["REPORT_OUTCOME"],
+        )
+        self.assertIn('REPORT_OUTCOME" != "success', enforce["run"])
+        self.assertIn("degraded)", enforce["run"])
+        self.assertIn("exit 1", enforce["run"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- sync complete upstream artifact sets, including references, templates, scripts, binary files, cross-directory mappings, and path-level checkpoints
- model every external sidecar with a unique external or local-curation owner; all 151 active external entries / 2,121 files are now managed without ownership debt
- add crash-safe staged skill transactions and durable cross-file mapping journals with nofollow/CAS checks, rollback evidence, and fail-closed recovery
- harden commit-bound license evidence, provenance ingest, monitor semantics, three-state automation reports, and GitHub Issue reconciliation
- preserve the tracked canonical/OpenClaw `.claude/commands/webperf.md` artifact while ignoring runtime transaction state

## Validation

- full pipeline executed twice with identical worktree digest: `32e3cb2b317435820635a20065a2fa7a5abe2e0b9a1717f8b965bcd746ed7b1a`
- `python -m pytest -q tests`: 408 passed on both final runs
- provenance JSON Schema: 17 files, 0 errors
- source coverage: 289/289 (100%)
- license audit: 156 external origins, 0 missing, 0 disallowed
- artifact inventory: 151 entries / 2,121 files, 0 unavailable, drift, conflicts, stale targets, or write debt
- focused Ruff F checks, `py_compile`, validator, portfolio policy, README sync, quality lint, and `git diff --check`: passed
- independent parent-detach, symlink, special-mode, journal, rollback, and dry-run security re-audit: PASS
