### PR TITLE
chore: review weekly skill sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 - `schema`：数据库模式设计、迁移规划、索引策略和关系建模。
 - `skill-tester`：验证技能触发、执行步骤和输出结果是否符合预期。
 - `supabase`：开发和排查 Supabase 数据库、认证、存储及应用集成。
-- `supabase-postgres-best-practices`：用于编写、评审和优化 Supabase/Postgres 查询、Schema、索引和数据库配置。
+- `supabase-postgres-best-practices`：用于编写或评审 Supabase/Postgres 的查询、Schema、索引、RLS、连接配置与迁移。
 - `systematic-debugging`：通过复现、假设检验和证据定位故障根因。
 - `tailwind-design-system`：用于 Tailwind CSS 设计系统、主题 token、组件样式和响应式布局规范。
 - `tech-debt-tracker`：识别和量化技术债，确定修复优先级并跟踪治理进度。

--- a/docs/TAGS-INDEX.md
+++ b/docs/TAGS-INDEX.md
@@ -620,7 +620,7 @@
 | [typescript-best-practices](skills/developer-engineering/typescript-best-practices) | developer-engineering | ★★★★☆ | Use when writing or reviewing TypeScript for type safety, advanced types, API bo |
 | [vercel-react-best-practices](skills/developer-engineering/vercel-react-best-practices) | developer-engineering | ★★★★☆ | Optimize React and Next.js rendering, data fetching, bundles, and runtime perfor |
 | [subagent-driven-development](skills/ai-workflow/subagent-driven-development) | ai-workflow | ★★★☆☆ | Use when executing implementation plans with independent tasks in the current se |
-| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s |
+| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies,  |
 | [web-artifacts-builder](skills/developer-engineering/web-artifacts-builder) | developer-engineering | ★★★☆☆ | Build complex interactive HTML artifacts with React, Tailwind, and shadcn/ui whe |
 | [webapp-testing](skills/developer-engineering/webapp-testing) | developer-engineering | ★★★☆☆ | Use when testing local web applications with Playwright, verifying frontend beha |
 | [frontend-design](skills/developer-engineering/frontend-design) | developer-engineering | ★★☆☆☆ | Design and implement polished web components, pages, and applications with a coh |
@@ -1196,7 +1196,7 @@
 |-------|----------|---------|-------------|
 | [typescript-best-practices](skills/developer-engineering/typescript-best-practices) | developer-engineering | ★★★★☆ | Use when writing or reviewing TypeScript for type safety, advanced types, API bo |
 | [vercel-react-best-practices](skills/developer-engineering/vercel-react-best-practices) | developer-engineering | ★★★★☆ | Optimize React and Next.js rendering, data fetching, bundles, and runtime perfor |
-| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s |
+| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies,  |
 | [security-best-practices](skills/security-and-reliability/security-best-practices) | security-and-reliability | ★★★☆☆ | Use when checking language or framework security best practices, producing secur |
 
 ## builder
@@ -1507,7 +1507,7 @@
 |-------|----------|---------|-------------|
 | [neon-postgres](skills/developer-engineering/neon-postgres) | developer-engineering | ★★★★★ | Build or troubleshoot Neon Postgres connections, branching, pooling, scaling, Au |
 | [neon-postgres-egress-optimizer](skills/developer-engineering/neon-postgres-egress-optimizer) | developer-engineering | ★★★★☆ | Diagnose excessive Postgres or Neon network egress and database transfer costs b |
-| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s |
+| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies,  |
 
 ## review
 
@@ -2020,7 +2020,7 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [supabase](skills/developer-engineering/supabase) | developer-engineering | ★★★★☆ | Build or troubleshoot Supabase Database, Auth, Storage, Realtime, Edge Functions |
-| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s |
+| [supabase-postgres-best-practices](skills/developer-engineering/supabase-postgres-best-practices) | developer-engineering | ★★★☆☆ | Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies,  |
 
 ## terraform
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -2269,7 +2269,7 @@
     {
       "name": "supabase-postgres-best-practices",
       "category": "developer-engineering",
-      "description": "Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s database guidance; applicable to Postgres on any hosting platform.",
+      "description": "Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies, connection settings, or migrations with Supabase guidance; applicable to Postgres on any hosting platform.",
       "version": "1.1.1",
       "author": "supabase",
       "source": "github:supabase/agent-skills",
@@ -2284,7 +2284,7 @@
       "complexity": "intermediate",
       "created_at": "2026-05-05",
       "updated_at": "2026-09-06",
-      "line_count": 102,
+      "line_count": 115,
       "path": "skills/developer-engineering/supabase-postgres-best-practices/SKILL.md"
     },
     {

--- a/docs/sources/graphify-2026-04.skills.json
+++ b/docs/sources/graphify-2026-04.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://github.com/Graphify-Labs/graphify/releases/tag/v0.9.47",
-    "checked_at": "2026-08-20",
+    "checked_at": "2026-09-07",
     "note": "Official Graphify Codex skill artifact-set mirror. Python package and non-Codex client snapshots are intentionally excluded."
   },
   "official_references": [
@@ -33,10 +33,10 @@
       "upstream": {
         "repo": "Graphify-Labs/graphify",
         "path": "graphify/skill-codex.md",
-        "ref": "v0.9.47",
-        "last_checked_at": "2026-08-20",
-        "last_synced_at": "2026-08-20",
-        "last_synced_commit": "b14b52e94ec3d9840413d81777f4c134eac0a40d",
+        "ref": "v0.9.55",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "c9f99018774e2e0380e9f65b3959944559a0d5f6",
         "sync_mode": "monitor",
         "path_commit": "3d19463484ebcf773b399ddad9fd3363b2ab3bff"
       },
@@ -62,18 +62,18 @@
           ],
           "tracking": {
             "channel": "latest_release",
-            "ref": "v0.9.47",
-            "resolved_commit": "b14b52e94ec3d9840413d81777f4c134eac0a40d",
+            "ref": "v0.9.55",
+            "resolved_commit": "c9f99018774e2e0380e9f65b3959944559a0d5f6",
             "path_commit": "3d19463484ebcf773b399ddad9fd3363b2ab3bff",
             "content_sha256": "7bc85fef495f99d8f004a4a666072a796185ae2cd81f5a1fa844fe4a94f5efb9",
-            "last_checked_at": "2026-08-20",
-            "last_synced_at": "2026-08-20",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
               "content_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
               "spdx": "Apache-2.0",
-              "resolved_commit": "b14b52e94ec3d9840413d81777f4c134eac0a40d",
+              "resolved_commit": "c9f99018774e2e0380e9f65b3959944559a0d5f6",
               "api_spdx": "NOASSERTION"
             }
           }
@@ -193,6 +193,13 @@
       "target": "Graphify-Labs/graphify@v0.9.47",
       "result": "success",
       "evidence": "Resolved v0.9.47 to b14b52e94ec3d9840413d81777f4c134eac0a40d, verified LICENSE blob d645695673349e3947e8e5ae42332d0ac3164cd7, mirrored the Codex SKILL plus eight references, and removed 64 fully superseded managed snapshot files."
