### PR TITLE
fix: restore changelog refresh authentication

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -47,7 +48,7 @@ jobs:
 
       - name: Open PR with refreshed changelog
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore: refresh CHANGELOG from recent commits"
           title: "chore: refresh CHANGELOG.md"

--- a/tests/test_codeql_batch_a_security.py
+++ b/tests/test_codeql_batch_a_security.py
@@ -35,7 +35,7 @@ ALGORITHMIC_ART_VIEWER = (
     / "templates"
     / "viewer.html"
 )
-CREATE_PULL_REQUEST_V6_COMMIT = "c5a7806660adbe173f04e3e038b0ccdcd758773c"
+CREATE_PULL_REQUEST_V8_COMMIT = "5f6978faf089d4d20b00c7766989d076bb2fc7f1"
 P5_1_7_0_SHA384 = (
     "sha384-Mhzoc5EVkjFUVtIW2M3h8BgXtFlUsUpu9lTCThPrV7+"
     "k6MN6vTi079rew0LkvgFb"
@@ -70,9 +70,15 @@ class CodeQLBatchASecurityTests(unittest.TestCase):
             )
         )
         self.assertEqual(
-            f"peter-evans/create-pull-request@{CREATE_PULL_REQUEST_V6_COMMIT}",
+            f"peter-evans/create-pull-request@{CREATE_PULL_REQUEST_V8_COMMIT}",
             create_pr["uses"],
         )
+        checkout = next(
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        self.assertFalse(checkout["with"]["persist-credentials"])
 
     def test_harvest_passes_untrusted_filters_as_gh_argv(self):
         repo_value = "owner/repo; touch /tmp/must-not-run"


### PR DESCRIPTION
## 根因

`Changelog Refresh` run 34074185675 在 `create-pull-request` 执行 `git remote prune origin` 时收到 `Duplicate header: Authorization`。checkout 保留的认证与 create-pull-request 再配置的认证重复。

## 修复

- `actions/checkout@v7.0.1` 设置 `persist-credentials: false`，把分支推送认证交给 create-pull-request 单一所有者。
- `peter-evans/create-pull-request` 从固定 v6 提升到 MIT 许可的 v8.1.1 固定提交 `5f6978f...`，使用 Node 24。
- 测试同时锁定完整 commit 与 credential ownership。

## 验证

- targeted 15 passed。
- 完整仓库管线 562 passed；287 strict PASS，0 WARN/FAIL；来源、许可、portfolio 与生成器门禁通过。
- 本机未安装 `actionlint`，因此该项明确未直跑；YAML 已由 PyYAML 测试加载，最终以 GitHub Actions 实际运行验收。