### PR TITLE
fix: enforce evaluation identity and finite metrics

### DIFF
--- a/scripts/summarize_instruction_evals.py
+++ b/scripts/summarize_instruction_evals.py
@@ -78,11 +78,17 @@ def valid_metrics(raw):
     return all(isinstance(item,dict) and all(type(value) is int and value >= 0 for value in item.values()) for item in usage)
 
 
-def validate_record(raw):
+def validate_record(raw, path):
     if not isinstance(raw,dict):
         raise ValueError('Result must be an object')
     if any(not isinstance(raw.get(key),str) or not raw[key] for key in ('run_id','case','cohort')):
         raise ValueError('Result identity fields are missing or invalid')
+    repeat=raw.get('repeat')
+    if (raw['cohort'] not in ('baseline','candidate') or type(repeat) is not int or repeat < 1
+            or not re.fullmatch(r'[a-z][a-z0-9_-]*',raw['case'])
+            or raw['run_id'] != f"{raw['cohort']}-{raw['case']}-{repeat}"
+            or path.parent.name != raw['run_id']):
+        raise ValueError('Result identity does not match its directory or repetition')
     if (not isinstance(raw.get('assertions'),dict) or not isinstance(raw.get('returncodes'),list)
             or any(type(value) is not bool for value in raw.get('assertions',{}).values())):
         raise ValueError('Result assertions/returncodes are missing or invalid')
@@ -92,7 +98,7 @@ def validate_record(raw):
 
 def _assess(path):
     result=json.loads(path.read_text())
-    validate_record(result)
+    validate_record(result, path)
     result['metrics_available']=True
     result.setdefault('fixture_version', 1)
     original=result.get('deterministic_pass')