+    },
+    {
+      "date": "2026-09-07",
+      "method": "commit-aware-manual-monitor-review",
+      "target": "Graphify-Labs/graphify@c9f99018774e2e0380e9f65b3959944559a0d5f6",
+      "result": "success",
+      "evidence": "Reviewed v0.9.47 through v0.9.55 (156 commits). The managed Codex entry and eight reference blobs are byte-identical, so no local skill text changed; runtime-only fixes remain outside this artifact set."
     }
   ]
 }

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -1,7 +1,7 @@
 {
   "video": {
     "url": "https://github.com/seaworld008/Commonly-used-high-value-skills",
-    "checked_at": "2026-09-06",
+    "checked_at": "2026-09-07",
     "note": "Auto-generated provenance mapping for all local skills."
   },
   "official_references": [
@@ -23,7 +23,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/agent-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -114,7 +114,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "bd6dac16d7dbac4ff4ce69e1cfa7c4866e4101cc6b83041837edb8632e6dd03f",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -217,7 +217,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/agent-workflow-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -243,7 +243,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "75654b20a03e752f79d9c5e2362dc2a50011a319b7651927e28455bc3d166501",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -268,7 +268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/agile-product-owner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -309,7 +309,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a51c7df49b6ae16e0b2dbba7ad910f7613bc2a1926a23330fc46548a9129f4be",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -352,7 +352,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/algorithmic-art",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -393,7 +393,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "779ee87762bdbc3c56d4397e0b666610af3ad6abbc3a9480a82a8de9898a4176",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -436,7 +436,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/andrej-karpathy-skills",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -462,7 +462,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c766537eecfb66b685104596ea29be912e8dded1507c09d1b5894f685bc15d9d",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-06-03"
           }
         }
@@ -487,7 +487,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-design-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -538,7 +538,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ed235881cfc758c7a705861cb279d266dc43ade63ee124eb585d3ca0a4f4fd20",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -593,7 +593,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-test-suite-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -624,7 +624,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "78f8d1463ee549f46e6d1bc486c35a79cb15f27f0123622612c43eba9a862ad6",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -655,7 +655,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/app-store-optimization",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -766,7 +766,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "89159a39fe6f0abb2dc9cde718c4cd380f31c07e216c163fa60994ad1342a38c",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -893,7 +893,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/brainstorming",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -919,7 +919,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6e477bf91f43f63b59b14d1ea606636684c01d7635b5bd5a27aa753f56bebf5a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -944,7 +944,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/brand-guidelines",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -975,7 +975,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "59b81f971c363a849236c928a444883da29381b933e86e9deb436d1223d06f44",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -1006,7 +1006,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/campaign-analytics",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -1087,7 +1087,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fde028bf1d5916c6163e759b68ce2fd3814ff5e69f1d6d9925621da7bca3ad65",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -1178,7 +1178,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/canvas-design",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -1614,7 +1614,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "24a21ebd36ab3465625c2bbc27e789b31a6acfa1f241cad9eb86a4d996f38284",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2131,7 +2131,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/chatgpt-apps",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -2207,7 +2207,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "908da9aa354c1713bc0a59801d98520d510e7b6249a64b3655366b42dcb208cf",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2292,7 +2292,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/cli-demo-generator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -2358,7 +2358,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ecb2ea56b91c570683467b41007c77cbc7dc35e307e274a63d4a4eef2bc1038c",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2431,7 +2431,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/cloudflare-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -4012,7 +4012,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3943705d4ddb29a0ab5318e9314ac54f67f42524af98144b5983a3810c4b8f54",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -5903,7 +5903,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/cloudflare-troubleshooting",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -5954,7 +5954,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "540e76056450f6169e8928f555ad05afc0d5c5d9dafffb2c39f62b894d8e239c",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6009,7 +6009,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/codebase-onboarding",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6040,7 +6040,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9b1a258a7a6608c1372f2aa94e81f015ed100f0a8bf8e9aa5a1f8dfb6374f6a1",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6071,7 +6071,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/codeql-security-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6097,7 +6097,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "601d8a67881a59afe7418fd5ad02b2f232434a39b227e73f11eac83aa0023658",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -6122,7 +6122,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/competitive-teardown",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6148,7 +6148,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "de2bb927b6f4f27fea731835afd3fb99a2b888aca4c3a6636dc848ca7a10596e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6173,7 +6173,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/competitors-analysis",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6219,7 +6219,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c581698651ec3320bc56d3f464d469eff4e20d3acbc3a4a892b39620331ec0dc",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6268,7 +6268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/comps-valuation-analyst",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6309,7 +6309,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c21312d3025195d7cd99337d70336a36a551e21e259661160663c72982f11d3a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6352,7 +6352,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/content-creator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6423,7 +6423,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ec4fb8915d3d1e583aa9bae81c05d2c17b85718d12c710713fd34329d98f39e7",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6502,7 +6502,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6598,7 +6598,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "62154d7cfec6b1b1fa7a4b974171bdd3e2ce07724a490d19453e0b9056124344",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6707,7 +6707,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-schema-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6738,7 +6738,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "890547056128aa3ca0c69e947a21548a42a6559d7812973071617b26ff02cff2",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6769,7 +6769,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/deep-research",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6825,7 +6825,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "777a8298ce9336f1fd787ee1c48a451f9ca8113f86230fc964127c52e8938ca5",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6886,7 +6886,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/dependency-auditor",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6987,7 +6987,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6513b81490dec7ec2798b172c9d73b0384dbc98d6efed74183c4caf324446e25",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7102,7 +7102,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/develop-web-game",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7158,7 +7158,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4bdf0629d8b4da8815e6676493820104b02abd1ef3386d91d4748878b6048a04",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7219,7 +7219,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/docs-cleaner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7255,7 +7255,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "252cb4eb6eda403f3eb36a8bb1998c0aef7e348c7e9d0351780cdbb2b6618420",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7292,7 +7292,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/docx",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7628,7 +7628,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fe5f8367b956e767368de0bca43f360181515f218d3c78a6c448edccde0f8ae7",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8025,7 +8025,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/earnings-call-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8066,7 +8066,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fba3ca2e9d69833dac59fd6ae9ee7e038fe46e8991bca5b9755272e8438d1e92",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -8109,7 +8109,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/env-secrets-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8140,7 +8140,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "575e55b4ed7fdf90b2609e83082830e29e2d0ef582d5897bd454592dbec40320",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8171,7 +8171,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/event-driven-tracker",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8212,7 +8212,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3477071c58f361e1a6e5a991f82ee365cd6aadd2e79f4a4597839b92c94661b1",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8255,7 +8255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/fact-checker",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8291,7 +8291,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1e090d7758c468ee90c7110ca9af6be7036ab60f3b926375f9eb99abc8af9b53",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8328,7 +8328,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/factor-backtester",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8369,7 +8369,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "83efe2153ff51c7d536ab2859f29f0402070b570933572709eea86dbbe60fe45",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8412,7 +8412,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8473,7 +8473,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "5945caec2c3f52bf77753af29f09a1b4485805720e744a2724abcab8999296d9",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8540,7 +8540,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma-implement-design",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8591,7 +8591,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "63066764bb4d239dae61110c55880f0ab7ac3d187f501bf8bde74eeb4eb908a7",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8646,7 +8646,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-analyst",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8732,7 +8732,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "98cc5c391ae368aee4acc1ee72735bfb99799ea708127f79b6cb07eac5227f93",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8829,7 +8829,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-data-collector",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8925,7 +8925,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e44d7827bb3d9990e172d6a85b8a56e09e904d864992f837153f2d6545b06839",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9034,7 +9034,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/frontend-design",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9065,7 +9065,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "99572db2097b44dcf7128bfbca9ad7381aba6cf6a9bb3ca49597e8bf54cf0d64",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9096,7 +9096,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-address-comments",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9147,7 +9147,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "02d4b209a05ff328d9d3bc75fd3055d93624ed8383c167346b6146d2d90e65e9",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9202,7 +9202,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-fix-ci",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9253,7 +9253,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e134886addd4b4f14283fceb1db731435ac165c3139515e3562ab00fdec1bab5",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9308,7 +9308,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/git-worktree-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9334,7 +9334,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a7659ca434d8bc5da75ae6566afec4edcc6c25a5df9461e04e38f26b052c47b5",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9359,7 +9359,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/github",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9385,7 +9385,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f78d268b7277c99c035136e10ab3e36109af9c0b0bb18bd6910de3e16bf21b12",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9410,7 +9410,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/github-contributor",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9456,7 +9456,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6aee04e08ce486b580c1dc990e6ecb3a7dd838d6b5fdb90e2aedb26c1a053af4",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9505,7 +9505,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/github-ops",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9556,7 +9556,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3ab328fa2a1ccf0c302b63a7346a152237f4cfcfee0f2c4e20f4c693371f9b2e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9611,7 +9611,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/gpt-image2",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9652,7 +9652,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b8d2c12060758999684174b754ed5a3004d83550660a377f8404f386269e4f1f",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9695,7 +9695,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/graphql-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9721,7 +9721,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "16016d2a6375c885eae6f069c53616c66463d6390637d91c10fbf4054041cf2f",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9746,7 +9746,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/grype-syft-sbom-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9772,7 +9772,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3a1762c57fc9ea40a97141703e232c5aa4d72b627dc8f396f7dc0e654c906f17",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -9797,7 +9797,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/hermes-open-gsd-workflow",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-08-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9822,7 +9822,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6e1bbecf1c863b1b9895ac94eb66e57750877363b483805cbba4cb39b880c52d",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-08-20"
           }
         }
