### PR TITLE
fix: resolve scanner clear-text logging alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 - `python-performance`：用于 Python 性能分析、内存优化、热点路径调优和并发模式评审。
 - `qa-expert`：用于质量保障、expert，支持开发、调试、评审和交付。
 - `react-native-engineering`：用于构建、审查、调试、测试、升级和发布 React Native 与 Expo 应用，覆盖新架构、原生模块、性能、EAS 和双平台验证。
-- `repomix-safe-mixer`：用于repomix、safe、mixer，支持开发、调试、评审和交付。
+- `repomix-safe-mixer`：打包代码前扫描凭据、输出脱敏报告，并在发现风险时阻止打包。
 - `rust-engineer`：用于 Rust 代码开发、所有权和生命周期调试、异步模式选择和系统性能优化。
 - `schema`：数据库模式设计、迁移规划、索引策略和关系建模。
 - `skill-tester`：用于技能、tester，支持开发、调试、评审和交付。

--- a/docs/TAGS-INDEX.md
+++ b/docs/TAGS-INDEX.md
@@ -599,7 +599,7 @@
 | [pr-review-expert](skills/developer-engineering/pr-review-expert) | developer-engineering | ★★★★★ | Structured, systematic code review for GitHub PRs and GitLab MRs. Goes beyond st |
 | [promptfoo-evaluation](skills/developer-engineering/promptfoo-evaluation) | developer-engineering | ★★★★★ | Configures and runs LLM evaluation using Promptfoo framework. Use when setting u |
 | [qa-expert](skills/developer-engineering/qa-expert) | developer-engineering | ★★★★★ | This skill should be used when establishing comprehensive QA testing processes f |
-| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Safely package codebases with repomix by automatically detecting and removing ha |
+| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Scan for hardcoded credentials, report redacted findings, and block repomix pack |
 | [schema](skills/developer-engineering/schema) | developer-engineering | ★★★★★ | 数据库模式设计、迁移规划、索引策略和关系建模。 |
 | [skill-tester](skills/developer-engineering/skill-tester) | developer-engineering | ★★★★★ | Name: skill-tester Tier: POWERFUL Category: Engineering Quality Assurance Depend |
 | [tech-debt-tracker](skills/developer-engineering/tech-debt-tracker) | developer-engineering | ★★★★★ | Tier: POWERFUL 🔥 Category: Engineering Process Automation Expertise: Code Qualit |
@@ -3677,7 +3677,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Safely package codebases with repomix by automatically detecting and removing ha |
+| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Scan for hardcoded credentials, report redacted findings, and block repomix pack |
 
 ## mobile
 
@@ -4253,7 +4253,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Safely package codebases with repomix by automatically detecting and removing ha |
+| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Scan for hardcoded credentials, report redacted findings, and block repomix pack |
 
 ## reporting
 
@@ -4349,7 +4349,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Safely package codebases with repomix by automatically detecting and removing ha |
+| [repomix-safe-mixer](skills/developer-engineering/repomix-safe-mixer) | developer-engineering | ★★★★★ | Scan for hardcoded credentials, report redacted findings, and block repomix pack |
 
 ## sarif
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -2170,8 +2170,8 @@
     {
       "name": "repomix-safe-mixer",
       "category": "developer-engineering",
-      "description": "Safely package codebases with repomix by automatically detecting and removing hardcoded credentials before packing. Use when packaging code for distribution, creating reference packages, or when the user mentions security concerns about sharing code with repomix.",
-      "version": "1.0.0",
+      "description": "Scan for hardcoded credentials, report redacted findings, and block repomix packaging when risks are found. Use when packaging code for distribution, creating reference packages, or checking credentials before sharing a codebase.",
+      "version": "1.0.1",
       "author": "seaworld008",
       "source": "in-house",
       "source_url": "",
@@ -2184,8 +2184,8 @@
       "quality": 5,
       "complexity": "intermediate",
       "created_at": "2026-03-04",
-      "updated_at": "2026-03-20",
-      "line_count": 325,
+      "updated_at": "2026-08-31",
+      "line_count": 331,
       "path": "skills/developer-engineering/repomix-safe-mixer/SKILL.md"
     },
     {

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -16600,7 +16600,7 @@
         "path": "skills/developer-engineering/repomix-safe-mixer",
         "ref": "main",
         "last_checked_at": "2026-08-31",
-        "last_synced_at": "2026-04-13",
+        "last_synced_at": "2026-08-31",
         "last_synced_commit": null,
         "sync_mode": "local-only"
       },
@@ -16639,9 +16639,9 @@
             "ref": "main",
             "resolved_commit": null,
             "path_commit": null,
