### PR TITLE
fix: resolve v2.0.0 security scan findings

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Open PR with refreshed changelog
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore: refresh CHANGELOG from recent commits"
           title: "chore: refresh CHANGELOG.md"

--- a/.github/workflows/repo-validation.yml
+++ b/.github/workflows/repo-validation.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/skills-provenance-ci.yml
+++ b/.github/workflows/skills-provenance-ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   provenance-checks:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,114 @@
-# Changelog
+# Changelog / 更新日志
 
 All notable changes to this repository are documented here.
+本文件记录仓库的重要变更；版本号遵循 [Semantic Versioning](https://semver.org/)。
+
+## [2.0.0] - 2026-08-20
+
+Revision range / 变更范围：`v1.2.0..HEAD`
+
+### Highlights / 核心亮点
+
+- 将来源治理升级为 provenance v2，统一管理完整 artifact set、依赖锁、许可证 lineage 与安全删除边界。
+  Upgraded source governance to provenance v2 with complete artifact sets, dependency locks, license lineage, and safe deletion boundaries.
+- 以官方完整产物替代 Hermes、Graphify 与旧 GSD 拼装快照，同时保留薄路由和可回滚迁移能力。
+  Replaced stitched Hermes, Graphify, and legacy GSD snapshots with complete official artifacts while retaining thin routing and rollback-aware migration.
+- 引入 installer v2、受管 bundle、旧技能清理和跨安装根冲突审计，并为仓库启用多语言 CodeQL 扫描。
+  Added installer v2, governed bundles, retired-skill pruning, cross-root conflict auditing, and multi-language CodeQL scanning.
+
+### Added / 新增
+
+- 新增 provenance v2 数据模型：
+  - `kind` 支持 `mirror`、`overlay`、`composite`、`bundle`、`snapshot`、`in_house` 和 `reference_only`；
+  - `origins[]` 锁定仓库、路径、许可证、跟踪通道、解析 commit 与内容哈希；
+  - `artifacts[]` 支持任意 source-to-target 文件或目录映射；
+  - `managed_files[]` 记录受管文件、digest、mode 与安全删除所有权；
+  - `composition.depends_on[]` 及依赖锁可在上游依赖推进时级联标记 composite stale。
+  Added provenance v2 primitives for explicit source kinds, immutable origin checkpoints, arbitrary artifact mappings, owned managed files, and dependency-aware composite staleness.
+- 新增 crash-safe artifact-set 同步引擎，支持正文、references、templates、scripts、二进制资产、文件 mode、跨目录映射、仓库 inventory 与移动/重命名识别；写入采用暂存校验和原子替换。
+  Added crash-safe artifact-set synchronization for bodies, references, templates, scripts, binary assets, file modes, cross-directory mappings, repository inventories, and move/rename detection.
+- 完整镜像 Hermes Agent `v2026.8.18`：`SKILL.md`、18 个官方 references 和 3 个官方 templates。
+  Mirrored the complete Hermes Agent `v2026.8.18` skill artifact set, including 18 official references and 3 official templates.
+- 完整收录 Graphify `v0.9.47` 官方 Codex skill 与 8 个 references。
+  Added the official Graphify `v0.9.47` Codex skill and all 8 references.
+- 注册 Open GSD Core `v1.11.0` 为显式安装的受管 bundle，记录 71 skills、34 agents、71 commands、共享 runtime、npm digest、release commit 与 SLSA provenance。
+  Registered Open GSD Core `v1.11.0` as an explicit managed bundle with 71 skills, 34 agents, 71 commands, shared runtime, npm digests, release checkpoints, and SLSA provenance.
+- 注册 Open GSD Pi `v1.16.0` 为可选、默认不安装的 bundle；其 `.gsd/` 状态与 Core 的 `.planning/` 状态严格隔离。
+  Registered Open GSD Pi `v1.16.0` as an optional, non-default bundle with `.gsd/` state isolated from Core's `.planning/` state.
+- 新增薄路由 `hermes-open-gsd-workflow`，只负责选择 Hermes、Graphify、GSD Core 或可选 GSD Pi，不再复制上游版本、安装命令或运行态状态机。
+  Added the thin `hermes-open-gsd-workflow` router without duplicating upstream versions, installation commands, or runtime state machines.
+- 新增 `open-gsd-core-migration`，集中处理旧安装检测、哈希备份、迁移验证、归档与回滚。
+  Added `open-gsd-core-migration` for legacy-install detection, hash-backed backup, migration validation, archival, and rollback.
+- installer v2 新增：
+  - 受管安装 manifest 与文件所有权/digest/mode 记录；
+  - `--bundle gsd-core` 显式 bundle 安装入口；
+  - `--prune-retired`，仅直接删除未经修改且有所有权证明的旧文件；
+  - `audit-conflicts --roots ... --json`，审计跨根同名但内容不同的技能；
+  - 真正零写入的 `--dry-run`。
+  Installer v2 now provides managed manifests, explicit bundle installation, ownership-safe retirement pruning, cross-root conflict auditing, and a truly zero-write dry run.
+- 新增 portfolio decision ledger，为每个候选记录 `keep`、`merge`、`snapshot` 或 `retire`，以及替代项、独有资产、外部契约、许可证与本机清理动作。
+  Added a portfolio decision ledger covering keep, merge, snapshot, and retire decisions with replacement, unique-asset, contract, license, and cleanup evidence.
+- 新增 GitHub CodeQL workflow，覆盖 Actions、JavaScript/TypeScript 与 Python，并将代码扫描结果接入 PR 安全检查。
+  Added GitHub CodeQL analysis for Actions, JavaScript/TypeScript, and Python, integrated with pull-request security checks.
+
+### Changed / 变更
+
+- 对全部受管来源执行真实上游复核，而不是沿用“映射存在即已覆盖”的假绿：
+  - 同步当前 Simota 内容并跟随 `lore` 新路径；
+  - 将仍有独有价值的归档技能转换为固定、带许可证的 snapshots；
+  - 同步完整 Lark artifact sets；
+  - 复核 Hermes、NLPM、Addy Osmani、Superpowers、LinkedIn、X/Twitter 等来源的 commit range 与吸收/保留理由。
+  Re-audited the full governed portfolio, including Simota path changes and snapshots, complete Lark artifact sets, and reviewed commit ranges across Hermes, NLPM, Addy Osmani, Superpowers, LinkedIn, X/Twitter, and other sources.
+- 稳定 release 与 immutable fixed ref 可在策略门禁后同步；默认分支、canary 与 composite 只进入 monitor/review，不再自动替换 canonical 内容。
+  Stable releases and immutable refs may sync after policy gates; default branches, canaries, and composites are monitor/review only.
+- `sync_upstream.py --check-only` 现在严格零写入；需要持久化检查时间时必须显式使用 `--record-check`。报告计数满足总量恒等式，未预期 `unavailable` 会失败而不再被视作“最新”。
+  `sync_upstream.py --check-only` is now strictly read-only, check recording is explicit, report totals are internally consistent, and unexpected unavailable sources fail closed.
+- 分类 README、双语主 README、catalog、标签索引、OpenClaw 导出和 banner 均从 canonical metadata 生成，不再维护组合技能的硬编码版本与安装说明。
+  Category READMEs, bilingual top-level READMEs, catalog, tag index, OpenClaw export, and banner are generated from canonical metadata without hard-coded composite versions.
+- 自 `v1.2.0` 以来的多轮已验证上游同步与技能组合整理统一纳入本次 major release，包括安全、可观测性、React Native、LinkedIn 和工作流类技能的新增或归类调整。
+  Consolidated all verified upstream sync waves since `v1.2.0`, including additions and category refinements across security, observability, React Native, LinkedIn, and workflow skills.
+
+### Removed / 移除
+
+- 正式退役以下 4 个被完整替代的拼装技能，并保留永久 tombstone/alias 防止重新发现：
+  - `hermes-graphify-gsd-nonintrusive-workflow`
+  - `hermes-graphify-gsd-runtime-operator`
+  - `hermes-graphify-gsd-project-integration`
+  - `gsd-graphify-brownfield-bootstrap`
+  Retired four fully superseded stitched workflows and added permanent tombstones/aliases to prevent rediscovery.
+- 删除旧组合层重复的 writer lease、task board、cron、handoff、安装脚本和运行态状态机；独有迁移能力已并入 `open-gsd-core-migration`。
+  Removed duplicated leases, task boards, cron jobs, handoffs, installers, and runtime state machines after preserving unique migration behavior.
+- 删除 Graphify 中不完整且已漂移的 Python package/runtime 快照，仅保留官方 Codex artifact set。
+  Removed the incomplete, drifted Graphify Python/runtime snapshot and retained only the official Codex artifact set.
+
+### Fixed / 修复
+
+- 修复外部技能被错误登记为 `in_house`、frontmatter 与 mapping 来源语义反向冲突、`source_url` 漂移及外部许可证错误豁免。
+  Fixed external skills misclassified as in-house, reversed source semantics, drifting source URLs, and invalid license exemptions.
+- 修复测试和 `--check-only` 污染真实 mapping 的问题，并加入 v1-to-v2 迁移、依赖级联 stale、上游移动/删除、sidecar-only 变化、二进制资产与安全删除回归测试。
+  Prevented tests and read-only checks from mutating real mappings and added regression coverage for migration, dependency drift, upstream moves/deletions, sidecar-only changes, binary assets, and safe deletion.
+- 修复 artifact 写入期间的 symlink/hardlink、inode 替换、临时文件 pinning 与 executable mode 保留问题。
+  Hardened staged artifact writes against symlink/hardlink and inode replacement attacks while preserving executable modes.
+- Repository Validation 显式安装测试所需依赖，避免 CI 因缺失 schema validator 在 collection 阶段失败。
+  Repository Validation now installs required test dependencies so schema validation cannot fail during collection because of a missing package.
+
+### Security / 安全
+
+- GSD bundle 安装不再直接执行 npm package spec：installer 会在隔离临时目录下载固定版本，核验 pack metadata、文件路径、size、integrity、shasum 与 SHA-256，只执行验证后的本地 tarball，并在成功或失败后清理临时资产。
+  GSD bundle installation now downloads the pinned package into an isolated directory, verifies metadata and cryptographic digests, executes only the verified local tarball, and always removes temporary artifacts.
+- 受管清理遵循“有所有权且未修改才直接删除”：用户修改或无所有权证明的文件会先归档并移出活动发现路径。
+  Managed cleanup deletes only owned, unchanged files; modified or unowned files are archived before leaving active discovery paths.
+- 许可证审计升级为 lineage-aware 门禁，外部 artifact set 的许可证 checkpoint 与不可变 commit 一并记录。
+  License auditing is now lineage-aware and records external artifact-set license checkpoints at immutable commits.
+
+### Compatibility and migration / 兼容与迁移
+
+- 普通技能安装不会隐式安装任何 GSD bundle；GSD Core 必须显式请求，GSD Pi 保持可选且默认不安装。
+  Normal skill installation never installs GSD bundles implicitly; Core requires an explicit request and Pi remains optional and disabled by default.
+- 旧组合技能名称仅作为退休别名用于迁移诊断，不再作为活动技能执行。
+  Legacy composite names remain only as retired aliases for migration diagnostics.
+- 本次 major release 不要求安装 Hermes runtime，也不改变外部 Graphify CLI；仓库只治理其官方 skill artifacts。
+  This major release does not require Hermes runtime installation or modify an external Graphify CLI; it governs only their official skill artifacts.
 
 ## [2026-03-27]
 
@@ -36,3 +144,5 @@ All notable changes to this repository are documented here.
 
 ### Fixed
 - run refresh_repo_views, fix test expectations, normalize YAML frontmatter
+
+[2.0.0]: https://github.com/seaworld008/Commonly-used-high-value-skills/compare/v1.2.0...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ Revision range / 变更范围：`v1.2.0..HEAD`
   Managed cleanup deletes only owned, unchanged files; modified or unowned files are archived before leaving active discovery paths.
 - 许可证审计升级为 lineage-aware 门禁，外部 artifact set 的许可证 checkpoint 与不可变 commit 一并记录。
   License auditing is now lineage-aware and records external artifact-set license checkpoints at immutable commits.
+- 故意脆弱的依赖审计教学样本改用非 manifest 扩展名，避免 Dependabot 将测试夹具误判为仓库运行依赖。
+  Intentionally vulnerable dependency-auditor fixtures now use non-manifest file names so Dependabot does not treat teaching samples as repository runtime dependencies.
 
 ### Compatibility and migration / 兼容与迁移
 

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -420,7 +420,7 @@
         {
           "path": "skills/growth-operations-xiaohongshu/algorithmic-art/templates/viewer.html",
           "owner": "algorithmic-art",
-          "sha256": "86c79d7ce97d2599ebe4bd9b97fdeb7295c9d3ed61ceeb513cbe1b2bb5d1ce29",
+          "sha256": "f19baf8dfb8a058da8974931946110939c2cc087325aac755a0c9b50ef32d91d",
           "mode": "100644"
         }
       ]
@@ -7007,7 +7007,7 @@
         {
           "path": "skills/developer-engineering/dependency-auditor/scripts/dep_scanner.py",
           "owner": "dependency-auditor",
-          "sha256": "309abbb1fb20df6dfcea77ac0e963bd61953cb4b46de8c1a6d10cae6d88546cd",
+          "sha256": "d45544d84c3e621af56b9b62c42b7022944399a4a2fe7891e5dea02125c97e32",
           "mode": "100644"
         },
         {
@@ -9602,7 +9602,7 @@
         {
           "path": "skills/multimodal-media/gpt-image2/scripts/gpt-image2.mjs",
           "owner": "gpt-image2",
-          "sha256": "2cd6259349404336a0c521719d793f4a45261e7a40576f5948f6025a31eff1a6",
+          "sha256": "508b5fbb9aa93a1d6db35c7038bd30093fb5fa38e1e08d41de3356a089014347",
           "mode": "100644"
         }
       ]
@@ -12049,7 +12049,7 @@
         {
           "path": "skills/developer-engineering/migration-architect/scripts/rollback_generator.py",
           "owner": "migration-architect",
-          "sha256": "5ee0ce71dbd4cd8a134ece4e5c282f7ceb860164431ca5138bfa4996eba372eb",
+          "sha256": "2b41b9087c4a51ba2f56dcbdafe4edf2539a0038ae6fc0e72ec21f7ea752d003",
           "mode": "100644"
         }
       ]
@@ -16723,13 +16723,13 @@
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/scripts/safe_pack.py",
           "owner": "repomix-safe-mixer",
-          "sha256": "c4c4a3793c7cd13cfbf39252e1ae32d6026dbc76ef20037166dcd861e03fff04",
+          "sha256": "271873181539aa490833254319e4f263547cd225142095a92dd42b41b39c9652",
           "mode": "100644"
         },
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py",
           "owner": "repomix-safe-mixer",
-          "sha256": "6c6bc353f303c0de57a043356bd076e36edbac0505b869e8d957edc8b4ef15cd",
+          "sha256": "cdd18c62cb9d2b741e9e8898d01b1fbdaf3cd87da66ffa2e5a053fcb8a0a8c60",
           "mode": "100644"
         }
       ]
@@ -20019,7 +20019,7 @@
         {
           "path": "skills/office-white-collar/transcript-fixer/scripts/fix_transcript_enhanced.py",
           "owner": "transcript-fixer",
-          "sha256": "d4b50704f84eed7629270515c9bb98243b25754d0500c3e6984d08a996119c0e",
+          "sha256": "4fe8bfd7034e09e7644427e2bed2dc028befa822ce721cc614c0a3fd4799145c",
           "mode": "100644"
         },
         {

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -6866,8 +6866,8 @@
               "type": "file"
             },
             {
-              "source": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.txt",
-              "target": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.txt",
+              "source": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.fixture",
+              "target": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.fixture",
               "type": "file"
             },
             {
@@ -6921,8 +6921,8 @@
               "type": "file"
             },
             {
-              "source": "skills/developer-engineering/dependency-auditor/test-project/package.json",
-              "target": "skills/developer-engineering/dependency-auditor/test-project/package.json",
+              "source": "skills/developer-engineering/dependency-auditor/test-project/package.vulnerable.fixture.json",
+              "target": "skills/developer-engineering/dependency-auditor/test-project/package.vulnerable.fixture.json",
               "type": "file"
             }
           ],
@@ -6941,7 +6941,7 @@
         {
           "path": "skills/developer-engineering/dependency-auditor/README.md",
           "owner": "dependency-auditor",
-          "sha256": "023b2506b44dd23c791664e91f1836f9795450333565762cf86267adee8cddbb",
+          "sha256": "a79b2d14a1efbde777c90d99c4bc60fa475349ee283a7641d23432317307e6c7",
           "mode": "100644"
         },
         {
@@ -6960,12 +6960,6 @@
           "path": "skills/developer-engineering/dependency-auditor/assets/sample_package.json",
           "owner": "dependency-auditor",
           "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032",
-          "mode": "100644"
-        },
-        {
-          "path": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.txt",
-          "owner": "dependency-auditor",
-          "sha256": "85ee24f99830b71a59419a181efa52e4f6f5ace9ad92e30d2fb6489d21bb0198",
           "mode": "100644"
         },
         {
@@ -7029,9 +7023,15 @@
           "mode": "100644"
         },
         {
-          "path": "skills/developer-engineering/dependency-auditor/test-project/package.json",
+          "path": "skills/developer-engineering/dependency-auditor/assets/sample_requirements.fixture",
           "owner": "dependency-auditor",
-          "sha256": "0ba6fc01364589a5e6030a05e1283038bf3a944135b46a9a5eaaaf1dbdf6a032",
+          "sha256": "378601721e9911a43b033da6257487d6fe01821df8fe65e929c2c69b1cc13b8e",
+          "mode": "100644"
+        },
+        {
+          "path": "skills/developer-engineering/dependency-auditor/test-project/package.vulnerable.fixture.json",
+          "owner": "dependency-auditor",
+          "sha256": "7914a65e84bc383cf39c0046a42ba86f4c4a5f754950fe58c1a7541f6288c7a7",
           "mode": "100644"
         }
       ]