@@ -9874,7 +9874,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/i18n-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9910,7 +9910,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "22362aa3948df93fca08fa3fcfc8d27919f32162518dd9792c16d47dbfecf8c5",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9947,7 +9947,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/imagegen",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10023,7 +10023,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c04737fc1cb5b9ef26d6c6536090291e72ef40d1c21f550ab46de777fcffa72a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10108,7 +10108,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/incident-commander",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10259,7 +10259,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "352913d93f9e067afa0cbbd4baae16c5d798b18cf53e53ba15e36cc9695ea0b6",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10434,7 +10434,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/input-guard",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10530,7 +10530,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "8fcd74363c383de5aef899edf9eda04e8a3a9ddd0e7390f11098e910095f42ea",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10639,7 +10639,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/interview-system-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10730,7 +10730,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2dee1bf1517f08ad20525217591cb946e794137b2de93e431bfffe8a762dda14",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10833,7 +10833,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/investment-memo-writer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10874,7 +10874,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "01a9223eca330801d029f944b0fc9a2d4831420998b302755527e6a9a3d82b86",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10917,7 +10917,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/jupyter-notebook",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10998,7 +10998,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4dd0013c707d867b4b73663e303df58529076dd7b97269210d9e2343386ff60b",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11089,7 +11089,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/link-checker",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11115,7 +11115,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1ad3d11001bb0156a26babb26fabc45671cfb3d5bbd4124aa241583f44513c7f",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -11140,7 +11140,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/macro-regime-monitor",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11181,7 +11181,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "00c60df37247faddd1b6d1974a69b6f6efca950a6bca161c20199656f318bf6e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11224,7 +11224,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/markdown-tools",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11290,7 +11290,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3812f49fd9a9d4768a6b032fd99e0470ef18feb6e2f35114fa9256c74e823a31",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11363,7 +11363,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11414,7 +11414,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c2d3217518b232d0fd3d558f7ddd155c605c991125f9970d8ca802318b6e69c6",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11469,7 +11469,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11515,7 +11515,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9e3ea580efc25683476bea87ef8946d26fa39036009aedee85dcbe327737047a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11564,7 +11564,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/mcp-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11635,7 +11635,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1a1b536474ef865b9645b099225c3d0c3e84747cb1934894f3f5fc0d99ea7406",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11714,7 +11714,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/meeting-minutes-taker",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11760,7 +11760,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2c77bee9a6906a9a45fd646554610b04d9c35651e69a3b329c10641839f45413",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11809,7 +11809,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/mermaid-tools",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11855,7 +11855,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "55b4bea0043d5c6bdb409ee15dc087798f905f87031285b0562b1ccdd94acbe2",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11904,7 +11904,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/migration-architect",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12025,7 +12025,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "010e501b68fb4d07497eaff26f8572000bdfe2a44785d08406bcdb0bbd579d5e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -12164,7 +12164,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/monorepo-navigator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12195,7 +12195,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "729fb62d9b764798d077af785691a8a77574eea7f3c585e0a890f5e911cd29cb",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -12226,7 +12226,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/netlify-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12287,7 +12287,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "61b3aa40783a4cf69c5774a1cdcca444feba5b50d2e8efa6b59fe8626fe9b1db",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12354,7 +12354,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12465,7 +12465,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "437fbfdc6d1c2dbcaed1407400cedc1ec2859dcccc229f84bcc3a19465684694",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12592,7 +12592,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12708,7 +12708,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4d53b6c34f428c680620e23749cac2424996855e8185ba23422fbdde2b913afa",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12841,7 +12841,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-research-documentation",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12977,7 +12977,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a134865e4f0a6081d62f3d3aa54274815f8d3989efa3f03da5afbaa1e7a7f619",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -13134,7 +13134,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13250,7 +13250,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9a98edca0bfa49486bf71dcf57e1c9bd4303e324a0893a74c67f89c89708efd6",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -13383,7 +13383,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/observability-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13469,7 +13469,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3418cd7169e32914279e6291f8782f39f1819aea432371c71730c5e7db9da240",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13566,7 +13566,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/openai-docs",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13612,7 +13612,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ce90cced2efb71277864dc380d1ac2394320e387fc9cf66296ae31525f0585ce",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13661,7 +13661,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/options-strategy-evaluator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13702,7 +13702,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "685a9f9e083225a37295f1253081ea58f02645cef6b2fd233284d89eeb13aa77",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13745,7 +13745,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/osv-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13771,7 +13771,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "27144186eed821b292fe0f5d898634fa4e32960a2d03f1ba4e190932b56e77b3",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -13796,7 +13796,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pdf",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13887,7 +13887,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "d217160ceaaf0e1184f12b7e21dccdd2efcd76fa66c8cf4eeadda3769a72832a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13990,7 +13990,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/performance-profiler",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14021,7 +14021,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "239b4f8955157a8e879a0bde945eeae700489af231f071245653b7fa77379863",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -14052,7 +14052,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14118,7 +14118,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6215b59eff5b77ba1b61174a3b37df64d16da6276d0bd8c76e1e43345fb1ca72",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -14191,7 +14191,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright-pro",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14217,7 +14217,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9612c0614e151c581982b6c141300f11703848fc6fe481cc8838d6b40ea60b27",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-06-03"
           }
         }
