### PR TITLE
fix: correct catalog metadata and complete maintenance audit

### DIFF
--- a/docs/TAGS-INDEX.md
+++ b/docs/TAGS-INDEX.md
@@ -1,6 +1,6 @@
 # Tags Index
 
-> Auto-generated from 1103 skill-tag mappings across 499 tags.
+> Auto-generated from 1094 skill-tag mappings across 487 tags.
 > Last updated: see git log.
 
 ## Quick Navigation
@@ -17,7 +17,7 @@
 - [`design`](#design) (16)
 - [`finance`](#finance) (16)
 - [`automation`](#automation) (15)
-- [`growth`](#growth) (14)
+- [`growth`](#growth) (15)
 - [`planning`](#planning) (14)
 - [`sre`](#sre) (14)
 - [`devops`](#devops) (13)
@@ -26,10 +26,11 @@
 - [`productivity`](#productivity) (10)
 - [`deployment`](#deployment) (7)
 - [`designer`](#designer) (7)
-- [`api`](#api) (5)
+- [`api`](#api) (6)
 - [`code-review`](#code-review) (5)
 - [`expert`](#expert) (5)
 - [`manager`](#manager) (5)
+- [`mcp`](#mcp) (5)
 - [`skill`](#skill) (5)
 - [`analysis`](#analysis) (4)
 - [`appsec`](#appsec) (4)
@@ -43,8 +44,6 @@
 - [`github`](#github) (4)
 - [`knowledge`](#knowledge) (4)
 - [`kubernetes`](#kubernetes) (4)
-- [`markdown`](#markdown) (4)
-- [`mcp`](#mcp) (4)
 - [`media`](#media) (4)
 - [`memory`](#memory) (4)
 - [`notion`](#notion) (4)
@@ -61,6 +60,8 @@
 - [`frontend`](#frontend) (3)
 - [`generator`](#generator) (3)
 - [`git`](#git) (3)
+- [`knowledge-base`](#knowledge-base) (3)
+- [`markdown`](#markdown) (3)
 - [`meeting`](#meeting) (3)
 - [`office`](#office) (3)
 - [`postgres`](#postgres) (3)
@@ -95,7 +96,6 @@
 - [`graphql`](#graphql) (2)
 - [`hermes`](#hermes) (2)
 - [`integrations`](#integrations) (2)
-- [`knowledge-base`](#knowledge-base) (2)
 - [`linkedin`](#linkedin) (2)
 - [`metrics`](#metrics) (2)
 - [`minutes`](#minutes) (2)
@@ -144,7 +144,6 @@
 - [`android`](#android) (1)
 - [`animation`](#animation) (1)
 - [`api-and-interface-design`](#api-and-interface-design) (1)
-- [`api-development`](#api-development) (1)
 - [`application-security`](#application-security) (1)
 - [`approval`](#approval) (1)
 - [`apps`](#apps) (1)
@@ -164,8 +163,6 @@
 - [`base`](#base) (1)
 - [`beacon`](#beacon) (1)
 - [`billing`](#billing) (1)
-- [`bot-mode`](#bot-mode) (1)
-- [`bots`](#bots) (1)
 - [`brainstorming`](#brainstorming) (1)
 - [`brand`](#brand) (1)
 - [`breach`](#breach) (1)
@@ -224,7 +221,6 @@
 - [`dependency-scanning`](#dependency-scanning) (1)
 - [`deprecation-and-migration`](#deprecation-and-migration) (1)
 - [`design-system`](#design-system) (1)
-- [`desktop-plugins`](#desktop-plugins) (1)
 - [`develop`](#develop) (1)
 - [`diagram`](#diagram) (1)
 - [`dialectic`](#dialectic) (1)
@@ -248,7 +244,6 @@
 - [`fact`](#fact) (1)
 - [`factor`](#factor) (1)
 - [`factory`](#factory) (1)
-- [`features`](#features) (1)
 - [`feedback`](#feedback) (1)
 - [`files`](#files) (1)
 - [`filing`](#filing) (1)
@@ -367,7 +362,6 @@
 - [`pdf`](#pdf) (1)
 - [`penetration-testing`](#penetration-testing) (1)
 - [`performance-optimization`](#performance-optimization) (1)
-- [`petdex`](#petdex) (1)
 - [`pipe`](#pipe) (1)
 - [`planning-and-task-breakdown`](#planning-and-task-breakdown) (1)
 - [`pmm`](#pmm) (1)
@@ -418,7 +412,6 @@
 - [`science`](#science) (1)
 - [`scout`](#scout) (1)
 - [`scraper`](#scraper) (1)
-- [`scraping`](#scraping) (1)
 - [`screener`](#screener) (1)
 - [`screenshot`](#screenshot) (1)
 - [`search`](#search) (1)
@@ -429,7 +422,6 @@
 - [`self`](#self) (1)
 - [`semgrep`](#semgrep) (1)
 - [`sentry`](#sentry) (1)
-- [`session-summary`](#session-summary) (1)
 - [`setup`](#setup) (1)
 - [`shard`](#shard) (1)
 - [`sheets`](#sheets) (1)
@@ -438,7 +430,6 @@
 - [`sigil`](#sigil) (1)
 - [`sketch`](#sketch) (1)
 - [`skill-quality`](#skill-quality) (1)
-- [`skins`](#skins) (1)
 - [`slack`](#slack) (1)
 - [`social`](#social) (1)
 - [`solution`](#solution) (1)
@@ -470,7 +461,6 @@
 - [`test-driven-development`](#test-driven-development) (1)
 - [`tester`](#tester) (1)
 - [`theme`](#theme) (1)
-- [`themes`](#themes) (1)
 - [`threat`](#threat) (1)
 - [`tome`](#tome) (1)
 - [`tone`](#tone) (1)
@@ -480,7 +470,6 @@
 - [`transitions`](#transitions) (1)
 - [`triage`](#triage) (1)
 - [`troubleshooting`](#troubleshooting) (1)
-- [`tui-widgets`](#tui-widgets) (1)
 - [`typescript`](#typescript) (1)
 - [`typography`](#typography) (1)
 - [`ui`](#ui) (1)
@@ -489,7 +478,6 @@
 - [`ux`](#ux) (1)
 - [`validation`](#validation) (1)
 - [`valuation`](#valuation) (1)
-- [`vault`](#vault) (1)
 - [`vetter`](#vetter) (1)
 - [`visual-regression`](#visual-regression) (1)
 - [`voice`](#voice) (1)
@@ -930,7 +918,7 @@
 
 ## growth
 
-**14 skills**
+**15 skills**
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
@@ -946,6 +934,7 @@
 | [marketing-strategy-pmm](skills/growth-operations-xiaohongshu/marketing-strategy-pmm) | growth-operations-xiaohongshu | ★★★★★ | Product marketing skill for positioning, GTM strategy, competitive intelligence, |
 | [pulse](skills/growth-operations-xiaohongshu/pulse) | growth-operations-xiaohongshu | ★★★★★ | 关键指标、埋点、漏斗、留存和仪表盘规格设计。 |
 | [social-media-analyzer](skills/growth-operations-xiaohongshu/social-media-analyzer) | growth-operations-xiaohongshu | ★★★★★ | Analyze social campaign engagement, ROI, audience behavior, and platform compari |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
 | [tweetclaw-source-research](skills/growth-operations-xiaohongshu/tweetclaw-source-research) | growth-operations-xiaohongshu | ★★★★☆ | Use TweetClaw through OpenClaw to collect X/Twitter source context before drafti |
 | [twitter-reader](skills/growth-operations-xiaohongshu/twitter-reader) | growth-operations-xiaohongshu | ★★★☆☆ | Read Twitter/X posts and threads from supplied URLs, including author, text, tim |
 
@@ -1097,12 +1086,13 @@
 
 ## api
 
-**5 skills**
+**6 skills**
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [api-design-reviewer](skills/developer-engineering/api-design-reviewer) | developer-engineering | ★★★★★ | Use when reviewing API designs for consistency, usability, versioning, error sem |
 | [api-test-suite-builder](skills/developer-engineering/api-test-suite-builder) | developer-engineering | ★★★★★ | Generate API tests from routes and contracts for authentication, validation, pag |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
 | [mcporter](skills/ai-agent-platform/mcporter) | ai-agent-platform | ★★★★☆ | Use when a user explicitly needs terminal-based MCP discovery, schema inspection |
 | [arxiv](skills/knowledge-and-pm-integrations/arxiv) | knowledge-and-pm-integrations | ★★★★☆ | Search arXiv papers by keyword, author, category, or ID. |
 | [lark-openapi-explorer](skills/knowledge-and-pm-integrations/lark-openapi-explorer) | knowledge-and-pm-integrations | ★★★★☆ | 飞书/Lark 原生 OpenAPI 探索：从官方文档库中挖掘未经 CLI 封装的原生 OpenAPI 接口。当用户的需求无法被现有 lark-* skill  |
@@ -1142,6 +1132,18 @@
 | [product-manager-toolkit](skills/product-design/product-manager-toolkit) | product-design | ★★★★★ | Prioritize features, synthesize customer research, and write PRDs or go-to-marke |
 | [git-worktree-manager](skills/developer-engineering/git-worktree-manager) | developer-engineering | ★★★★☆ | Create, inspect, and clean up Git worktrees for parallel development, with expli |
 | [portfolio-risk-manager](skills/finance-investing/portfolio-risk-manager) | finance-investing | ★★☆☆☆ | Use when reviewing portfolio exposures, checking concentration and beta risk, su |
+
+## mcp
+
+**5 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [mcp-builder](skills/developer-engineering/mcp-builder) | developer-engineering | ★★★★★ | Build MCP servers that expose external APIs or services through well-scoped tool |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
+| [mcporter](skills/ai-agent-platform/mcporter) | ai-agent-platform | ★★★★☆ | Use when a user explicitly needs terminal-based MCP discovery, schema inspection |
+| [native-mcp](skills/ai-agent-platform/native-mcp) | ai-agent-platform | ★★★★☆ | Configure Hermes Agent''s built-in MCP client: server discovery, stdio/HTTP conn |
+| [linear](skills/knowledge-and-pm-integrations/linear) | knowledge-and-pm-integrations | ★★★★☆ | 用于管理 Linear issues、项目、团队和协作状态。 |
 
 ## skill
 
@@ -1286,28 +1288,6 @@
 | [azure-kubernetes](skills/devops-sre/azure-kubernetes) | devops-sre | ★★★★☆ | Plan and configure Azure Kubernetes Service clusters, including SKU, networking, |
 | [cc-devops-skills](skills/devops-sre/cc-devops-skills) | devops-sre | ★★★★☆ | SRE, DevOps, Kubernetes, CI/CD, PromQL, Terraform, Docker, and incident operatio |
 | [trivy-vulnerability-scanner](skills/security-and-reliability/trivy-vulnerability-scanner) | security-and-reliability | ★★★★☆ | 用于通过 Trivy 扫描仓库、容器镜像、文件系统、rootfs、SBOM、Kubernetes、IaC、密钥、许可证和系统 CVE。 |
-
-## markdown
-
-**4 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
-| [markdown-tools](skills/office-white-collar/markdown-tools) | office-white-collar | ★★★★☆ | Convert PDF, DOCX, PPTX, and other documents to Markdown, preserving tables, ima |
-| [lark-markdown](skills/knowledge-and-pm-integrations/lark-markdown) | knowledge-and-pm-integrations | ★★★☆☆ | 飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较 |
-| [obsidian](skills/knowledge-and-pm-integrations/obsidian) | knowledge-and-pm-integrations | ★★★☆☆ | Read, search, create, or edit notes in an authorized Obsidian vault while preser |
-
-## mcp
-
-**4 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [mcp-builder](skills/developer-engineering/mcp-builder) | developer-engineering | ★★★★★ | Build MCP servers that expose external APIs or services through well-scoped tool |
-| [mcporter](skills/ai-agent-platform/mcporter) | ai-agent-platform | ★★★★☆ | Use when a user explicitly needs terminal-based MCP discovery, schema inspection |
-| [native-mcp](skills/ai-agent-platform/native-mcp) | ai-agent-platform | ★★★★☆ | Configure Hermes Agent''s built-in MCP client: server discovery, stdio/HTTP conn |
-| [linear](skills/knowledge-and-pm-integrations/linear) | knowledge-and-pm-integrations | ★★★★☆ | 用于管理 Linear issues、项目、团队和协作状态。 |
 
 ## media
 
@@ -1479,6 +1459,26 @@
 | [using-git-worktrees](skills/ai-workflow/using-git-worktrees) | ai-workflow | ★★★★☆ | Use when starting feature work that needs isolation from current workspace or be |
 | [git-worktree-manager](skills/developer-engineering/git-worktree-manager) | developer-engineering | ★★★★☆ | Create, inspect, and clean up Git worktrees for parallel development, with expli |
 
+## knowledge-base
+
+**3 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [lark-wiki](skills/knowledge-and-pm-integrations/lark-wiki) | knowledge-and-pm-integrations | ★★★★☆ | 管理飞书知识空间、成员和文档节点，查询或调整节点层级。支持飞书或 doubao.com 的 /wiki/ 链接和 token；文件上传转 lark-drive， |
+| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
+| [obsidian](skills/knowledge-and-pm-integrations/obsidian) | knowledge-and-pm-integrations | ★★★☆☆ | Read, search, create, or edit notes in an authorized Obsidian vault while preser |
+
+## markdown
+
+**3 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
+| [markdown-tools](skills/office-white-collar/markdown-tools) | office-white-collar | ★★★★☆ | Convert PDF, DOCX, PPTX, and other documents to Markdown, preserving tables, ima |
+| [lark-markdown](skills/knowledge-and-pm-integrations/lark-markdown) | knowledge-and-pm-integrations | ★★★☆☆ | 飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较 |
+
 ## meeting
 
 **3 skills**
@@ -1545,7 +1545,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Per-callback HMAC secret returned by the signed event delivery API. |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
 | [linkedin](skills/operations-general/linkedin) | operations-general | ★★★★★ | General-purpose LinkedIn automation – fetch profiles, search people and companie |
 | [tweetclaw-source-research](skills/growth-operations-xiaohongshu/tweetclaw-source-research) | growth-operations-xiaohongshu | ★★★★☆ | Use TweetClaw through OpenClaw to collect X/Twitter source context before drafti |
 
@@ -1575,7 +1575,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Per-callback HMAC secret returned by the signed event delivery API. |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
 | [tweetclaw-source-research](skills/growth-operations-xiaohongshu/tweetclaw-source-research) | growth-operations-xiaohongshu | ★★★★☆ | Use TweetClaw through OpenClaw to collect X/Twitter source context before drafti |
 | [twitter-reader](skills/growth-operations-xiaohongshu/twitter-reader) | growth-operations-xiaohongshu | ★★★☆☆ | Read Twitter/X posts and threads from supplied URLs, including author, text, tim |
 
@@ -1796,15 +1796,6 @@
 |-------|----------|---------|-------------|
 | [mcporter](skills/ai-agent-platform/mcporter) | ai-agent-platform | ★★★★☆ | Use when a user explicitly needs terminal-based MCP discovery, schema inspection |
 | [native-mcp](skills/ai-agent-platform/native-mcp) | ai-agent-platform | ★★★★☆ | Configure Hermes Agent''s built-in MCP client: server discovery, stdio/HTTP conn |
-
-## knowledge-base
-
-**2 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [lark-wiki](skills/knowledge-and-pm-integrations/lark-wiki) | knowledge-and-pm-integrations | ★★★★☆ | 管理飞书知识空间、成员和文档节点，查询或调整节点层级。支持飞书或 doubao.com 的 /wiki/ 链接和 token；文件上传转 lark-drive， |
-| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
 
 ## linkedin
 
@@ -2100,7 +2091,7 @@
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
-| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Per-callback HMAC secret returned by the signed event delivery API. |
+| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Use Xquik for X/Twitter research and connected-account actions; Radar and suppor |
 | [tweetclaw-source-research](skills/growth-operations-xiaohongshu/tweetclaw-source-research) | growth-operations-xiaohongshu | ★★★★☆ | Use TweetClaw through OpenClaw to collect X/Twitter source context before drafti |
 
 ## academic
@@ -2222,14 +2213,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [api-and-interface-design](skills/ai-workflow/api-and-interface-design) | ai-workflow | ★★★★★ | Design REST/GraphQL APIs, module interfaces, and type contracts when creating en |
-
-## api-development
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Per-callback HMAC secret returned by the signed event delivery API. |
 
 ## application-security
 
@@ -2382,22 +2365,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [billing-automation](skills/engineering-workflow-automation/billing-automation) | engineering-workflow-automation | ★★★☆☆ | Build automated billing systems for recurring payments, invoicing, subscription  |
-
-## bot-mode
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-
-## bots
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
 
 ## brainstorming
 
@@ -2863,14 +2830,6 @@
 |-------|----------|---------|-------------|
 | [ui-ux-pro-max](skills/product-design/ui-ux-pro-max) | product-design | ★★★★☆ | Front-end UI/UX design intelligence for creating, reviewing, and hardening polis |
 
-## desktop-plugins
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-
 ## develop
 
 **1 skills**
@@ -3054,14 +3013,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [theme-factory](skills/operations-general/theme-factory) | operations-general | ★★★☆☆ | Use when styling artifacts with reusable themes, applying preset color/font syst |
-
-## features
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
 
 ## feedback
 
@@ -4007,14 +3958,6 @@
 |-------|----------|---------|-------------|
 | [performance-optimization](skills/ai-workflow/performance-optimization) | ai-workflow | ★★★★★ | Investigate and improve measured frontend, backend, query, or database bottlenec |
 
-## petdex
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-
 ## pipe
 
 **1 skills**
@@ -4415,14 +4358,6 @@
 |-------|----------|---------|-------------|
 | [web-scraper](skills/engineering-workflow-automation/web-scraper) | engineering-workflow-automation | ★★★★☆ | Use when users need webpage scraping, structured data extraction, crawling strat |
 
-## scraping
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [x-twitter-scraper](skills/growth-operations-xiaohongshu/x-twitter-scraper) | growth-operations-xiaohongshu | ★★★★★ | Per-callback HMAC secret returned by the signed event delivery API. |
-
 ## screener
 
 **1 skills**
@@ -4503,14 +4438,6 @@
 |-------|----------|---------|-------------|
 | [sentry](skills/security-and-reliability/sentry) | security-and-reliability | ★★★★☆ | 用于只读查询 Sentry issues、events 和服务健康数据，汇总线上错误并辅助生产问题排查。 |
 
-## session-summary
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [honcho](skills/openclaw-memory-and-safety/honcho) | openclaw-memory-and-safety | ★★★★☆ | Configure and troubleshoot Honcho memory for Hermes. |
-
 ## setup
 
 **1 skills**
@@ -4574,14 +4501,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [nlpm-audit](skills/ai-workflow/nlpm-audit) | ai-workflow | ★★★★☆ | Audit SKILL.md, AGENTS.md, prompts, hooks, and plugin manifests for instruction  |
-
-## skins
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
 
 ## slack
 
@@ -4831,14 +4750,6 @@
 |-------|----------|---------|-------------|
 | [theme-factory](skills/operations-general/theme-factory) | operations-general | ★★★☆☆ | Use when styling artifacts with reusable themes, applying preset color/font syst |
 
-## themes
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-
 ## threat
 
 **1 skills**
@@ -4911,14 +4822,6 @@
 |-------|----------|---------|-------------|
 | [cloudflare-troubleshooting](skills/devops-sre/cloudflare-troubleshooting) | devops-sre | ★★★★★ | Diagnose Cloudflare DNS, TLS, redirects, and configuration issues using live API |
 
-## tui-widgets
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-
 ## typescript
 
 **1 skills**
@@ -4982,14 +4885,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [comps-valuation-analyst](skills/finance-investing/comps-valuation-analyst) | finance-investing | ★★☆☆☆ | Use when valuing a public company with peer multiples, building comparable-compa |
-
-## vault
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [obsidian](skills/knowledge-and-pm-integrations/obsidian) | knowledge-and-pm-integrations | ★★★☆☆ | Read, search, create, or edit notes in an authorized Obsidian vault while preser |
 
 ## vetter
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -211,14 +211,6 @@
         "spawning",
         "cli",
         "gateway",
-        "bots",
-        "bot-mode",
-        "features",
-        "themes",
-        "skins",
-        "desktop-plugins",
-        "tui-widgets",
-        "petdex",
         "development"
       ],
       "quality": 4,
@@ -2251,8 +2243,8 @@
       "name": "supabase",
       "category": "developer-engineering",
       "description": "Build or troubleshoot Supabase Database, Auth, Storage, Realtime, Edge Functions, and client/SSR integrations; use current platform documentation.",
-      "version": "0.1.2",
-      "author": "supabase",
+      "version": "1.0.4",
+      "author": "seaworld008",
       "source": "github:supabase/agent-skills",
       "source_url": "https://skills.sh/supabase/agent-skills/supabase",
       "tags": [
@@ -2262,7 +2254,7 @@
       "quality": 4,
       "complexity": "intermediate",
       "created_at": "2026-06-03",
-      "updated_at": "2026-09-06",
+      "updated_at": "2026-09-07",
       "line_count": 188,
       "path": "skills/developer-engineering/supabase/SKILL.md"
     },
@@ -2270,8 +2262,8 @@
       "name": "supabase-postgres-best-practices",
       "category": "developer-engineering",
       "description": "Use when writing or reviewing Postgres schemas, queries, indexes, RLS policies, connection settings, or migrations with Supabase guidance; applicable to Postgres on any hosting platform.",
-      "version": "1.1.1",
-      "author": "supabase",
+      "version": "1.0.4",
+      "author": "seaworld008",
       "source": "github:supabase/agent-skills",
       "source_url": "https://skills.sh/supabase/agent-skills/supabase-postgres-best-practices",
       "tags": [
@@ -2394,8 +2386,8 @@
       "name": "vercel-react-best-practices",
       "category": "developer-engineering",
       "description": "Optimize React and Next.js rendering, data fetching, bundles, and runtime performance using Vercel''s engineering guidance.",
-      "version": "1.0.0",
-      "author": "vercel",
+      "version": "1.0.2",
+      "author": "seaworld008",
       "source": "github:vercel-labs/agent-skills",
       "source_url": "https://github.com/vercel-labs/agent-skills/blob/b8caa260a420a73042e35521de4b5c8baf6446cc/skills/react-best-practices/SKILL.md",
       "tags": [
@@ -2479,8 +2471,8 @@
       "name": "azure-kubernetes",
       "category": "devops-sre",
       "description": "Plan and configure Azure Kubernetes Service clusters, including SKU, networking, identity, deployment readiness, and operational constraints.",
-      "version": "1.1.4",
-      "author": "Microsoft",
+      "version": "1.0.3",
+      "author": "seaworld008",
       "source": "github:microsoft/azure-skills",
       "source_url": "https://skills.sh/microsoft/azure-skills/azure-kubernetes",
       "tags": [
@@ -3646,17 +3638,18 @@
     {
       "name": "x-twitter-scraper",
       "category": "growth-operations-xiaohongshu",
-      "description": "Per-callback HMAC secret returned by the signed event delivery API.",
+      "description": "Use Xquik for X/Twitter research and connected-account actions; Radar and support workflows require a named request. Offline text analysis does not need this skill.",
       "version": "1.0.5",
-      "author": "Xquik",
+      "author": "Xquik <support@xquik.com>",
       "source": "github:Xquik-dev/x-twitter-scraper",
       "source_url": "https://github.com/Xquik-dev/x-twitter-scraper/tree/3b12bf550dd2804056c09dc3925c7dae5369665c/skills/x-twitter-scraper",
       "tags": [
+        "growth",
+        "social-media",
         "twitter",
         "x",
-        "social-media",
-        "api-development",
-        "scraping"
+        "api",
+        "mcp"
       ],
       "quality": 5,
       "complexity": "advanced",
@@ -4367,10 +4360,9 @@
       "source": "github:NousResearch/hermes-agent",
       "source_url": "https://github.com/NousResearch/hermes-agent/blob/main/skills/note-taking/obsidian/SKILL.md",
       "tags": [
-        "Obsidian",
-        "Notes",
-        "Markdown",
-        "Vault"
+        "obsidian",
+        "notes",
+        "knowledge-base"
       ],
       "quality": 3,
       "complexity": "intermediate",
@@ -4830,8 +4822,7 @@
         "Profiles",
         "Observation",
         "Dialectic",
-        "User-Modeling",
-        "Session-Summary"
+        "User-Modeling"
       ],
       "quality": 4,
       "complexity": "intermediate",

--- a/docs/maintenance-2026-09-07.md
+++ b/docs/maintenance-2026-09-07.md
@@ -1,0 +1,29 @@
+# 2026-09-07 技能组合维护与收尾检查
+
+## 组合与来源
+
+- 保持 284 个规范技能、36 个永久退休墓碑；无新增、退役或合并技能，辅助制品保留。更新 Supabase/Postgres 数据库专用验收指导与 Supabase 文档入口。
+- 初始全量来源扫描 149 项：116 equal、8 monitor review、25 个政策保留快照、0 unavailable、0 rollback。8 项已人工复核并记录至精确提交；三组定向复扫均无剩余 monitor review。
+- Graphify `v0.9.47..v0.9.55`：156 个提交，Codex 入口和 8 个 reference blob 完全一致。
+- Hermes `77915e34..693641aa`：159 个提交，6 个监控技能入口 blob 不变；稳定发布仍为 `v2026.8.31`。
+- NLPM `dffbb03c..eb6b088f`：10 个提交只改变报告、追踪与仪表盘，受管 README 不变。
+- Issue #93 的 Lark/Hermes 历史提交已被现有复核检查点覆盖，附比较证据关闭；候选按能力缺口筛选，没有数量型扩充。
+
+## 修复与审查
+
+- PR #102 优化 Postgres supplement 与 monitor 检查点；合并命令未 fail-fast，导致两条新审查意见未处理即合并。随后 PR #103 修复更新日期和 review 记录选择，原线程全部回复并解决。后续合并独立检查成功状态、未解决线程、当前 head，并使用 `--match-head-commit`。
+- PR #104 修复 checkout 与 create-pull-request 的重复 Authorization header，固定 MIT 许可的 create-pull-request v8.1.1；Changelog 重跑 `34074618417` 成功。
+- PR #99 刷新后仅新增 15 行，既有历史保留；6 项 CI 和该 head 的 Codex Review 完成后合并。
+- 收尾检查发现 catalog/tag 解析把嵌套 metadata 提升为顶层字段，覆盖本地版本、作者、触发描述和标签。两个生成器现在忽略缩进行，与仓库现有顶层解析约定一致，新增回归用例。
+- 健康评估器支持仓库外输出路径，回归测试改用仓库外临时目录。
+- 修复 Supabase `monitoring-and-debugging.md` 的真实 404，官方现行入口为 `observability.md`，直接请求返回 200。
+
+## 验证范围
+
+- 完整本地管线：563 pytest 通过；287 strict PASS、0 WARN/FAIL；284 个入口指令审计无发现。
+- 组合 271 keep / 13 review；墓碑违规 0。155 个外部许可条目合规，缺失/禁止许可 0；来源覆盖 284/284，2,286 个受管文件无摘要、模式或归属欠账。
+- 全量外链复扫 390 个地址，按现有探测政策不可达 0。Semantic Scholar 存在 429 限流，首轮一个请求超时后重试恢复；429 表示服务可达但访问受限，不是 API 功能成功。
+- Issue #100 的原始地址已复查；新增 Supabase 404 已修复。未通过忽略域名或放宽状态码掩盖错误。
+- 工作流 actionlint、Python 编译、Node 语法/help/targets、npm pack dry-run、OpenClaw 视频映射、健康评估、生成器幂等及 diff 空白检查通过。
+- 两次孤儿 index.lock 经确认无进程/句柄持有后精确移除；失效 worktree 记录未清理，客户端与运行时未安装。
+- 这些是仓库、来源和静态验证证据；不表示数据库生产性能、在线迁移或模型任务成功率已经实测。

--- a/docs/sources/reclassified-external-skills-2026-08.skills.json
+++ b/docs/sources/reclassified-external-skills-2026-08.skills.json
@@ -1714,7 +1714,7 @@
             "ref": "main",
             "resolved_commit": "8331f910845103c08d51f6ca1d86ebb7d1f745e3",
             "path_commit": "3a4f0ce0782e0cbdcf187c362e8d15d9e324462b",
-            "content_sha256": "ee08743f47109c41514e4c3399f0238a7a314d73a99328804886ab098109b084",
+            "content_sha256": "a5ae4435980821666128af5d206dbfac427fc956fad340e4fb384d012bcf29e3",
             "last_checked_at": "2026-08-31",
             "last_synced_at": "2026-08-31",
             "license_checkpoint": {
@@ -1759,7 +1759,7 @@
         },
         {
           "path": "skills/developer-engineering/supabase/SKILL.md",
-          "sha256": "ee08743f47109c41514e4c3399f0238a7a314d73a99328804886ab098109b084",
+          "sha256": "a5ae4435980821666128af5d206dbfac427fc956fad340e4fb384d012bcf29e3",
           "owner": "supabase",
           "mode": "100644"
         },

--- a/openclaw-skills/supabase/SKILL.md
+++ b/openclaw-skills/supabase/SKILL.md
@@ -2,14 +2,14 @@
 name: supabase
 description: 'Build or troubleshoot Supabase Database, Auth, Storage, Realtime, Edge Functions, and client/SSR integrations; use current platform documentation.'
 zh_description: "开发和排查 Supabase 数据库、认证、存储及应用集成。"
-version: "1.0.3"
+version: "1.0.4"
 author: "seaworld008"
 source: "github:supabase/agent-skills"
 source_url: "https://skills.sh/supabase/agent-skills/supabase"
 license: MIT
 tags: '["development", "supabase"]'
 created_at: "2026-06-03"
-updated_at: "2026-09-06"
+updated_at: "2026-09-07"
 quality: 4
 complexity: "intermediate"
 metadata:
@@ -152,7 +152,7 @@ Do NOT use `apply_migration` to change a local database schema — it writes a m
 
 ## Debugging
 
-When you get an error on a Supabase-related request, for example an error code from the Supabase REST API, Postgres database, or PostgREST, an empty result, getting blocked by RLS unexpectedly, or an error from a Supabase service like Auth, Realtime, Edge Functions, or Storage, you **must** fetch Supabase's [Monitoring and Debugging](https://supabase.com/docs/guides/monitoring-and-debugging.md) documentation before diagnosing or proposing a fix, rather than working from memory. The same docs also cover performance optimizations, such as slow queries and missing indexes.
+When diagnosing Supabase REST API, Postgres, PostgREST, RLS, Auth, Realtime, Edge Functions, or Storage errors, consult the current [Observability](https://supabase.com/docs/guides/observability.md) documentation and follow its relevant diagnostic links. Use the same entry point for performance investigations such as slow queries and missing indexes.
 
 ## Reference Guides
 

--- a/scripts/build_catalog_json.py
+++ b/scripts/build_catalog_json.py
@@ -20,7 +20,7 @@ def parse_frontmatter(text: str) -> dict:
         return {}
     fm = {}
     for line in m.group(1).splitlines():
-        if ":" in line:
+        if ":" in line and not line.startswith((" ", "\t")):
             key, _, val = line.partition(":")
             key = key.strip()
             val = val.strip().strip('"').strip("'")

--- a/scripts/evaluate_repo_health.py
+++ b/scripts/evaluate_repo_health.py
@@ -93,7 +93,12 @@ def main() -> int:
     thresholds = config.get("health_thresholds", {})
     checks, passed = evaluate(report, thresholds)
     write_markdown(checks, passed, REPO_ROOT / args.output_md)
-    print(f"Wrote {(REPO_ROOT / args.output_md).relative_to(REPO_ROOT)}")
+    output = REPO_ROOT / args.output_md
+    try:
+        display_path = output.relative_to(REPO_ROOT)
+    except ValueError:
+        display_path = output
+    print(f"Wrote {display_path}")
     return 0 if passed else 1
 
 

--- a/scripts/generate_tags_index.py
+++ b/scripts/generate_tags_index.py
@@ -17,7 +17,7 @@ def parse_frontmatter(text: str) -> dict:
         return {}
     fm = {}
     for line in m.group(1).splitlines():
-        if ":" in line:
+        if ":" in line and not line.startswith((" ", "\t")):
             key, _, val = line.partition(":")
             key = key.strip()
             val = val.strip().strip('"').strip("'")

--- a/skills/developer-engineering/supabase/SKILL.md
+++ b/skills/developer-engineering/supabase/SKILL.md
@@ -2,14 +2,14 @@
 name: supabase
 description: 'Build or troubleshoot Supabase Database, Auth, Storage, Realtime, Edge Functions, and client/SSR integrations; use current platform documentation.'
 zh_description: "开发和排查 Supabase 数据库、认证、存储及应用集成。"
-version: "1.0.3"
+version: "1.0.4"
 author: "seaworld008"
 source: "github:supabase/agent-skills"
 source_url: "https://skills.sh/supabase/agent-skills/supabase"
 license: MIT
 tags: '["development", "supabase"]'
 created_at: "2026-06-03"
-updated_at: "2026-09-06"
+updated_at: "2026-09-07"
 quality: 4
 complexity: "intermediate"
 metadata:
@@ -152,7 +152,7 @@ Do NOT use `apply_migration` to change a local database schema — it writes a m
 
 ## Debugging
 
-When you get an error on a Supabase-related request, for example an error code from the Supabase REST API, Postgres database, or PostgREST, an empty result, getting blocked by RLS unexpectedly, or an error from a Supabase service like Auth, Realtime, Edge Functions, or Storage, you **must** fetch Supabase's [Monitoring and Debugging](https://supabase.com/docs/guides/monitoring-and-debugging.md) documentation before diagnosing or proposing a fix, rather than working from memory. The same docs also cover performance optimizations, such as slow queries and missing indexes.
+When diagnosing Supabase REST API, Postgres, PostgREST, RLS, Auth, Realtime, Edge Functions, or Storage errors, consult the current [Observability](https://supabase.com/docs/guides/observability.md) documentation and follow its relevant diagnostic links. Use the same entry point for performance investigations such as slow queries and missing indexes.
 
 ## Reference Guides
 

--- a/tests/test_build_catalog_json.py
+++ b/tests/test_build_catalog_json.py
@@ -23,6 +23,30 @@ def load_module():
 
 
 class BuildCatalogJsonTests(unittest.TestCase):
+    def test_nested_metadata_does_not_override_catalog_or_tag_fields(self):
+        module = load_module()
+        import generate_tags_index
+
+        content = """---
+name: local-skill
+version: '1.0.4'
+author: local-curator
+tags: '[postgres, review]'
+metadata:
+  name: upstream-name
+  version: '1.1.1'
+  author: upstream-author
+  tags: '[upstream]'
+---
+"""
+        for parser in (module.parse_frontmatter, generate_tags_index.parse_frontmatter):
+            with self.subTest(parser=parser.__module__):
+                fields = parser(content)
+                self.assertEqual("local-skill", fields["name"])
+                self.assertEqual("1.0.4", fields["version"])
+                self.assertEqual("local-curator", fields["author"])
+                self.assertEqual("[postgres, review]", fields["tags"])
+
     def test_resolve_generated_at_preserves_existing_value(self):
         module = load_module()
 

--- a/tests/test_evaluate_repo_health.py
+++ b/tests/test_evaluate_repo_health.py
@@ -33,7 +33,7 @@ def run_generate(*args: str) -> subprocess.CompletedProcess[str]:
 
 class EvaluateRepoHealthTests(unittest.TestCase):
     def test_evaluate_repo_health_passes_on_current_state(self) -> None:
-        with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+        with tempfile.TemporaryDirectory() as tmp:
             tmp_dir = Path(tmp)
             reports_dir = tmp_dir / "reports"
             reports_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pr4_upstream_decisions.py
+++ b/tests/test_pr4_upstream_decisions.py
@@ -75,6 +75,7 @@ def test_reviewed_monitor_checkpoints_advance_without_body_churn() -> None:
             for attempt in reversed(mapping_data["verification_attempts"])
             if attempt["method"] == "commit-aware-manual-monitor-review"
             and attempt["target"].startswith(f"{origin['repo']}@")
+            and attempt["result"] == "success"
         )
         reviewed_commit = reviewed["target"].rsplit("@", 1)[1]
         assert reviewed["result"] == "success"


### PR DESCRIPTION
目录与标签生成器错误地把嵌套 metadata 提升为顶层字段，使本地技能版本、作者和触发描述被上游元数据覆盖。现在与仓库其他生成器一样只解析顶层字段，并从规范源重新生成目录和标签。

同时修复 Supabase 文档入口的 404、健康评估器向仓库外路径输出时的异常，并让 monitor 测试忽略失败复核记录。维护记录见 docs/maintenance-2026-09-07.md。

验证：563 pytest、287 strict 检查、来源/许可/退休策略、全量 390 URL 探测、actionlint、Python/Node/npm、OpenClaw、健康与生成器幂等检查通过。URL 探测按既有策略把 429 记为可达但受限，不代表 API 调用成功。无新增或退役技能。

Closes #100