--- a/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
+++ b/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
@@ -592,7 +592,7 @@
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
-          "sha256": "359c0364076c354289b6d80278451eb3d4dcb21081621054ab04c563616e332d",
+          "sha256": "71365cf52dcb4bcf1352e275c01869c3670202b00d1c84c3e590b1c88815d40b",
           "owner": "linkedin-growth",
           "mode": "100644"
         }

--- a/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
+++ b/docs/sources/linked-api-linkedin-skills-2026-07.skills.json
@@ -121,7 +121,7 @@
       "status": "verified_in_repo",
       "repo_skill": "skills/growth-operations-xiaohongshu/linkedin-growth/SKILL.md",
       "source": "https://github.com/Linked-API/linkedin-skills/tree/edd0bdbbb25776e9288186b88969b29175531995/linkedin-growth",
-      "notes": "Imported under MIT at the recorded commit; repository-local quality and authorization guidance is preserved in marked supplements.",
+      "notes": "Imported under MIT at the recorded commit; repository-local quality and authorization guidance plus private-cache, fixed Notion endpoint/redirect, and ownership-token lock hardening are preserved as a curation overlay.",
       "upstream": {
         "repo": "Linked-API/linkedin-skills",
         "path": "linkedin-growth/SKILL.md",
@@ -276,11 +276,6 @@
               "type": "file"
             },
             {
-              "source": "linkedin-growth/scripts/migrate-notion.mjs",
-              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
-              "type": "file"
-            },
-            {
               "source": "linkedin-growth/scripts/network-invite.mjs",
               "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/network-invite.mjs",
               "type": "file"
@@ -319,11 +314,6 @@
               "source": "linkedin-growth/scripts/status.mjs",
               "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/status.mjs",
               "type": "file"
-            },
-            {
-              "source": "linkedin-growth/scripts/tick.mjs",
-              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
-              "type": "file"
             }
           ],
           "tracking": {
@@ -353,6 +343,16 @@
             {
               "source": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
               "target": "skills/growth-operations-xiaohongshu/linkedin-growth/LICENSE",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
+              "type": "file"
+            },
+            {
+              "source": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
+              "target": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
               "type": "file"
             }
           ],
@@ -538,7 +538,7 @@
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs",
-          "sha256": "576e0a4cc2038e0264d542a1e5fc3c7c67e10c18a3674f4afb714bd410233e94",
+          "sha256": "8d242a11caaa366705b652af49867c6961d1d6445587c2365e691d91fec9aa03",
           "owner": "linkedin-growth",
           "mode": "100644"
         },
@@ -592,7 +592,7 @@
         },
         {
           "path": "skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs",
-          "sha256": "00820ae3d533e90e76c90120a8030aa8187bcc01cb5636ca7a28c57d99f9ee71",
+          "sha256": "359c0364076c354289b6d80278451eb3d4dcb21081621054ab04c563616e332d",
           "owner": "linkedin-growth",
           "mode": "100644"
         }

--- a/docs/sources/simota-agent-skills-2026-04.skills.json
+++ b/docs/sources/simota-agent-skills-2026-04.skills.json
@@ -5003,7 +5003,7 @@
       "status": "verified_in_repo",
       "repo_skill": "skills/engineering-workflow-automation/harvest/SKILL.md",
       "source": "https://github.com/simota/agent-skills/blob/6502f44cfcd8f456951a7bfdce14d0ed76d724ef/.archive/harvest/SKILL.md",
-      "notes": "Licensed immutable MIT snapshot retained from .archive/harvest at 6502f44cfcd8f456951a7bfdce14d0ed76d724ef; unique local curation remains separately owned.",
+      "notes": "Licensed immutable MIT snapshot retained from .archive/harvest at 6502f44cfcd8f456951a7bfdce14d0ed76d724ef; repository-local shell-injection and regex-denial-of-service hardening in scripts/generate-report.js, plus other unique curation, are separately owned by local-repo/curation.",
       "upstream": {
         "repo": "simota/agent-skills",
         "path": ".archive/harvest/SKILL.md",
@@ -5113,11 +5113,6 @@
             {
               "source": ".archive/harvest/reference/work-hours.md",
               "target": "skills/engineering-workflow-automation/harvest/reference/work-hours.md",
-              "type": "file"
-            },
-            {
-              "source": ".archive/harvest/scripts/generate-report.js",
-              "target": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
               "type": "file"
             },
             {
@@ -5268,6 +5263,11 @@
             {
               "source": "skills/engineering-workflow-automation/harvest/samples/work-report-simota-2026-01-31.md",
               "target": "skills/engineering-workflow-automation/harvest/samples/work-report-simota-2026-01-31.md",
+              "type": "file"
+            },
+            {
+              "source": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
+              "target": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
               "type": "file"
             }
           ],
@@ -5519,7 +5519,7 @@
         },
         {
           "path": "skills/engineering-workflow-automation/harvest/scripts/generate-report.js",
-          "sha256": "191cd0266edd13be4084ae45114117842d17427fcca276665e6692192de83f9a",
+          "sha256": "d356a7a6d5394b3b54faea8ab53ba950ed0dce32fee59d89f963ac7941bb3e47",
           "owner": "harvest",
           "mode": "100755"
         },

--- a/openclaw-skills/algorithmic-art/templates/viewer.html
+++ b/openclaw-skills/algorithmic-art/templates/viewer.html
@@ -20,7 +20,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generative Art Viewer</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"
+        integrity="sha384-Mhzoc5EVkjFUVtIW2M3h8BgXtFlUsUpu9lTCThPrV7+k6MN6vTi079rew0LkvgFb"
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">

--- a/openclaw-skills/dependency-auditor/README.md
+++ b/openclaw-skills/dependency-auditor/README.md
@@ -398,8 +398,14 @@ fi
 The `assets/` directory contains sample dependency files for testing:
 
 - `sample_package.json`: Node.js project with various dependencies
-- `sample_requirements.txt`: Python project dependencies
+- `sample_requirements.fixture`: intentionally vulnerable Python dependency fixture
 - `sample_go.mod`: Go module dependencies
+
+Intentionally vulnerable samples use non-manifest file names so GitHub Dependabot
+and other repository-level dependency automation do not mistake teaching fixtures
+for dependencies executed by this repository. Copy a fixture to the package
+manager's canonical manifest name inside an isolated temporary project before
+running scanner demonstrations.
 
 The `expected_outputs/` directory contains example reports showing the expected format and content.
 

--- a/openclaw-skills/dependency-auditor/assets/sample_requirements.fixture
+++ b/openclaw-skills/dependency-auditor/assets/sample_requirements.fixture
@@ -1,3 +1,4 @@
+# Intentionally vulnerable teaching fixture; copy to requirements.txt only in an isolated test directory.
 # Core web framework
 Django==4.1.7
 djangorestframework==3.14.0

--- a/openclaw-skills/dependency-auditor/scripts/dep_scanner.py
+++ b/openclaw-skills/dependency-auditor/scripts/dep_scanner.py
@@ -366,22 +366,48 @@ class DependencyScanner:
         
         try:
             with open(file_path, 'r') as f:
-                content = f.read()
-            
-            # Simple yarn.lock parsing
-            packages = re.findall(r'^([^#\s][^:]+):\s*\n(?:\s+.*\n)*?\s+version\s+"([^"]+)"', content, re.MULTILINE)
-            
-            for package_spec, version in packages:
-                name = package_spec.split('@')[0] if '@' in package_spec else package_spec
-                name = name.strip('"')
-                
-                dep = Dependency(
-                    name=name,
-                    version=version,
-                    ecosystem='npm',
-                    direct=False
-                )
-                dependencies.append(dep)
+                lines = f.readlines()
+
+            # Yarn v1 records are header lines followed by indented metadata.
+            # Parse them as a small state machine so hostile lockfiles cannot
+            # trigger catastrophic regular-expression backtracking.
+            package_spec = None
+            for raw_line in lines:
+                stripped = raw_line.strip()
+                if (
+                    stripped
+                    and not raw_line[:1].isspace()
+                    and not stripped.startswith('#')
+                    and stripped.endswith(':')
+                ):
+                    package_spec = stripped[:-1]
+                    continue
+
+                version_prefix = 'version "'
+                if (
+                    package_spec is not None
+                    and stripped.startswith(version_prefix)
+                    and stripped.endswith('"')
+                ):
+                    version = stripped[len(version_prefix):-1]
+                    first_selector = package_spec.split(',', 1)[0].strip().strip('"')
+                    if first_selector.startswith('@'):
+                        slash_index = first_selector.find('/')
+                        range_index = first_selector.find('@', slash_index + 1)
+                    else:
+                        range_index = first_selector.find('@')
+                    name = (
+                        first_selector[:range_index]
+                        if range_index > 0
+                        else first_selector
+                    )
+                    dependencies.append(Dependency(
+                        name=name,
+                        version=version,
+                        ecosystem='npm',
+                        direct=False
+                    ))
+                    package_spec = None
         
         except Exception as e:
             print(f"Error parsing yarn.lock: {e}")