@@ -14242,7 +14242,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/portfolio-risk-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14298,7 +14298,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "907d765cddf3cbb762180b3bbc4dea030050526620dfa6422da9a83762a6a452",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -14359,7 +14359,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pptx",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14735,7 +14735,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "87a473811703deaf4b16aeea54a286d0fa5eba743a17abc34bb5eb31845f0a2c",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15180,7 +15180,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/pr-review-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15206,7 +15206,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "0ed7e74d0359d5d9cbe9843b90e2ef413ae90d9e7eda7f7d8b7f5b5c3fbe5405",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15231,7 +15231,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-manager-toolkit",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15282,7 +15282,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "14b3d430c0a7ae1dfe91249d37e31d2ed8cb48b157b54787fabf990eae9d2c41",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15337,7 +15337,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-strategist",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15383,7 +15383,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "56b244f859e08d7498eb5f002ce7084c9b78bab6200264ecf284237c9f8afe5d",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15432,7 +15432,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/prompt-optimizer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15483,7 +15483,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "64b7bcfe8a73d8f503f42e320d16ab4b873ee4c01952b595e611739b848aeef8",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15538,7 +15538,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/promptfoo-evaluation",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15579,7 +15579,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "34b1b2a2747d90d1aa87087867205f6209d2de14627431e9b093f113abc30334",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15622,7 +15622,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/qa-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15693,7 +15693,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "65305a25ea8eb640fc67adb2ca90e42ac25547e5f5b0cd5353ffdb3564c557a4",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15772,7 +15772,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/rag-architect",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15828,7 +15828,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b30905d4f0057b200c78bd49b8fa58a95d3eac872023f0bedbc4477d0ec8dcd9",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15889,7 +15889,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/react-native-engineering",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15920,7 +15920,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "d7631cd7bc71c499a3dcd12d383c051d1bb7f0dd41ef758723bf99461a3b74b6",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15951,7 +15951,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/task-understanding-decomposition/reflect-learn",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16092,7 +16092,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "715c19b6a196d0a5556af819b84cdf4cdfb4e2d12781f453245d133c0743fb31",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16255,7 +16255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/release-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16351,7 +16351,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "72ec85dbf6499776f03ba33ff629f9dc4a26510caf050a43032502b690efb1a7",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16460,7 +16460,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/render-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16586,7 +16586,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "74b6e71dbe48fb7dbe8d125eb0733d68043c0cd1693ab75e9849f251279866c3",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -16731,7 +16731,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/repomix-safe-mixer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-08-31",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16772,7 +16772,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c38e786b95d843f7fa7993ebffee2da85b63efe0e83419ad42e7def25451bda5",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-08-31"
           }
         }