-            "content_sha256": "ad2013350af8c0a8fd300077e5df9cd341d03ec32a3b838030483b2db5468978",
+            "content_sha256": "c38e786b95d843f7fa7993ebffee2da85b63efe0e83419ad42e7def25451bda5",
             "last_checked_at": "2026-08-31",
-            "last_synced_at": "2026-04-13"
+            "last_synced_at": "2026-08-31"
           }
         }
       ],
@@ -16649,7 +16649,7 @@
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/SKILL.md",
           "owner": "repomix-safe-mixer",
-          "sha256": "ad2013350af8c0a8fd300077e5df9cd341d03ec32a3b838030483b2db5468978",
+          "sha256": "c38e786b95d843f7fa7993ebffee2da85b63efe0e83419ad42e7def25451bda5",
           "mode": "100644"
         },
         {
@@ -16667,7 +16667,7 @@
         {
           "path": "skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py",
           "owner": "repomix-safe-mixer",
-          "sha256": "cdd18c62cb9d2b741e9e8898d01b1fbdaf3cd87da66ffa2e5a053fcb8a0a8c60",
+          "sha256": "5f2e0f618ffb2d15a5552e426e1be4fe613264c3db97ebde03806ade2113d5ea",
           "mode": "100644"
         }
       ]

--- a/openclaw-skills/repomix-safe-mixer/SKILL.md
+++ b/openclaw-skills/repomix-safe-mixer/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: repomix-safe-mixer
-description: 'Safely package codebases with repomix by automatically detecting and removing hardcoded credentials before packing. Use when packaging code for distribution, creating reference packages, or when the user mentions security concerns about sharing code with repomix.'
-zh_description: "用于repomix、safe、mixer，支持开发、调试、评审和交付。"
-version: "1.0.0"
+description: 'Scan for hardcoded credentials, report redacted findings, and block repomix packaging when risks are found. Use when packaging code for distribution, creating reference packages, or checking credentials before sharing a codebase.'
+zh_description: "打包代码前扫描凭据、输出脱敏报告，并在发现风险时阻止打包。"
+version: "1.0.1"
 author: "seaworld008"
 source: "in-house"
 source_url: ""
 tags: '["development", "mixer", "repomix", "safe"]'
 created_at: "2026-03-04"
-updated_at: "2026-03-20"
+updated_at: "2026-08-31"
 quality: 5
 complexity: "intermediate"
 ---
@@ -17,7 +17,8 @@ complexity: "intermediate"
 
 ## Overview
 
-Safely package codebases with repomix by automatically detecting and removing hardcoded credentials.
+Scan for hardcoded credentials before packaging codebases with repomix, report
+redacted findings, and block packaging until the user resolves them.
 
 This skill prevents accidental credential exposure when packaging code with repomix. It scans for hardcoded secrets (API keys, database credentials, tokens), reports findings, and ensures safe packaging.
 
@@ -60,7 +61,7 @@ python3 scripts/safe_pack.py ./my-project
 
 🔴 supabase_url: 1 instance(s)
    - src/client.ts:5
-     Match: https://your-project-ref.supabase.co
+     Match: [REDACTED]
 
 ❌ Cannot pack: Secrets detected!
 ```
@@ -98,6 +99,11 @@ python3 scripts/safe_pack.py \
 ## Standalone Secret Scanning
 
 Use `scan_secrets.py` from this skill's `scripts/` directory for scanning only (without packing).
+
+Text reports show file/line locations, a fixed `potential credential` label, and
+`[REDACTED]` instead of match content. They never echo rule metadata. Use `--json`
+when rule types are needed; its `type` field remains available while `match` and
+`context` stay redacted. Findings still return exit code 1; a clean scan returns 0.
 
 ```bash
 python3 scripts/scan_secrets.py <directory>

--- a/openclaw-skills/repomix-safe-mixer/scripts/scan_secrets.py
+++ b/openclaw-skills/repomix-safe-mixer/scripts/scan_secrets.py
@@ -153,7 +153,8 @@ def print_report(findings: List[SecretFinding], directory: Path):
     for file_path in sorted(by_file.keys()):
         print(f"📄 {file_path}")
         for finding in by_file[file_path]:
-            print(f"   Line {finding.line_num}: {finding.pattern_name}")
+            # Keep rule metadata out of text logs; structured JSON retains the type.
+            print(f"   Line {finding.line_num}: potential credential")
             print(f"      Match: {REDACTED}")
         print()
 