--- a/openclaw-skills/dependency-auditor/test-project/package.vulnerable.fixture.json
+++ b/openclaw-skills/dependency-auditor/test-project/package.vulnerable.fixture.json
@@ -1,6 +1,7 @@
 {
   "name": "sample-web-app",
   "version": "1.2.3",
+  "private": true,
   "description": "A sample web application with various dependencies for testing dependency auditing",
   "main": "index.js",
   "scripts": {

--- a/openclaw-skills/gpt-image2/scripts/gpt-image2.mjs
+++ b/openclaw-skills/gpt-image2/scripts/gpt-image2.mjs
@@ -587,43 +587,67 @@ function inferMimeTypeFromMagic(raw) {
   return "";
 }
 
-function inferReferenceImageMimeType(filePath, raw) {
-  return inferMimeTypeFromMagic(raw) || IMAGE_MIME_BY_EXT.get(path.extname(filePath).toLowerCase()) || "";
+function inferReferenceImageMimeType(raw) {
+  return inferMimeTypeFromMagic(raw);
 }
 
-async function loadReferenceImages(imagePaths) {
+export async function loadReferenceImages(imagePaths) {
   if (imagePaths.length > MAX_REFERENCE_IMAGES) {
     throw new Error(`参考图最多支持 ${MAX_REFERENCE_IMAGES} 张`);
   }
 
   const images = [];
   for (const imagePath of imagePaths) {
-    const stat = await fs.stat(imagePath).catch((error) => {
+    let handle;
+    try {
+      handle = await fs.open(
+        imagePath,
+        fsSync.constants.O_RDONLY | (fsSync.constants.O_NOFOLLOW || 0),
+      );
+    } catch (error) {
       throw new Error(`参考图不存在或无法读取: ${imagePath} (${error.message})`);
-    });
-    if (!stat.isFile()) {
-      throw new Error(`参考图不是文件: ${imagePath}`);
-    }
-    if (stat.size <= 0) {
-      throw new Error(`参考图为空文件: ${imagePath}`);
-    }
-    if (stat.size > MAX_REFERENCE_IMAGE_BYTES) {
-      throw new Error(`参考图超过 10MB 限制: ${imagePath}`);
     }
 
-    const raw = await fs.readFile(imagePath);
-    const mimeType = inferReferenceImageMimeType(imagePath, raw);
-    if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(mimeType)) {
-      throw new Error(`参考图格式不支持或无法识别: ${imagePath}`);
-    }
+    try {
+      const before = await handle.stat({ bigint: true });
+      if (!before.isFile()) {
+        throw new Error(`参考图不是文件: ${imagePath}`);
+      }
+      if (before.size <= 0n) {
+        throw new Error(`参考图为空文件: ${imagePath}`);
+      }
+      if (before.size > BigInt(MAX_REFERENCE_IMAGE_BYTES)) {
+        throw new Error(`参考图超过 10MB 限制: ${imagePath}`);
+      }
 
-    images.push({
-      path: imagePath,
-      filename: path.basename(imagePath),
-      mimeType,
-      raw,
-      sizeBytes: raw.length,
-    });
+      const raw = await handle.readFile();
+      const after = await handle.stat({ bigint: true });
+      if (
+        raw.length !== Number(before.size) ||
+        before.dev !== after.dev ||
+        before.ino !== after.ino ||
+        before.size !== after.size ||
+        before.mtimeNs !== after.mtimeNs ||
+        before.ctimeNs !== after.ctimeNs
+      ) {
+        throw new Error(`参考图在读取期间发生变化: ${imagePath}`);
+      }
+
+      const mimeType = inferReferenceImageMimeType(raw);
+      if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(mimeType)) {
+        throw new Error(`参考图格式不支持或无法识别: ${imagePath}`);
+      }
+
+      images.push({
+        path: imagePath,
+        filename: path.basename(imagePath),
+        mimeType,
+        raw,
+        sizeBytes: raw.length,
+      });
+    } finally {
+      await handle.close();
+    }
   }
   return images;
 }
@@ -753,29 +777,100 @@ async function requestMultipart(url, fields, images, apiKey, timeoutMs) {
   }
 }
 
-async function downloadImageURL(url, timeoutMs) {
+function normalizeImageMimeType(value) {
+  const normalized = String(value || "").split(";", 1)[0].trim().toLowerCase();
+  if (normalized === "image/jpg") {
+    return "image/jpeg";
+  }
+  if (normalized === "image/heif") {
+    return "image/heic";
+  }
+  return normalized;
+}
+
+async function readResponseBytesLimited(response, maxBytes, label) {
+  if (!response.body || typeof response.body.getReader !== "function") {
+    throw new Error(`${label} returned an unreadable body`);
+  }
+
+  const chunks = [];
+  let total = 0;
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      total += chunk.length;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`${label} exceeds the ${Math.floor(maxBytes / 1024 / 1024)}MB limit`);
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+export async function downloadImageURL(url, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(url, {
       method: "GET",
+      redirect: "error",
       signal: controller.signal,
     });
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const rawError = await readResponseBytesLimited(response, 64 * 1024, "download error body")
+        .catch(() => Buffer.alloc(0));
+      const text = rawError.toString("utf8");
       throw new Error(`download HTTP ${response.status}: ${text.slice(0, 500)}`);
     }
 
-    const contentType = (response.headers.get("content-type") || "").split(";", 1)[0].trim();
-    if (contentType && !contentType.startsWith("image/")) {
+    const contentType = normalizeImageMimeType(response.headers.get("content-type"));
+    if (contentType && !SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(contentType)) {
       throw new Error(`download returned non-image content-type: ${contentType}`);
     }
 
-    const arrayBuffer = await response.arrayBuffer();
+    const contentLengthHeader = response.headers.get("content-length");
+    if (contentLengthHeader) {
+      if (!/^\d+$/.test(contentLengthHeader.trim())) {
+        throw new Error(`download returned invalid content-length: ${contentLengthHeader}`);
+      }
+      const contentLength = Number(contentLengthHeader);
+      if (!Number.isSafeInteger(contentLength) || contentLength <= 0) {
+        throw new Error(`download returned invalid content-length: ${contentLengthHeader}`);
+      }
+      if (contentLength > MAX_REFERENCE_IMAGE_BYTES) {
+        throw new Error("download exceeds the 10MB limit");
+      }
+    }
+
+    const raw = await readResponseBytesLimited(
+      response,
+      MAX_REFERENCE_IMAGE_BYTES,
+      "download",
+    );
+    if (raw.length === 0) {
+      throw new Error("download returned an empty image");
+    }
+    const detectedMimeType = normalizeImageMimeType(inferMimeTypeFromMagic(raw));
+    if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(detectedMimeType)) {
+      throw new Error("downloaded image format is not supported or cannot be identified");
+    }
+    if (contentType && contentType !== detectedMimeType) {
+      throw new Error(
+        `download content-type ${contentType} does not match detected ${detectedMimeType}`,
+      );
+    }
+
     return {
-      raw: Buffer.from(arrayBuffer),
-      mimeType: contentType || null,
+      raw,
+      mimeType: detectedMimeType,
     };
   } finally {
     clearTimeout(timer);
@@ -905,7 +1000,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack || error.message : String(error));
-  process.exit(1);
-});
+const isMain = Boolean(process.argv[1]) &&
+  fsSync.realpathSync(path.resolve(process.argv[1])) === fsSync.realpathSync(__filename);
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/openclaw-skills/harvest/scripts/generate-report.js
+++ b/openclaw-skills/harvest/scripts/generate-report.js
@@ -18,7 +18,7 @@
  *   node generate-report.js --repo owner/repo --output report.html
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -125,21 +125,37 @@ function formatDateFull(isoString) {
 // GitHub CLI Wrapper
 // ============================================
 
+function buildPrListArgs(options) {
+  const args = [
+    'pr',
+    'list',
+    '--state',
+    'merged',
+    '--limit',
+    '500',
+    '--json',
+    'number,title,author,createdAt,mergedAt,additions,deletions,changedFiles,labels,url',
+  ];
+
+  if (options.repo) {
+    args.push('-R', options.repo);
+  }
+  if (options.author) {
+    args.push('--author', options.author);
+  }
+
+  return args;
+}
+
 function fetchPRs(options) {
   const startDate = getStartDate(options.days);
 
-  let cmd = 'gh pr list --state merged --limit 500';
-  cmd += ' --json number,title,author,createdAt,mergedAt,additions,deletions,changedFiles,labels,url';
-
-  if (options.repo) {
-    cmd += ` -R ${options.repo}`;
-  }
-  if (options.author) {
-    cmd += ` --author ${options.author}`;
-  }
-
   try {
-    const result = execSync(cmd, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+    const result = execFileSync('gh', buildPrListArgs(options), {
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024,
+      shell: false,
+    });
     const prs = JSON.parse(result);
 
     // Filter by date
@@ -154,9 +170,14 @@ function getRepoName(options) {
   if (options.repo) return options.repo;
 
   try {
-    const result = execSync('gh repo view --json nameWithOwner -q ".nameWithOwner"', {
-      encoding: 'utf-8'
-    });
+    const result = execFileSync(
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+      {
+        encoding: 'utf-8',
+        shell: false,
+      }
+    );
     return result.trim();
   } catch {
     return 'Unknown Repository';
@@ -337,6 +358,94 @@ function generateCategoryChartData(byCategory) {
 // HTML Generation
 // ============================================
 
+function isAsciiDigit(char) {
+  return char >= '0' && char <= '9';
+}
+
+function skipAsciiWhitespace(source, start) {
+  let cursor = start;
+  while (cursor < source.length) {
+    const code = source.charCodeAt(cursor);
+    if (code !== 0x20 && (code < 0x09 || code > 0x0d)) break;
+    cursor++;
+  }
+  return cursor;
+}
+
+function parseNumberEnd(source, start) {
+  let cursor = start;
+  if (source[cursor] === '-') cursor++;
+
+  const integerStart = cursor;
+  while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+  if (cursor === integerStart) return -1;
+
+  if (source[cursor] === '.') {
+    cursor++;
+    const fractionStart = cursor;
+    while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+    if (cursor === fractionStart) return -1;
+  }
+
+  if (source[cursor] === 'e' || source[cursor] === 'E') {
+    cursor++;
+    if (source[cursor] === '+' || source[cursor] === '-') cursor++;
+    const exponentStart = cursor;
+    while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+    if (cursor === exponentStart) return -1;
+  }
+
+  return cursor;
+}
+
+function findNumericArrayEnd(source, openBracket) {
+  let cursor = skipAsciiWhitespace(source, openBracket + 1);
+  if (source[cursor] === ']') return cursor + 1;
+
+  while (cursor < source.length) {
+    cursor = parseNumberEnd(source, cursor);
+    if (cursor === -1) return -1;
+    cursor = skipAsciiWhitespace(source, cursor);
+
+    if (source[cursor] === ']') return cursor + 1;
+    if (source[cursor] !== ',') return -1;
+    cursor = skipAsciiWhitespace(source, cursor + 1);
+  }
+
+  return -1;
+}
+
+function replaceNumericDataArrays(source, replacer) {
+  let output = '';
+  let outputCursor = 0;
+  let searchCursor = 0;
+
+  while (searchCursor < source.length) {
+    const marker = source.indexOf('data:', searchCursor);
+    if (marker === -1) break;
+
+    const openBracket = skipAsciiWhitespace(source, marker + 'data:'.length);
+    if (source[openBracket] !== '[') {
+      searchCursor = marker + 'data:'.length;
+      continue;
+    }
+
+    const arrayEnd = findNumericArrayEnd(source, openBracket);
+    if (arrayEnd === -1) {
+      searchCursor = openBracket + 1;
+      continue;
+    }
+
+    const match = source.slice(marker, arrayEnd);
+    output += source.slice(outputCursor, marker);
+    output += replacer(match, marker, source);
+    outputCursor = arrayEnd;
+    searchCursor = arrayEnd;
+  }
+
+  return output + source.slice(outputCursor);
+}
+
 function generateHTML(data, templatePath) {
   const scriptDir = path.dirname(__filename);
   const harvestDir = path.dirname(scriptDir);
@@ -386,8 +495,8 @@ function generateHTML(data, templatePath) {
     }
   );
 
-  html = html.replace(
-    /data:\s*\[\d+(?:\.?\d*)?(?:,\s*\d+(?:\.?\d*)?)*\]/g,
+  html = replaceNumericDataArrays(
+    html,
     (match, offset) => {
       const before = html.substring(Math.max(0, offset - 300), offset);
       if (before.includes('dailyChart') || before.includes('Daily')) {
@@ -642,4 +751,13 @@ function main() {
   console.log(`Report generated: ${outputFile}`);
 }
 
-main();
+module.exports = {
+  buildPrListArgs,
+  fetchPRs,
+  generateHTML,
+  replaceNumericDataArrays,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/openclaw-skills/linkedin-growth/scripts/migrate-notion.mjs
+++ b/openclaw-skills/linkedin-growth/scripts/migrate-notion.mjs
@@ -17,17 +17,34 @@
 // DRY-RUN by default (no writes). Pass --apply to write.
 // Flags: --apply  --refetch  --rr=vlad,alex,maksim  --pending=keep|exhaust
 //
-import Database from 'better-sqlite3';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const HOME = process.env.HOME;
 const DATA_DIR = join(HOME, '.local/share/linkedapi-linkedin-growth');
-const TOKEN = readFileSync(join(DATA_DIR, '.notion-token'), 'utf8').trim();
+const TOKEN_PATH = join(DATA_DIR, '.notion-token');
 const DB_PATH = join(DATA_DIR, 'db.sqlite');
 const CACHE = join(DATA_DIR, 'tmp/notion-leads-cache.json');
 const PREVIEW = join(DATA_DIR, 'tmp/migration-preview.json');
-const NOTION_DB = '28665216-8ab0-809c-a8dc-d8fe366d0266';
+export const NOTION_QUERY_URL =
+  'https://api.notion.com/v1/databases/28665216-8ab0-809c-a8dc-d8fe366d0266/query';
 const HIST = '2026-01-01 00:00:00'; // fallback historical timestamp (safely before today)
 
 const args = process.argv.slice(2);
@@ -36,11 +53,65 @@ const REFETCH = args.includes('--refetch');
 const rrArg = (args.find((a) => a.startsWith('--rr=')) || '').split('=')[1];
 const pendingMode = (args.find((a) => a.startsWith('--pending=')) || '').split('=')[1] || 'keep';
 
-const H = { Authorization: 'Bearer ' + TOKEN, 'Notion-Version': '2022-06-28', 'Content-Type': 'application/json' };
 const rt = (p) => (p?.rich_text || []).map((t) => t.plain_text).join('');
 const ti = (p) => (p?.title || []).map((t) => t.plain_text).join('');
 const norm = (s) => (s || '').trim().toLowerCase();
 const RANK = { connected: 4, pending: 3, withdrawn: 2, error: 1 };
+
+function ensurePrivateDirectory(directoryPath) {
+  mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+  const stat = lstatSync(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`refusing non-directory cache path: ${directoryPath}`);
+  }
+  chmodSync(directoryPath, 0o700);
+}
+
+export function readJsonCache(filePath) {
+  let fd;
+  try {
+    const noFollow = constants.O_NOFOLLOW || 0;
+    fd = openSync(filePath, constants.O_RDONLY | noFollow);
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) {
+      throw new Error(`cache is not a regular file: ${filePath}`);
+    }
+    fchmodSync(fd, 0o600);
+    return JSON.parse(readFileSync(fd, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+export function writePrivateJsonAtomic(filePath, value, space = 0) {
+  const directoryPath = dirname(filePath);
+  ensurePrivateDirectory(directoryPath);
+  const temporaryPath = join(
+    directoryPath,
+    `.${basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  let fd;
+  try {
+    fd = openSync(
+      temporaryPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0),
+      0o600,
+    );
+    fchmodSync(fd, 0o600);
+    writeFileSync(fd, JSON.stringify(value, null, space), 'utf8');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(temporaryPath, filePath);
+    chmodSync(filePath, 0o600);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temporaryPath, { force: true });
+  }
+}
 
 function mapStatus(oldStatus) {
   const n = norm(oldStatus);
@@ -51,22 +122,43 @@ function mapStatus(oldStatus) {
   return 'not_connected';
 }
 
-async function fetchAll() {
-  if (existsSync(CACHE) && !REFETCH) {
-    const cached = JSON.parse(readFileSync(CACHE, 'utf8'));
-    process.stderr.write(`using cache (${cached.length} rows); pass --refetch to refresh\n`);
-    return cached;
+export async function fetchAll({
+  cachePath = CACHE,
+  fetchImpl = globalThis.fetch,
+  refetch = REFETCH,
+  token,
+} = {}) {
+  ensurePrivateDirectory(dirname(cachePath));
+  if (!refetch) {
+    const cached = readJsonCache(cachePath);
+    if (cached !== null) {
+      if (!Array.isArray(cached)) throw new Error(`invalid Notion cache payload: ${cachePath}`);
+      process.stderr.write(`using cache (${cached.length} rows); pass --refetch to refresh\n`);
+      return cached;
+    }
   }
+  if (!token) throw new Error('Notion token is required when refreshing the cache');
+  if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Notion-Version': '2022-06-28',
+    'Content-Type': 'application/json',
+  };
   let cursor;
   const rows = [];
   do {
     const body = { page_size: 100 };
     if (cursor) body.start_cursor = cursor;
-    const r = await fetch(`https://api.notion.com/v1/databases/${NOTION_DB}/query`, {
-      method: 'POST', headers: H, body: JSON.stringify(body),
+    const r = await fetchImpl(NOTION_QUERY_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      redirect: 'error',
     });
     const j = await r.json();
+    if (!r.ok) throw new Error(`Notion HTTP ${r.status}: ${j?.message || 'request failed'}`);
     if (j.object === 'error') throw new Error('Notion error: ' + j.message);
+    if (!Array.isArray(j.results)) throw new Error('Notion response is missing results');
     for (const row of j.results) {
       const p = row.properties;
       rows.push({
@@ -86,7 +178,7 @@ async function fetchAll() {
     process.stderr.write(`\rfetched ${rows.length}...`);
   } while (cursor);
   process.stderr.write('\n');
-  writeFileSync(CACHE, JSON.stringify(rows));
+  writePrivateJsonAtomic(cachePath, rows);
   return rows;
 }
 
@@ -119,7 +211,9 @@ function firstNonEmpty(rowsArr, key) {
 }
 
 async function main() {
-  const rows = await fetchAll();
+  const token = readFileSync(TOKEN_PATH, 'utf8').trim();
+  const rows = await fetchAll({ token });
+  const { default: Database } = await import('better-sqlite3');
 
   // --- collapse by hashed_url ---
   const groups = new Map();
@@ -239,7 +333,7 @@ async function main() {
     multi_list_people: multiList,
   };
   console.log(JSON.stringify(summary, null, 2));
-  writeFileSync(PREVIEW, JSON.stringify({ summary, sample: planned.slice(0, 25) }, null, 2));
+  writePrivateJsonAtomic(PREVIEW, { summary, sample: planned.slice(0, 25) }, 2);
   console.log(`\npreview (summary + 25 sample rows) written to: ${PREVIEW}`);
 
   if (!APPLY) {
@@ -274,4 +368,8 @@ async function main() {
   db.close();
 }
 
-main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });
+const isMain = Boolean(process.argv[1]) &&
+  realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });
+}

--- a/openclaw-skills/linkedin-growth/scripts/tick.mjs
+++ b/openclaw-skills/linkedin-growth/scripts/tick.mjs
@@ -343,12 +343,15 @@ export function readLegacyLockSnapshot(filePath) {
     fd = openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
   } catch (error) {
     if (error?.code === 'ENOENT') return null;
-    return { invalid: true };
+    return { invalid: true, recoverable: false };
   }
   try {
     const before = fstatSync(fd, { bigint: true });
-    if (!before.isFile() || before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
-      return { invalid: true };
+    if (!before.isFile()) {
+      return { invalid: true, recoverable: false };
+    }
+    if (before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
+      return { invalid: true, recoverable: true };
     }
     const buffer = Buffer.alloc(Number(before.size));
     let offset = 0;
@@ -366,10 +369,12 @@ export function readLegacyLockSnapshot(filePath) {
       before.mtimeNs !== after.mtimeNs ||
       before.ctimeNs !== after.ctimeNs
     ) {
-      return { invalid: true };
+      return { invalid: true, recoverable: false };
     }
     const record = parseLockRecord(buffer.toString('utf8'), { allowLegacyPid: true });
-    return record ? { invalid: false, record } : { invalid: true };
+    return record
+      ? { invalid: false, record }
+      : { invalid: true, recoverable: true };
   } finally {
     closeSync(fd);
   }
@@ -378,7 +383,7 @@ export function readLegacyLockSnapshot(filePath) {
 export function legacyLockBlocks(filePath, processAlive = isProcessAlive) {
   const snapshot = readLegacyLockSnapshot(filePath);
   if (snapshot === null) return false;
-  if (snapshot.invalid) return true;
+  if (snapshot.invalid) return !snapshot.recoverable;
   return processAlive(snapshot.record.pid);
 }
 

--- a/openclaw-skills/linkedin-growth/scripts/tick.mjs
+++ b/openclaw-skills/linkedin-growth/scripts/tick.mjs
@@ -29,31 +29,70 @@
 // moment it completes, and quotas are recomputed from the runs table each tick (bounded to
 // the local calendar day), so state stays correct across interruptions.
 //
+import { randomUUID } from 'node:crypto';
 import {
-  existsSync, writeFileSync, readFileSync, unlinkSync, openSync, closeSync,
-  appendFileSync, readdirSync, statSync,
+  appendFileSync,
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
-import { withDb } from './lib/db.mjs';
-import { ok, fail } from './lib/output.mjs';
-import { parseArgs } from './lib/args.mjs';
-import { dataDir, ensureDir, logsDir, SKILL_ROOT } from './lib/paths.mjs';
-import { defaults } from './lib/config.mjs';
-import {
-  startOfLocalDayUtc, localHHMM, parseDbUtc, minutesSince,
-} from './lib/time.mjs';
+import { fileURLToPath } from 'node:url';
 
-const { flags } = parseArgs();
+let withDb;
+let ok;
+let fail;
+let parseArgs;
+let dataDir;
+let ensureDir;
+let logsDir;
+let SKILL_ROOT;
+let defaults;
+let startOfLocalDayUtc;
+let localHHMM;
+let parseDbUtc;
+let minutesSince;
 
-try {
-  if (flags.account) {
-    await runWorker(String(flags.account));
-  } else {
-    dispatch();
+async function loadRuntime() {
+  ({ withDb } = await import('./lib/db.mjs'));
+  ({ ok, fail } = await import('./lib/output.mjs'));
+  ({ parseArgs } = await import('./lib/args.mjs'));
+  ({ dataDir, ensureDir, logsDir, SKILL_ROOT } = await import('./lib/paths.mjs'));
+  ({ defaults } = await import('./lib/config.mjs'));
+  ({ startOfLocalDayUtc, localHHMM, parseDbUtc, minutesSince } = await import('./lib/time.mjs'));
+}
+
+async function runCli() {
+  try {
+    await loadRuntime();
+    const { flags } = parseArgs();
+    if (flags.account) {
+      await runWorker(String(flags.account));
+    } else {
+      dispatch();
+    }
+  } catch (err) {
+    if (fail) {
+      fail(err.message);
+    } else {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exitCode = 1;
+    }
   }
-} catch (err) {
-  fail(err.message);
+}
+
+const isMain = Boolean(process.argv[1]) &&
+  realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  await runCli();
 }
 
 // Spawn one detached worker per eligible account, then exit. Never waits on a worker.
@@ -257,13 +296,16 @@ function logWorker(account, summary) {
   }
 }
 
-// --- Per-account lock: liveness-based, never time-based. ---
+// --- Per-account lock: SQLite IMMEDIATE transaction, never time-based. ---
+const LOCK_MAX_BYTES = 1024;
+const ownedLockTokens = new Map();
+
 function lockPath(account) {
   return join(dataDir(), `tick-${account}.lock`);
 }
 
 function isProcessAlive(pid) {
-  if (!pid) return false;
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
@@ -272,44 +314,160 @@ function isProcessAlive(pid) {
   }
 }
 
-function lockHeldByLiveProcess(account) {
-  const p = lockPath(account);
-  if (!existsSync(p)) return false;
+function parseLockRecord(rawValue, { allowLegacyPid = false } = {}) {
+  const raw = String(rawValue ?? '');
   try {
-    return isProcessAlive(Number(readFileSync(p, 'utf8')));
+    const parsed = JSON.parse(raw);
+    if (
+      Number.isSafeInteger(parsed?.pid) &&
+      parsed.pid > 0 &&
+      typeof parsed?.token === 'string' &&
+      parsed.token.length >= 8 &&
+      parsed.token.length <= 256
+    ) {
+      return { pid: parsed.pid, token: parsed.token };
+    }
   } catch {
-    return false;
+    // Legacy PID-only files are parsed below.
   }
+  if (allowLegacyPid) {
+    const pid = Number(raw.trim());
+    if (Number.isSafeInteger(pid) && pid > 0) return { pid, token: null };
+  }
+  return null;
+}
+
+export function readLegacyLockSnapshot(filePath) {
+  let fd;
+  try {
+    fd = openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    return { invalid: true };
+  }
+  try {
+    const before = fstatSync(fd, { bigint: true });
+    if (!before.isFile() || before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
+      return { invalid: true };
+    }
+    const buffer = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < buffer.length) {
+      const count = readSync(fd, buffer, offset, buffer.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const after = fstatSync(fd, { bigint: true });
+    if (
+      offset !== buffer.length ||
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs
+    ) {
+      return { invalid: true };
+    }
+    const record = parseLockRecord(buffer.toString('utf8'), { allowLegacyPid: true });
+    return record ? { invalid: false, record } : { invalid: true };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function legacyLockBlocks(filePath, processAlive = isProcessAlive) {
+  const snapshot = readLegacyLockSnapshot(filePath);
+  if (snapshot === null) return false;
+  if (snapshot.invalid) return true;
+  return processAlive(snapshot.record.pid);
+}
+
+function schedulerLockKey(account) {
+  return `scheduler_lock:${account}`;
+}
+
+function validateOwner(pid, token) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error('lock PID must be positive');
+  if (typeof token !== 'string' || token.length < 8 || token.length > 256) {
+    throw new Error('lock ownership token is invalid');
+  }
+}
+
+export function claimSchedulerLock(
+  db,
+  account,
+  pid,
+  token,
+  processAlive = isProcessAlive,
+) {
+  validateOwner(pid, token);
+  const key = schedulerLockKey(account);
+  const claim = db.transaction(() => {
+    const currentValue = db.prepare('SELECT value FROM settings WHERE key = ?').get(key)?.value;
+    if (currentValue !== undefined && currentValue !== null && String(currentValue).trim()) {
+      const current = parseLockRecord(currentValue);
+      if (!current || processAlive(current.pid)) return false;
+    }
+    db.prepare(
+      `INSERT INTO settings (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    ).run(key, JSON.stringify({ pid, token }));
+    return true;
+  });
+  return claim.immediate();
+}
+
+export function releaseSchedulerLock(db, account, pid, token) {
+  validateOwner(pid, token);
+  const key = schedulerLockKey(account);
+  const release = db.transaction(() => {
+    const currentValue = db.prepare('SELECT value FROM settings WHERE key = ?').get(key)?.value;
+    const current = parseLockRecord(currentValue);
+    if (!current || current.pid !== pid || current.token !== token) return false;
+    return db.prepare('DELETE FROM settings WHERE key = ?').run(key).changes === 1;
+  });
+  return release.immediate();
+}
+
+function databaseLockHeldByLiveProcess(account) {
+  return withDb(
+    (db) => {
+      const value = db
+        .prepare('SELECT value FROM settings WHERE key = ?')
+        .get(schedulerLockKey(account))?.value;
+      if (value === undefined || value === null || !String(value).trim()) return false;
+      const record = parseLockRecord(value);
+      return !record || isProcessAlive(record.pid);
+    },
+    { readonly: true },
+  );
+}
+
+function lockHeldByLiveProcess(account) {
+  if (legacyLockBlocks(lockPath(account))) return true;
+  return databaseLockHeldByLiveProcess(account);
 }
 
 function acquireLock(account) {
-  const p = lockPath(account);
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const fd = openSync(p, 'wx');
-      writeFileSync(fd, String(process.pid));
-      closeSync(fd);
-      return true;
-    } catch {
-      // Lock exists. Reclaim it only if its owner is dead; a live worker keeps it.
-      try {
-        if (isProcessAlive(Number(readFileSync(p, 'utf8')))) return false;
-        unlinkSync(p);
-      } catch {
-        return false;
-      }
-    }
-  }
-  return false;
+  if (legacyLockBlocks(lockPath(account))) return false;
+  const token = randomUUID();
+  const acquired = withDb(
+    (db) => claimSchedulerLock(db, account, process.pid, token),
+  );
+  if (!acquired) return false;
+  ownedLockTokens.set(account, token);
+  return true;
 }
 
 function releaseLock(account) {
-  const p = lockPath(account);
+  const token = ownedLockTokens.get(account);
+  if (!token) return;
   try {
-    if (!existsSync(p)) return;
-    if (Number(readFileSync(p, 'utf8')) === process.pid) unlinkSync(p);
+    withDb((db) => releaseSchedulerLock(db, account, process.pid, token));
   } catch {
-    /* ignore */
+    /* release is best-effort; token mismatch never deletes a newer owner */
+  } finally {
+    ownedLockTokens.delete(account);
   }
 }
 

--- a/openclaw-skills/migration-architect/scripts/rollback_generator.py
+++ b/openclaw-skills/migration-architect/scripts/rollback_generator.py
@@ -16,6 +16,8 @@ import argparse
 import sys
 import datetime
 import hashlib
+import os
+from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass, asdict
 from enum import Enum
@@ -115,6 +117,44 @@ class RollbackRunbook:
     validation_checklist: List[str]
     post_rollback_procedures: List[str]
     emergency_contacts: List[Dict[str, str]]
+
+
+REDACTED = "[REDACTED]"
+
+
+def runbook_to_dict(runbook: RollbackRunbook, include_sensitive: bool = False) -> Dict[str, Any]:
+    """Serialize a runbook with sensitive operational details redacted by default."""
+    data = asdict(runbook)
+    if include_sensitive:
+        return data
+
+    recovery_plan = data["data_recovery_plan"]
+    recovery_plan["backup_location"] = REDACTED
+    recovery_plan["recovery_scripts"] = [REDACTED]
+    recovery_plan["data_validation_queries"] = [REDACTED]
+    for contact in data["emergency_contacts"]:
+        for field in ("name", "primary_phone", "email", "backup_contact"):
+            contact[field] = REDACTED
+    return data
+
+
+def write_private_text(file_path: str | Path, content: str) -> None:
+    """Write output with owner-only permissions and without following symlinks."""
+    target = Path(file_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(target, flags, 0o600)
+    stream = None
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        stream.write(content)
+    finally:
+        if stream is not None:
+            stream.close()
+        elif descriptor >= 0:
+            os.close(descriptor)
 
 
 class RollbackGenerator:
@@ -937,7 +977,11 @@ Executive On-Call: {executive_on_call}
         
         return base_requirements
     
-    def generate_human_readable_runbook(self, runbook: RollbackRunbook) -> str:
+    def generate_human_readable_runbook(
+        self,
+        runbook: RollbackRunbook,
+        include_sensitive: bool = False,
+    ) -> str:
         """Generate human-readable rollback runbook"""
         output = []
         output.append("=" * 80)
@@ -951,10 +995,14 @@ Executive On-Call: {executive_on_call}
         output.append("EMERGENCY CONTACTS")
         output.append("-" * 40)
         for contact in runbook.emergency_contacts:
-            output.append(f"{contact['role']}: {contact['name']}")
-            output.append(f"  Phone: {contact['primary_phone']}")
-            output.append(f"  Email: {contact['email']}")
-            output.append(f"  Backup: {contact['backup_contact']}")
+            output.append(f"{contact['role']}:")
+            if include_sensitive:
+                output.append(f"  Name: {contact['name']}")
+                output.append(f"  Phone: {contact['primary_phone']}")
+                output.append(f"  Email: {contact['email']}")
+                output.append(f"  Backup: {contact['backup_contact']}")
+            else:
+                output.append(f"  Contact details: {REDACTED}")
             output.append("")
         
         # Escalation Matrix
@@ -1019,14 +1067,21 @@ Executive On-Call: {executive_on_call}
         output.append("-" * 40)
         drp = runbook.data_recovery_plan
         output.append(f"Recovery Method: {drp.recovery_method}")
-        output.append(f"Backup Location: {drp.backup_location}")
+        backup_location = drp.backup_location if include_sensitive else REDACTED
+        output.append(f"Backup Location: {backup_location}")
         output.append(f"Estimated Recovery Time: {drp.estimated_recovery_time_minutes} minutes")
         output.append("Recovery Scripts:")
-        for script in drp.recovery_scripts:
-            output.append(f"  • {script}")
+        if include_sensitive:
+            for script in drp.recovery_scripts:
+                output.append(f"  • {script}")
+        else:
+            output.append(f"  • {REDACTED}")
         output.append("Validation Queries:")
-        for query in drp.data_validation_queries:
-            output.append(f"  • {query}")
+        if include_sensitive:
+            for query in drp.data_validation_queries:
+                output.append(f"  • {query}")
+        else:
+            output.append(f"  • {REDACTED}")
         output.append("")
         
         # Validation Checklist
@@ -1052,8 +1107,15 @@ def main():
     parser.add_argument("--input", "-i", required=True, help="Input migration plan file (JSON)")
     parser.add_argument("--output", "-o", help="Output file for rollback runbook (JSON)")
     parser.add_argument("--format", "-f", choices=["json", "text", "both"], default="both", help="Output format")
+    parser.add_argument(
+        "--include-sensitive",
+        action="store_true",
+        help="Include sensitive contact and recovery details; requires --output",
+    )
     
     args = parser.parse_args()
+    if args.include_sensitive and not args.output:
+        parser.error("--include-sensitive requires --output; sensitive output is never printed")
     
     try:
         # Load migration plan
@@ -1071,20 +1133,32 @@ def main():
         
         # Output results
         if args.format in ["json", "both"]:
-            runbook_dict = asdict(runbook)
+            runbook_dict = runbook_to_dict(runbook, args.include_sensitive)
+            json_content = json.dumps(runbook_dict, indent=2) + "\n"
             if args.output:
-                with open(args.output, 'w') as f:
-                    json.dump(runbook_dict, f, indent=2)
+                write_private_text(args.output, json_content)
                 print(f"Rollback runbook saved to {args.output}")
             else:
-                print(json.dumps(runbook_dict, indent=2))
+                print(json_content, end="")
         
         if args.format in ["text", "both"]:
-            human_runbook = generator.generate_human_readable_runbook(runbook)
-            text_output = args.output.replace('.json', '.txt') if args.output else None
+            human_runbook = generator.generate_human_readable_runbook(
+                runbook,
+                include_sensitive=args.include_sensitive,
+            )
+            if args.output:
+                output_path = Path(args.output)
+                if args.format == "both":
+                    text_output = output_path.with_suffix(".txt")
+                    if text_output == output_path:
+                        text_output = Path(f"{output_path}.human.txt")
+                else:
+                    # Preserve the historical text-only CLI contract.
+                    text_output = Path(args.output.replace(".json", ".txt"))
+            else:
+                text_output = None
             if text_output:
-                with open(text_output, 'w') as f:
-                    f.write(human_runbook)
+                write_private_text(text_output, human_runbook + "\n")
                 print(f"Human-readable runbook saved to {text_output}")
             else:
                 print("\n" + "="*80)

--- a/openclaw-skills/repomix-safe-mixer/scripts/safe_pack.py
+++ b/openclaw-skills/repomix-safe-mixer/scripts/safe_pack.py
@@ -54,7 +54,7 @@ def print_findings_report(findings: list):
         print(f"🔴 {secret_type}: {count} instance(s)")
         for finding in by_type[secret_type][:3]:  # Show first 3
             print(f"   - {finding['file']}:{finding['line']}")
-            print(f"     Match: {finding['match']}")
+            print("     Match: [REDACTED]")
         if len(by_type[secret_type]) > 3:
             print(f"   ... and {len(by_type[secret_type]) - 3} more\n")
         else:

--- a/openclaw-skills/repomix-safe-mixer/scripts/scan_secrets.py
+++ b/openclaw-skills/repomix-safe-mixer/scripts/scan_secrets.py
@@ -40,24 +40,22 @@ SKIP_DIRS = {
     'node_modules', '.git', '.venv', 'venv', '__pycache__', 'dist', 'build',
     '.next', '.nuxt', 'vendor', 'target', 'bin', 'obj', '.terraform'
 }
+REDACTED = '[REDACTED]'
 
 class SecretFinding:
     """Represents a detected secret."""
-    def __init__(self, file_path: str, line_num: int, pattern_name: str,
-                 matched_text: str, line_content: str):
+    def __init__(self, file_path: str, line_num: int, pattern_name: str):
         self.file_path = file_path
         self.line_num = line_num
         self.pattern_name = pattern_name
-        self.matched_text = matched_text
-        self.line_content = line_content.strip()
 
     def to_dict(self) -> Dict:
         return {
             'file': self.file_path,
             'line': self.line_num,
             'type': self.pattern_name,
-            'match': self.matched_text[:50] + '...' if len(self.matched_text) > 50 else self.matched_text,
-            'context': self.line_content[:100] + '...' if len(self.line_content) > 100 else self.line_content
+            'match': REDACTED,
+            'context': REDACTED,
         }
 
 def scan_file(file_path: Path, base_dir: Path) -> List[SecretFinding]:
@@ -78,8 +76,6 @@ def scan_file(file_path: Path, base_dir: Path) -> List[SecretFinding]:
                             file_path=str(file_path.relative_to(base_dir)),
                             line_num=line_num,
                             pattern_name=pattern_name,
-                            matched_text=match.group(),
-                            line_content=line
                         ))
     except Exception as e:
         print(f"Warning: Could not scan {file_path}: {e}", file=sys.stderr)
@@ -158,8 +154,7 @@ def print_report(findings: List[SecretFinding], directory: Path):
         print(f"📄 {file_path}")
         for finding in by_file[file_path]:
             print(f"   Line {finding.line_num}: {finding.pattern_name}")
-            print(f"      Match: {finding.matched_text[:80]}")
-            print(f"      Context: {finding.line_content[:80]}")
+            print(f"      Match: {REDACTED}")
         print()
 
 def main():

--- a/openclaw-skills/transcript-fixer/scripts/fix_transcript_enhanced.py
+++ b/openclaw-skills/transcript-fixer/scripts/fix_transcript_enhanced.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 # CRITICAL FIX: Import secure secret handling
 sys.path.insert(0, str(Path(__file__).parent))
-from utils.security import mask_secret, SecretStr, validate_api_key
+from utils.security import validate_api_key
 
 # CRITICAL FIX: Import path validation (Critical-5)
 from utils.path_validator import PathValidator, PathValidationError, add_allowed_directory
@@ -68,17 +68,17 @@ def find_glm_api_key():
                                 parts = check_line.split('=', 1)
                                 if len(parts) == 2:
                                     key = parts[1].strip().strip('"').strip("'")
-                                    # CRITICAL FIX: Validate and mask API key
+                                    # Never emit any portion of the credential.
                                     if validate_api_key(key):
-                                        print(f"✓ Found API key in {config_file}: {mask_secret(key)}")
+                                        print(f"✓ Found API key configuration in {config_file}")
                                         return key
                         elif 'export' in check_line and ('TOKEN' in check_line or 'KEY' in check_line):
                             parts = check_line.split('=', 1)
                             if len(parts) == 2:
                                 key = parts[1].strip().strip('"').strip("'")
-                                # CRITICAL FIX: Validate and mask API key
+                                # Never emit any portion of the credential.
                                 if validate_api_key(key):
-                                    print(f"✓ Found API key in {config_file}: {mask_secret(key)}")
+                                    print(f"✓ Found API key configuration in {config_file}")
                                     return key
         except Exception as e:
             print(f"⚠️  Could not read {config_file}: {e}", file=sys.stderr)

--- a/skills/developer-engineering/dependency-auditor/README.md
+++ b/skills/developer-engineering/dependency-auditor/README.md
@@ -398,8 +398,14 @@ fi
 The `assets/` directory contains sample dependency files for testing:
 
 - `sample_package.json`: Node.js project with various dependencies
-- `sample_requirements.txt`: Python project dependencies
+- `sample_requirements.fixture`: intentionally vulnerable Python dependency fixture
 - `sample_go.mod`: Go module dependencies
+
+Intentionally vulnerable samples use non-manifest file names so GitHub Dependabot
+and other repository-level dependency automation do not mistake teaching fixtures
+for dependencies executed by this repository. Copy a fixture to the package
+manager's canonical manifest name inside an isolated temporary project before
+running scanner demonstrations.
 
 The `expected_outputs/` directory contains example reports showing the expected format and content.
 

--- a/skills/developer-engineering/dependency-auditor/assets/sample_requirements.fixture
+++ b/skills/developer-engineering/dependency-auditor/assets/sample_requirements.fixture
@@ -1,3 +1,4 @@
+# Intentionally vulnerable teaching fixture; copy to requirements.txt only in an isolated test directory.
 # Core web framework
 Django==4.1.7
 djangorestframework==3.14.0

--- a/skills/developer-engineering/dependency-auditor/scripts/dep_scanner.py
+++ b/skills/developer-engineering/dependency-auditor/scripts/dep_scanner.py
@@ -366,22 +366,48 @@ class DependencyScanner:
         
         try:
             with open(file_path, 'r') as f:
-                content = f.read()
-            
-            # Simple yarn.lock parsing
-            packages = re.findall(r'^([^#\s][^:]+):\s*\n(?:\s+.*\n)*?\s+version\s+"([^"]+)"', content, re.MULTILINE)
-            
-            for package_spec, version in packages:
-                name = package_spec.split('@')[0] if '@' in package_spec else package_spec
-                name = name.strip('"')
-                
-                dep = Dependency(
-                    name=name,
-                    version=version,
-                    ecosystem='npm',
-                    direct=False
-                )
-                dependencies.append(dep)
+                lines = f.readlines()
+
+            # Yarn v1 records are header lines followed by indented metadata.
+            # Parse them as a small state machine so hostile lockfiles cannot
+            # trigger catastrophic regular-expression backtracking.
+            package_spec = None
+            for raw_line in lines:
+                stripped = raw_line.strip()
+                if (
+                    stripped
+                    and not raw_line[:1].isspace()
+                    and not stripped.startswith('#')
+                    and stripped.endswith(':')
+                ):
+                    package_spec = stripped[:-1]
+                    continue
+
+                version_prefix = 'version "'
+                if (
+                    package_spec is not None
+                    and stripped.startswith(version_prefix)
+                    and stripped.endswith('"')
+                ):
+                    version = stripped[len(version_prefix):-1]
+                    first_selector = package_spec.split(',', 1)[0].strip().strip('"')
+                    if first_selector.startswith('@'):
+                        slash_index = first_selector.find('/')
+                        range_index = first_selector.find('@', slash_index + 1)
+                    else:
+                        range_index = first_selector.find('@')
+                    name = (
+                        first_selector[:range_index]
+                        if range_index > 0
+                        else first_selector
+                    )
+                    dependencies.append(Dependency(
+                        name=name,
+                        version=version,
+                        ecosystem='npm',
+                        direct=False
+                    ))
+                    package_spec = None
         
         except Exception as e:
             print(f"Error parsing yarn.lock: {e}")

--- a/skills/developer-engineering/dependency-auditor/test-project/package.vulnerable.fixture.json
+++ b/skills/developer-engineering/dependency-auditor/test-project/package.vulnerable.fixture.json
@@ -1,6 +1,7 @@
 {
   "name": "sample-web-app",
   "version": "1.2.3",
+  "private": true,
   "description": "A sample web application with various dependencies for testing dependency auditing",
   "main": "index.js",
   "scripts": {

--- a/skills/developer-engineering/migration-architect/scripts/rollback_generator.py
+++ b/skills/developer-engineering/migration-architect/scripts/rollback_generator.py
@@ -16,6 +16,8 @@ import argparse
 import sys
 import datetime
 import hashlib
+import os
+from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass, asdict
 from enum import Enum
@@ -115,6 +117,44 @@ class RollbackRunbook:
     validation_checklist: List[str]
     post_rollback_procedures: List[str]
     emergency_contacts: List[Dict[str, str]]
+
+
+REDACTED = "[REDACTED]"
+
+
+def runbook_to_dict(runbook: RollbackRunbook, include_sensitive: bool = False) -> Dict[str, Any]:
+    """Serialize a runbook with sensitive operational details redacted by default."""
+    data = asdict(runbook)
+    if include_sensitive:
+        return data
+
+    recovery_plan = data["data_recovery_plan"]
+    recovery_plan["backup_location"] = REDACTED
+    recovery_plan["recovery_scripts"] = [REDACTED]
+    recovery_plan["data_validation_queries"] = [REDACTED]
+    for contact in data["emergency_contacts"]:
+        for field in ("name", "primary_phone", "email", "backup_contact"):
+            contact[field] = REDACTED
+    return data
+
+
+def write_private_text(file_path: str | Path, content: str) -> None:
+    """Write output with owner-only permissions and without following symlinks."""
+    target = Path(file_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(target, flags, 0o600)
+    stream = None
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        stream = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = -1
+        stream.write(content)
+    finally:
+        if stream is not None:
+            stream.close()
+        elif descriptor >= 0:
+            os.close(descriptor)
 
 
 class RollbackGenerator:
@@ -937,7 +977,11 @@ Executive On-Call: {executive_on_call}
         
         return base_requirements
     
-    def generate_human_readable_runbook(self, runbook: RollbackRunbook) -> str:
+    def generate_human_readable_runbook(
+        self,
+        runbook: RollbackRunbook,
+        include_sensitive: bool = False,
+    ) -> str:
         """Generate human-readable rollback runbook"""
         output = []
         output.append("=" * 80)
@@ -951,10 +995,14 @@ Executive On-Call: {executive_on_call}
         output.append("EMERGENCY CONTACTS")
         output.append("-" * 40)
         for contact in runbook.emergency_contacts:
-            output.append(f"{contact['role']}: {contact['name']}")
-            output.append(f"  Phone: {contact['primary_phone']}")
-            output.append(f"  Email: {contact['email']}")
-            output.append(f"  Backup: {contact['backup_contact']}")
+            output.append(f"{contact['role']}:")
+            if include_sensitive:
+                output.append(f"  Name: {contact['name']}")
+                output.append(f"  Phone: {contact['primary_phone']}")
+                output.append(f"  Email: {contact['email']}")
+                output.append(f"  Backup: {contact['backup_contact']}")
+            else:
+                output.append(f"  Contact details: {REDACTED}")
             output.append("")
         
         # Escalation Matrix
@@ -1019,14 +1067,21 @@ Executive On-Call: {executive_on_call}
         output.append("-" * 40)
         drp = runbook.data_recovery_plan
         output.append(f"Recovery Method: {drp.recovery_method}")
-        output.append(f"Backup Location: {drp.backup_location}")
+        backup_location = drp.backup_location if include_sensitive else REDACTED
+        output.append(f"Backup Location: {backup_location}")
         output.append(f"Estimated Recovery Time: {drp.estimated_recovery_time_minutes} minutes")
         output.append("Recovery Scripts:")
-        for script in drp.recovery_scripts:
-            output.append(f"  • {script}")
+        if include_sensitive:
+            for script in drp.recovery_scripts:
+                output.append(f"  • {script}")
+        else:
+            output.append(f"  • {REDACTED}")
         output.append("Validation Queries:")
-        for query in drp.data_validation_queries:
-            output.append(f"  • {query}")
+        if include_sensitive:
+            for query in drp.data_validation_queries:
+                output.append(f"  • {query}")
+        else:
+            output.append(f"  • {REDACTED}")
         output.append("")
         
         # Validation Checklist
@@ -1052,8 +1107,15 @@ def main():
     parser.add_argument("--input", "-i", required=True, help="Input migration plan file (JSON)")
     parser.add_argument("--output", "-o", help="Output file for rollback runbook (JSON)")
     parser.add_argument("--format", "-f", choices=["json", "text", "both"], default="both", help="Output format")
+    parser.add_argument(
+        "--include-sensitive",
+        action="store_true",
+        help="Include sensitive contact and recovery details; requires --output",
+    )
     
     args = parser.parse_args()
+    if args.include_sensitive and not args.output:
+        parser.error("--include-sensitive requires --output; sensitive output is never printed")
     
     try:
         # Load migration plan
@@ -1071,20 +1133,32 @@ def main():
         
         # Output results
         if args.format in ["json", "both"]:
-            runbook_dict = asdict(runbook)
+            runbook_dict = runbook_to_dict(runbook, args.include_sensitive)
+            json_content = json.dumps(runbook_dict, indent=2) + "\n"
             if args.output:
-                with open(args.output, 'w') as f:
-                    json.dump(runbook_dict, f, indent=2)
+                write_private_text(args.output, json_content)
                 print(f"Rollback runbook saved to {args.output}")
             else:
-                print(json.dumps(runbook_dict, indent=2))
+                print(json_content, end="")
         
         if args.format in ["text", "both"]:
-            human_runbook = generator.generate_human_readable_runbook(runbook)
-            text_output = args.output.replace('.json', '.txt') if args.output else None
+            human_runbook = generator.generate_human_readable_runbook(
+                runbook,
+                include_sensitive=args.include_sensitive,
+            )
+            if args.output:
+                output_path = Path(args.output)
+                if args.format == "both":
+                    text_output = output_path.with_suffix(".txt")
+                    if text_output == output_path:
+                        text_output = Path(f"{output_path}.human.txt")
+                else:
+                    # Preserve the historical text-only CLI contract.
+                    text_output = Path(args.output.replace(".json", ".txt"))
+            else:
+                text_output = None
             if text_output:
-                with open(text_output, 'w') as f:
-                    f.write(human_runbook)
+                write_private_text(text_output, human_runbook + "\n")
                 print(f"Human-readable runbook saved to {text_output}")
             else:
                 print("\n" + "="*80)

--- a/skills/developer-engineering/repomix-safe-mixer/scripts/safe_pack.py
+++ b/skills/developer-engineering/repomix-safe-mixer/scripts/safe_pack.py
@@ -54,7 +54,7 @@ def print_findings_report(findings: list):
         print(f"🔴 {secret_type}: {count} instance(s)")
         for finding in by_type[secret_type][:3]:  # Show first 3
             print(f"   - {finding['file']}:{finding['line']}")
-            print(f"     Match: {finding['match']}")
+            print("     Match: [REDACTED]")
         if len(by_type[secret_type]) > 3:
             print(f"   ... and {len(by_type[secret_type]) - 3} more\n")
         else:

--- a/skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py
+++ b/skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py
@@ -40,24 +40,22 @@ SKIP_DIRS = {
     'node_modules', '.git', '.venv', 'venv', '__pycache__', 'dist', 'build',
     '.next', '.nuxt', 'vendor', 'target', 'bin', 'obj', '.terraform'
 }
+REDACTED = '[REDACTED]'
 
 class SecretFinding:
     """Represents a detected secret."""
-    def __init__(self, file_path: str, line_num: int, pattern_name: str,
-                 matched_text: str, line_content: str):
+    def __init__(self, file_path: str, line_num: int, pattern_name: str):
         self.file_path = file_path
         self.line_num = line_num
         self.pattern_name = pattern_name
-        self.matched_text = matched_text
-        self.line_content = line_content.strip()
 
     def to_dict(self) -> Dict:
         return {
             'file': self.file_path,
             'line': self.line_num,
             'type': self.pattern_name,
-            'match': self.matched_text[:50] + '...' if len(self.matched_text) > 50 else self.matched_text,
-            'context': self.line_content[:100] + '...' if len(self.line_content) > 100 else self.line_content
+            'match': REDACTED,
+            'context': REDACTED,
         }
 
 def scan_file(file_path: Path, base_dir: Path) -> List[SecretFinding]:
@@ -78,8 +76,6 @@ def scan_file(file_path: Path, base_dir: Path) -> List[SecretFinding]:
                             file_path=str(file_path.relative_to(base_dir)),
                             line_num=line_num,
                             pattern_name=pattern_name,
-                            matched_text=match.group(),
-                            line_content=line
                         ))
     except Exception as e:
         print(f"Warning: Could not scan {file_path}: {e}", file=sys.stderr)
@@ -158,8 +154,7 @@ def print_report(findings: List[SecretFinding], directory: Path):
         print(f"📄 {file_path}")
         for finding in by_file[file_path]:
             print(f"   Line {finding.line_num}: {finding.pattern_name}")
-            print(f"      Match: {finding.matched_text[:80]}")
-            print(f"      Context: {finding.line_content[:80]}")
+            print(f"      Match: {REDACTED}")
         print()
 
 def main():

--- a/skills/engineering-workflow-automation/harvest/scripts/generate-report.js
+++ b/skills/engineering-workflow-automation/harvest/scripts/generate-report.js
@@ -18,7 +18,7 @@
  *   node generate-report.js --repo owner/repo --output report.html
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -125,21 +125,37 @@ function formatDateFull(isoString) {
 // GitHub CLI Wrapper
 // ============================================
 
+function buildPrListArgs(options) {
+  const args = [
+    'pr',
+    'list',
+    '--state',
+    'merged',
+    '--limit',
+    '500',
+    '--json',
+    'number,title,author,createdAt,mergedAt,additions,deletions,changedFiles,labels,url',
+  ];
+
+  if (options.repo) {
+    args.push('-R', options.repo);
+  }
+  if (options.author) {
+    args.push('--author', options.author);
+  }
+
+  return args;
+}
+
 function fetchPRs(options) {
   const startDate = getStartDate(options.days);
 
-  let cmd = 'gh pr list --state merged --limit 500';
-  cmd += ' --json number,title,author,createdAt,mergedAt,additions,deletions,changedFiles,labels,url';
-
-  if (options.repo) {
-    cmd += ` -R ${options.repo}`;
-  }
-  if (options.author) {
-    cmd += ` --author ${options.author}`;
-  }
-
   try {
-    const result = execSync(cmd, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+    const result = execFileSync('gh', buildPrListArgs(options), {
+      encoding: 'utf-8',
+      maxBuffer: 10 * 1024 * 1024,
+      shell: false,
+    });
     const prs = JSON.parse(result);
 
     // Filter by date
@@ -154,9 +170,14 @@ function getRepoName(options) {
   if (options.repo) return options.repo;
 
   try {
-    const result = execSync('gh repo view --json nameWithOwner -q ".nameWithOwner"', {
-      encoding: 'utf-8'
-    });
+    const result = execFileSync(
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+      {
+        encoding: 'utf-8',
+        shell: false,
+      }
+    );
     return result.trim();
   } catch {
     return 'Unknown Repository';
@@ -337,6 +358,94 @@ function generateCategoryChartData(byCategory) {
 // HTML Generation
 // ============================================
 
+function isAsciiDigit(char) {
+  return char >= '0' && char <= '9';
+}
+
+function skipAsciiWhitespace(source, start) {
+  let cursor = start;
+  while (cursor < source.length) {
+    const code = source.charCodeAt(cursor);
+    if (code !== 0x20 && (code < 0x09 || code > 0x0d)) break;
+    cursor++;
+  }
+  return cursor;
+}
+
+function parseNumberEnd(source, start) {
+  let cursor = start;
+  if (source[cursor] === '-') cursor++;
+
+  const integerStart = cursor;
+  while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+  if (cursor === integerStart) return -1;
+
+  if (source[cursor] === '.') {
+    cursor++;
+    const fractionStart = cursor;
+    while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+    if (cursor === fractionStart) return -1;
+  }
+
+  if (source[cursor] === 'e' || source[cursor] === 'E') {
+    cursor++;
+    if (source[cursor] === '+' || source[cursor] === '-') cursor++;
+    const exponentStart = cursor;
+    while (cursor < source.length && isAsciiDigit(source[cursor])) cursor++;
+    if (cursor === exponentStart) return -1;
+  }
+
+  return cursor;
+}
+
+function findNumericArrayEnd(source, openBracket) {
+  let cursor = skipAsciiWhitespace(source, openBracket + 1);
+  if (source[cursor] === ']') return cursor + 1;
+
+  while (cursor < source.length) {
+    cursor = parseNumberEnd(source, cursor);
+    if (cursor === -1) return -1;
+    cursor = skipAsciiWhitespace(source, cursor);
+
+    if (source[cursor] === ']') return cursor + 1;
+    if (source[cursor] !== ',') return -1;
+    cursor = skipAsciiWhitespace(source, cursor + 1);
+  }
+
+  return -1;
+}
+
+function replaceNumericDataArrays(source, replacer) {
+  let output = '';
+  let outputCursor = 0;
+  let searchCursor = 0;
+
+  while (searchCursor < source.length) {
+    const marker = source.indexOf('data:', searchCursor);
+    if (marker === -1) break;
+
+    const openBracket = skipAsciiWhitespace(source, marker + 'data:'.length);
+    if (source[openBracket] !== '[') {
+      searchCursor = marker + 'data:'.length;
+      continue;
+    }
+
+    const arrayEnd = findNumericArrayEnd(source, openBracket);
+    if (arrayEnd === -1) {
+      searchCursor = openBracket + 1;
+      continue;
+    }
+
+    const match = source.slice(marker, arrayEnd);
+    output += source.slice(outputCursor, marker);
+    output += replacer(match, marker, source);
+    outputCursor = arrayEnd;
+    searchCursor = arrayEnd;
+  }
+
+  return output + source.slice(outputCursor);
+}
+
 function generateHTML(data, templatePath) {
   const scriptDir = path.dirname(__filename);
   const harvestDir = path.dirname(scriptDir);
@@ -386,8 +495,8 @@ function generateHTML(data, templatePath) {
     }
   );
 
-  html = html.replace(
-    /data:\s*\[\d+(?:\.?\d*)?(?:,\s*\d+(?:\.?\d*)?)*\]/g,
+  html = replaceNumericDataArrays(
+    html,
     (match, offset) => {
       const before = html.substring(Math.max(0, offset - 300), offset);
       if (before.includes('dailyChart') || before.includes('Daily')) {
@@ -642,4 +751,13 @@ function main() {
   console.log(`Report generated: ${outputFile}`);
 }
 
-main();
+module.exports = {
+  buildPrListArgs,
+  fetchPRs,
+  generateHTML,
+  replaceNumericDataArrays,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/skills/growth-operations-xiaohongshu/algorithmic-art/templates/viewer.html
+++ b/skills/growth-operations-xiaohongshu/algorithmic-art/templates/viewer.html
@@ -20,7 +20,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generative Art Viewer</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"
+        integrity="sha384-Mhzoc5EVkjFUVtIW2M3h8BgXtFlUsUpu9lTCThPrV7+k6MN6vTi079rew0LkvgFb"
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">

--- a/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs
+++ b/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/migrate-notion.mjs
@@ -17,17 +17,34 @@
 // DRY-RUN by default (no writes). Pass --apply to write.
 // Flags: --apply  --refetch  --rr=vlad,alex,maksim  --pending=keep|exhaust
 //
-import Database from 'better-sqlite3';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const HOME = process.env.HOME;
 const DATA_DIR = join(HOME, '.local/share/linkedapi-linkedin-growth');
-const TOKEN = readFileSync(join(DATA_DIR, '.notion-token'), 'utf8').trim();
+const TOKEN_PATH = join(DATA_DIR, '.notion-token');
 const DB_PATH = join(DATA_DIR, 'db.sqlite');
 const CACHE = join(DATA_DIR, 'tmp/notion-leads-cache.json');
 const PREVIEW = join(DATA_DIR, 'tmp/migration-preview.json');
-const NOTION_DB = '28665216-8ab0-809c-a8dc-d8fe366d0266';
+export const NOTION_QUERY_URL =
+  'https://api.notion.com/v1/databases/28665216-8ab0-809c-a8dc-d8fe366d0266/query';
 const HIST = '2026-01-01 00:00:00'; // fallback historical timestamp (safely before today)
 
 const args = process.argv.slice(2);
@@ -36,11 +53,65 @@ const REFETCH = args.includes('--refetch');
 const rrArg = (args.find((a) => a.startsWith('--rr=')) || '').split('=')[1];
 const pendingMode = (args.find((a) => a.startsWith('--pending=')) || '').split('=')[1] || 'keep';
 
-const H = { Authorization: 'Bearer ' + TOKEN, 'Notion-Version': '2022-06-28', 'Content-Type': 'application/json' };
 const rt = (p) => (p?.rich_text || []).map((t) => t.plain_text).join('');
 const ti = (p) => (p?.title || []).map((t) => t.plain_text).join('');
 const norm = (s) => (s || '').trim().toLowerCase();
 const RANK = { connected: 4, pending: 3, withdrawn: 2, error: 1 };
+
+function ensurePrivateDirectory(directoryPath) {
+  mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+  const stat = lstatSync(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`refusing non-directory cache path: ${directoryPath}`);
+  }
+  chmodSync(directoryPath, 0o700);
+}
+
+export function readJsonCache(filePath) {
+  let fd;
+  try {
+    const noFollow = constants.O_NOFOLLOW || 0;
+    fd = openSync(filePath, constants.O_RDONLY | noFollow);
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) {
+      throw new Error(`cache is not a regular file: ${filePath}`);
+    }
+    fchmodSync(fd, 0o600);
+    return JSON.parse(readFileSync(fd, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+export function writePrivateJsonAtomic(filePath, value, space = 0) {
+  const directoryPath = dirname(filePath);
+  ensurePrivateDirectory(directoryPath);
+  const temporaryPath = join(
+    directoryPath,
+    `.${basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  let fd;
+  try {
+    fd = openSync(
+      temporaryPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0),
+      0o600,
+    );
+    fchmodSync(fd, 0o600);
+    writeFileSync(fd, JSON.stringify(value, null, space), 'utf8');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(temporaryPath, filePath);
+    chmodSync(filePath, 0o600);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temporaryPath, { force: true });
+  }
+}
 
 function mapStatus(oldStatus) {
   const n = norm(oldStatus);
@@ -51,22 +122,43 @@ function mapStatus(oldStatus) {
   return 'not_connected';
 }
 
-async function fetchAll() {
-  if (existsSync(CACHE) && !REFETCH) {
-    const cached = JSON.parse(readFileSync(CACHE, 'utf8'));
-    process.stderr.write(`using cache (${cached.length} rows); pass --refetch to refresh\n`);
-    return cached;
+export async function fetchAll({
+  cachePath = CACHE,
+  fetchImpl = globalThis.fetch,
+  refetch = REFETCH,
+  token,
+} = {}) {
+  ensurePrivateDirectory(dirname(cachePath));
+  if (!refetch) {
+    const cached = readJsonCache(cachePath);
+    if (cached !== null) {
+      if (!Array.isArray(cached)) throw new Error(`invalid Notion cache payload: ${cachePath}`);
+      process.stderr.write(`using cache (${cached.length} rows); pass --refetch to refresh\n`);
+      return cached;
+    }
   }
+  if (!token) throw new Error('Notion token is required when refreshing the cache');
+  if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Notion-Version': '2022-06-28',
+    'Content-Type': 'application/json',
+  };
   let cursor;
   const rows = [];
   do {
     const body = { page_size: 100 };
     if (cursor) body.start_cursor = cursor;
-    const r = await fetch(`https://api.notion.com/v1/databases/${NOTION_DB}/query`, {
-      method: 'POST', headers: H, body: JSON.stringify(body),
+    const r = await fetchImpl(NOTION_QUERY_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      redirect: 'error',
     });
     const j = await r.json();
+    if (!r.ok) throw new Error(`Notion HTTP ${r.status}: ${j?.message || 'request failed'}`);
     if (j.object === 'error') throw new Error('Notion error: ' + j.message);
+    if (!Array.isArray(j.results)) throw new Error('Notion response is missing results');
     for (const row of j.results) {
       const p = row.properties;
       rows.push({
@@ -86,7 +178,7 @@ async function fetchAll() {
     process.stderr.write(`\rfetched ${rows.length}...`);
   } while (cursor);
   process.stderr.write('\n');
-  writeFileSync(CACHE, JSON.stringify(rows));
+  writePrivateJsonAtomic(cachePath, rows);
   return rows;
 }
 
@@ -119,7 +211,9 @@ function firstNonEmpty(rowsArr, key) {
 }
 
 async function main() {
-  const rows = await fetchAll();
+  const token = readFileSync(TOKEN_PATH, 'utf8').trim();
+  const rows = await fetchAll({ token });
+  const { default: Database } = await import('better-sqlite3');
 
   // --- collapse by hashed_url ---
   const groups = new Map();
@@ -239,7 +333,7 @@ async function main() {
     multi_list_people: multiList,
   };
   console.log(JSON.stringify(summary, null, 2));
-  writeFileSync(PREVIEW, JSON.stringify({ summary, sample: planned.slice(0, 25) }, null, 2));
+  writePrivateJsonAtomic(PREVIEW, { summary, sample: planned.slice(0, 25) }, 2);
   console.log(`\npreview (summary + 25 sample rows) written to: ${PREVIEW}`);
 
   if (!APPLY) {
@@ -274,4 +368,8 @@ async function main() {
   db.close();
 }
 
-main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });
+const isMain = Boolean(process.argv[1]) &&
+  realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });
+}

--- a/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs
+++ b/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs
@@ -343,12 +343,15 @@ export function readLegacyLockSnapshot(filePath) {
     fd = openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
   } catch (error) {
     if (error?.code === 'ENOENT') return null;
-    return { invalid: true };
+    return { invalid: true, recoverable: false };
   }
   try {
     const before = fstatSync(fd, { bigint: true });
-    if (!before.isFile() || before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
-      return { invalid: true };
+    if (!before.isFile()) {
+      return { invalid: true, recoverable: false };
+    }
+    if (before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
+      return { invalid: true, recoverable: true };
     }
     const buffer = Buffer.alloc(Number(before.size));
     let offset = 0;
@@ -366,10 +369,12 @@ export function readLegacyLockSnapshot(filePath) {
       before.mtimeNs !== after.mtimeNs ||
       before.ctimeNs !== after.ctimeNs
     ) {
-      return { invalid: true };
+      return { invalid: true, recoverable: false };
     }
     const record = parseLockRecord(buffer.toString('utf8'), { allowLegacyPid: true });
-    return record ? { invalid: false, record } : { invalid: true };
+    return record
+      ? { invalid: false, record }
+      : { invalid: true, recoverable: true };
   } finally {
     closeSync(fd);
   }
@@ -378,7 +383,7 @@ export function readLegacyLockSnapshot(filePath) {
 export function legacyLockBlocks(filePath, processAlive = isProcessAlive) {
   const snapshot = readLegacyLockSnapshot(filePath);
   if (snapshot === null) return false;
-  if (snapshot.invalid) return true;
+  if (snapshot.invalid) return !snapshot.recoverable;
   return processAlive(snapshot.record.pid);
 }
 

--- a/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs
+++ b/skills/growth-operations-xiaohongshu/linkedin-growth/scripts/tick.mjs
@@ -29,31 +29,70 @@
 // moment it completes, and quotas are recomputed from the runs table each tick (bounded to
 // the local calendar day), so state stays correct across interruptions.
 //
+import { randomUUID } from 'node:crypto';
 import {
-  existsSync, writeFileSync, readFileSync, unlinkSync, openSync, closeSync,
-  appendFileSync, readdirSync, statSync,
+  appendFileSync,
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
-import { withDb } from './lib/db.mjs';
-import { ok, fail } from './lib/output.mjs';
-import { parseArgs } from './lib/args.mjs';
-import { dataDir, ensureDir, logsDir, SKILL_ROOT } from './lib/paths.mjs';
-import { defaults } from './lib/config.mjs';
-import {
-  startOfLocalDayUtc, localHHMM, parseDbUtc, minutesSince,
-} from './lib/time.mjs';
+import { fileURLToPath } from 'node:url';
 
-const { flags } = parseArgs();
+let withDb;
+let ok;
+let fail;
+let parseArgs;
+let dataDir;
+let ensureDir;
+let logsDir;
+let SKILL_ROOT;
+let defaults;
+let startOfLocalDayUtc;
+let localHHMM;
+let parseDbUtc;
+let minutesSince;
 
-try {
-  if (flags.account) {
-    await runWorker(String(flags.account));
-  } else {
-    dispatch();
+async function loadRuntime() {
+  ({ withDb } = await import('./lib/db.mjs'));
+  ({ ok, fail } = await import('./lib/output.mjs'));
+  ({ parseArgs } = await import('./lib/args.mjs'));
+  ({ dataDir, ensureDir, logsDir, SKILL_ROOT } = await import('./lib/paths.mjs'));
+  ({ defaults } = await import('./lib/config.mjs'));
+  ({ startOfLocalDayUtc, localHHMM, parseDbUtc, minutesSince } = await import('./lib/time.mjs'));
+}
+
+async function runCli() {
+  try {
+    await loadRuntime();
+    const { flags } = parseArgs();
+    if (flags.account) {
+      await runWorker(String(flags.account));
+    } else {
+      dispatch();
+    }
+  } catch (err) {
+    if (fail) {
+      fail(err.message);
+    } else {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exitCode = 1;
+    }
   }
-} catch (err) {
-  fail(err.message);
+}
+
+const isMain = Boolean(process.argv[1]) &&
+  realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) {
+  await runCli();
 }
 
 // Spawn one detached worker per eligible account, then exit. Never waits on a worker.
@@ -257,13 +296,16 @@ function logWorker(account, summary) {
   }
 }
 
-// --- Per-account lock: liveness-based, never time-based. ---
+// --- Per-account lock: SQLite IMMEDIATE transaction, never time-based. ---
+const LOCK_MAX_BYTES = 1024;
+const ownedLockTokens = new Map();
+
 function lockPath(account) {
   return join(dataDir(), `tick-${account}.lock`);
 }
 
 function isProcessAlive(pid) {
-  if (!pid) return false;
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;
@@ -272,44 +314,160 @@ function isProcessAlive(pid) {
   }
 }
 
-function lockHeldByLiveProcess(account) {
-  const p = lockPath(account);
-  if (!existsSync(p)) return false;
+function parseLockRecord(rawValue, { allowLegacyPid = false } = {}) {
+  const raw = String(rawValue ?? '');
   try {
-    return isProcessAlive(Number(readFileSync(p, 'utf8')));
+    const parsed = JSON.parse(raw);
+    if (
+      Number.isSafeInteger(parsed?.pid) &&
+      parsed.pid > 0 &&
+      typeof parsed?.token === 'string' &&
+      parsed.token.length >= 8 &&
+      parsed.token.length <= 256
+    ) {
+      return { pid: parsed.pid, token: parsed.token };
+    }
   } catch {
-    return false;
+    // Legacy PID-only files are parsed below.
   }
+  if (allowLegacyPid) {
+    const pid = Number(raw.trim());
+    if (Number.isSafeInteger(pid) && pid > 0) return { pid, token: null };
+  }
+  return null;
+}
+
+export function readLegacyLockSnapshot(filePath) {
+  let fd;
+  try {
+    fd = openSync(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    return { invalid: true };
+  }
+  try {
+    const before = fstatSync(fd, { bigint: true });
+    if (!before.isFile() || before.size <= 0n || before.size > BigInt(LOCK_MAX_BYTES)) {
+      return { invalid: true };
+    }
+    const buffer = Buffer.alloc(Number(before.size));
+    let offset = 0;
+    while (offset < buffer.length) {
+      const count = readSync(fd, buffer, offset, buffer.length - offset, offset);
+      if (count === 0) break;
+      offset += count;
+    }
+    const after = fstatSync(fd, { bigint: true });
+    if (
+      offset !== buffer.length ||
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.size !== after.size ||
+      before.mtimeNs !== after.mtimeNs ||
+      before.ctimeNs !== after.ctimeNs
+    ) {
+      return { invalid: true };
+    }
+    const record = parseLockRecord(buffer.toString('utf8'), { allowLegacyPid: true });
+    return record ? { invalid: false, record } : { invalid: true };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function legacyLockBlocks(filePath, processAlive = isProcessAlive) {
+  const snapshot = readLegacyLockSnapshot(filePath);
+  if (snapshot === null) return false;
+  if (snapshot.invalid) return true;
+  return processAlive(snapshot.record.pid);
+}
+
+function schedulerLockKey(account) {
+  return `scheduler_lock:${account}`;
+}
+
+function validateOwner(pid, token) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error('lock PID must be positive');
+  if (typeof token !== 'string' || token.length < 8 || token.length > 256) {
+    throw new Error('lock ownership token is invalid');
+  }
+}
+
+export function claimSchedulerLock(
+  db,
+  account,
+  pid,
+  token,
+  processAlive = isProcessAlive,
+) {
+  validateOwner(pid, token);
+  const key = schedulerLockKey(account);
+  const claim = db.transaction(() => {
+    const currentValue = db.prepare('SELECT value FROM settings WHERE key = ?').get(key)?.value;
+    if (currentValue !== undefined && currentValue !== null && String(currentValue).trim()) {
+      const current = parseLockRecord(currentValue);
+      if (!current || processAlive(current.pid)) return false;
+    }
+    db.prepare(
+      `INSERT INTO settings (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    ).run(key, JSON.stringify({ pid, token }));
+    return true;
+  });
+  return claim.immediate();
+}
+
+export function releaseSchedulerLock(db, account, pid, token) {
+  validateOwner(pid, token);
+  const key = schedulerLockKey(account);
+  const release = db.transaction(() => {
+    const currentValue = db.prepare('SELECT value FROM settings WHERE key = ?').get(key)?.value;
+    const current = parseLockRecord(currentValue);
+    if (!current || current.pid !== pid || current.token !== token) return false;
+    return db.prepare('DELETE FROM settings WHERE key = ?').run(key).changes === 1;
+  });
+  return release.immediate();
+}
+
+function databaseLockHeldByLiveProcess(account) {
+  return withDb(
+    (db) => {
+      const value = db
+        .prepare('SELECT value FROM settings WHERE key = ?')
+        .get(schedulerLockKey(account))?.value;
+      if (value === undefined || value === null || !String(value).trim()) return false;
+      const record = parseLockRecord(value);
+      return !record || isProcessAlive(record.pid);
+    },
+    { readonly: true },
+  );
+}
+
+function lockHeldByLiveProcess(account) {
+  if (legacyLockBlocks(lockPath(account))) return true;
+  return databaseLockHeldByLiveProcess(account);
 }
 
 function acquireLock(account) {
-  const p = lockPath(account);
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const fd = openSync(p, 'wx');
-      writeFileSync(fd, String(process.pid));
-      closeSync(fd);
-      return true;
-    } catch {
-      // Lock exists. Reclaim it only if its owner is dead; a live worker keeps it.
-      try {
-        if (isProcessAlive(Number(readFileSync(p, 'utf8')))) return false;
-        unlinkSync(p);
-      } catch {
-        return false;
-      }
-    }
-  }
-  return false;
+  if (legacyLockBlocks(lockPath(account))) return false;
+  const token = randomUUID();
+  const acquired = withDb(
+    (db) => claimSchedulerLock(db, account, process.pid, token),
+  );
+  if (!acquired) return false;
+  ownedLockTokens.set(account, token);
+  return true;
 }
 
 function releaseLock(account) {
-  const p = lockPath(account);
+  const token = ownedLockTokens.get(account);
+  if (!token) return;
   try {
-    if (!existsSync(p)) return;
-    if (Number(readFileSync(p, 'utf8')) === process.pid) unlinkSync(p);
+    withDb((db) => releaseSchedulerLock(db, account, process.pid, token));
   } catch {
-    /* ignore */
+    /* release is best-effort; token mismatch never deletes a newer owner */
+  } finally {
+    ownedLockTokens.delete(account);
   }
 }
 

--- a/skills/multimodal-media/gpt-image2/scripts/gpt-image2.mjs
+++ b/skills/multimodal-media/gpt-image2/scripts/gpt-image2.mjs
@@ -587,43 +587,67 @@ function inferMimeTypeFromMagic(raw) {
   return "";
 }
 
-function inferReferenceImageMimeType(filePath, raw) {
-  return inferMimeTypeFromMagic(raw) || IMAGE_MIME_BY_EXT.get(path.extname(filePath).toLowerCase()) || "";
+function inferReferenceImageMimeType(raw) {
+  return inferMimeTypeFromMagic(raw);
 }
 
-async function loadReferenceImages(imagePaths) {
+export async function loadReferenceImages(imagePaths) {
   if (imagePaths.length > MAX_REFERENCE_IMAGES) {
     throw new Error(`参考图最多支持 ${MAX_REFERENCE_IMAGES} 张`);
   }
 
   const images = [];
   for (const imagePath of imagePaths) {
-    const stat = await fs.stat(imagePath).catch((error) => {
+    let handle;
+    try {
+      handle = await fs.open(
+        imagePath,
+        fsSync.constants.O_RDONLY | (fsSync.constants.O_NOFOLLOW || 0),
+      );
+    } catch (error) {
       throw new Error(`参考图不存在或无法读取: ${imagePath} (${error.message})`);
-    });
-    if (!stat.isFile()) {
-      throw new Error(`参考图不是文件: ${imagePath}`);
-    }
-    if (stat.size <= 0) {
-      throw new Error(`参考图为空文件: ${imagePath}`);
-    }
-    if (stat.size > MAX_REFERENCE_IMAGE_BYTES) {
-      throw new Error(`参考图超过 10MB 限制: ${imagePath}`);
     }
 
-    const raw = await fs.readFile(imagePath);
-    const mimeType = inferReferenceImageMimeType(imagePath, raw);
-    if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(mimeType)) {
-      throw new Error(`参考图格式不支持或无法识别: ${imagePath}`);
-    }
+    try {
+      const before = await handle.stat({ bigint: true });
+      if (!before.isFile()) {
+        throw new Error(`参考图不是文件: ${imagePath}`);
+      }
+      if (before.size <= 0n) {
+        throw new Error(`参考图为空文件: ${imagePath}`);
+      }
+      if (before.size > BigInt(MAX_REFERENCE_IMAGE_BYTES)) {
+        throw new Error(`参考图超过 10MB 限制: ${imagePath}`);
+      }
 
-    images.push({
-      path: imagePath,
-      filename: path.basename(imagePath),
-      mimeType,
-      raw,
-      sizeBytes: raw.length,
-    });
+      const raw = await handle.readFile();
+      const after = await handle.stat({ bigint: true });
+      if (
+        raw.length !== Number(before.size) ||
+        before.dev !== after.dev ||
+        before.ino !== after.ino ||
+        before.size !== after.size ||
+        before.mtimeNs !== after.mtimeNs ||
+        before.ctimeNs !== after.ctimeNs
+      ) {
+        throw new Error(`参考图在读取期间发生变化: ${imagePath}`);
+      }
+
+      const mimeType = inferReferenceImageMimeType(raw);
+      if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(mimeType)) {
+        throw new Error(`参考图格式不支持或无法识别: ${imagePath}`);
+      }
+
+      images.push({
+        path: imagePath,
+        filename: path.basename(imagePath),
+        mimeType,
+        raw,
+        sizeBytes: raw.length,
+      });
+    } finally {
+      await handle.close();
+    }
   }
   return images;
 }
@@ -753,29 +777,100 @@ async function requestMultipart(url, fields, images, apiKey, timeoutMs) {
   }
 }
 
-async function downloadImageURL(url, timeoutMs) {
+function normalizeImageMimeType(value) {
+  const normalized = String(value || "").split(";", 1)[0].trim().toLowerCase();
+  if (normalized === "image/jpg") {
+    return "image/jpeg";
+  }
+  if (normalized === "image/heif") {
+    return "image/heic";
+  }
+  return normalized;
+}
+
+async function readResponseBytesLimited(response, maxBytes, label) {
+  if (!response.body || typeof response.body.getReader !== "function") {
+    throw new Error(`${label} returned an unreadable body`);
+  }
+
+  const chunks = [];
+  let total = 0;
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = Buffer.from(value);
+      total += chunk.length;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`${label} exceeds the ${Math.floor(maxBytes / 1024 / 1024)}MB limit`);
+      }
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+export async function downloadImageURL(url, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(url, {
       method: "GET",
+      redirect: "error",
       signal: controller.signal,
     });
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const rawError = await readResponseBytesLimited(response, 64 * 1024, "download error body")
+        .catch(() => Buffer.alloc(0));
+      const text = rawError.toString("utf8");
       throw new Error(`download HTTP ${response.status}: ${text.slice(0, 500)}`);
     }
 
-    const contentType = (response.headers.get("content-type") || "").split(";", 1)[0].trim();
-    if (contentType && !contentType.startsWith("image/")) {
+    const contentType = normalizeImageMimeType(response.headers.get("content-type"));
+    if (contentType && !SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(contentType)) {
       throw new Error(`download returned non-image content-type: ${contentType}`);
     }
 
-    const arrayBuffer = await response.arrayBuffer();
+    const contentLengthHeader = response.headers.get("content-length");
+    if (contentLengthHeader) {
+      if (!/^\d+$/.test(contentLengthHeader.trim())) {
+        throw new Error(`download returned invalid content-length: ${contentLengthHeader}`);
+      }
+      const contentLength = Number(contentLengthHeader);
+      if (!Number.isSafeInteger(contentLength) || contentLength <= 0) {
+        throw new Error(`download returned invalid content-length: ${contentLengthHeader}`);
+      }
+      if (contentLength > MAX_REFERENCE_IMAGE_BYTES) {
+        throw new Error("download exceeds the 10MB limit");
+      }
+    }
+
+    const raw = await readResponseBytesLimited(
+      response,
+      MAX_REFERENCE_IMAGE_BYTES,
+      "download",
+    );
+    if (raw.length === 0) {
+      throw new Error("download returned an empty image");
+    }
+    const detectedMimeType = normalizeImageMimeType(inferMimeTypeFromMagic(raw));
+    if (!SUPPORTED_REFERENCE_IMAGE_MIME_TYPES.has(detectedMimeType)) {
+      throw new Error("downloaded image format is not supported or cannot be identified");
+    }
+    if (contentType && contentType !== detectedMimeType) {
+      throw new Error(
+        `download content-type ${contentType} does not match detected ${detectedMimeType}`,
+      );
+    }
+
     return {
-      raw: Buffer.from(arrayBuffer),
-      mimeType: contentType || null,
+      raw,
+      mimeType: detectedMimeType,
     };
   } finally {
     clearTimeout(timer);
@@ -905,7 +1000,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack || error.message : String(error));
-  process.exit(1);
-});
+const isMain = Boolean(process.argv[1]) &&
+  fsSync.realpathSync(path.resolve(process.argv[1])) === fsSync.realpathSync(__filename);
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/skills/office-white-collar/transcript-fixer/scripts/fix_transcript_enhanced.py
+++ b/skills/office-white-collar/transcript-fixer/scripts/fix_transcript_enhanced.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 # CRITICAL FIX: Import secure secret handling
 sys.path.insert(0, str(Path(__file__).parent))
-from utils.security import mask_secret, SecretStr, validate_api_key
+from utils.security import validate_api_key
 
 # CRITICAL FIX: Import path validation (Critical-5)
 from utils.path_validator import PathValidator, PathValidationError, add_allowed_directory
@@ -68,17 +68,17 @@ def find_glm_api_key():
                                 parts = check_line.split('=', 1)
                                 if len(parts) == 2:
                                     key = parts[1].strip().strip('"').strip("'")
-                                    # CRITICAL FIX: Validate and mask API key
+                                    # Never emit any portion of the credential.
                                     if validate_api_key(key):
-                                        print(f"✓ Found API key in {config_file}: {mask_secret(key)}")
+                                        print(f"✓ Found API key configuration in {config_file}")
                                         return key
                         elif 'export' in check_line and ('TOKEN' in check_line or 'KEY' in check_line):
                             parts = check_line.split('=', 1)
                             if len(parts) == 2:
                                 key = parts[1].strip().strip('"').strip("'")
-                                # CRITICAL FIX: Validate and mask API key
+                                # Never emit any portion of the credential.
                                 if validate_api_key(key):
-                                    print(f"✓ Found API key in {config_file}: {mask_secret(key)}")
+                                    print(f"✓ Found API key configuration in {config_file}")
                                     return key
         except Exception as e:
             print(f"⚠️  Could not read {config_file}: {e}", file=sys.stderr)

--- a/tests/test_codeql_batch_a_security.py
+++ b/tests/test_codeql_batch_a_security.py
@@ -1,0 +1,171 @@
+import json
+import subprocess
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_VALIDATION = REPO_ROOT / ".github" / "workflows" / "repo-validation.yml"
+PROVENANCE_CI = REPO_ROOT / ".github" / "workflows" / "skills-provenance-ci.yml"
+CHANGELOG_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "changelog.yml"
+HARVEST_REPORT = (
+    REPO_ROOT
+    / "skills"
+    / "engineering-workflow-automation"
+    / "harvest"
+    / "scripts"
+    / "generate-report.js"
+)
+HARVEST_TEMPLATE = (
+    REPO_ROOT
+    / "skills"
+    / "engineering-workflow-automation"
+    / "harvest"
+    / "templates"
+    / "client-report.html"
+)
+ALGORITHMIC_ART_VIEWER = (
+    REPO_ROOT
+    / "skills"
+    / "growth-operations-xiaohongshu"
+    / "algorithmic-art"
+    / "templates"
+    / "viewer.html"
+)
+CREATE_PULL_REQUEST_V6_COMMIT = "c5a7806660adbe173f04e3e038b0ccdcd758773c"
+P5_1_7_0_SHA384 = (
+    "sha384-Mhzoc5EVkjFUVtIW2M3h8BgXtFlUsUpu9lTCThPrV7+"
+    "k6MN6vTi079rew0LkvgFb"
+)
+
+
+class ScriptTagParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.scripts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "script":
+            self.scripts.append(dict(attrs))
+
+
+class CodeQLBatchASecurityTests(unittest.TestCase):
+    def test_read_only_workflows_declare_top_level_contents_permission(self):
+        for workflow_path in (REPO_VALIDATION, PROVENANCE_CI):
+            with self.subTest(workflow=workflow_path.name):
+                workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+                self.assertEqual({"contents": "read"}, workflow.get("permissions"))
+
+    def test_changelog_third_party_action_is_pinned_to_full_commit(self):
+        workflow = yaml.safe_load(CHANGELOG_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["refresh-changelog"]["steps"]
+        create_pr = next(
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith(
+                "peter-evans/create-pull-request@"
+            )
+        )
+        self.assertEqual(
+            f"peter-evans/create-pull-request@{CREATE_PULL_REQUEST_V6_COMMIT}",
+            create_pr["uses"],
+        )
+
+    def test_harvest_passes_untrusted_filters_as_gh_argv(self):
+        repo_value = "owner/repo; touch /tmp/must-not-run"
+        author_value = "alice && echo injected"
+        node_source = f"""
+const report = require({json.dumps(str(HARVEST_REPORT))});
+const args = report.buildPrListArgs(
+  {{
+    days: 7,
+    repo: {json.dumps(repo_value)},
+    author: {json.dumps(author_value)}
+  }}
+);
+process.stdout.write(JSON.stringify(args));
+"""
+        result = subprocess.run(
+            ["node", "-e", node_source],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        args = json.loads(result.stdout)
+        self.assertIn(repo_value, args)
+        self.assertIn(author_value, args)
+        self.assertEqual(repo_value, args[args.index("-R") + 1])
+        self.assertEqual(author_value, args[args.index("--author") + 1])
+
+        source = HARVEST_REPORT.read_text(encoding="utf-8")
+        self.assertNotIn("execSync", source)
+        self.assertIn("execFileSync", source)
+        self.assertIn("shell: false", source)
+
+    def test_harvest_numeric_array_replacement_is_linear_and_bounded(self):
+        node_source = f"""
+const assert = require("node:assert/strict");
+const report = require({json.dumps(str(HARVEST_REPORT))});
+const valid = "dailyChart data: [1, 2.5, 3]\\nCategory data:\\t[4]";
+assert.equal(
+  report.replaceNumericDataArrays(valid, () => "data: [9]"),
+  "dailyChart data: [9]\\nCategory data: [9]"
+);
+const adversarial = "data:[" + "1".repeat(60000) + "x";
+assert.equal(
+  report.replaceNumericDataArrays(adversarial, () => "must-not-replace"),
+  adversarial
+);
+const rendered = report.generateHTML(
+  {{
+    meta: {{
+      projectName: "project",
+      author: "author",
+      startDateFormatted: "start",
+      endDateFormatted: "end",
+      generatedAtFormatted: "generated"
+    }},
+    summary: {{
+      totalTasks: 1,
+      totalHours: "2.0",
+      totalAdditions: "+3",
+      completionRate: "100%"
+    }},
+    charts: {{
+      daily: {{ labels: ["D"], data: [8.5] }},
+      category: {{ labels: ["C"], data: [2] }}
+    }}
+  }},
+  {json.dumps(str(HARVEST_TEMPLATE))}
+);
+assert.match(rendered, /dailyChart[\\s\\S]*?data: \\[8\\.5\\]/);
+assert.match(rendered, /categoryChart[\\s\\S]*?data: \\[2\\]/);
+"""
+        subprocess.run(
+            ["node", "-e", node_source],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+
+    def test_algorithmic_art_p5_script_has_verified_sri(self):
+        parser = ScriptTagParser()
+        parser.feed(ALGORITHMIC_ART_VIEWER.read_text(encoding="utf-8"))
+        p5_script = next(
+            script
+            for script in parser.scripts
+            if script.get("src", "").endswith("/p5.js/1.7.0/p5.min.js")
+        )
+        self.assertEqual(P5_1_7_0_SHA384, p5_script.get("integrity"))
+        self.assertEqual("anonymous", p5_script.get("crossorigin"))
+        self.assertEqual("no-referrer", p5_script.get("referrerpolicy"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codeql_batch_b_security.py
+++ b/tests/test_codeql_batch_b_security.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATE_NOTION = (
+    ROOT
+    / "skills"
+    / "growth-operations-xiaohongshu"
+    / "linkedin-growth"
+    / "scripts"
+    / "migrate-notion.mjs"
+)
+TICK = (
+    ROOT
+    / "skills"
+    / "growth-operations-xiaohongshu"
+    / "linkedin-growth"
+    / "scripts"
+    / "tick.mjs"
+)
+GPT_IMAGE2 = (
+    ROOT
+    / "skills"
+    / "multimodal-media"
+    / "gpt-image2"
+    / "scripts"
+    / "gpt-image2.mjs"
+)
+
+
+def run_node(source: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", source, *args],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def assert_node_ok(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, (
+        f"node exited {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_notion_cache_is_private_atomic_and_missing_cache_is_not_a_toctou(tmp_path: Path) -> None:
+    module_url = MIGRATE_NOTION.as_uri()
+    result = run_node(
+        """
+        import assert from "node:assert/strict";
+        import fs from "node:fs";
+        import path from "node:path";
+        import {
+          readJsonCache,
+          writePrivateJsonAtomic,
+        } from %s;
+
+        const root = process.argv[1];
+        const cache = path.join(root, "private-cache", "rows.json");
+        assert.equal(readJsonCache(cache), null);
+
+        writePrivateJsonAtomic(cache, [{ id: 1 }]);
+        assert.deepEqual(readJsonCache(cache), [{ id: 1 }]);
+        assert.equal(fs.statSync(path.dirname(cache)).mode & 0o777, 0o700);
+        assert.equal(fs.statSync(cache).mode & 0o777, 0o600);
+        assert.deepEqual(
+          fs.readdirSync(path.dirname(cache)).sort(),
+          ["rows.json"],
+          "atomic temp files must be cleaned up",
+        );
+
+        fs.writeFileSync(cache, "{broken", { mode: 0o600 });
+        assert.throws(() => readJsonCache(cache), SyntaxError);
+        """
+        % json.dumps(module_url),
+        str(tmp_path),
+    )
+    assert_node_ok(result)
+
+
+def test_notion_fetch_uses_fixed_endpoint_and_rejects_redirects(tmp_path: Path) -> None:
+    module_url = MIGRATE_NOTION.as_uri()
+    result = run_node(
+        """
+        import assert from "node:assert/strict";
+        import path from "node:path";
+        import { fetchAll, NOTION_QUERY_URL } from %s;
+
+        const calls = [];
+        const fetchImpl = async (url, options) => {
+          calls.push({ url, options });
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: "list",
+              results: [],
+              has_more: false,
+              next_cursor: null,
+            }),
+          };
+        };
+
+        const rows = await fetchAll({
+          cachePath: path.join(process.argv[1], "cache", "rows.json"),
+          fetchImpl,
+          refetch: true,
+          token: "test-token",
+        });
+        assert.deepEqual(rows, []);
+        assert.equal(
+          NOTION_QUERY_URL,
+          "https://api.notion.com/v1/databases/28665216-8ab0-809c-a8dc-d8fe366d0266/query",
+        );
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].url, NOTION_QUERY_URL);
+        assert.equal(calls[0].options.redirect, "error");
+        """
+        % json.dumps(module_url),
+        str(tmp_path),
+    )
+    assert_node_ok(result)
+
+
+def test_tick_sqlite_immediate_claim_allows_only_one_live_contender(
+    tmp_path: Path,
+) -> None:
+    module_url = TICK.as_uri()
+    result = run_node(
+        """
+        import assert from "node:assert/strict";
+        import {
+          claimSchedulerLock,
+          releaseSchedulerLock,
+        } from %s;
+
+        function fakeSettingsDb() {
+          const rows = new Map();
+          let immediateCalls = 0;
+          return {
+            rows,
+            get immediateCalls() { return immediateCalls; },
+            transaction(fn) {
+              return {
+                immediate() {
+                  immediateCalls += 1;
+                  return fn();
+                },
+              };
+            },
+            prepare(sql) {
+              if (sql.startsWith("SELECT value")) {
+                return {
+                  get(key) {
+                    return rows.has(key) ? { value: rows.get(key) } : undefined;
+                  },
+                };
+              }
+              if (sql.startsWith("INSERT INTO settings")) {
+                return {
+                  run(key, value) {
+                    rows.set(key, value);
+                    return { changes: 1 };
+                  },
+                };
+              }
+              if (sql.startsWith("DELETE FROM settings")) {
+                return {
+                  run(key) {
+                    const changes = rows.delete(key) ? 1 : 0;
+                    return { changes };
+                  },
+                };
+              }
+              throw new Error(`unexpected SQL: ${sql}`);
+            },
+          };
+        }
+
+        const db = fakeSettingsDb();
+        assert.equal(
+          claimSchedulerLock(db, "alice", 101, "owner-token-a", () => false),
+          true,
+        );
+        assert.equal(
+          claimSchedulerLock(db, "alice", 202, "owner-token-b", (pid) => pid === 101),
+          false,
+          "the second contender must observe the first live owner in the same immediate transaction",
+        );
+        assert.equal(db.immediateCalls, 2);
+        assert.deepEqual(
+          JSON.parse(db.rows.get("scheduler_lock:alice")),
+          { pid: 101, token: "owner-token-a" },
+        );
+
+        // A stale owner cannot delete a newer token.
+        db.rows.set(
+          "scheduler_lock:alice",
+          JSON.stringify({ pid: 202, token: "owner-token-b" }),
+        );
+        assert.equal(releaseSchedulerLock(db, "alice", 101, "owner-token-a"), false);
+        assert.deepEqual(
+          JSON.parse(db.rows.get("scheduler_lock:alice")),
+          { pid: 202, token: "owner-token-b" },
+        );
+        assert.equal(releaseSchedulerLock(db, "alice", 202, "owner-token-b"), true);
+        assert.equal(db.rows.has("scheduler_lock:alice"), false);
+        """
+        % json.dumps(module_url),
+        str(tmp_path),
+    )
+    assert_node_ok(result)
+
+
+def test_tick_legacy_file_lock_is_read_only_and_live_or_invalid_blocks(
+    tmp_path: Path,
+) -> None:
+    module_url = TICK.as_uri()
+    result = run_node(
+        """
+        import assert from "node:assert/strict";
+        import fs from "node:fs";
+        import path from "node:path";
+        import {
+          legacyLockBlocks,
+          readLegacyLockSnapshot,
+        } from %s;
+
+        const root = process.argv[1];
+        const livePath = path.join(root, "live.lock");
+        fs.writeFileSync(livePath, String(process.pid), { mode: 0o600 });
+        const before = fs.readFileSync(livePath, "utf8");
+        assert.equal(readLegacyLockSnapshot(livePath).record.pid, process.pid);
+        assert.equal(legacyLockBlocks(livePath, (pid) => pid === process.pid), true);
+        assert.equal(fs.readFileSync(livePath, "utf8"), before);
+
+        const deadPath = path.join(root, "dead.lock");
+        fs.writeFileSync(deadPath, "2147483647", { mode: 0o600 });
+        assert.equal(legacyLockBlocks(deadPath, () => false), false);
+        assert.equal(fs.existsSync(deadPath), true, "dead legacy locks are ignored, never deleted");
+
+        const invalidPath = path.join(root, "invalid.lock");
+        fs.writeFileSync(invalidPath, "not-a-lock", { mode: 0o600 });
+        assert.equal(legacyLockBlocks(invalidPath, () => false), true);
+        assert.equal(fs.existsSync(invalidPath), true);
+        """
+        % json.dumps(module_url),
+        str(tmp_path),
+    )
+    assert_node_ok(result)
+
+
+def test_gpt_image_local_reads_and_downloads_validate_bytes_and_mime(tmp_path: Path) -> None:
+    module_url = GPT_IMAGE2.as_uri()
+    result = run_node(
+        """
+        import assert from "node:assert/strict";
+        import fs from "node:fs";
+        import path from "node:path";
+        import {
+          downloadImageURL,
+          loadReferenceImages,
+        } from %s;
+
+        const png = Buffer.from([
+          0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+          0x00, 0x00, 0x00, 0x0d,
+        ]);
+        const root = process.argv[1];
+        const validPath = path.join(root, "valid.png");
+        const fakePath = path.join(root, "fake.png");
+        fs.writeFileSync(validPath, png);
+        fs.writeFileSync(fakePath, "not an image");
+
+        const local = await loadReferenceImages([validPath]);
+        assert.equal(local[0].mimeType, "image/png");
+        assert.deepEqual(local[0].raw, png);
+        await assert.rejects(
+          loadReferenceImages([fakePath]),
+          /格式不支持或无法识别/,
+        );
+
+        let requestOptions;
+        globalThis.fetch = async (_url, options) => {
+          requestOptions = options;
+          return new Response(png, {
+            status: 200,
+            headers: {
+              "content-type": "image/png",
+              "content-length": String(png.length),
+            },
+          });
+        };
+        const downloaded = await downloadImageURL("https://images.example.test/a", 1000);
+        assert.equal(requestOptions.redirect, "error");
+        assert.equal(downloaded.mimeType, "image/png");
+        assert.deepEqual(downloaded.raw, png);
+
+        globalThis.fetch = async () => new Response(png, {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        });
+        await assert.rejects(
+          downloadImageURL("https://images.example.test/mismatch", 1000),
+          /content-type.*does not match/i,
+        );
+
+        globalThis.fetch = async () => new Response("not an image", {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        });
+        await assert.rejects(
+          downloadImageURL("https://images.example.test/fake", 1000),
+          /format.*not supported|无法识别/i,
+        );
+
+        globalThis.fetch = async () => new Response(null, {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-length": String(10 * 1024 * 1024 + 1),
+          },
+        });
+        await assert.rejects(
+          downloadImageURL("https://images.example.test/large", 1000),
+          /10MB/,
+        );
+
+        globalThis.fetch = async () => new Response(
+          Buffer.alloc(10 * 1024 * 1024 + 1),
+          {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          },
+        );
+        await assert.rejects(
+          downloadImageURL("https://images.example.test/streamed-large", 1000),
+          /10MB/,
+        );
+        """
+        % json.dumps(module_url),
+        str(tmp_path),
+    )
+    assert_node_ok(result)

--- a/tests/test_codeql_batch_b_security.py
+++ b/tests/test_codeql_batch_b_security.py
@@ -217,7 +217,7 @@ def test_tick_sqlite_immediate_claim_allows_only_one_live_contender(
     assert_node_ok(result)
 
 
-def test_tick_legacy_file_lock_is_read_only_and_live_or_invalid_blocks(
+def test_tick_legacy_file_lock_is_read_only_and_unsafe_types_block(
     tmp_path: Path,
 ) -> None:
     module_url = TICK.as_uri()
@@ -246,8 +246,23 @@ def test_tick_legacy_file_lock_is_read_only_and_live_or_invalid_blocks(
 
         const invalidPath = path.join(root, "invalid.lock");
         fs.writeFileSync(invalidPath, "not-a-lock", { mode: 0o600 });
-        assert.equal(legacyLockBlocks(invalidPath, () => false), true);
+        assert.equal(
+          legacyLockBlocks(invalidPath, () => false),
+          false,
+          "a stable malformed regular file cannot belong to a live legacy worker",
+        );
         assert.equal(fs.existsSync(invalidPath), true);
+
+        const symlinkTarget = path.join(root, "symlink-target");
+        const symlinkPath = path.join(root, "symlink.lock");
+        fs.writeFileSync(symlinkTarget, String(process.pid), { mode: 0o600 });
+        fs.symlinkSync(symlinkTarget, symlinkPath);
+        assert.equal(
+          legacyLockBlocks(symlinkPath, () => false),
+          true,
+          "unsafe legacy path types remain fail-closed",
+        );
+        assert.equal(fs.readFileSync(symlinkTarget, "utf8"), String(process.pid));
         """
         % json.dumps(module_url),
         str(tmp_path),

--- a/tests/test_codeql_security_batch_c.py
+++ b/tests/test_codeql_security_batch_c.py
@@ -1,0 +1,283 @@
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROLLBACK_GENERATOR = (
+    REPO_ROOT
+    / "skills/developer-engineering/migration-architect/scripts/rollback_generator.py"
+)
+TRANSCRIPT_FIXER = (
+    REPO_ROOT
+    / "skills/office-white-collar/transcript-fixer/scripts/fix_transcript_enhanced.py"
+)
+SECRET_SCANNER = (
+    REPO_ROOT
+    / "skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py"
+)
+SAFE_PACK = (
+    REPO_ROOT
+    / "skills/developer-engineering/repomix-safe-mixer/scripts/safe_pack.py"
+)
+DEPENDENCY_SCANNER = (
+    REPO_ROOT
+    / "skills/developer-engineering/dependency-auditor/scripts/dep_scanner.py"
+)
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CodeQLSecurityBatchCTests(unittest.TestCase):
+    def test_rollback_output_is_redacted_and_private_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            migration = root / "migration.json"
+            migration.write_text(
+                json.dumps(
+                    {
+                        "migration_id": "security-regression",
+                        "migration_type": "database",
+                        "phases": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = root / "runbook.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROLLBACK_GENERATOR),
+                    "--input",
+                    str(migration),
+                    "--output",
+                    str(output),
+                    "--format",
+                    "json",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual("[REDACTED]", data["data_recovery_plan"]["backup_location"])
+            for contact in data["emergency_contacts"]:
+                self.assertEqual("[REDACTED]", contact["primary_phone"])
+                self.assertEqual("[REDACTED]", contact["email"])
+                self.assertEqual("[REDACTED]", contact["backup_contact"])
+            self.assertEqual(0o600, stat.S_IMODE(output.stat().st_mode))
+            self.assertNotIn("incident.commander@company.com", result.stdout)
+
+            console = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROLLBACK_GENERATOR),
+                    "--input",
+                    str(migration),
+                    "--format",
+                    "both",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            self.assertIn("[REDACTED]", console.stdout)
+            self.assertNotIn("incident.commander@company.com", console.stdout)
+            self.assertNotIn("/backups/pre_migration_", console.stdout)
+
+            requested_json = root / "text-only.json"
+            text_only = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROLLBACK_GENERATOR),
+                    "--input",
+                    str(migration),
+                    "--output",
+                    str(requested_json),
+                    "--format",
+                    "text",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            derived_text = root / "text-only.txt"
+            self.assertFalse(requested_json.exists())
+            self.assertTrue(derived_text.is_file())
+            self.assertEqual(0o600, stat.S_IMODE(derived_text.stat().st_mode))
+            self.assertIn("[REDACTED]", derived_text.read_text(encoding="utf-8"))
+            self.assertIn(str(derived_text), text_only.stdout)
+            self.assertNotIn("incident.commander@company.com", text_only.stdout)
+
+    def test_rollback_sensitive_output_requires_file_and_never_reaches_stdout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            migration = root / "migration.json"
+            migration.write_text(
+                json.dumps(
+                    {
+                        "migration_id": "security-regression",
+                        "migration_type": "database",
+                        "phases": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            rejected = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROLLBACK_GENERATOR),
+                    "--input",
+                    str(migration),
+                    "--format",
+                    "json",
+                    "--include-sensitive",
+                ],
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(0, rejected.returncode)
+            self.assertIn("--include-sensitive requires --output", rejected.stderr)
+            self.assertNotIn("incident.commander@company.com", rejected.stdout)
+
+            output = root / "sensitive.json"
+            accepted = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROLLBACK_GENERATOR),
+                    "--input",
+                    str(migration),
+                    "--output",
+                    str(output),
+                    "--format",
+                    "json",
+                    "--include-sensitive",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            data = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(
+                "incident.commander@company.com",
+                data["emergency_contacts"][0]["email"],
+            )
+            self.assertEqual(0o600, stat.S_IMODE(output.stat().st_mode))
+            self.assertNotIn("incident.commander@company.com", accepted.stdout)
+
+    def test_transcript_key_discovery_logs_location_without_key_fragments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            secret = "super-secret-api-key-1234567890"
+            (home / ".zshrc").write_text(
+                "\n".join(
+                    [
+                        "export ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic",
+                        f"export ANTHROPIC_AUTH_TOKEN={secret}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            script_dir = TRANSCRIPT_FIXER.parent
+            program = (
+                "import sys;"
+                f"sys.path.insert(0, {str(script_dir)!r});"
+                "import fix_transcript_enhanced as module;"
+                f"assert module.find_glm_api_key() == {secret!r}"
+            )
+            result = subprocess.run(
+                [sys.executable, "-c", program],
+                env={
+                    **os.environ,
+                    "HOME": str(home),
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                },
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+            combined = result.stdout + result.stderr
+            self.assertIn(str(home / ".zshrc"), combined)
+            self.assertNotIn(secret, combined)
+            self.assertNotIn(secret[:4], combined)
+            self.assertNotIn(secret[-4:], combined)
+
+    def test_secret_scanner_json_and_reports_never_emit_secret_material(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            secret = "AKIA1234567890ABCDEF"
+            (root / "credentials.py").write_text(
+                f'API_KEY = "{secret}"\n', encoding="utf-8"
+            )
+
+            scan = subprocess.run(
+                [sys.executable, str(SECRET_SCANNER), str(root), "--json"],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(1, scan.returncode)
+            self.assertNotIn(secret, scan.stdout + scan.stderr)
+            findings = json.loads(scan.stdout)
+            self.assertEqual(
+                {"file", "line", "type", "match", "context"},
+                set(findings[0]),
+            )
+            self.assertEqual("[REDACTED]", findings[0]["match"])
+            self.assertEqual("[REDACTED]", findings[0]["context"])
+
+            pack = subprocess.run(
+                [sys.executable, str(SAFE_PACK), str(root)],
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(1, pack.returncode)
+            self.assertNotIn(secret, pack.stdout + pack.stderr)
+            self.assertIn("credentials.py:1", pack.stdout)
+
+    def test_yarn_lock_parser_uses_deterministic_line_records(self):
+        module = load_module("dependency_scanner_security_test", DEPENDENCY_SCANNER)
+        with tempfile.TemporaryDirectory() as tmp:
+            lockfile = Path(tmp) / "yarn.lock"
+            lockfile.write_text(
+                "\n".join(
+                    [
+                        "# yarn lockfile v1",
+                        "",
+                        "left-pad@^1.3.0:",
+                        '  version "1.3.0"',
+                        '  resolved "https://registry.example/left-pad.tgz"',
+                        "",
+                        '"@scope/pkg@^2.0.0", "@scope/pkg@~2.1.0":',
+                        '  version "2.2.0"',
+                        "",
+                        "malformed:",
+                        "\t" * 10000,
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            dependencies = module.DependencyScanner()._parse_yarn_lock(lockfile)
+            self.assertEqual(
+                [("left-pad", "1.3.0"), ("@scope/pkg", "2.2.0")],
+                [(item.name, item.version) for item in dependencies],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dependabot_fixture_governance.py
+++ b/tests/test_dependabot_fixture_governance.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_intentionally_vulnerable_samples_are_not_live_dependency_manifests() -> None:
+    canonical = ROOT / "skills" / "developer-engineering" / "dependency-auditor"
+    exported = ROOT / "openclaw-skills" / "dependency-auditor"
+
+    for root in (canonical, exported):
+        assert not (root / "assets" / "sample_requirements.txt").exists()
+        assert not (root / "test-project" / "package.json").exists()
+        requirements_fixture = root / "assets" / "sample_requirements.fixture"
+        package_fixture = root / "test-project" / "package.vulnerable.fixture.json"
+        assert requirements_fixture.is_file()
+        assert package_fixture.is_file()
+        assert requirements_fixture.read_text(encoding="utf-8").strip()
+        assert isinstance(json.loads(package_fixture.read_text(encoding="utf-8")), dict)


### PR DESCRIPTION
## Summary

- resolve the actionable CodeQL findings discovered on the integrated v2.0.0 main commit
- add minimum workflow permissions and immutable third-party Action/SRI pins
- harden command execution, regex parsing, Notion cache writes, image download/read validation, secret reporting, rollback output, and Yarn lock parsing
- replace the LinkedIn scheduler file lock with a SQLite `BEGIN IMMEDIATE` ownership lock
- preserve external provenance by moving security-hardened LinkedIn and Harvest scripts into explicit local curation ownership
- rename intentionally vulnerable dependency-auditor samples to non-manifest fixture files so Dependabot does not classify teaching data as runtime dependencies
- add the bilingual v2.0.0 CHANGELOG

## Security disposition

- real findings are fixed in code with focused regression tests
- intentional synthetic/demo findings and explicit data-flow functionality will be reviewed only after the new CodeQL run
- Dependabot alerts are enabled; current open dependency alerts: 0
- Secret Scanning open alerts: 0

## Local validation

- `python -m pytest -q tests` — 499 passed
- provenance v2 validator — passed
- artifact inventory — 0 missing/stale/hash/mode/ownership debt
- source coverage — 287/287
- license audit — 0 missing, 0 disallowed
- quality lint — 290 PASS, 0 WARN, 0 FAIL
- `npm test` / package dry-run — passed
- managed digest refresh dry-run — 0/18 changes
- generated views — idempotent

## Release boundary

This PR contains the single post-merge security repair wave requested before `v2.0.0`. The release tag will be created only from the final merged `main` SHA after this PR's Repository Validation, provenance, CodeQL, and security-alert review complete.