@@ -16815,7 +16815,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/runbook-generator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16841,7 +16841,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e92099a6bddcfd6b57684a6e33e98a4fc06f656bc56956ff135bcc057cb80760",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16866,7 +16866,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/saas-scaffolder",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16892,7 +16892,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "928b0a14f5950fcca7216ebe127af0141a4bdedf13863ae11f8d48c43debc695",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16917,7 +16917,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/screenshot",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16993,7 +16993,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3fd7db89e5960cfe4a2e2b297482eaca8e883093ab96cd5d417ee50907347e20",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17078,7 +17078,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/sec-filing-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17119,7 +17119,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "649f70b91f89ed4098e9b4aba3efec6dc6bee314e569d45903f6869f9700d64e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17162,7 +17162,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-auditor",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17188,7 +17188,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1c4df82bc9666d4a5122af7c979d926d232af02f6434cb391bd04cec023c29ad",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17213,7 +17213,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17299,7 +17299,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4db2acd0105711f9393ad1fb6ea2d8c7f679ad7c4cdd4ce05fbf68383fc02c79",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17396,7 +17396,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-ownership-map",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17457,7 +17457,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b753fa83ade0d5ad2de81c6db02a549550ed90e662a79ccdb5fe6dea5a7cc8df",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17524,7 +17524,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-threat-model",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17570,7 +17570,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c160a69178eebfb9a81adedff1bfb1c40fea04efe19b38db163a6811c447889d",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17619,7 +17619,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/semgrep-appsec-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17645,7 +17645,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f3b65b67690e67daffcb4f16284b9f04669ed6296caa99ac6bbb452d9147c433",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -17670,7 +17670,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/senior-devops",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17726,7 +17726,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ab36439cf582127bfb61a919bd0d394b8fb6e44131bb11548a33062b1080db27",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17787,7 +17787,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/sentry",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17838,7 +17838,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "8609b7f9b771c38657357a13860f8c73a7bc15a49065ad43b8510e8e74fd9b7f",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17893,7 +17893,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/skill-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17939,7 +17939,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "7546eeaf40224123484ccc0a4b46cde9dfbe0dd379f77702ea2db255d2421b25",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17988,7 +17988,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/skill-tester",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18089,7 +18089,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3c68377a06bf747352a2a9b58e2463882562250de671bfd38908f7e2c2dee5ef",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18204,7 +18204,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/skill-vetter",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18230,7 +18230,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b6f372ea6a7ea5fefac23a647713adf53209596c0070b5b73f66c503a25cd441",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -18255,7 +18255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/slack-gif-creator",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18311,7 +18311,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2b1b0258a35ae42ec381a8dab85b9040db102b32934ef2f24880cc2967b89fc4",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18372,7 +18372,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/social-media-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18428,7 +18428,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1e28a390d44a3c5eb368954c551b1f1e872e107e5cec9063b5acf39e5f3c168b",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18489,7 +18489,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/sora",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18580,7 +18580,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cfa57468ab8b44d2f24c7c47dbefec63062944f799644fc9c259de13852c5b47",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18683,7 +18683,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/speech",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18784,7 +18784,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "5b795a6ea7bb9071379c99a40f9449f0d12dbb4f91197aa15d38f4fc6b719b98",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18899,7 +18899,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/stock-screener-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18940,7 +18940,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "33917e0b49f76de0afca871cbeef5c6dfaf623e82b5ba25fdda8fef5c5065790",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18983,7 +18983,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/tech-debt-tracker",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19094,7 +19094,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "343d79ed6f560ab063831cb8e9322f685f4385d3907d775b35df897729e972a4",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -19221,7 +19221,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/theme-factory",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19307,7 +19307,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1f5696d4a3f8ad841484c1e8fc8826537fe68bb5f92c51c656778e8de21d8925",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -19404,7 +19404,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/transcribe",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19460,7 +19460,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f1d6d43ec7c6cf25110e5b7989bfda4c94965208b8d291ea23daf8a89c89b4bc",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -19521,7 +19521,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/transcript-fixer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19887,7 +19887,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f24e3341a0f6924375d651833df3f33f7a46389a6ebe0dfa1ca751a54be3579e",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20320,7 +20320,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/trivy-vulnerability-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20346,7 +20346,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "eee5fe50f8a2109f45f3876c911e724d2bb37601173162f56294a86ece2743d4",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -20371,7 +20371,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/tweetclaw-source-research",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20397,7 +20397,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "986497802fe1d6e61ebf506031b3cc2462eed4ed69719d6d9071c0e19fa2af71",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20422,7 +20422,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/twitter-reader",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20463,7 +20463,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c000c45d59d47400fcf9c0597444877106705c82de3b35c1334ba700106cc718",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20506,7 +20506,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/typescript-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20532,7 +20532,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fb632ff254d4f16b5948cc6b97c997d7ec311dc9d662ae56e1da5de895fa66dc",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -20557,7 +20557,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-design-system",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20608,7 +20608,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "981044cf73505517e8ef52c40375c0f1fcb85a8079b93b0487edf1ac20c688be",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20663,7 +20663,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-ux-pro-max",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20689,7 +20689,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "41ccf421965450292154081f8a22c99f90eca6109600920e9bc7ddddceb5b7b7",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20714,7 +20714,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ux-researcher-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20765,7 +20765,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6b28615667885c6bf8907169805df1c73070df05c400afe67498acb400732cf2",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20820,7 +20820,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/vercel-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20871,7 +20871,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cd0abede816c5923986340edd5bd59ca17a9c2a027296248c35757d4e778661a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -20926,7 +20926,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/vuls-linux-cve-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20952,7 +20952,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ee9788e397a3c01d8f6f901b87a53c97e444cac0c36aaf4bb745e5dade5815c9",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -20977,7 +20977,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/web-artifacts-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21023,7 +21023,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "55be83111388ee3673a9637df90b46d25dee017d004184bc5926cec335f06141",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21072,7 +21072,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/web-scraper",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21098,7 +21098,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cd046dba98e766a09700ec4237ad7428f26654acb2b8923e17330b249bdef5f3",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -21123,7 +21123,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/webapp-testing",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21174,7 +21174,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2d3577154f057a693b0e5c8e92010b19c4ecbda6c47ba9a82d42dc2caef9b85a",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -21229,7 +21229,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/writing-plans",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21255,7 +21255,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "544f2aa7cc37212b5cf2c2f6e863908b9e19401a681632e4722ee14913974cef",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21280,7 +21280,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/xlsx",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21606,7 +21606,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b76f382d38d1d8b4891373ba6d4a33b815daf4c9e7b34803f2bae2d38c1c3a91",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21991,7 +21991,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/yeet",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
+        "last_checked_at": "2026-09-07",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -22037,7 +22037,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "791a6872bb42d430167691254d5ec7dd3ebac41c617a66255ecfe4a13435b331",
-            "last_checked_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -22408,6 +22408,13 @@
     },
     {
       "date": "2026-09-06",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 131 local skills"
+    },
+    {
+      "date": "2026-09-07",
       "method": "local-scan",
       "target": "skills/*/*/SKILL.md",
       "result": "success",

--- a/docs/sources/nous-hermes-agent-2026-04.skills.json
+++ b/docs/sources/nous-hermes-agent-2026-04.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://github.com/NousResearch/hermes-agent",
-    "checked_at": "2026-09-06",
+    "checked_at": "2026-09-07",
     "note": "Curated subset from Hermes Agent focused on persistent knowledge workflows and self-improving agent infrastructure."
   },
   "official_references": [
@@ -29,9 +29,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "skills/research/llm-wiki/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "1c9433897c7b8a3b2754a84875e8f86d0a42991a"
       },
@@ -52,17 +52,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "1c9433897c7b8a3b2754a84875e8f86d0a42991a",
             "content_sha256": "ec7139cd3fa884f964888400e1e20bd9215329c84ddbec8b026e116bd4c6eb5d",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -312,9 +312,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "optional-skills/autonomous-ai-agents/honcho/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "b0ef72a8a0a20fb9dd85d1e74b85edabc0c80813"
       },
@@ -335,17 +335,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "b0ef72a8a0a20fb9dd85d1e74b85edabc0c80813",
             "content_sha256": "43e95dc0e4c847ade2bbddf4c934cecbe24777e439cdb2099c62914c1e0c9571",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -423,9 +423,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "skills/software-development/codebase-inspection/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "c49fa88b80753071e7b7bb83e2882232e43e87c0"
       },
@@ -446,17 +446,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "c49fa88b80753071e7b7bb83e2882232e43e87c0",
             "content_sha256": "7eb5a51d0533dfe2aa16878abe9134965d8a948611eac36c868f6254e914aa7a",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -482,9 +482,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "skills/research/arxiv/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "c49fa88b80753071e7b7bb83e2882232e43e87c0"
       },
@@ -505,17 +505,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "c49fa88b80753071e7b7bb83e2882232e43e87c0",
             "content_sha256": "82b9c9b0645d0c3a4ab5ef9387e1fa54eed3dc9e726bdc5d35f8b553f45a3bb6",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -541,9 +541,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "skills/note-taking/obsidian/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "1c9433897c7b8a3b2754a84875e8f86d0a42991a"
       },
@@ -564,17 +564,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "1c9433897c7b8a3b2754a84875e8f86d0a42991a",
             "content_sha256": "585889941580c52f96c3775c81a761d96e540d46d2e2244d163da65b9776403f",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -600,9 +600,9 @@
         "repo": "NousResearch/hermes-agent",
         "path": "optional-skills/mcp/mcporter/SKILL.md",
         "ref": "main",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
         "sync_mode": "monitor",
         "path_commit": "b0ef72a8a0a20fb9dd85d1e74b85edabc0c80813"
       },
@@ -623,17 +623,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+            "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
             "path_commit": "b0ef72a8a0a20fb9dd85d1e74b85edabc0c80813",
             "content_sha256": "e6bc7bb0650355a0ec887ed53f4d2244998d4521ffd2f5bc4d393aa699235e40",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "75410e73319c72cd3e991a501c5455eb78f38375",
               "content_sha256": "821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6",
               "spdx": "MIT",