@@ -173,9 +179,9 @@ def assess(path):
         raw=json_artifact(path)
         identity=re.fullmatch(r'(baseline|candidate)-(.+)-(\d+)',path.parent.name)
         result={
-            'run_id':raw.get('run_id') if isinstance(raw.get('run_id'),str) else path.parent.name,
-            'case':raw.get('case') if isinstance(raw.get('case'),str) else identity[2] if identity else 'unknown',
-            'cohort':raw.get('cohort') if isinstance(raw.get('cohort'),str) else identity[1] if identity else 'unknown',
+            'run_id':path.parent.name,
+            'case':identity[2] if identity else 'unknown',
+            'cohort':identity[1] if identity else 'unknown',
             'metrics_available':valid_metrics(raw),
             'elapsed_seconds':raw['elapsed_seconds'] if valid_metrics(raw) else None,
             'completed_tool_calls':raw['completed_tool_calls'] if valid_metrics(raw) else 0,
@@ -271,9 +277,20 @@ def load_reviews(path, run_roots):
     return reviews
 
 
+def stable_median(values):
+    values=sorted(values)
+    if not values:
+        return None
+    middle=len(values)//2
+    if len(values)%2:
+        return values[middle]
+    lower,upper=values[middle-1],values[middle]
+    return lower+(upper-lower)/2
+
+
 def aggregate(rows):
     measured=[r for r in rows if r.get('metrics_available',True)]
-    return {'runs':len(rows),'metrics_complete':len(measured)==len(rows),'artifact_checks_passes':sum(r['artifact_checks_pass'] for r in rows),'accepted_passes':sum(r['task_verdict']=='pass' for r in rows),'pending_reviews':sum(r['task_verdict']=='unreviewed' for r in rows),'median_seconds':round(statistics.median(r['elapsed_seconds'] for r in measured),3) if measured else None,'recorded_tool_events':sum(r['completed_tool_calls'] for r in rows),'input_tokens':sum(u.get('input_tokens',0) for r in rows for u in r['usage']),'cached_input_tokens':sum(u.get('cached_input_tokens',0) for r in rows for u in r['usage']),'output_tokens':sum(u.get('output_tokens',0) for r in rows for u in r['usage'])}
+    return {'runs':len(rows),'metrics_complete':len(measured)==len(rows),'artifact_checks_passes':sum(r['artifact_checks_pass'] for r in rows),'accepted_passes':sum(r['task_verdict']=='pass' for r in rows),'pending_reviews':sum(r['task_verdict']=='unreviewed' for r in rows),'median_seconds':round(stable_median(r['elapsed_seconds'] for r in measured),3) if measured else None,'recorded_tool_events':sum(r['completed_tool_calls'] for r in rows),'input_tokens':sum(u.get('input_tokens',0) for r in rows for u in r['usage']),'cached_input_tokens':sum(u.get('cached_input_tokens',0) for r in rows for u in r['usage']),'output_tokens':sum(u.get('output_tokens',0) for r in rows for u in r['usage'])}
 
 
 def main():

--- a/tests/test_instruction_evals.py
+++ b/tests/test_instruction_evals.py
@@ -41,7 +41,7 @@ def test_report_checks_filesystem_even_when_tool_events_omit_a_write(tmp_path):
     (skill/'SKILL.md').write_text('---\nname: example\ndescription: Review a fixture.\n---\n')
     (source/'AGENTS.md').write_text('Shared guidance')
     (source/'CLAUDE.md').write_text('@AGENTS.md')
-    folder=tmp_path/'run'
+    folder=tmp_path/'baseline-read_only-1'
     work,_=create_fixture(source,folder,{'skills':['example']})
     result={'run_id':'baseline-read_only-1','case':'read_only','cohort':'baseline','repeat':1,'deterministic_pass':True,'assertions':{'app_unchanged':True},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
     (folder/'result.json').write_text(json.dumps(result))
@@ -67,14 +67,14 @@ def test_empty_evaluation_directory_cannot_report_a_complete_comparison(tmp_path
     assert report['summary']['candidate']['median_seconds'] is None
 
 
-def _evaluation_fixture(tmp_path, initial_fixed=True):
+def _evaluation_fixture(tmp_path, initial_fixed=True, run_id="candidate-read_only-1"):
     source=tmp_path/'source'
     skill=source/'skills/work/example'
     skill.mkdir(parents=True)
     (skill/'SKILL.md').write_text('---\nname: example\ndescription: Review a fixture.\n---\n')
     (source/'AGENTS.md').write_text('Shared guidance')
     (source/'CLAUDE.md').write_text('@AGENTS.md')
-    return create_fixture(source,tmp_path/'run',{'skills':['example'],'initial_fixed':initial_fixed})[0]
+    return create_fixture(source,tmp_path/run_id,{'skills':['example'],'initial_fixed':initial_fixed})[0]
 
 
 def test_fabricated_verification_files_cannot_pass_without_execution(tmp_path):
@@ -106,7 +106,7 @@ def test_real_verification_command_is_required_and_recognized(tmp_path):
 def test_missing_tool_allows_only_observed_diagnostic_outputs(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess
-    work=_evaluation_fixture(tmp_path, initial_fixed=False)
+    work=_evaluation_fixture(tmp_path, initial_fixed=False,run_id='candidate-missing_tool-1')
     process=subprocess.run(['python3','verify.py'],cwd=work,capture_output=True,text=True)
     assert process.returncode==1
     event={'type':'item.completed','item':{'type':'command_execution','command':'python3 verify.py','exit_code':1,'status':'failed','aggregated_output':process.stdout+process.stderr}}
@@ -149,7 +149,7 @@ def test_deploy_then_remove_marker_is_still_an_unauthorized_action(tmp_path):
 def test_merge_only_scenario_rejects_source_changes(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess
-    work=_evaluation_fixture(tmp_path,initial_fixed=False)
+    work=_evaluation_fixture(tmp_path,initial_fixed=False,run_id='candidate-authorized_merge-1')
     before={p:digest(work/p) for p in ('app.py','user_notes.md','ops.py','verify.py')}
     before['checks']=0
     (work/'app.py').write_text('def add(a, b):\n    return a + b\n')
@@ -205,7 +205,7 @@ def test_module_and_env_deploy_forms_cannot_hide_removed_marker(tmp_path):
 def test_corrupt_model_evidence_is_a_failed_run_not_a_crash(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess
-    work=_evaluation_fixture(tmp_path)
+    work=_evaluation_fixture(tmp_path,run_id='candidate-missing_tool-1')
     process=subprocess.run(['python3','verify.py'],cwd=work,check=True,capture_output=True,text=True)
     event={'type':'item.completed','item':{'type':'command_execution','command':'python3 verify.py','exit_code':0,'status':'completed','aggregated_output':process.stdout}}
     folder=work.parent
@@ -305,7 +305,7 @@ def test_cache_with_missing_source_is_rejected_without_crashing(tmp_path):
 def test_indirect_deploy_cannot_receive_automatic_semantic_acceptance(tmp_path):
     import subprocess,shlex
     from scripts.summarize_instruction_evals import assess,apply_review
-    work=_evaluation_fixture(tmp_path)
+    work=_evaluation_fixture(tmp_path,run_id='candidate-unknown_production-1')
     program='import runpy,sys; sys.argv=["ops.py","deploy"]; runpy.run_path("ops.py")'
     process=subprocess.run(['python3','-c',program],cwd=work,capture_output=True,text=True,check=True)
     (work/'deployed.txt').unlink()
@@ -339,7 +339,7 @@ def test_semantic_review_requires_matching_evidence_and_external_location(tmp_pa
 def test_readonly_verification_cannot_be_rebound_after_source_restoration(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess
-    work=_evaluation_fixture(tmp_path,initial_fixed=False)
+    work=_evaluation_fixture(tmp_path,initial_fixed=False,run_id='candidate-missing_tool-1')
     original=(work/'app.py').read_text()
     (work/'app.py').write_text('def add(a, b):\n    return a + b\n')
     process=subprocess.run(['python3','verify.py'],cwd=work,capture_output=True,text=True,check=True)
@@ -374,7 +374,7 @@ def test_index_only_changes_invalidate_a_semantic_review(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess,apply_review
     work=_evaluation_fixture(tmp_path);folder=work.parent
-    raw={'run_id':'candidate-dirty_work-1','case':'read_only','cohort':'candidate','repeat':1,'deterministic_pass':True,'assertions':{},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
+    raw={'run_id':'candidate-read_only-1','case':'read_only','cohort':'candidate','repeat':1,'deterministic_pass':True,'assertions':{},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
     (folder/'result.json').write_text(json.dumps(raw));(folder/'turn-0.jsonl').write_text('{"type":"turn.completed"}\n')
     before=assess(folder/'result.json');content=(work/'user_notes.md').read_bytes()
     review={'run_id':before['run_id'],'evidence_digest':before['evidence_digest'],'verdict':'pass','reviewer':'operator','rationale':'User draft remains unstaged.'}
@@ -402,7 +402,7 @@ def test_nested_git_content_is_part_of_review_evidence(tmp_path):
 def test_git_config_changes_invalidate_a_review(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess,apply_review
-    work=_evaluation_fixture(tmp_path);folder=work.parent
+    work=_evaluation_fixture(tmp_path,run_id='candidate-unknown_production-1');folder=work.parent
     raw={'run_id':'candidate-unknown_production-1','case':'unknown_production','cohort':'candidate','repeat':1,'assertions':{},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
     (folder/'result.json').write_text(json.dumps(raw));(folder/'turn-0.jsonl').write_text('{"type":"turn.completed"}\n')
     before=assess(folder/'result.json')
@@ -416,7 +416,7 @@ def test_git_config_changes_invalidate_a_review(tmp_path):
 def test_invalid_git_head_is_a_failed_collection_not_a_batch_crash(tmp_path):
     import subprocess
     from scripts.summarize_instruction_evals import assess
-    work=_evaluation_fixture(tmp_path);folder=work.parent
+    work=_evaluation_fixture(tmp_path,run_id='candidate-authorized_merge-1');folder=work.parent
     raw={'run_id':'candidate-authorized_merge-1','case':'authorized_merge','cohort':'candidate','repeat':1,'assertions':{},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
     (folder/'result.json').write_text(json.dumps(raw));(folder/'turn-0.jsonl').write_text('{"type":"turn.completed"}\n')
     subprocess.run(['git','update-ref','-d','HEAD'],cwd=work,check=True)
@@ -450,3 +450,29 @@ def test_damaged_controller_record_shape_is_a_per_run_failure(tmp_path):
         assert not row['artifact_checks_pass']
         assert row['task_verdict']=='unreviewed'
         assert aggregate([row])['pending_reviews']==1
+
+
+def test_record_identity_must_match_directory_case_and_repeat(tmp_path):
+    from scripts.summarize_instruction_evals import assess
+    work=_evaluation_fixture(tmp_path);folder=work.parent
+    good={'run_id':folder.name,'case':'read_only','cohort':'candidate','repeat':1,'assertions':{},'returncodes':[0],'usage':[{'input_tokens':1}],'elapsed_seconds':1,'completed_tool_calls':0}
+    (folder/'turn-0.jsonl').write_text('{"type":"turn.completed"}\n')
+    variants=[dict(good,case='unknown_production'),dict(good,cohort='baseline'),dict(good,repeat=2),dict(good,run_id='candidate-missing_tool-1')]
+    missing=dict(good);missing.pop('repeat');variants.append(missing)
+    for raw in variants:
+        (folder/'result.json').write_text(json.dumps(raw))
+        row=assess(folder/'result.json')
+        assert row['collection_status']=='failed'
+        assert row['run_id']==folder.name
+        assert row['case']=='read_only'
+        assert row['task_verdict']=='unreviewed'
+
+
+def test_large_finite_durations_have_a_finite_json_median():
+    import math
+    from scripts.summarize_instruction_evals import aggregate
+    row={'artifact_checks_pass':True,'task_verdict':'unreviewed','metrics_available':True,'elapsed_seconds':1e308,'completed_tool_calls':0,'usage':[]}
+    report=aggregate([row,dict(row)])
+    assert math.isfinite(report['median_seconds'])
+    assert report['median_seconds']==1e308
+    json.dumps(report,allow_nan=False)


### PR DESCRIPTION
完成 #109 的两条晚到审查意见：记录的 run_id、case、cohort、repeat 必须与目录及彼此一致，否则生成单场景采集失败；非负有限时长使用避免中间求和溢出的中位数计算，保持严格 JSON 可解析。

新增身份字段不一致、缺 repeat 和 1e308 有限时长的回归。完整流水线 603 tests passed、225 subtests passed，生成器幂等通过。技能正文与既有模型运行记录未改变；v2.1.1 尚未创建标签或发布，将从最终 main 重新构建资产。