--- a/skills/developer-engineering/README.md
+++ b/skills/developer-engineering/README.md
@@ -49,7 +49,7 @@
 | `python-performance` | 用于 Python 性能分析、内存优化、热点路径调优和并发模式评审。 | [目录](./python-performance/) | [SKILL.md](./python-performance/SKILL.md) |
 | `qa-expert` | 用于质量保障、expert，支持开发、调试、评审和交付。 | [目录](./qa-expert/) | [SKILL.md](./qa-expert/SKILL.md) |
 | `react-native-engineering` | 用于构建、审查、调试、测试、升级和发布 React Native 与 Expo 应用，覆盖新架构、原生模块、性能、EAS 和双平台验证。 | [目录](./react-native-engineering/) | [SKILL.md](./react-native-engineering/SKILL.md) |
-| `repomix-safe-mixer` | 用于repomix、safe、mixer，支持开发、调试、评审和交付。 | [目录](./repomix-safe-mixer/) | [SKILL.md](./repomix-safe-mixer/SKILL.md) |
+| `repomix-safe-mixer` | 打包代码前扫描凭据、输出脱敏报告，并在发现风险时阻止打包。 | [目录](./repomix-safe-mixer/) | [SKILL.md](./repomix-safe-mixer/SKILL.md) |
 | `rust-engineer` | 用于 Rust 代码开发、所有权和生命周期调试、异步模式选择和系统性能优化。 | [目录](./rust-engineer/) | [SKILL.md](./rust-engineer/SKILL.md) |
 | `schema` | 数据库模式设计、迁移规划、索引策略和关系建模。 | [目录](./schema/) | [SKILL.md](./schema/SKILL.md) |
 | `skill-tester` | 用于技能、tester，支持开发、调试、评审和交付。 | [目录](./skill-tester/) | [SKILL.md](./skill-tester/SKILL.md) |

--- a/skills/developer-engineering/repomix-safe-mixer/SKILL.md
+++ b/skills/developer-engineering/repomix-safe-mixer/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: repomix-safe-mixer
-description: 'Safely package codebases with repomix by automatically detecting and removing hardcoded credentials before packing. Use when packaging code for distribution, creating reference packages, or when the user mentions security concerns about sharing code with repomix.'
-zh_description: "用于repomix、safe、mixer，支持开发、调试、评审和交付。"
-version: "1.0.0"
+description: 'Scan for hardcoded credentials, report redacted findings, and block repomix packaging when risks are found. Use when packaging code for distribution, creating reference packages, or checking credentials before sharing a codebase.'
+zh_description: "打包代码前扫描凭据、输出脱敏报告，并在发现风险时阻止打包。"
+version: "1.0.1"
 author: "seaworld008"
 source: "in-house"
 source_url: ""
 tags: '["development", "mixer", "repomix", "safe"]'
 created_at: "2026-03-04"
-updated_at: "2026-03-20"
+updated_at: "2026-08-31"
 quality: 5
 complexity: "intermediate"
 ---
@@ -17,7 +17,8 @@ complexity: "intermediate"
 
 ## Overview
 
-Safely package codebases with repomix by automatically detecting and removing hardcoded credentials.
+Scan for hardcoded credentials before packaging codebases with repomix, report
+redacted findings, and block packaging until the user resolves them.
 
 This skill prevents accidental credential exposure when packaging code with repomix. It scans for hardcoded secrets (API keys, database credentials, tokens), reports findings, and ensures safe packaging.
 
@@ -60,7 +61,7 @@ python3 scripts/safe_pack.py ./my-project
 
 🔴 supabase_url: 1 instance(s)
    - src/client.ts:5
-     Match: https://your-project-ref.supabase.co
+     Match: [REDACTED]
 
 ❌ Cannot pack: Secrets detected!
 ```
@@ -98,6 +99,11 @@ python3 scripts/safe_pack.py \
 ## Standalone Secret Scanning
 
 Use `scan_secrets.py` from this skill's `scripts/` directory for scanning only (without packing).
+
+Text reports show file/line locations, a fixed `potential credential` label, and
+`[REDACTED]` instead of match content. They never echo rule metadata. Use `--json`
+when rule types are needed; its `type` field remains available while `match` and
+`context` stay redacted. Findings still return exit code 1; a clean scan returns 0.
 
 ```bash
 python3 scripts/scan_secrets.py <directory>

--- a/skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py
+++ b/skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py
@@ -153,7 +153,8 @@ def print_report(findings: List[SecretFinding], directory: Path):
     for file_path in sorted(by_file.keys()):
         print(f"📄 {file_path}")
         for finding in by_file[file_path]:
-            print(f"   Line {finding.line_num}: {finding.pattern_name}")
+            # Keep rule metadata out of text logs; structured JSON retains the type.
+            print(f"   Line {finding.line_num}: potential credential")
             print(f"      Match: {REDACTED}")
         print()
 