-              "resolved_commit": "77915e344cb0cd8e20661d4a7b393f987a2eef32",
+              "resolved_commit": "693641aa8b4359c602283bdbbc14041e03bc47bc",
               "api_spdx": "MIT"
             }
           }
@@ -818,6 +818,13 @@
       "target": "NousResearch/hermes-agent@77915e344cb0cd8e20661d4a7b393f987a2eef32",
       "result": "success",
       "evidence": "Explicit reviewer checkpoint recorded after curating durable method, compatibility, security, CI, and validation changes."
+    },
+    {
+      "date": "2026-09-07",
+      "method": "commit-aware-manual-monitor-review",
+      "target": "NousResearch/hermes-agent@693641aa8b4359c602283bdbbc14041e03bc47bc",
+      "result": "success",
+      "evidence": "Reviewed 159 commits after 77915e344cb0cd8e20661d4a7b393f987a2eef32. All six monitored skill blobs are unchanged and the latest stable release remains v2026.8.31, so no local skill text changed."
     }
   ]
 }

--- a/docs/sources/reclassified-external-skills-2026-08.skills.json
+++ b/docs/sources/reclassified-external-skills-2026-08.skills.json
@@ -1995,7 +1995,7 @@
             "ref": "main",
             "resolved_commit": "8331f910845103c08d51f6ca1d86ebb7d1f745e3",
             "path_commit": "32912161e2732c3e5001c6811a76c1f8308ed0da",
-            "content_sha256": "ff127c241eecb2c683d1dda0406dde5f90ef771655f6d001d461929534be8192",
+            "content_sha256": "2e78057e19e117750fe1c59147428e649538cc85a4975400225f97d7d6fb3e3a",
             "last_checked_at": "2026-08-31",
             "last_synced_at": "2026-08-31",
             "license_checkpoint": {
@@ -2018,7 +2018,7 @@
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/SKILL.md",
-          "sha256": "ff127c241eecb2c683d1dda0406dde5f90ef771655f6d001d461929534be8192",
+          "sha256": "2e78057e19e117750fe1c59147428e649538cc85a4975400225f97d7d6fb3e3a",
           "owner": "supabase-postgres-best-practices",
           "mode": "100644"
         },

--- a/docs/sources/xiaolai-nlpm-2026-06.skills.json
+++ b/docs/sources/xiaolai-nlpm-2026-06.skills.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "video": {
     "url": "https://nlpm.com/",
-    "checked_at": "2026-09-06",
+    "checked_at": "2026-09-07",
     "note": "Curated from xiaolai/nlpm after reviewing the website, why page, README, LICENSE, author docs, rules, scoring, and testing materials. Imported as an original repository skill that captures the durable audit method rather than mirroring the full upstream command/plugin product."
   },
   "official_references": [
@@ -50,9 +50,9 @@
         "path": "README.md",
         "ref": "main",
         "sync_mode": "monitor",
-        "last_checked_at": "2026-09-06",
-        "last_synced_at": "2026-09-06",
-        "last_synced_commit": "dffbb03c449fa70bf0cfd2c16ff13055130d794c",
+        "last_checked_at": "2026-09-07",
+        "last_synced_at": "2026-09-07",
+        "last_synced_commit": "eb6b088f0218f82a34000f356dd094a242d50a5c",
         "path_commit": "5959cde46b0c79129dd791e3e0639adb0bdf7222"
       },
       "kind": "overlay",
@@ -72,17 +72,17 @@
           "tracking": {
             "channel": "default_branch",
             "ref": "main",
-            "resolved_commit": "dffbb03c449fa70bf0cfd2c16ff13055130d794c",
+            "resolved_commit": "eb6b088f0218f82a34000f356dd094a242d50a5c",
             "path_commit": "5959cde46b0c79129dd791e3e0639adb0bdf7222",
             "content_sha256": "0f4df860e8ab1b47d45b439b49b1fb595cf258bf3b5216a5e1a6d78426cb23a8",
-            "last_checked_at": "2026-09-06",
-            "last_synced_at": "2026-09-06",
+            "last_checked_at": "2026-09-07",
+            "last_synced_at": "2026-09-07",
             "license_checkpoint": {
               "path": "LICENSE",
               "blob_sha": "554937c222c6dd2db191634da77b5486a4a0410b",
               "content_sha256": "87b3f4064cb76d1c7cc8c39546d7d62790b76372f37cfb9de1bb828a5f652b51",
               "spdx": "ISC",
-              "resolved_commit": "dffbb03c449fa70bf0cfd2c16ff13055130d794c",
+              "resolved_commit": "eb6b088f0218f82a34000f356dd094a242d50a5c",
               "api_spdx": "ISC"
             }
           }
@@ -290,6 +290,13 @@
       "target": "xiaolai/nlpm@dffbb03c449fa70bf0cfd2c16ff13055130d794c",
       "result": "success",
       "evidence": "Explicit reviewer checkpoint recorded after curating durable method, compatibility, security, CI, and validation changes."
+    },
+    {
+      "date": "2026-09-07",
+      "method": "commit-aware-manual-monitor-review",
+      "target": "xiaolai/nlpm@eb6b088f0218f82a34000f356dd094a242d50a5c",
+      "result": "success",
+      "evidence": "Reviewed 10 commits after dffbb03c449fa70bf0cfd2c16ff13055130d794c. Changes are tracking logs, a daily report, and dashboard data; the managed README blob is unchanged, so no local skill text changed."
     }
   ]
 }

--- a/openclaw-skills/supabase-postgres-best-practices/SKILL.md
+++ b/openclaw-skills/supabase-postgres-best-practices/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: supabase-postgres-best-practices
-description: 'Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s database guidance; applicable to Postgres on any hosting platform.'
-zh_description: "用于编写、评审和优化 Supabase/Postgres 查询、Schema、索引和数据库配置。"
-version: "1.0.3"
+description: 'Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies, connection settings, or migrations with Supabase guidance; applicable to Postgres on any hosting platform.'
+zh_description: "用于编写或评审 Supabase/Postgres 的查询、Schema、索引、RLS、连接配置与迁移。"
+version: "1.0.4"
 author: "seaworld008"
 source: "github:supabase/agent-skills"
 source_url: "https://skills.sh/supabase/agent-skills/supabase-postgres-best-practices"
@@ -73,30 +73,43 @@ Each rule file contains:
 - https://supabase.com/docs/guides/database/overview
 - https://supabase.com/docs/guides/auth/row-level-security
 <!-- LOCAL-QUALITY-SUPPLEMENT:START -->
-## Usage Notes
+## Review Workflow
 
-This supplement is maintained by the repository sync pipeline. It keeps the
-imported upstream skill usable inside this curated collection when the upstream
-source is intentionally concise.
+Select only the rule files that match the task. Start with correctness and
+access control, then measure performance before proposing tuning changes.
 
