### PR TITLE
fix: address weekly review findings

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -2283,7 +2283,7 @@
       "quality": 3,
       "complexity": "intermediate",
       "created_at": "2026-05-05",
-      "updated_at": "2026-09-06",
+      "updated_at": "2026-09-07",
       "line_count": 115,
       "path": "skills/developer-engineering/supabase-postgres-best-practices/SKILL.md"
     },

--- a/docs/sources/reclassified-external-skills-2026-08.skills.json
+++ b/docs/sources/reclassified-external-skills-2026-08.skills.json
@@ -1995,7 +1995,7 @@
             "ref": "main",
             "resolved_commit": "8331f910845103c08d51f6ca1d86ebb7d1f745e3",
             "path_commit": "32912161e2732c3e5001c6811a76c1f8308ed0da",
-            "content_sha256": "2e78057e19e117750fe1c59147428e649538cc85a4975400225f97d7d6fb3e3a",
+            "content_sha256": "06641745423da5a205f718e1a363d98165b76023ba84c32ce3ce80163bfb8c13",
             "last_checked_at": "2026-08-31",
             "last_synced_at": "2026-08-31",
             "license_checkpoint": {
@@ -2018,7 +2018,7 @@
         },
         {
           "path": "skills/developer-engineering/supabase-postgres-best-practices/SKILL.md",
-          "sha256": "2e78057e19e117750fe1c59147428e649538cc85a4975400225f97d7d6fb3e3a",
+          "sha256": "06641745423da5a205f718e1a363d98165b76023ba84c32ce3ce80163bfb8c13",
           "owner": "supabase-postgres-best-practices",
           "mode": "100644"
         },

--- a/openclaw-skills/supabase-postgres-best-practices/SKILL.md
+++ b/openclaw-skills/supabase-postgres-best-practices/SKILL.md
@@ -9,7 +9,7 @@ source_url: "https://skills.sh/supabase/agent-skills/supabase-postgres-best-prac
 license: MIT
 tags: '["best", "development", "postgres", "supabase"]'
 created_at: "2026-05-05"
-updated_at: "2026-09-06"
+updated_at: "2026-09-07"
 quality: 3
 complexity: "intermediate"
 metadata:

--- a/skills/developer-engineering/supabase-postgres-best-practices/SKILL.md
+++ b/skills/developer-engineering/supabase-postgres-best-practices/SKILL.md
@@ -9,7 +9,7 @@ source_url: "https://skills.sh/supabase/agent-skills/supabase-postgres-best-prac
 license: MIT
 tags: '["best", "development", "postgres", "supabase"]'
 created_at: "2026-05-05"
-updated_at: "2026-09-06"
+updated_at: "2026-09-07"
 quality: 3
 complexity: "intermediate"
 metadata:

--- a/tests/test_graphify_official_artifacts.py
+++ b/tests/test_graphify_official_artifacts.py
@@ -54,7 +54,12 @@ def test_graphify_release_mapping_has_single_owner_and_exact_hashes() -> None:
     }]
     assert origin["tracking"]["channel"] == "latest_release"
     assert origin["tracking"]["ref"].startswith("v")
-    reviewed = mapping["verification_attempts"][-1]
+    reviewed = next(
+        attempt
+        for attempt in reversed(mapping["verification_attempts"])
+        if attempt["method"] == "commit-aware-manual-monitor-review"
+        and attempt["target"].startswith(f"{origin['repo']}@")
+    )
     assert reviewed["method"] == "commit-aware-manual-monitor-review"
     assert reviewed["result"] == "success"
     reviewed_commit = reviewed["target"].rsplit("@", 1)[1]

--- a/tests/test_graphify_official_artifacts.py
+++ b/tests/test_graphify_official_artifacts.py
@@ -59,6 +59,7 @@ def test_graphify_release_mapping_has_single_owner_and_exact_hashes() -> None:
         for attempt in reversed(mapping["verification_attempts"])
         if attempt["method"] == "commit-aware-manual-monitor-review"
         and attempt["target"].startswith(f"{origin['repo']}@")
+        and attempt["result"] == "success"
     )
     assert reviewed["method"] == "commit-aware-manual-monitor-review"
     assert reviewed["result"] == "success"


### PR DESCRIPTION
## 修复

- 将 `supabase-postgres-best-practices` 的 `updated_at` 同步到 `2026-09-07`，并刷新 catalog、OpenClaw 导出与 provenance 摘要。
- Graphify 测试改为按 `method + repo` 反向查找最近成功 monitor review，避免后续追加其他合法验证记录时无关失败。

修复 PR #102 合并后发现的两条有效 Codex Review 反馈。

## 验证

- targeted：6 passed。
- 完整 `python scripts/validate_repository.py --refresh`：562 passed；287 strict PASS，0 WARN/FAIL。
- 来源、许可、墓碑、健康、OpenClaw、Python、Node/npm 与生成器幂等门禁通过。