--- a/tests/test_secret_scanner_reports.py
+++ b/tests/test_secret_scanner_reports.py
@@ -1,0 +1,86 @@
+"""Report boundaries use harmless sentinels, never credential-shaped fixtures."""
+import contextlib
+import importlib.util
+import io
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills/developer-engineering/repomix-safe-mixer/scripts/scan_secrets.py"
+)
+SENTINEL = "non-sensitive-regression-marker"
+
+
+def load_scanner():
+    spec = importlib.util.spec_from_file_location("scanner_report_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SecretScannerReportTests(unittest.TestCase):
+    def test_text_report_does_not_echo_rule_metadata(self):
+        scanner = load_scanner()
+        finding = scanner.SecretFinding("src/config.py", 7, SENTINEL)
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            scanner.print_report([finding], Path("project"))
+        self.assertNotIn(SENTINEL, output.getvalue())
+        self.assertIn("src/config.py", output.getvalue())
+        self.assertIn("Line 7: potential credential", output.getvalue())
+        self.assertIn("Match: [REDACTED]", output.getvalue())
+
+    def test_text_and_json_cli_redact_matches_and_keep_detection_exit_code(self):
+        for json_mode in (False, True):
+            with self.subTest(json_mode=json_mode), tempfile.TemporaryDirectory() as tmp:
+                scanner = load_scanner()
+                root = Path(tmp)
+                (root / "input.py").write_text(f'value = "{SENTINEL}"\n', encoding="utf-8")
+                output, errors = io.StringIO(), io.StringIO()
+                argv = [str(SCRIPT), str(root)] + (["--json"] if json_mode else [])
+                with (
+                    patch.object(scanner, "SECRET_PATTERNS", {"regression_rule": re.escape(SENTINEL)}),
+                    patch.object(scanner.sys, "argv", argv),
+                    contextlib.redirect_stdout(output),
+                    contextlib.redirect_stderr(errors),
+                    self.assertRaises(SystemExit) as exit_context,
+                ):
+                    scanner.main()
+                self.assertEqual(1, exit_context.exception.code)
+                self.assertNotIn(SENTINEL, output.getvalue() + errors.getvalue())
+                self.assertIn("[REDACTED]", output.getvalue())
+                if json_mode:
+                    self.assertEqual(
+                        [{
+                            "file": "input.py", "line": 1, "type": "regression_rule",
+                            "match": "[REDACTED]", "context": "[REDACTED]",
+                        }],
+                        json.loads(output.getvalue()),
+                    )
+                else:
+                    self.assertIn("Line 1: potential credential", output.getvalue())
+                    self.assertNotIn("regression_rule", output.getvalue())
+
+    def test_clean_cli_keeps_success_exit_code(self):
+        for json_mode in (False, True):
+            with self.subTest(json_mode=json_mode), tempfile.TemporaryDirectory() as tmp:
+                scanner = load_scanner()
+                output = io.StringIO()
+                argv = [str(SCRIPT), tmp] + (["--json"] if json_mode else [])
+                with (
+                    patch.object(scanner.sys, "argv", argv),
+                    contextlib.redirect_stdout(output),
+                    self.assertRaises(SystemExit) as exit_context,
+                ):
+                    scanner.main()
+                self.assertEqual(0, exit_context.exception.code)
+                if json_mode:
+                    self.assertEqual([], json.loads(output.getvalue()))
+                else:
+                    self.assertIn("No secrets detected!", output.getvalue())


### PR DESCRIPTION
## 问题与修复
处理 CodeQL 告警 https://github.com/seaworld008/Commonly-used-high-value-skills/security/code-scanning/36 。当前告警将规则字典元数据作为敏感数据追踪到文本日志；命中内容原已脱敏。

- 文本报告改为固定 potential credential 提示，仅保留定位信息，不再回显规则元数据。
- JSON 的 type 字段保持兼容，match/context 继续 REDACTED；检测规则与退出码不变。
- 新增无敏感性标记测试，覆盖元数据不回显、文本/JSON命中脱敏、检测退出码1及空扫描退出码0。未新增仿真凭据。
- 更新技能说明及版本1.0.1，修正文档自动删除凭据的旧描述；通过流水线再生来源digest、目录、catalog、tags与OpenClaw导出。
- 不修改CodeQL规则或扫描范围、不dismiss告警、不修改退役政策或本机安装。

## 验证
- 定向8 tests+4 subtests通过。
- 完整本地流水线：553 tests+223 subtests，287 strict PASS/0 WARN/FAIL，来源/许可/portfolio/健康/视频/冲突检查通过。
- Python严格编译、Node语法、安装器help/targets、npm pack dry-run、git diff --check通过。
- 7814个既有tracked文件重复生成一致，48个本地补充块保留；新增测试单独纳入提交。

## 验收边界
远程PR检查全部通过后合并，并核验最新main的告警36自然变为fixed且开放代码扫描告警为0。CI任务成功不替代告警状态验证。