-## Common Patterns
+1. Identify the database version, hosting constraints, workload shape, and
+   whether the task changes data or only reviews SQL.
+2. Read the relevant `query-`, `conn-`, `security-`, `schema-`, `lock-`,
+   `data-`, or `monitor-` references; avoid loading the full rule set by default.
+3. Preserve existing RLS and privilege boundaries. Treat disabling RLS,
+   broadening grants, destructive DDL, and production writes as separate,
+   explicitly authorized actions.
+4. For performance claims, capture the query shape and an `EXPLAIN` or
+   `EXPLAIN (ANALYZE, BUFFERS)` result in a safe environment. Do not infer an
+   improvement from the presence of an index alone.
+5. Verify migrations on a representative schema, including rollback or a
+   forward-fix path, lock duration, and compatibility with concurrent traffic.
 
-```text
-1. Confirm that the user's task matches the skill trigger.
-2. Read the relevant project files or user-provided context before acting.
-3. Choose the smallest reversible action that advances the task.
-4. Run the verification command or manual check that proves the result.
-5. Report the outcome, evidence, and any remaining risk.
-```
+## Acceptance Evidence
+
+- Query tuning: compare plans and measured latency or buffer usage under the
+  same parameters and representative data distribution.
+- Index changes: confirm intended scans use the index and account for write,
+  storage, and maintenance overhead.
+- RLS or privilege changes: test allowed and denied paths with the actual roles;
+  service-role success is not proof that end-user policies work.
+- Connection changes: verify pool mode, transaction semantics, prepared
+  statement compatibility, connection limits, and saturation behavior.
+- Schema changes: verify constraints, backfill behavior, lock exposure, and the
+  recovery procedure before production rollout.
 
 ## Boundaries
 
-- Prefer the upstream workflow for Supabase Postgres Best Practices; this section only adds local quality
-  guardrails.
-- Do not invent project facts when required files, vaults, services, or tools are
-  unavailable.
-- Stop and ask for clarification when the next action could overwrite user work,
-  expose private data, or change production state.
-- Treat skill selection as routing, not ceremony: invoke only the narrowest
-  applicable workflow and keep user or repository instructions authoritative.
+- Never run `EXPLAIN ANALYZE` on a mutating statement in production without an
+  explicitly safe transaction and authorization; plain `EXPLAIN` is the safer
+  default for uncertain statements.
+- Do not present generic PostgreSQL advice as a Supabase platform guarantee.
+- Static SQL review and local tests do not prove production capacity, failover,
+  replication health, or zero-downtime migration behavior.
 <!-- LOCAL-QUALITY-SUPPLEMENT:END -->

--- a/skills/developer-engineering/README.md
+++ b/skills/developer-engineering/README.md
@@ -54,7 +54,7 @@
 | `schema` | 数据库模式设计、迁移规划、索引策略和关系建模。 | [目录](./schema/) | [SKILL.md](./schema/SKILL.md) |
 | `skill-tester` | 验证技能触发、执行步骤和输出结果是否符合预期。 | [目录](./skill-tester/) | [SKILL.md](./skill-tester/SKILL.md) |
 | `supabase` | 开发和排查 Supabase 数据库、认证、存储及应用集成。 | [目录](./supabase/) | [SKILL.md](./supabase/SKILL.md) |
-| `supabase-postgres-best-practices` | 用于编写、评审和优化 Supabase/Postgres 查询、Schema、索引和数据库配置。 | [目录](./supabase-postgres-best-practices/) | [SKILL.md](./supabase-postgres-best-practices/SKILL.md) |
+| `supabase-postgres-best-practices` | 用于编写或评审 Supabase/Postgres 的查询、Schema、索引、RLS、连接配置与迁移。 | [目录](./supabase-postgres-best-practices/) | [SKILL.md](./supabase-postgres-best-practices/SKILL.md) |
 | `systematic-debugging` | 通过复现、假设检验和证据定位故障根因。 | [目录](./systematic-debugging/) | [SKILL.md](./systematic-debugging/SKILL.md) |
 | `tailwind-design-system` | 用于 Tailwind CSS 设计系统、主题 token、组件样式和响应式布局规范。 | [目录](./tailwind-design-system/) | [SKILL.md](./tailwind-design-system/SKILL.md) |
 | `tech-debt-tracker` | 识别和量化技术债，确定修复优先级并跟踪治理进度。 | [目录](./tech-debt-tracker/) | [SKILL.md](./tech-debt-tracker/SKILL.md) |

--- a/skills/developer-engineering/supabase-postgres-best-practices/SKILL.md
+++ b/skills/developer-engineering/supabase-postgres-best-practices/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: supabase-postgres-best-practices
-description: 'Review Postgres schemas, queries, indexes, RLS, and migrations using Supabase''s database guidance; applicable to Postgres on any hosting platform.'
-zh_description: "用于编写、评审和优化 Supabase/Postgres 查询、Schema、索引和数据库配置。"
-version: "1.0.3"
+description: 'Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies, connection settings, or migrations with Supabase guidance; applicable to Postgres on any hosting platform.'
+zh_description: "用于编写或评审 Supabase/Postgres 的查询、Schema、索引、RLS、连接配置与迁移。"
+version: "1.0.4"
 author: "seaworld008"
 source: "github:supabase/agent-skills"
 source_url: "https://skills.sh/supabase/agent-skills/supabase-postgres-best-practices"
@@ -73,30 +73,43 @@ Each rule file contains:
 - https://supabase.com/docs/guides/database/overview
 - https://supabase.com/docs/guides/auth/row-level-security
 <!-- LOCAL-QUALITY-SUPPLEMENT:START -->
-## Usage Notes
+## Review Workflow
 
-This supplement is maintained by the repository sync pipeline. It keeps the
-imported upstream skill usable inside this curated collection when the upstream
-source is intentionally concise.
+Select only the rule files that match the task. Start with correctness and
+access control, then measure performance before proposing tuning changes.
 
-## Common Patterns
+1. Identify the database version, hosting constraints, workload shape, and
+   whether the task changes data or only reviews SQL.
+2. Read the relevant `query-`, `conn-`, `security-`, `schema-`, `lock-`,
+   `data-`, or `monitor-` references; avoid loading the full rule set by default.
+3. Preserve existing RLS and privilege boundaries. Treat disabling RLS,
+   broadening grants, destructive DDL, and production writes as separate,
+   explicitly authorized actions.
+4. For performance claims, capture the query shape and an `EXPLAIN` or
+   `EXPLAIN (ANALYZE, BUFFERS)` result in a safe environment. Do not infer an
+   improvement from the presence of an index alone.
+5. Verify migrations on a representative schema, including rollback or a
+   forward-fix path, lock duration, and compatibility with concurrent traffic.
 
-```text
-1. Confirm that the user's task matches the skill trigger.
-2. Read the relevant project files or user-provided context before acting.
-3. Choose the smallest reversible action that advances the task.
-4. Run the verification command or manual check that proves the result.
-5. Report the outcome, evidence, and any remaining risk.
-```
+## Acceptance Evidence
+
+- Query tuning: compare plans and measured latency or buffer usage under the
+  same parameters and representative data distribution.
+- Index changes: confirm intended scans use the index and account for write,
+  storage, and maintenance overhead.
+- RLS or privilege changes: test allowed and denied paths with the actual roles;
+  service-role success is not proof that end-user policies work.
+- Connection changes: verify pool mode, transaction semantics, prepared
+  statement compatibility, connection limits, and saturation behavior.
+- Schema changes: verify constraints, backfill behavior, lock exposure, and the
+  recovery procedure before production rollout.
 
 ## Boundaries
 
-- Prefer the upstream workflow for Supabase Postgres Best Practices; this section only adds local quality
-  guardrails.
-- Do not invent project facts when required files, vaults, services, or tools are
-  unavailable.
-- Stop and ask for clarification when the next action could overwrite user work,
-  expose private data, or change production state.
-- Treat skill selection as routing, not ceremony: invoke only the narrowest
-  applicable workflow and keep user or repository instructions authoritative.
+- Never run `EXPLAIN ANALYZE` on a mutating statement in production without an
+  explicitly safe transaction and authorization; plain `EXPLAIN` is the safer
+  default for uncertain statements.
+- Do not present generic PostgreSQL advice as a Supabase platform guarantee.
+- Static SQL review and local tests do not prove production capacity, failover,
+  replication health, or zero-downtime migration behavior.
 <!-- LOCAL-QUALITY-SUPPLEMENT:END -->

--- a/tests/test_graphify_official_artifacts.py
+++ b/tests/test_graphify_official_artifacts.py
@@ -6,7 +6,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_ROOT = REPO_ROOT / "skills/developer-engineering/graphify"
 MAPPING_PATH = REPO_ROOT / "docs/sources/graphify-2026-04.skills.json"
-RELEASE_COMMIT = "b14b52e94ec3d9840413d81777f4c134eac0a40d"
 EXPECTED_RELATIVE_FILES = {
     "SKILL.md",
     "EXTENDED.md",
@@ -54,8 +53,12 @@ def test_graphify_release_mapping_has_single_owner_and_exact_hashes() -> None:
         "type": "file",
     }]
     assert origin["tracking"]["channel"] == "latest_release"
-    assert origin["tracking"]["ref"] == "v0.9.47"
-    assert origin["tracking"]["resolved_commit"] == RELEASE_COMMIT
+    assert origin["tracking"]["ref"].startswith("v")
+    reviewed = mapping["verification_attempts"][-1]
+    assert reviewed["method"] == "commit-aware-manual-monitor-review"
+    assert reviewed["result"] == "success"
+    reviewed_commit = reviewed["target"].rsplit("@", 1)[1]
+    assert origin["tracking"]["resolved_commit"] == reviewed_commit
     assert origin["tracking"]["license_checkpoint"] == {
         "path": "LICENSE",
         "blob_sha": "d645695673349e3947e8e5ae42332d0ac3164cd7",
@@ -63,7 +66,7 @@ def test_graphify_release_mapping_has_single_owner_and_exact_hashes() -> None:
             "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
         ),
         "spdx": "Apache-2.0",
-        "resolved_commit": RELEASE_COMMIT,
+        "resolved_commit": reviewed_commit,
         "api_spdx": "NOASSERTION",
     }
 
@@ -98,7 +101,7 @@ def test_graphify_release_mapping_has_single_owner_and_exact_hashes() -> None:
     assert origin["tracking"]["content_sha256"] == skill_hash
 
 
-def test_graphify_references_match_reviewed_v0947_hashes() -> None:
+def test_graphify_references_match_reviewed_release_hashes() -> None:
     expected_hashes = {
         "add-watch.md": "b3f67570240582689c2834b4831917550c2d1aaf042148868c39dcbf387ce3fd",
         "exports.md": "ee47fae477f106d8aed38798c58493b5a7f060a0d9d2581ce6132302827bc14b",

--- a/tests/test_pr4_upstream_decisions.py
+++ b/tests/test_pr4_upstream_decisions.py
@@ -55,24 +55,31 @@ def test_reviewed_monitor_checkpoints_advance_without_body_churn() -> None:
         (
             "addyosmani-agent-skills-2026-04.skills.json",
             "api-and-interface-design",
-            "48cb1168aeaaa70dfc2bbf709eddfa2a8ed8129a",
         ),
         (
             "firebase-agent-skills-2026-07.skills.json",
             "firebase-security-rules-auditor",
-            "a0b4e143f40c1ebe05fe5f9a4787fecd4da8f478",
         ),
         (
             "xiaolai-nlpm-2026-06.skills.json",
             "nlpm-audit",
-            "dffbb03c449fa70bf0cfd2c16ff13055130d794c",
         ),
     )
-    for mapping_name, slug, commit in cases:
-        item = entry(mapping(mapping_name), slug)
+    for mapping_name, slug in cases:
+        mapping_data = mapping(mapping_name)
+        item = entry(mapping_data, slug)
+        origin = item["origins"][0]
         tracking = item["origins"][0]["tracking"]
-        assert tracking["resolved_commit"] == commit
-        assert tracking["license_checkpoint"]["resolved_commit"] == commit
+        reviewed = next(
+            attempt
+            for attempt in reversed(mapping_data["verification_attempts"])
+            if attempt["method"] == "commit-aware-manual-monitor-review"
+            and attempt["target"].startswith(f"{origin['repo']}@")
+        )
+        reviewed_commit = reviewed["target"].rsplit("@", 1)[1]
+        assert reviewed["result"] == "success"
+        assert tracking["resolved_commit"] == reviewed_commit
+        assert tracking["license_checkpoint"]["resolved_commit"] == reviewed_commit
         assert_managed_inventory(item)
 
 


### PR DESCRIPTION
## 变更

- 提交级复核 Graphify v0.9.55、Hermes `693641aa` 与 NLPM `eb6b088f`；受管技能制品未变化，仅推进已审 provenance 检查点。
- 将 `supabase-postgres-best-practices` 的通用本地补充改为数据库专用流程，覆盖查询计划、RLS、连接池、迁移锁和生产验证边界。
- 修复两条把历史 monitor 检查点当永久常量的测试，改为验证当前 tracking、许可证锁和最新成功 review 证据的一致性。
- 无新增、退役或合并技能；保留 284 个规范技能、36 个永久墓碑和 47 个本地补充块。

## 验证

- `python scripts/validate_repository.py --refresh`：562 tests；287 strict PASS，0 WARN/FAIL；来源覆盖 284/284；许可 missing/disallowed 0；墓碑违规 0。
- OpenClaw 视频来源、全量 Python 编译、Node installer syntax/help/targets/bundles、`npm pack --dry-run --silent`、repo health PASS、`git diff --check` 均通过。
- 生成器双跑 diff SHA 一致；提交后生成器重跑 `git diff --exit-code` 通过。

## 边界

这是静态仓库与来源治理验证，不代表 Supabase 生产性能、迁移零停机或 Hermes/Graphify 本机运行时验收。