### PR TITLE
Add yylo skills: ledger-tasks-yylo, workflow-yylo, wiki-yylo, artifact-yylo

### DIFF
--- a/.github/assets/repo-banner.svg
+++ b/.github/assets/repo-banner.svg
@@ -42,7 +42,7 @@
     <rect x="0" y="0" width="508" height="42" rx="21" fill="#020617" fill-opacity="0.28" stroke="#FFFFFF" stroke-opacity="0.15"/>
     <circle cx="24" cy="21" r="8" fill="#34D399"/>
     <text x="44" y="28" fill="#D1FAE5" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">
-      284 skills · 16 categories · upstream sync
+      288 skills · 16 categories · upstream sync
     </text>
 
     <text x="0" y="124" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="56" font-weight="850">
@@ -107,7 +107,7 @@
       AI Workflow
     </text>
     <text x="72" y="208" fill="#CBD5E1" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700">
-      47 skills
+      51 skills
     </text>
 
     <rect x="28" y="234" width="336" height="54" rx="15" fill="#FFFFFF" fill-opacity="0.08" stroke="#FFFFFF" stroke-opacity="0.13"/>
@@ -124,7 +124,7 @@
       Skills
     </text>
     <text x="52" y="370" fill="#FFFFFF" font-family="Segoe UI, Arial, sans-serif" font-size="28" font-weight="850">
-      284
+      288
     </text>
 
     <rect x="208" y="318" width="152" height="62" rx="17" fill="#FFFFFF" fill-opacity="0.09" stroke="#FFFFFF" stroke-opacity="0.13"/>

--- a/README.en.md
+++ b/README.en.md
@@ -5,12 +5,12 @@
 [![简体中文](https://img.shields.io/badge/README-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-1677ff)](./README.md)
 [![English](https://img.shields.io/badge/README-English-111111)](./README.en.md)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-Compatible-00b894)](./openclaw-skills/README.md)
-[![Skills](https://img.shields.io/badge/Skills-284-7c3aed)](./skills/)
+[![Skills](https://img.shields.io/badge/Skills-288-7c3aed)](./skills/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 A high-value skills repository for AI developers, organized by real work scenarios such as developer engineering, DevOps, automation, finance, design, knowledge workflows, and reliability.
 
-This repository currently contains **16 categories / 284 skills**.
+This repository currently contains **16 categories / 288 skills**.
 
 ## Who This Is For
 
@@ -337,7 +337,7 @@ openclaw-skills/                        # Generated flat export for OpenClaw
 2. Open the relevant `SKILL.md` and read its triggers, workflow, boundaries, and scripts.
 3. If a skill includes `scripts/`, `references/`, or `assets/`, reuse those files before recreating similar content.
 
-## Skill Overview (by category, 16 categories / 284 skills)
+## Skill Overview (by category, 16 categories / 288 skills)
 
 <a id="cat-developer-engineering"></a>
 ### 1. Developer Engineering (developer-engineering, 47)
@@ -391,11 +391,12 @@ openclaw-skills/                        # Generated flat export for OpenClaw
 - [`webapp-testing`](./skills/developer-engineering/webapp-testing/)
 
 <a id="cat-ai-workflow"></a>
-### 2. AI Workflow (ai-workflow, 47)
+### 2. AI Workflow (ai-workflow, 51)
 
 - [`agent-workflow-designer`](./skills/ai-workflow/agent-workflow-designer/)
 - [`andrej-karpathy-skills`](./skills/ai-workflow/andrej-karpathy-skills/)
 - [`api-and-interface-design`](./skills/ai-workflow/api-and-interface-design/)
+- [`artifact-yylo`](./skills/ai-workflow/artifact-yylo/)
 - [`brainstorming`](./skills/ai-workflow/brainstorming/)
 - [`browser-testing-with-devtools`](./skills/ai-workflow/browser-testing-with-devtools/)
 - [`ci-cd-and-automation`](./skills/ai-workflow/ci-cd-and-automation/)
@@ -416,6 +417,7 @@ openclaw-skills/                        # Generated flat export for OpenClaw
 - [`idea-refine`](./skills/ai-workflow/idea-refine/)
 - [`incremental-implementation`](./skills/ai-workflow/incremental-implementation/)
 - [`interview-me`](./skills/ai-workflow/interview-me/)
+- [`ledger-tasks-yylo`](./skills/ai-workflow/ledger-tasks-yylo/)
 - [`nexus`](./skills/ai-workflow/nexus/)
 - [`nlpm-audit`](./skills/ai-workflow/nlpm-audit/)
 - [`observability-and-instrumentation`](./skills/ai-workflow/observability-and-instrumentation/)
@@ -438,6 +440,8 @@ openclaw-skills/                        # Generated flat export for OpenClaw
 - [`using-git-worktrees`](./skills/ai-workflow/using-git-worktrees/)
 - [`using-superpowers`](./skills/ai-workflow/using-superpowers/)
 - [`verification-before-completion`](./skills/ai-workflow/verification-before-completion/)
+- [`wiki-yylo`](./skills/ai-workflow/wiki-yylo/)
+- [`workflow-yylo`](./skills/ai-workflow/workflow-yylo/)
 - [`writing-plans`](./skills/ai-workflow/writing-plans/)
 - [`writing-skills`](./skills/ai-workflow/writing-skills/)
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![简体中文](https://img.shields.io/badge/README-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-1677ff)](./README.md)
 [![English](https://img.shields.io/badge/README-English-111111)](./README.en.md)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-Compatible-00b894)](./openclaw-skills/README.md)
-[![Skills](https://img.shields.io/badge/Skills-284-7c3aed)](./skills/)
+[![Skills](https://img.shields.io/badge/Skills-288-7c3aed)](./skills/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-面向全球 AI 开发者与 Agent 工作流构建者的高价值 Skills 仓库，覆盖开发工程、DevOps、产品设计、运营、办公自动化、金融投资、AI 平台与安全治理等高频任务场景。当前共 **16 个分类 / 284 个技能**。
+面向全球 AI 开发者与 Agent 工作流构建者的高价值 Skills 仓库，覆盖开发工程、DevOps、产品设计、运营、办公自动化、金融投资、AI 平台与安全治理等高频任务场景。当前共 **16 个分类 / 288 个技能**。
 
 ## 为什么值得收藏
 
@@ -386,7 +386,7 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 2. 打开对应技能的 `SKILL.md` 查看触发条件、操作流程和脚本说明。
 3. 若技能下含 `scripts/`、`references/`、`assets/`，优先复用现成内容。
 
-## 技能总览（按分类，16 类 / 284 技能）
+## 技能总览（按分类，16 类 / 288 技能）
 
 <a id="cat-developer-engineering"></a>
 ### 1. 开发工程（developer-engineering，47）
@@ -440,11 +440,12 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 - `webapp-testing`：用于使用 Playwright 测试本地 Web 应用、验证前端行为、截图和查看浏览器日志。
 
 <a id="cat-ai-workflow"></a>
-### 2. AI 工作流（ai-workflow，47）
+### 2. AI 工作流（ai-workflow，51）
 
 - `agent-workflow-designer`：设计多智能体协作流程、任务交接、状态管理和故障恢复。
 - `andrej-karpathy-skills`：用于应用 Andrej Karpathy 风格的 AI 学习、构建和研究实践。
 - `api-and-interface-design`：设计稳定的 API、模块接口和类型契约。
+- `artifact-yylo`：捕获与检索 YYLO Ledger 工件记录：按用途选择档案与载荷模式，附加来源与保留策略，沉淀不可变、防泄密的运行证据。
 - `brainstorming`：用于在实现前澄清创意型产品或工程需求，探索目标、约束、方案与取舍。
 - `browser-testing-with-devtools`：用于通过浏览器 DevTools 测试、调试和验证前端行为。
 - `ci-cd-and-automation`：建立和优化持续集成、质量检查与部署自动化。
@@ -465,6 +466,7 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 - `idea-refine`：澄清初步想法，比较方案并检验关键假设。
 - `incremental-implementation`：将功能拆成可验证的小步改动并逐步完成实现。
 - `interview-me`：通过逐问访谈澄清真实需求、目标用户与成功标准，避免在含糊请求上过早实施。
+- `ledger-tasks-yylo`：YYLO Ledger 看板任务管理完整参考：创建、检索、状态流转、依赖与排序、冷归档与多目录合并，以及控制器路由与环境变量。
 - `nexus`：多智能体任务分解、链路编排、执行协调和结果整合。
 - `nlpm-audit`：审计 SKILL.md、AGENTS.md、CLAUDE.md、插件清单、hooks、commands 和提示词，检查安装一致性、质量评分、安全风险与版本漂移。
 - `observability-and-instrumentation`：为生产代码设计日志、指标、追踪和告警，使行为可观测、问题可诊断。
@@ -487,6 +489,8 @@ openclaw-skills/                        # 为 OpenClaw 生成的扁平兼容导�
 - `using-git-worktrees`：用于使用 Git worktree 隔离并行开发和审查工作。
 - `using-superpowers`：用于使用 Superpowers 工作流提升计划、执行和验证质量。
 - `verification-before-completion`：在宣告完成前核对当前代码的验证证据与适用范围。
+- `wiki-yylo`：把 YYLO Ledger wiki 记录当作持久项目知识：先检索后创建、按记录类型正确分类，并通过修订安全契约更新 Markdown。
+- `workflow-yylo`：以 YYLO Ledger 工作流记录为中心：安全创建、校验与修订可执行工作流定义，并保持存储、执行与运行证据三类边界分离。
 - `writing-plans`：编写包含任务依赖、修改范围和验收方法的实现计划。
 - `writing-skills`：编写可复用的技能指导并验证实际触发和执行行为。
 

--- a/docs/TAGS-INDEX.md
+++ b/docs/TAGS-INDEX.md
@@ -1,11 +1,11 @@
 # Tags Index
 
-> Auto-generated from 1094 skill-tag mappings across 487 tags.
+> Auto-generated from 1114 skill-tag mappings across 495 tags.
 > Last updated: see git log.
 
 ## Quick Navigation
 
-- [`workflow`](#workflow) (59)
+- [`workflow`](#workflow) (60)
 - [`development`](#development) (45)
 - [`agent`](#agent) (37)
 - [`ai`](#ai) (37)
@@ -24,6 +24,7 @@
 - [`marketing`](#marketing) (13)
 - [`product`](#product) (12)
 - [`productivity`](#productivity) (10)
+- [`cli`](#cli) (8)
 - [`deployment`](#deployment) (7)
 - [`designer`](#designer) (7)
 - [`api`](#api) (6)
@@ -37,13 +38,13 @@
 - [`architect`](#architect) (4)
 - [`best`](#best) (4)
 - [`builder`](#builder) (4)
-- [`cli`](#cli) (4)
 - [`cve`](#cve) (4)
 - [`deploy`](#deploy) (4)
 - [`docs`](#docs) (4)
 - [`github`](#github) (4)
 - [`knowledge`](#knowledge) (4)
 - [`kubernetes`](#kubernetes) (4)
+- [`markdown`](#markdown) (4)
 - [`media`](#media) (4)
 - [`memory`](#memory) (4)
 - [`notion`](#notion) (4)
@@ -54,6 +55,7 @@
 - [`skills`](#skills) (4)
 - [`tools`](#tools) (4)
 - [`vulnerability-scanning`](#vulnerability-scanning) (4)
+- [`yylo`](#yylo) (4)
 - [`ci`](#ci) (3)
 - [`creator`](#creator) (3)
 - [`database`](#database) (3)
@@ -61,7 +63,6 @@
 - [`generator`](#generator) (3)
 - [`git`](#git) (3)
 - [`knowledge-base`](#knowledge-base) (3)
-- [`markdown`](#markdown) (3)
 - [`meeting`](#meeting) (3)
 - [`office`](#office) (3)
 - [`postgres`](#postgres) (3)
@@ -74,10 +75,12 @@
 - [`twitter`](#twitter) (3)
 - [`vercel`](#vercel) (3)
 - [`web`](#web) (3)
+- [`wiki`](#wiki) (3)
 - [`agent-skill`](#agent-skill) (2)
 - [`analyst`](#analyst) (2)
 - [`analyzer`](#analyzer) (2)
 - [`app`](#app) (2)
+- [`artifacts`](#artifacts) (2)
 - [`auditor`](#auditor) (2)
 - [`checker`](#checker) (2)
 - [`cloudflare`](#cloudflare) (2)
@@ -125,8 +128,8 @@
 - [`threat-modeling`](#threat-modeling) (2)
 - [`tracker`](#tracker) (2)
 - [`transcript`](#transcript) (2)
+- [`validation`](#validation) (2)
 - [`verification`](#verification) (2)
-- [`wiki`](#wiki) (2)
 - [`worktree`](#worktree) (2)
 - [`x`](#x) (2)
 - [`academic`](#academic) (1)
@@ -134,6 +137,7 @@
 - [`acquisition`](#acquisition) (1)
 - [`address`](#address) (1)
 - [`agent-audit`](#agent-audit) (1)
+- [`agent-automation`](#agent-automation) (1)
 - [`agent-workflow`](#agent-workflow) (1)
 - [`agents`](#agents) (1)
 - [`agile`](#agile) (1)
@@ -150,7 +154,6 @@
 - [`architecture`](#architecture) (1)
 - [`arena`](#arena) (1)
 - [`art`](#art) (1)
-- [`artifacts`](#artifacts) (1)
 - [`arxiv`](#arxiv) (1)
 - [`attendance`](#attendance) (1)
 - [`auth`](#auth) (1)
@@ -216,6 +219,7 @@
 - [`delivery`](#delivery) (1)
 - [`demand`](#demand) (1)
 - [`demo`](#demo) (1)
+- [`dependencies`](#dependencies) (1)
 - [`dependency`](#dependency) (1)
 - [`dependency-audit`](#dependency-audit) (1)
 - [`dependency-scanning`](#dependency-scanning) (1)
@@ -239,6 +243,7 @@
 - [`evaluator`](#evaluator) (1)
 - [`event`](#event) (1)
 - [`events`](#events) (1)
+- [`evidence`](#evidence) (1)
 - [`execution`](#execution) (1)
 - [`expo`](#expo) (1)
 - [`fact`](#fact) (1)
@@ -298,6 +303,8 @@
 - [`iso27001`](#iso27001) (1)
 - [`issues`](#issues) (1)
 - [`jupyter`](#jupyter) (1)
+- [`kanban`](#kanban) (1)
+- [`knowledge-management`](#knowledge-management) (1)
 - [`landing`](#landing) (1)
 - [`latch`](#latch) (1)
 - [`lead-generation`](#lead-generation) (1)
@@ -376,6 +383,7 @@
 - [`prompt-engineering`](#prompt-engineering) (1)
 - [`promptfoo`](#promptfoo) (1)
 - [`promql`](#promql) (1)
+- [`provenance`](#provenance) (1)
 - [`pulse`](#pulse) (1)
 - [`pygount`](#pygount) (1)
 - [`python`](#python) (1)
@@ -454,6 +462,7 @@
 - [`systematic`](#systematic) (1)
 - [`tailwind`](#tailwind) (1)
 - [`taker`](#taker) (1)
+- [`task-management`](#task-management) (1)
 - [`tasks`](#tasks) (1)
 - [`teardown`](#teardown) (1)
 - [`tech`](#tech) (1)
@@ -476,7 +485,6 @@
 - [`user-modeling`](#user-modeling) (1)
 - [`using-agent-skills`](#using-agent-skills) (1)
 - [`ux`](#ux) (1)
-- [`validation`](#validation) (1)
 - [`valuation`](#valuation) (1)
 - [`vetter`](#vetter) (1)
 - [`visual-regression`](#visual-regression) (1)
@@ -497,7 +505,7 @@
 
 ## workflow
 
-**59 skills**
+**60 skills**
 
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
@@ -556,6 +564,7 @@
 | [billing-automation](skills/engineering-workflow-automation/billing-automation) | engineering-workflow-automation | ★★★☆☆ | Build automated billing systems for recurring payments, invoicing, subscription  |
 | [gh-fix-ci](skills/engineering-workflow-automation/gh-fix-ci) | engineering-workflow-automation | ★★★☆☆ | Inspect and fix failing GitHub Actions PR checks using gh logs and focused valid |
 | [lark-approval](skills/knowledge-and-pm-integrations/lark-approval) | knowledge-and-pm-integrations | ★★★☆☆ | 飞书审批：查询和处理审批待办/已办/实例，搜索可发起审批定义、查看定义详情并发起原生审批实例。当用户要处理审批任务、查看审批实例、搜索或发起审批时使用。审批待办 |
+| [workflow-yylo](skills/ai-workflow/workflow-yylo) | ai-workflow | ★★☆☆☆ | Create and maintain validated YYLO Ledger workflow Records while keeping storage |
 | [agent-browser](skills/engineering-workflow-automation/agent-browser) | engineering-workflow-automation | ★★☆☆☆ | Use when an agent needs real browser automation for semantic element targeting,  |
 | [gh-address-comments](skills/engineering-workflow-automation/gh-address-comments) | engineering-workflow-automation | ★★☆☆☆ | Use when addressing GitHub PR review comments or issue comments on the current b |
 | [github](skills/engineering-workflow-automation/github) | engineering-workflow-automation | ★★☆☆☆ | Use when automating GitHub issues, pull requests, reviews, CI checks, labels, re |
@@ -1056,6 +1065,21 @@
 | [docs-cleaner](skills/operations-general/docs-cleaner) | operations-general | ★★★☆☆ | Consolidate overlapping documentation and remove repetition while preserving use |
 | [theme-factory](skills/operations-general/theme-factory) | operations-general | ★★★☆☆ | Use when styling artifacts with reusable themes, applying preset color/font syst |
 
+## cli
+
+**8 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [cli-demo-generator](skills/developer-engineering/cli-demo-generator) | developer-engineering | ★★★★★ | Create terminal recordings and animated CLI demo GIFs from command workflows or  |
+| [linkedin](skills/operations-general/linkedin) | operations-general | ★★★★★ | General-purpose LinkedIn automation – fetch profiles, search people and companie |
+| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
+| [ledger-tasks-yylo](skills/ai-workflow/ledger-tasks-yylo) | ai-workflow | ★★★★☆ | Comprehensive guide for YYLO Ledger task management: all commands (create, list, |
+| [lark-meeting](skills/knowledge-and-pm-integrations/lark-meeting) | knowledge-and-pm-integrations | ★★★★☆ | Use Lark CLI to locate meetings, manage Minutes and AI notes, inspect transcript |
+| [wiki-yylo](skills/ai-workflow/wiki-yylo) | ai-workflow | ★★★☆☆ | Use YYLO Ledger wiki Records as durable project knowledge. Search before creatin |
+| [artifact-yylo](skills/ai-workflow/artifact-yylo) | ai-workflow | ★★☆☆☆ | Capture and retrieve durable YYLO Ledger artifact Records with intentional profi |
+| [workflow-yylo](skills/ai-workflow/workflow-yylo) | ai-workflow | ★★☆☆☆ | Create and maintain validated YYLO Ledger workflow Records while keeping storage |
+
 ## deployment
 
 **7 skills**
@@ -1212,17 +1236,6 @@
 | [web-artifacts-builder](skills/developer-engineering/web-artifacts-builder) | developer-engineering | ★★★☆☆ | Build complex interactive HTML artifacts with React, Tailwind, and shadcn/ui whe |
 | [stock-screener-builder](skills/finance-investing/stock-screener-builder) | finance-investing | ★★☆☆☆ | Use when building a stock screen, filtering a universe by valuation, growth, qua |
 
-## cli
-
-**4 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [cli-demo-generator](skills/developer-engineering/cli-demo-generator) | developer-engineering | ★★★★★ | Create terminal recordings and animated CLI demo GIFs from command workflows or  |
-| [linkedin](skills/operations-general/linkedin) | operations-general | ★★★★★ | General-purpose LinkedIn automation – fetch profiles, search people and companie |
-| [hermes-agent](skills/ai-agent-platform/hermes-agent) | ai-agent-platform | ★★★★☆ | Use, configure, theme, extend, and orchestrate Hermes Agent. |
-| [lark-meeting](skills/knowledge-and-pm-integrations/lark-meeting) | knowledge-and-pm-integrations | ★★★★☆ | Use Lark CLI to locate meetings, manage Minutes and AI notes, inspect transcript |
-
 ## cve
 
 **4 skills**
@@ -1288,6 +1301,17 @@
 | [azure-kubernetes](skills/devops-sre/azure-kubernetes) | devops-sre | ★★★★☆ | Plan and configure Azure Kubernetes Service clusters, including SKU, networking, |
 | [cc-devops-skills](skills/devops-sre/cc-devops-skills) | devops-sre | ★★★★☆ | SRE, DevOps, Kubernetes, CI/CD, PromQL, Terraform, Docker, and incident operatio |
 | [trivy-vulnerability-scanner](skills/security-and-reliability/trivy-vulnerability-scanner) | security-and-reliability | ★★★★☆ | 用于通过 Trivy 扫描仓库、容器镜像、文件系统、rootfs、SBOM、Kubernetes、IaC、密钥、许可证和系统 CVE。 |
+
+## markdown
+
+**4 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
+| [markdown-tools](skills/office-white-collar/markdown-tools) | office-white-collar | ★★★★☆ | Convert PDF, DOCX, PPTX, and other documents to Markdown, preserving tables, ima |
+| [wiki-yylo](skills/ai-workflow/wiki-yylo) | ai-workflow | ★★★☆☆ | Use YYLO Ledger wiki Records as durable project knowledge. Search before creatin |
+| [lark-markdown](skills/knowledge-and-pm-integrations/lark-markdown) | knowledge-and-pm-integrations | ★★★☆☆ | 操作飞书云空间中的 Markdown 文件：读取、创建、上传、局部编辑和比较。用于飞书 Markdown 资源操作；本地 Markdown 编辑无需此技能，导入 |
 
 ## media
 
@@ -1399,6 +1423,17 @@
 | [trivy-vulnerability-scanner](skills/security-and-reliability/trivy-vulnerability-scanner) | security-and-reliability | ★★★★☆ | 用于通过 Trivy 扫描仓库、容器镜像、文件系统、rootfs、SBOM、Kubernetes、IaC、密钥、许可证和系统 CVE。 |
 | [vuls-linux-cve-scanner](skills/security-and-reliability/vuls-linux-cve-scanner) | security-and-reliability | ★★★★☆ | 用于通过 Vuls 对 Linux、FreeBSD、容器、WordPress、库和网络设备执行 Agentless CVE 扫描。 |
 
+## yylo
+
+**4 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [ledger-tasks-yylo](skills/ai-workflow/ledger-tasks-yylo) | ai-workflow | ★★★★☆ | Comprehensive guide for YYLO Ledger task management: all commands (create, list, |
+| [wiki-yylo](skills/ai-workflow/wiki-yylo) | ai-workflow | ★★★☆☆ | Use YYLO Ledger wiki Records as durable project knowledge. Search before creatin |
+| [artifact-yylo](skills/ai-workflow/artifact-yylo) | ai-workflow | ★★☆☆☆ | Capture and retrieve durable YYLO Ledger artifact Records with intentional profi |
+| [workflow-yylo](skills/ai-workflow/workflow-yylo) | ai-workflow | ★★☆☆☆ | Create and maintain validated YYLO Ledger workflow Records while keeping storage |
+
 ## ci
 
 **3 skills**
@@ -1468,16 +1503,6 @@
 | [lark-wiki](skills/knowledge-and-pm-integrations/lark-wiki) | knowledge-and-pm-integrations | ★★★★☆ | 管理飞书知识空间、成员和文档节点，查询或调整节点层级。支持飞书或 doubao.com 的 /wiki/ 链接和 token；文件上传转 lark-drive， |
 | [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
 | [obsidian](skills/knowledge-and-pm-integrations/obsidian) | knowledge-and-pm-integrations | ★★★☆☆ | Read, search, create, or edit notes in an authorized Obsidian vault while preser |
-
-## markdown
-
-**3 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
-| [markdown-tools](skills/office-white-collar/markdown-tools) | office-white-collar | ★★★★☆ | Convert PDF, DOCX, PPTX, and other documents to Markdown, preserving tables, ima |
-| [lark-markdown](skills/knowledge-and-pm-integrations/lark-markdown) | knowledge-and-pm-integrations | ★★★☆☆ | 操作飞书云空间中的 Markdown 文件：读取、创建、上传、局部编辑和比较。用于飞书 Markdown 资源操作；本地 Markdown 编辑无需此技能，导入 |
 
 ## meeting
 
@@ -1599,6 +1624,16 @@
 | [web-scraper](skills/engineering-workflow-automation/web-scraper) | engineering-workflow-automation | ★★★★☆ | Use when users need webpage scraping, structured data extraction, crawling strat |
 | [web-artifacts-builder](skills/developer-engineering/web-artifacts-builder) | developer-engineering | ★★★☆☆ | Build complex interactive HTML artifacts with React, Tailwind, and shadcn/ui whe |
 
+## wiki
+
+**3 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [lark-wiki](skills/knowledge-and-pm-integrations/lark-wiki) | knowledge-and-pm-integrations | ★★★★☆ | 管理飞书知识空间、成员和文档节点，查询或调整节点层级。支持飞书或 doubao.com 的 /wiki/ 链接和 token；文件上传转 lark-drive， |
+| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
+| [wiki-yylo](skills/ai-workflow/wiki-yylo) | ai-workflow | ★★★☆☆ | Use YYLO Ledger wiki Records as durable project knowledge. Search before creatin |
+
 ## agent-skill
 
 **2 skills**
@@ -1634,6 +1669,15 @@
 |-------|----------|---------|-------------|
 | [app-store-optimization](skills/growth-operations-xiaohongshu/app-store-optimization) | growth-operations-xiaohongshu | ★★★★★ | App Store Optimization toolkit for researching keywords, optimizing metadata, an |
 | [nextjs-app-router](skills/developer-engineering/nextjs-app-router) | developer-engineering | ★★★★☆ | Master Next.js 14+ App Router with Server Components, streaming, parallel routes |
+
+## artifacts
+
+**2 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [web-artifacts-builder](skills/developer-engineering/web-artifacts-builder) | developer-engineering | ★★★☆☆ | Build complex interactive HTML artifacts with React, Tailwind, and shadcn/ui whe |
+| [artifact-yylo](skills/ai-workflow/artifact-yylo) | ai-workflow | ★★☆☆☆ | Capture and retrieve durable YYLO Ledger artifact Records with intentional profi |
 
 ## auditor
 
@@ -2058,6 +2102,15 @@
 | [lark-meeting](skills/knowledge-and-pm-integrations/lark-meeting) | knowledge-and-pm-integrations | ★★★★☆ | Use Lark CLI to locate meetings, manage Minutes and AI notes, inspect transcript |
 | [transcript-fixer](skills/office-white-collar/transcript-fixer) | office-white-collar | ★★★★☆ | Correct speech-recognition errors, homophones, and mixed Chinese/English termino |
 
+## validation
+
+**2 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [security-audit](skills/security-and-reliability/security-audit) | security-and-reliability | ★★★★☆ | Audit codebases for exploitable security vulnerabilities with concrete attack pa |
+| [workflow-yylo](skills/ai-workflow/workflow-yylo) | ai-workflow | ★★☆☆☆ | Create and maintain validated YYLO Ledger workflow Records while keeping storage |
+
 ## verification
 
 **2 skills**
@@ -2066,15 +2119,6 @@
 |-------|----------|---------|-------------|
 | [andrej-karpathy-skills](skills/ai-workflow/andrej-karpathy-skills) | ai-workflow | ★★★★☆ | Karpathy-inspired coding discipline for AI agents: think before coding, keep cha |
 | [verification-before-completion](skills/ai-workflow/verification-before-completion) | ai-workflow | ★★★★☆ | Use when about to claim work is complete, fixed, or passing, before committing o |
-
-## wiki
-
-**2 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [lark-wiki](skills/knowledge-and-pm-integrations/lark-wiki) | knowledge-and-pm-integrations | ★★★★☆ | 管理飞书知识空间、成员和文档节点，查询或调整节点层级。支持飞书或 doubao.com 的 /wiki/ 链接和 token；文件上传转 lark-drive， |
-| [llm-wiki](skills/knowledge-and-pm-integrations/llm-wiki) | knowledge-and-pm-integrations | ★★★★☆ | Karpathy''s LLM Wiki: build/query interlinked markdown KB. |
 
 ## worktree
 
@@ -2133,6 +2177,14 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [nlpm-audit](skills/ai-workflow/nlpm-audit) | ai-workflow | ★★★★☆ | Audit SKILL.md, AGENTS.md, prompts, hooks, and plugin manifests for instruction  |
+
+## agent-automation
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [workflow-yylo](skills/ai-workflow/workflow-yylo) | ai-workflow | ★★☆☆☆ | Create and maintain validated YYLO Ledger workflow Records while keeping storage |
 
 ## agent-workflow
 
@@ -2261,14 +2313,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [algorithmic-art](skills/growth-operations-xiaohongshu/algorithmic-art) | growth-operations-xiaohongshu | ★★★★★ | Create original generative art with p5.js, seeded randomness, flow fields, parti |
-
-## artifacts
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [web-artifacts-builder](skills/developer-engineering/web-artifacts-builder) | developer-engineering | ★★★☆☆ | Build complex interactive HTML artifacts with React, Tailwind, and shadcn/ui whe |
 
 ## arxiv
 
@@ -2790,6 +2834,14 @@
 |-------|----------|---------|-------------|
 | [cli-demo-generator](skills/developer-engineering/cli-demo-generator) | developer-engineering | ★★★★★ | Create terminal recordings and animated CLI demo GIFs from command workflows or  |
 
+## dependencies
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [ledger-tasks-yylo](skills/ai-workflow/ledger-tasks-yylo) | ai-workflow | ★★★★☆ | Comprehensive guide for YYLO Ledger task management: all commands (create, list, |
+
 ## dependency
 
 **1 skills**
@@ -2973,6 +3025,14 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [lark-event](skills/knowledge-and-pm-integrations/lark-event) | knowledge-and-pm-integrations | ★★★★☆ | Consume Lark/Feishu events as NDJSON with lark-cli for messaging, approvals, tas |
+
+## evidence
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [artifact-yylo](skills/ai-workflow/artifact-yylo) | ai-workflow | ★★☆☆☆ | Capture and retrieve durable YYLO Ledger artifact Records with intentional profi |
 
 ## execution
 
@@ -3445,6 +3505,22 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [jupyter-notebook](skills/engineering-workflow-automation/jupyter-notebook) | engineering-workflow-automation | ★★★★☆ | Use when the user asks to create, scaffold, or edit Jupyter notebooks (`.ipynb`) |
+
+## kanban
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [ledger-tasks-yylo](skills/ai-workflow/ledger-tasks-yylo) | ai-workflow | ★★★★☆ | Comprehensive guide for YYLO Ledger task management: all commands (create, list, |
+
+## knowledge-management
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [wiki-yylo](skills/ai-workflow/wiki-yylo) | ai-workflow | ★★★☆☆ | Use YYLO Ledger wiki Records as durable project knowledge. Search before creatin |
 
 ## landing
 
@@ -4070,6 +4146,14 @@
 |-------|----------|---------|-------------|
 | [cc-devops-skills](skills/devops-sre/cc-devops-skills) | devops-sre | ★★★★☆ | SRE, DevOps, Kubernetes, CI/CD, PromQL, Terraform, Docker, and incident operatio |
 
+## provenance
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [artifact-yylo](skills/ai-workflow/artifact-yylo) | ai-workflow | ★★☆☆☆ | Capture and retrieve durable YYLO Ledger artifact Records with intentional profi |
+
 ## pulse
 
 **1 skills**
@@ -4694,6 +4778,14 @@
 |-------|----------|---------|-------------|
 | [meeting-minutes-taker](skills/office-white-collar/meeting-minutes-taker) | office-white-collar | ★★★★★ | Turn meeting transcripts into accurate minutes with decisions, actions, owners,  |
 
+## task-management
+
+**1 skills**
+
+| Skill | Category | Quality | Description |
+|-------|----------|---------|-------------|
+| [ledger-tasks-yylo](skills/ai-workflow/ledger-tasks-yylo) | ai-workflow | ★★★★☆ | Comprehensive guide for YYLO Ledger task management: all commands (create, list, |
+
 ## tasks
 
 **1 skills**
@@ -4869,14 +4961,6 @@
 | Skill | Category | Quality | Description |
 |-------|----------|---------|-------------|
 | [ui-ux-pro-max](skills/product-design/ui-ux-pro-max) | product-design | ★★★★☆ | Front-end UI/UX design intelligence for creating, reviewing, and hardening polis |
-
-## validation
-
-**1 skills**
-
-| Skill | Category | Quality | Description |
-|-------|----------|---------|-------------|
-| [security-audit](skills/security-and-reliability/security-audit) | security-and-reliability | ★★★★☆ | Audit codebases for exploitable security vulnerabilities with concrete attack pa |
 
 ## valuation
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,12 +1,12 @@
 {
   "version": "1.0.0",
   "generated_at": "2026-06-08",
-  "total_skills": 284,
+  "total_skills": 288,
   "total_categories": 16,
   "categories": [
     {
       "name": "ai-workflow",
-      "count": 47
+      "count": 51
     },
     {
       "name": "developer-engineering",
@@ -432,6 +432,28 @@
       "updated_at": "2026-09-07",
       "line_count": 379,
       "path": "skills/ai-workflow/api-and-interface-design/SKILL.md"
+    },
+    {
+      "name": "artifact-yylo",
+      "category": "ai-workflow",
+      "description": "Capture and retrieve durable YYLO Ledger artifact Records with intentional profiles, payload modes, provenance, retention, and secret-safe immutable evidence.",
+      "version": "2.0.0",
+      "author": "yylo-dev",
+      "source": "github:yylo-dev/yylo-skills",
+      "source_url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/artifact-yylo",
+      "tags": [
+        "yylo",
+        "artifacts",
+        "evidence",
+        "provenance",
+        "cli"
+      ],
+      "quality": 2,
+      "complexity": "intermediate",
+      "created_at": "2026-09-11",
+      "updated_at": "2026-09-11",
+      "line_count": 83,
+      "path": "skills/ai-workflow/artifact-yylo/SKILL.md"
     },
     {
       "name": "brainstorming",
@@ -862,6 +884,28 @@
       "updated_at": "2026-09-07",
       "line_count": 237,
       "path": "skills/ai-workflow/interview-me/SKILL.md"
+    },
+    {
+      "name": "ledger-tasks-yylo",
+      "category": "ai-workflow",
+      "description": "Comprehensive guide for YYLO Ledger task management: all commands (create, list, search, get, mark, update, archive, deps, ready, order, merge), dependency management, best practices, and workflow patterns.",
+      "version": "2.0.0",
+      "author": "yylo-dev",
+      "source": "github:yylo-dev/yylo-skills",
+      "source_url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/ledger-tasks-yylo",
+      "tags": [
+        "yylo",
+        "kanban",
+        "task-management",
+        "dependencies",
+        "cli"
+      ],
+      "quality": 4,
+      "complexity": "intermediate",
+      "created_at": "2026-09-11",
+      "updated_at": "2026-09-11",
+      "line_count": 191,
+      "path": "skills/ai-workflow/ledger-tasks-yylo/SKILL.md"
     },
     {
       "name": "nexus",
@@ -1328,6 +1372,50 @@
       "updated_at": "2026-09-06",
       "line_count": 131,
       "path": "skills/ai-workflow/verification-before-completion/SKILL.md"
+    },
+    {
+      "name": "wiki-yylo",
+      "category": "ai-workflow",
+      "description": "Use YYLO Ledger wiki Records as durable project knowledge. Search before creating, classify information correctly, and make revision-safe Markdown updates without editing Ledger storage directly.",
+      "version": "2.0.0",
+      "author": "yylo-dev",
+      "source": "github:yylo-dev/yylo-skills",
+      "source_url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/wiki-yylo",
+      "tags": [
+        "yylo",
+        "wiki",
+        "knowledge-management",
+        "markdown",
+        "cli"
+      ],
+      "quality": 3,
+      "complexity": "intermediate",
+      "created_at": "2026-09-11",
+      "updated_at": "2026-09-11",
+      "line_count": 90,
+      "path": "skills/ai-workflow/wiki-yylo/SKILL.md"
+    },
+    {
+      "name": "workflow-yylo",
+      "category": "ai-workflow",
+      "description": "Create and maintain validated YYLO Ledger workflow Records while keeping storage, execution, and run evidence as separate explicit boundaries.",
+      "version": "2.0.0",
+      "author": "yylo-dev",
+      "source": "github:yylo-dev/yylo-skills",
+      "source_url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/workflow-yylo",
+      "tags": [
+        "yylo",
+        "workflow",
+        "validation",
+        "agent-automation",
+        "cli"
+      ],
+      "quality": 2,
+      "complexity": "intermediate",
+      "created_at": "2026-09-11",
+      "updated_at": "2026-09-11",
+      "line_count": 84,
+      "path": "skills/ai-workflow/workflow-yylo/SKILL.md"
     },
     {
       "name": "writing-plans",

--- a/docs/sources/in-house.skills.json
+++ b/docs/sources/in-house.skills.json
@@ -1,7 +1,7 @@
 {
   "video": {
     "url": "https://github.com/seaworld008/Commonly-used-high-value-skills",
-    "checked_at": "2026-09-07",
+    "checked_at": "2026-09-11",
     "note": "Auto-generated provenance mapping for all local skills."
   },
   "official_references": [
@@ -23,7 +23,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/agent-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -114,7 +114,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "bd6dac16d7dbac4ff4ce69e1cfa7c4866e4101cc6b83041837edb8632e6dd03f",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -217,7 +217,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/agent-workflow-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -243,7 +243,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "75654b20a03e752f79d9c5e2362dc2a50011a319b7651927e28455bc3d166501",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -268,7 +268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/agile-product-owner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -309,7 +309,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a51c7df49b6ae16e0b2dbba7ad910f7613bc2a1926a23330fc46548a9129f4be",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -352,7 +352,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/algorithmic-art",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -393,7 +393,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "779ee87762bdbc3c56d4397e0b666610af3ad6abbc3a9480a82a8de9898a4176",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -436,7 +436,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/andrej-karpathy-skills",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -462,7 +462,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c766537eecfb66b685104596ea29be912e8dded1507c09d1b5894f685bc15d9d",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-06-03"
           }
         }
@@ -487,7 +487,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-design-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -538,7 +538,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ed235881cfc758c7a705861cb279d266dc43ade63ee124eb585d3ca0a4f4fd20",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -593,7 +593,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/api-test-suite-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -624,7 +624,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "78f8d1463ee549f46e6d1bc486c35a79cb15f27f0123622612c43eba9a862ad6",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -655,7 +655,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/app-store-optimization",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -766,7 +766,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "89159a39fe6f0abb2dc9cde718c4cd380f31c07e216c163fa60994ad1342a38c",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -893,7 +893,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/brainstorming",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -919,7 +919,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6e477bf91f43f63b59b14d1ea606636684c01d7635b5bd5a27aa753f56bebf5a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -944,7 +944,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/brand-guidelines",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -975,7 +975,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9fbb18e6226ae411630978874f831992d8b7ab091a9b13c77dfeb9b45dd14839",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -1006,7 +1006,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/campaign-analytics",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -1087,7 +1087,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fde028bf1d5916c6163e759b68ce2fd3814ff5e69f1d6d9925621da7bca3ad65",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -1178,7 +1178,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/canvas-design",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -1614,7 +1614,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "24a21ebd36ab3465625c2bbc27e789b31a6acfa1f241cad9eb86a4d996f38284",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2131,7 +2131,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/chatgpt-apps",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -2207,7 +2207,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "908da9aa354c1713bc0a59801d98520d510e7b6249a64b3655366b42dcb208cf",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2292,7 +2292,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/cli-demo-generator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -2358,7 +2358,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ecb2ea56b91c570683467b41007c77cbc7dc35e307e274a63d4a4eef2bc1038c",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -2431,7 +2431,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/cloudflare-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -4012,7 +4012,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3943705d4ddb29a0ab5318e9314ac54f67f42524af98144b5983a3810c4b8f54",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -5903,7 +5903,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/cloudflare-troubleshooting",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -5954,7 +5954,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "540e76056450f6169e8928f555ad05afc0d5c5d9dafffb2c39f62b894d8e239c",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6009,7 +6009,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/codebase-onboarding",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6040,7 +6040,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9b1a258a7a6608c1372f2aa94e81f015ed100f0a8bf8e9aa5a1f8dfb6374f6a1",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6071,7 +6071,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/codeql-security-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6097,7 +6097,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "601d8a67881a59afe7418fd5ad02b2f232434a39b227e73f11eac83aa0023658",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -6122,7 +6122,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/competitive-teardown",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6148,7 +6148,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "de2bb927b6f4f27fea731835afd3fb99a2b888aca4c3a6636dc848ca7a10596e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6173,7 +6173,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/competitors-analysis",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6219,7 +6219,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c581698651ec3320bc56d3f464d469eff4e20d3acbc3a4a892b39620331ec0dc",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6268,7 +6268,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/comps-valuation-analyst",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6309,7 +6309,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c21312d3025195d7cd99337d70336a36a551e21e259661160663c72982f11d3a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6352,7 +6352,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/content-creator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6423,7 +6423,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ec4fb8915d3d1e583aa9bae81c05d2c17b85718d12c710713fd34329d98f39e7",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6502,7 +6502,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6598,7 +6598,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "62154d7cfec6b1b1fa7a4b974171bdd3e2ce07724a490d19453e0b9056124344",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6707,7 +6707,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/database-schema-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6738,7 +6738,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "890547056128aa3ca0c69e947a21548a42a6559d7812973071617b26ff02cff2",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6769,7 +6769,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/deep-research",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6825,7 +6825,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "777a8298ce9336f1fd787ee1c48a451f9ca8113f86230fc964127c52e8938ca5",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -6886,7 +6886,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/dependency-auditor",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -6987,7 +6987,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "bcf3d1b9d649be2d4c6b78d158d30ff902266c940dfa716704dd5734c35dc2bb",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7102,7 +7102,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/develop-web-game",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7158,7 +7158,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4bdf0629d8b4da8815e6676493820104b02abd1ef3386d91d4748878b6048a04",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7219,7 +7219,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/docs-cleaner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7255,7 +7255,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "252cb4eb6eda403f3eb36a8bb1998c0aef7e348c7e9d0351780cdbb2b6618420",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -7292,7 +7292,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/docx",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -7628,7 +7628,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fe5f8367b956e767368de0bca43f360181515f218d3c78a6c448edccde0f8ae7",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8025,7 +8025,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/earnings-call-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8066,7 +8066,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fba3ca2e9d69833dac59fd6ae9ee7e038fe46e8991bca5b9755272e8438d1e92",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -8109,7 +8109,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/env-secrets-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8140,7 +8140,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "575e55b4ed7fdf90b2609e83082830e29e2d0ef582d5897bd454592dbec40320",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8171,7 +8171,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/event-driven-tracker",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8212,7 +8212,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3477071c58f361e1a6e5a991f82ee365cd6aadd2e79f4a4597839b92c94661b1",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8255,7 +8255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/fact-checker",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8291,7 +8291,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1e090d7758c468ee90c7110ca9af6be7036ab60f3b926375f9eb99abc8af9b53",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8328,7 +8328,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/factor-backtester",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8369,7 +8369,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "83efe2153ff51c7d536ab2859f29f0402070b570933572709eea86dbbe60fe45",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8412,7 +8412,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8473,7 +8473,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "5945caec2c3f52bf77753af29f09a1b4485805720e744a2724abcab8999296d9",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8540,7 +8540,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/figma-implement-design",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8591,7 +8591,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "63066764bb4d239dae61110c55880f0ab7ac3d187f501bf8bde74eeb4eb908a7",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8646,7 +8646,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-analyst",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8732,7 +8732,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "98cc5c391ae368aee4acc1ee72735bfb99799ea708127f79b6cb07eac5227f93",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -8829,7 +8829,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/financial-data-collector",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -8925,7 +8925,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e44d7827bb3d9990e172d6a85b8a56e09e904d864992f837153f2d6545b06839",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9034,7 +9034,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/frontend-design",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9065,7 +9065,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "99572db2097b44dcf7128bfbca9ad7381aba6cf6a9bb3ca49597e8bf54cf0d64",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9096,7 +9096,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-address-comments",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9147,7 +9147,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "02d4b209a05ff328d9d3bc75fd3055d93624ed8383c167346b6146d2d90e65e9",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9202,7 +9202,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/gh-fix-ci",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9253,7 +9253,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e134886addd4b4f14283fceb1db731435ac165c3139515e3562ab00fdec1bab5",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9308,7 +9308,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/git-worktree-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9334,7 +9334,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a7659ca434d8bc5da75ae6566afec4edcc6c25a5df9461e04e38f26b052c47b5",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9359,7 +9359,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/github",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9385,7 +9385,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f78d268b7277c99c035136e10ab3e36109af9c0b0bb18bd6910de3e16bf21b12",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9410,7 +9410,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/github-contributor",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9456,7 +9456,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6aee04e08ce486b580c1dc990e6ecb3a7dd838d6b5fdb90e2aedb26c1a053af4",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9505,7 +9505,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/github-ops",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9556,7 +9556,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3ab328fa2a1ccf0c302b63a7346a152237f4cfcfee0f2c4e20f4c693371f9b2e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9611,7 +9611,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/gpt-image2",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9652,7 +9652,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b8d2c12060758999684174b754ed5a3004d83550660a377f8404f386269e4f1f",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9695,7 +9695,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/graphql-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9721,7 +9721,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "16016d2a6375c885eae6f069c53616c66463d6390637d91c10fbf4054041cf2f",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -9746,7 +9746,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/grype-syft-sbom-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9772,7 +9772,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3a1762c57fc9ea40a97141703e232c5aa4d72b627dc8f396f7dc0e654c906f17",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -9797,7 +9797,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/hermes-open-gsd-workflow",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-08-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9822,7 +9822,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6e1bbecf1c863b1b9895ac94eb66e57750877363b483805cbba4cb39b880c52d",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-08-20"
           }
         }
@@ -9874,7 +9874,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/i18n-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -9910,7 +9910,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "22362aa3948df93fca08fa3fcfc8d27919f32162518dd9792c16d47dbfecf8c5",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -9947,7 +9947,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/imagegen",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10023,7 +10023,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c04737fc1cb5b9ef26d6c6536090291e72ef40d1c21f550ab46de777fcffa72a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10108,7 +10108,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/incident-commander",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10259,7 +10259,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "352913d93f9e067afa0cbbd4baae16c5d798b18cf53e53ba15e36cc9695ea0b6",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10434,7 +10434,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/input-guard",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10530,7 +10530,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "8fcd74363c383de5aef899edf9eda04e8a3a9ddd0e7390f11098e910095f42ea",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10639,7 +10639,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/interview-system-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10730,7 +10730,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2dee1bf1517f08ad20525217591cb946e794137b2de93e431bfffe8a762dda14",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10833,7 +10833,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/investment-memo-writer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10874,7 +10874,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "01a9223eca330801d029f944b0fc9a2d4831420998b302755527e6a9a3d82b86",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -10917,7 +10917,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/jupyter-notebook",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -10998,7 +10998,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4dd0013c707d867b4b73663e303df58529076dd7b97269210d9e2343386ff60b",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11089,7 +11089,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/link-checker",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11115,7 +11115,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1ad3d11001bb0156a26babb26fabc45671cfb3d5bbd4124aa241583f44513c7f",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -11140,7 +11140,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/macro-regime-monitor",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11181,7 +11181,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "00c60df37247faddd1b6d1974a69b6f6efca950a6bca161c20199656f318bf6e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11224,7 +11224,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/markdown-tools",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11290,7 +11290,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3812f49fd9a9d4768a6b032fd99e0470ef18feb6e2f35114fa9256c74e823a31",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11363,7 +11363,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-demand-acquisition",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11414,7 +11414,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c2d3217518b232d0fd3d558f7ddd155c605c991125f9970d8ca802318b6e69c6",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11469,7 +11469,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/marketing-strategy-pmm",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11515,7 +11515,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9e3ea580efc25683476bea87ef8946d26fa39036009aedee85dcbe327737047a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11564,7 +11564,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/mcp-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11635,7 +11635,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1a1b536474ef865b9645b099225c3d0c3e84747cb1934894f3f5fc0d99ea7406",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11714,7 +11714,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/meeting-minutes-taker",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11760,7 +11760,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2c77bee9a6906a9a45fd646554610b04d9c35651e69a3b329c10641839f45413",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11809,7 +11809,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/mermaid-tools",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -11855,7 +11855,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "55b4bea0043d5c6bdb409ee15dc087798f905f87031285b0562b1ccdd94acbe2",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -11904,7 +11904,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/migration-architect",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12025,7 +12025,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "010e501b68fb4d07497eaff26f8572000bdfe2a44785d08406bcdb0bbd579d5e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -12164,7 +12164,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/monorepo-navigator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12195,7 +12195,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "729fb62d9b764798d077af785691a8a77574eea7f3c585e0a890f5e911cd29cb",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -12226,7 +12226,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/netlify-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12287,7 +12287,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "61b3aa40783a4cf69c5774a1cdcca444feba5b50d2e8efa6b59fe8626fe9b1db",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12354,7 +12354,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-knowledge-capture",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12465,7 +12465,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "437fbfdc6d1c2dbcaed1407400cedc1ec2859dcccc229f84bcc3a19465684694",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12592,7 +12592,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-meeting-intelligence",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12708,7 +12708,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4d53b6c34f428c680620e23749cac2424996855e8185ba23422fbdde2b913afa",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -12841,7 +12841,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-research-documentation",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -12977,7 +12977,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "a134865e4f0a6081d62f3d3aa54274815f8d3989efa3f03da5afbaa1e7a7f619",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -13134,7 +13134,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/knowledge-and-pm-integrations/notion-spec-to-implementation",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13250,7 +13250,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9a98edca0bfa49486bf71dcf57e1c9bd4303e324a0893a74c67f89c89708efd6",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -13383,7 +13383,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/observability-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13469,7 +13469,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "57830d644763089cbcd3118b49db277e763e2421f09933a6182edbc6cc7575e4",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13566,7 +13566,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-agent-platform/openai-docs",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13612,7 +13612,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ce90cced2efb71277864dc380d1ac2394320e387fc9cf66296ae31525f0585ce",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13661,7 +13661,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/options-strategy-evaluator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13702,7 +13702,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "685a9f9e083225a37295f1253081ea58f02645cef6b2fd233284d89eeb13aa77",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13745,7 +13745,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/osv-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13771,7 +13771,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "27144186eed821b292fe0f5d898634fa4e32960a2d03f1ba4e190932b56e77b3",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -13796,7 +13796,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pdf",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -13887,7 +13887,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "d217160ceaaf0e1184f12b7e21dccdd2efcd76fa66c8cf4eeadda3769a72832a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -13990,7 +13990,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/performance-profiler",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14021,7 +14021,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "239b4f8955157a8e879a0bde945eeae700489af231f071245653b7fa77379863",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -14052,7 +14052,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14118,7 +14118,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6215b59eff5b77ba1b61174a3b37df64d16da6276d0bd8c76e1e43345fb1ca72",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -14191,7 +14191,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/playwright-pro",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-06-03",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14217,7 +14217,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "9612c0614e151c581982b6c141300f11703848fc6fe481cc8838d6b40ea60b27",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-06-03"
           }
         }
@@ -14242,7 +14242,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/portfolio-risk-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14298,7 +14298,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "907d765cddf3cbb762180b3bbc4dea030050526620dfa6422da9a83762a6a452",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -14359,7 +14359,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/pptx",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -14735,7 +14735,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "87a473811703deaf4b16aeea54a286d0fa5eba743a17abc34bb5eb31845f0a2c",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15180,7 +15180,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/pr-review-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15206,7 +15206,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "0ed7e74d0359d5d9cbe9843b90e2ef413ae90d9e7eda7f7d8b7f5b5c3fbe5405",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15231,7 +15231,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-manager-toolkit",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15282,7 +15282,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "14b3d430c0a7ae1dfe91249d37e31d2ed8cb48b157b54787fabf990eae9d2c41",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15337,7 +15337,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/product-strategist",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15383,7 +15383,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "56b244f859e08d7498eb5f002ce7084c9b78bab6200264ecf284237c9f8afe5d",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15432,7 +15432,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/prompt-optimizer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15483,7 +15483,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "64b7bcfe8a73d8f503f42e320d16ab4b873ee4c01952b595e611739b848aeef8",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15538,7 +15538,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/promptfoo-evaluation",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15579,7 +15579,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "34b1b2a2747d90d1aa87087867205f6209d2de14627431e9b093f113abc30334",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15622,7 +15622,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/qa-expert",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15693,7 +15693,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "65305a25ea8eb640fc67adb2ca90e42ac25547e5f5b0cd5353ffdb3564c557a4",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15772,7 +15772,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/rag-architect",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15828,7 +15828,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b30905d4f0057b200c78bd49b8fa58a95d3eac872023f0bedbc4477d0ec8dcd9",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15889,7 +15889,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/react-native-engineering",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -15920,7 +15920,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "d7631cd7bc71c499a3dcd12d383c051d1bb7f0dd41ef758723bf99461a3b74b6",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -15951,7 +15951,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/task-understanding-decomposition/reflect-learn",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16092,7 +16092,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c3b2a4f19540ba9f69c9802b47a86fc375dac0939f170b2979e3d4fd61e6d8a8",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16255,7 +16255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/release-manager",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16351,7 +16351,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "72ec85dbf6499776f03ba33ff629f9dc4a26510caf050a43032502b690efb1a7",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16460,7 +16460,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/render-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16586,7 +16586,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "74b6e71dbe48fb7dbe8d125eb0733d68043c0cd1693ab75e9849f251279866c3",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -16731,7 +16731,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/repomix-safe-mixer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-08-31",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16772,7 +16772,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c38e786b95d843f7fa7993ebffee2da85b63efe0e83419ad42e7def25451bda5",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-08-31"
           }
         }
@@ -16815,7 +16815,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/openclaw-memory-and-safety/runbook-generator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16841,7 +16841,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "e92099a6bddcfd6b57684a6e33e98a4fc06f656bc56956ff135bcc057cb80760",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16866,7 +16866,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/saas-scaffolder",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16892,7 +16892,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "928b0a14f5950fcca7216ebe127af0141a4bdedf13863ae11f8d48c43debc695",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -16917,7 +16917,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/screenshot",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -16993,7 +16993,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "3fd7db89e5960cfe4a2e2b297482eaca8e883093ab96cd5d417ee50907347e20",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17078,7 +17078,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/sec-filing-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17119,7 +17119,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "649f70b91f89ed4098e9b4aba3efec6dc6bee314e569d45903f6869f9700d64e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17162,7 +17162,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-auditor",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17188,7 +17188,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1c4df82bc9666d4a5122af7c979d926d232af02f6434cb391bd04cec023c29ad",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17213,7 +17213,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17299,7 +17299,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "4db2acd0105711f9393ad1fb6ea2d8c7f679ad7c4cdd4ce05fbf68383fc02c79",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17396,7 +17396,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-ownership-map",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17457,7 +17457,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b753fa83ade0d5ad2de81c6db02a549550ed90e662a79ccdb5fe6dea5a7cc8df",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17524,7 +17524,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/security-threat-model",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17570,7 +17570,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c160a69178eebfb9a81adedff1bfb1c40fea04efe19b38db163a6811c447889d",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17619,7 +17619,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/semgrep-appsec-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17645,7 +17645,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f3b65b67690e67daffcb4f16284b9f04669ed6296caa99ac6bbb452d9147c433",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -17670,7 +17670,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/devops-sre/senior-devops",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17726,7 +17726,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ab36439cf582127bfb61a919bd0d394b8fb6e44131bb11548a33062b1080db27",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17787,7 +17787,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/sentry",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17838,7 +17838,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "8609b7f9b771c38657357a13860f8c73a7bc15a49065ad43b8510e8e74fd9b7f",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -17893,7 +17893,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/skill-reviewer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -17939,7 +17939,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ede942fd0d0e19165a1819765ee7c217c807cfaa848f50bd396347231408687e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -17988,7 +17988,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/skill-tester",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18089,7 +18089,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "28763aab312a42949b404f1146eceee443be54a23e9a45438da02b8435f3b5f0",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18204,7 +18204,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/skill-vetter",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18230,7 +18230,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b6f372ea6a7ea5fefac23a647713adf53209596c0070b5b73f66c503a25cd441",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -18255,7 +18255,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/slack-gif-creator",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18311,7 +18311,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2b1b0258a35ae42ec381a8dab85b9040db102b32934ef2f24880cc2967b89fc4",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18372,7 +18372,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/social-media-analyzer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18428,7 +18428,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1e28a390d44a3c5eb368954c551b1f1e872e107e5cec9063b5acf39e5f3c168b",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18489,7 +18489,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/sora",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18580,7 +18580,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cfa57468ab8b44d2f24c7c47dbefec63062944f799644fc9c259de13852c5b47",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18683,7 +18683,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/speech",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18784,7 +18784,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "5b795a6ea7bb9071379c99a40f9449f0d12dbb4f91197aa15d38f4fc6b719b98",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18899,7 +18899,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/finance-investing/stock-screener-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -18940,7 +18940,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "33917e0b49f76de0afca871cbeef5c6dfaf623e82b5ba25fdda8fef5c5065790",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -18983,7 +18983,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/tech-debt-tracker",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19094,7 +19094,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "24838f86ca48e952ef017f6eea360bac2d4fabc8f5c477a28a466a6b1416f5cd",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -19221,7 +19221,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/operations-general/theme-factory",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19307,7 +19307,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "1f5696d4a3f8ad841484c1e8fc8826537fe68bb5f92c51c656778e8de21d8925",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -19404,7 +19404,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/multimodal-media/transcribe",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19460,7 +19460,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f1d6d43ec7c6cf25110e5b7989bfda4c94965208b8d291ea23daf8a89c89b4bc",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -19521,7 +19521,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/transcript-fixer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -19887,7 +19887,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "f24e3341a0f6924375d651833df3f33f7a46389a6ebe0dfa1ca751a54be3579e",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20320,7 +20320,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/trivy-vulnerability-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20346,7 +20346,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "eee5fe50f8a2109f45f3876c911e724d2bb37601173162f56294a86ece2743d4",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -20371,7 +20371,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/tweetclaw-source-research",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20397,7 +20397,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "986497802fe1d6e61ebf506031b3cc2462eed4ed69719d6d9071c0e19fa2af71",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20422,7 +20422,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/growth-operations-xiaohongshu/twitter-reader",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20463,7 +20463,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "c000c45d59d47400fcf9c0597444877106705c82de3b35c1334ba700106cc718",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20506,7 +20506,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/typescript-best-practices",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20532,7 +20532,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "fb632ff254d4f16b5948cc6b97c997d7ec311dc9d662ae56e1da5de895fa66dc",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -20557,7 +20557,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-design-system",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20608,7 +20608,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "981044cf73505517e8ef52c40375c0f1fcb85a8079b93b0487edf1ac20c688be",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20663,7 +20663,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ui-ux-pro-max",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20689,7 +20689,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "41ccf421965450292154081f8a22c99f90eca6109600920e9bc7ddddceb5b7b7",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20714,7 +20714,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/product-design/ux-researcher-designer",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20765,7 +20765,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "6b28615667885c6bf8907169805df1c73070df05c400afe67498acb400732cf2",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -20820,7 +20820,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/deployment-platforms/vercel-deploy",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20871,7 +20871,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cd0abede816c5923986340edd5bd59ca17a9c2a027296248c35757d4e778661a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -20926,7 +20926,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/security-and-reliability/vuls-linux-cve-scanner",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-05-20",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -20952,7 +20952,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "ee9788e397a3c01d8f6f901b87a53c97e444cac0c36aaf4bb745e5dade5815c9",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-05-20"
           }
         }
@@ -20977,7 +20977,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/web-artifacts-builder",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21023,7 +21023,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "55be83111388ee3673a9637df90b46d25dee017d004184bc5926cec335f06141",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21072,7 +21072,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/web-scraper",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21098,7 +21098,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "cd046dba98e766a09700ec4237ad7428f26654acb2b8923e17330b249bdef5f3",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -21123,7 +21123,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/developer-engineering/webapp-testing",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-04-13",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21174,7 +21174,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "2d3577154f057a693b0e5c8e92010b19c4ecbda6c47ba9a82d42dc2caef9b85a",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-04-13"
           }
         }
@@ -21229,7 +21229,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/ai-workflow/writing-plans",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21255,7 +21255,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "544f2aa7cc37212b5cf2c2f6e863908b9e19401a681632e4722ee14913974cef",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21280,7 +21280,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/office-white-collar/xlsx",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -21606,7 +21606,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "b76f382d38d1d8b4891373ba6d4a33b815daf4c9e7b34803f2bae2d38c1c3a91",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -21991,7 +21991,7 @@
         "repo": "local-repo/in-house",
         "path": "skills/engineering-workflow-automation/yeet",
         "ref": "main",
-        "last_checked_at": "2026-09-07",
+        "last_checked_at": "2026-09-11",
         "last_synced_at": "2026-09-06",
         "last_synced_commit": null,
         "sync_mode": "local-only"
@@ -22037,7 +22037,7 @@
             "resolved_commit": null,
             "path_commit": null,
             "content_sha256": "791a6872bb42d430167691254d5ec7dd3ebac41c617a66255ecfe4a13435b331",
-            "last_checked_at": "2026-09-07",
+            "last_checked_at": "2026-09-11",
             "last_synced_at": "2026-09-06"
           }
         }
@@ -22415,6 +22415,13 @@
     },
     {
       "date": "2026-09-07",
+      "method": "local-scan",
+      "target": "skills/*/*/SKILL.md",
+      "result": "success",
+      "evidence": "Merged provenance for 131 local skills"
+    },
+    {
+      "date": "2026-09-11",
       "method": "local-scan",
       "target": "skills/*/*/SKILL.md",
       "result": "success",

--- a/docs/sources/yylo-dev-yylo-skills-2026-09.skills.json
+++ b/docs/sources/yylo-dev-yylo-skills-2026-09.skills.json
@@ -1,0 +1,410 @@
+{
+  "schema_version": 2,
+  "video": {
+    "url": "https://github.com/yylo-dev/yylo-skills",
+    "checked_at": "2026-09-11",
+    "note": "Curated from yylo-dev/yylo-skills (YYLO agent-workflow skills for YYLO CLI / YYLO Ledger) with exact-path upstream tracking enabled."
+  },
+  "official_references": [
+    {
+      "name": "YYLO Skills repository",
+      "url": "https://github.com/yylo-dev/yylo-skills",
+      "purpose": "Canonical upstream repository for the yylo skills."
+    },
+    {
+      "name": "YYLO Skills MIT license",
+      "url": "https://github.com/yylo-dev/yylo-skills/blob/506edfd8d3fab524df2fdbc0bc739af876c95aa1/LICENSE",
+      "purpose": "MIT license and copyright notice verified at the imported commit."
+    },
+    {
+      "name": "ledger-tasks-yylo upstream skill",
+      "url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/ledger-tasks-yylo",
+      "purpose": "Exact source directory for the imported ledger-tasks-yylo skill."
+    },
+    {
+      "name": "workflow-yylo upstream skill",
+      "url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/workflow-yylo",
+      "purpose": "Exact source directory for the imported workflow-yylo skill."
+    },
+    {
+      "name": "wiki-yylo upstream skill",
+      "url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/wiki-yylo",
+      "purpose": "Exact source directory for the imported wiki-yylo skill."
+    },
+    {
+      "name": "artifact-yylo upstream skill",
+      "url": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/artifact-yylo",
+      "purpose": "Exact source directory for the imported artifact-yylo skill."
+    }
+  ],
+  "skills": [
+    {
+      "video_name": "ledger-tasks-yylo",
+      "normalized_slug": "ledger-tasks-yylo",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-workflow/ledger-tasks-yylo/SKILL.md",
+      "source": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/ledger-tasks-yylo",
+      "notes": "Imported under MIT at the recorded commit; frontmatter adapted to the house schema (zh_description, tags, quality, provenance fields, description within the 240-char budget) and at most one heading normalized to the house section contract; prose and code blocks verbatim from upstream.",
+      "upstream": {
+        "repo": "yylo-dev/yylo-skills",
+        "path": "skills/ledger-tasks-yylo/SKILL.md",
+        "ref": "main",
+        "last_checked_at": "2026-09-11",
+        "last_synced_at": "2026-09-11",
+        "last_synced_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+        "sync_mode": "monitor",
+        "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1"
+      },
+      "kind": "overlay",
+      "sync_mode": "monitor",
+      "origins": [
+        {
+          "repo": "yylo-dev/yylo-skills",
+          "path": "skills/ledger-tasks-yylo/SKILL.md",
+          "license": "MIT",
+          "sync_mode": "monitor",
+          "artifacts": [
+            {
+              "source": "skills/ledger-tasks-yylo/SKILL.md",
+              "target": "skills/ai-workflow/ledger-tasks-yylo/SKILL.md"
+            }
+          ],
+          "tracking": {
+            "channel": "default_branch",
+            "ref": "main",
+            "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "content_sha256": "3f421a3a929d3c77dba610e2baae83569a918dc616a661531083b16d8176c4b4",
+            "blob_sha": "4b774de02a83aed9cf5b5f06defa253f7e83501c",
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c7cd735642b26f589cd949914afaa3a7abd2c360",
+              "content_sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+              "spdx": "MIT",
+              "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+              "api_spdx": "MIT"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/ledger-tasks-yylo",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/ledger-tasks-yylo/LICENSE",
+              "target": "skills/ai-workflow/ledger-tasks-yylo/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11"
+          }
+        }
+      ],
+      "managed_files": [
+        {
+          "path": "skills/ai-workflow/ledger-tasks-yylo/LICENSE",
+          "sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+          "owner": "ledger-tasks-yylo",
+          "mode": "100644"
+        },
+        {
+          "path": "skills/ai-workflow/ledger-tasks-yylo/SKILL.md",
+          "sha256": "3f421a3a929d3c77dba610e2baae83569a918dc616a661531083b16d8176c4b4",
+          "owner": "ledger-tasks-yylo",
+          "mode": "100644"
+        }
+      ]
+    },
+    {
+      "video_name": "workflow-yylo",
+      "normalized_slug": "workflow-yylo",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-workflow/workflow-yylo/SKILL.md",
+      "source": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/workflow-yylo",
+      "notes": "Imported under MIT at the recorded commit; frontmatter adapted to the house schema (zh_description, tags, quality, provenance fields, description within the 240-char budget) and at most one heading normalized to the house section contract; prose and code blocks verbatim from upstream.",
+      "upstream": {
+        "repo": "yylo-dev/yylo-skills",
+        "path": "skills/workflow-yylo/SKILL.md",
+        "ref": "main",
+        "last_checked_at": "2026-09-11",
+        "last_synced_at": "2026-09-11",
+        "last_synced_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+        "sync_mode": "monitor",
+        "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1"
+      },
+      "kind": "overlay",
+      "sync_mode": "monitor",
+      "origins": [
+        {
+          "repo": "yylo-dev/yylo-skills",
+          "path": "skills/workflow-yylo/SKILL.md",
+          "license": "MIT",
+          "sync_mode": "monitor",
+          "artifacts": [
+            {
+              "source": "skills/workflow-yylo/SKILL.md",
+              "target": "skills/ai-workflow/workflow-yylo/SKILL.md"
+            }
+          ],
+          "tracking": {
+            "channel": "default_branch",
+            "ref": "main",
+            "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "content_sha256": "b22e35ddb544814c7c97321504b32ca1cbd74f66233e60c5fa166a6b172495b6",
+            "blob_sha": "a37c284816dee329cefa87396aab1e739e859022",
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c7cd735642b26f589cd949914afaa3a7abd2c360",
+              "content_sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+              "spdx": "MIT",
+              "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+              "api_spdx": "MIT"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/workflow-yylo",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/workflow-yylo/LICENSE",
+              "target": "skills/ai-workflow/workflow-yylo/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11"
+          }
+        }
+      ],
+      "managed_files": [
+        {
+          "path": "skills/ai-workflow/workflow-yylo/LICENSE",
+          "sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+          "owner": "workflow-yylo",
+          "mode": "100644"
+        },
+        {
+          "path": "skills/ai-workflow/workflow-yylo/SKILL.md",
+          "sha256": "b22e35ddb544814c7c97321504b32ca1cbd74f66233e60c5fa166a6b172495b6",
+          "owner": "workflow-yylo",
+          "mode": "100644"
+        }
+      ]
+    },
+    {
+      "video_name": "wiki-yylo",
+      "normalized_slug": "wiki-yylo",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-workflow/wiki-yylo/SKILL.md",
+      "source": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/wiki-yylo",
+      "notes": "Imported under MIT at the recorded commit; frontmatter adapted to the house schema (zh_description, tags, quality, provenance fields, description within the 240-char budget) and at most one heading normalized to the house section contract; prose and code blocks verbatim from upstream.",
+      "upstream": {
+        "repo": "yylo-dev/yylo-skills",
+        "path": "skills/wiki-yylo/SKILL.md",
+        "ref": "main",
+        "last_checked_at": "2026-09-11",
+        "last_synced_at": "2026-09-11",
+        "last_synced_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+        "sync_mode": "monitor",
+        "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1"
+      },
+      "kind": "overlay",
+      "sync_mode": "monitor",
+      "origins": [
+        {
+          "repo": "yylo-dev/yylo-skills",
+          "path": "skills/wiki-yylo/SKILL.md",
+          "license": "MIT",
+          "sync_mode": "monitor",
+          "artifacts": [
+            {
+              "source": "skills/wiki-yylo/SKILL.md",
+              "target": "skills/ai-workflow/wiki-yylo/SKILL.md"
+            }
+          ],
+          "tracking": {
+            "channel": "default_branch",
+            "ref": "main",
+            "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "content_sha256": "98bb179862b5ef6b1cf9145318713f519dab5b81fc1c5718bffda7eea852c591",
+            "blob_sha": "290d2e9e3a80e67975dbe3c3063e5e23e8d14cfe",
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c7cd735642b26f589cd949914afaa3a7abd2c360",
+              "content_sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+              "spdx": "MIT",
+              "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+              "api_spdx": "MIT"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/wiki-yylo",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/wiki-yylo/LICENSE",
+              "target": "skills/ai-workflow/wiki-yylo/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11"
+          }
+        }
+      ],
+      "managed_files": [
+        {
+          "path": "skills/ai-workflow/wiki-yylo/LICENSE",
+          "sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+          "owner": "wiki-yylo",
+          "mode": "100644"
+        },
+        {
+          "path": "skills/ai-workflow/wiki-yylo/SKILL.md",
+          "sha256": "98bb179862b5ef6b1cf9145318713f519dab5b81fc1c5718bffda7eea852c591",
+          "owner": "wiki-yylo",
+          "mode": "100644"
+        }
+      ]
+    },
+    {
+      "video_name": "artifact-yylo",
+      "normalized_slug": "artifact-yylo",
+      "status": "verified_in_repo",
+      "repo_skill": "skills/ai-workflow/artifact-yylo/SKILL.md",
+      "source": "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/artifact-yylo",
+      "notes": "Imported under MIT at the recorded commit; frontmatter adapted to the house schema (zh_description, tags, quality, provenance fields, description within the 240-char budget) and at most one heading normalized to the house section contract; prose and code blocks verbatim from upstream.",
+      "upstream": {
+        "repo": "yylo-dev/yylo-skills",
+        "path": "skills/artifact-yylo/SKILL.md",
+        "ref": "main",
+        "last_checked_at": "2026-09-11",
+        "last_synced_at": "2026-09-11",
+        "last_synced_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+        "sync_mode": "monitor",
+        "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1"
+      },
+      "kind": "overlay",
+      "sync_mode": "monitor",
+      "origins": [
+        {
+          "repo": "yylo-dev/yylo-skills",
+          "path": "skills/artifact-yylo/SKILL.md",
+          "license": "MIT",
+          "sync_mode": "monitor",
+          "artifacts": [
+            {
+              "source": "skills/artifact-yylo/SKILL.md",
+              "target": "skills/ai-workflow/artifact-yylo/SKILL.md"
+            }
+          ],
+          "tracking": {
+            "channel": "default_branch",
+            "ref": "main",
+            "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "path_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+            "content_sha256": "614f9f5e84486b5a80475cd4acbeb18782a64482ced5df1c1dc22bd5ba1f80e4",
+            "blob_sha": "903722967c29874234f79255def3d1b4b323e55c",
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11",
+            "license_checkpoint": {
+              "path": "LICENSE",
+              "blob_sha": "c7cd735642b26f589cd949914afaa3a7abd2c360",
+              "content_sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+              "spdx": "MIT",
+              "resolved_commit": "506edfd8d3fab524df2fdbc0bc739af876c95aa1",
+              "api_spdx": "MIT"
+            }
+          }
+        },
+        {
+          "repo": "local-repo/curation",
+          "path": "skills/ai-workflow/artifact-yylo",
+          "license": null,
+          "sync_mode": "local-only",
+          "artifacts": [
+            {
+              "source": "skills/ai-workflow/artifact-yylo/LICENSE",
+              "target": "skills/ai-workflow/artifact-yylo/LICENSE",
+              "type": "file"
+            }
+          ],
+          "tracking": {
+            "channel": "local",
+            "ref": "local",
+            "resolved_commit": null,
+            "path_commit": null,
+            "content_sha256": null,
+            "last_checked_at": "2026-09-11",
+            "last_synced_at": "2026-09-11"
+          }
+        }
+      ],
+      "managed_files": [
+        {
+          "path": "skills/ai-workflow/artifact-yylo/LICENSE",
+          "sha256": "95f3d09ccad6480516255cb5927ad1c96f66fba7746fbece09e8bd476b0252be",
+          "owner": "artifact-yylo",
+          "mode": "100644"
+        },
+        {
+          "path": "skills/ai-workflow/artifact-yylo/SKILL.md",
+          "sha256": "614f9f5e84486b5a80475cd4acbeb18782a64482ced5df1c1dc22bd5ba1f80e4",
+          "owner": "artifact-yylo",
+          "mode": "100644"
+        }
+      ]
+    }
+  ],
+  "verification_attempts": [
+    {
+      "date": "2026-09-11",
+      "method": "github-api-license-commit-and-path-check",
+      "target": "repos/yylo-dev/yylo-skills",
+      "result": "success",
+      "evidence": "GitHub API resolved 506edfd8d3fab524df2fdbc0bc739af876c95aa1 on main, reported MIT via the repo license endpoint, and confirmed skills/ledger-tasks-yylo/SKILL.md, skills/workflow-yylo/SKILL.md, skills/wiki-yylo/SKILL.md, skills/artifact-yylo/SKILL.md plus the root LICENSE."
+    },
+    {
+      "date": "2026-09-11",
+      "method": "repository-quality-review",
+      "target": "skills/ai-workflow/*-yylo/SKILL.md",
+      "result": "success",
+      "evidence": "Verified complete house frontmatter (incl. zh_description), exact pinned source URLs, local MIT notices per skill, category placement, and honest quality tiers against the line floors."
+    }
+  ]
+}

--- a/openclaw-skills/artifact-yylo/LICENSE
+++ b/openclaw-skills/artifact-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openclaw-skills/artifact-yylo/SKILL.md
+++ b/openclaw-skills/artifact-yylo/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: artifact-yylo
+description: 'Capture and retrieve durable YYLO Ledger artifact Records with intentional profiles, payload modes, provenance, retention, and secret-safe immutable evidence.'
+zh_description: "捕获与检索 YYLO Ledger 工件记录：按用途选择档案与载荷模式，附加来源与保留策略，沉淀不可变、防泄密的运行证据。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/artifact-yylo"
+license: MIT
+tags: '[yylo, artifacts, evidence, provenance, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 2
+complexity: intermediate
+---
+
+# Use YYLO artifact Records
+
+Treat Ledger as the source of truth for artifact identity and metadata. Use
+`yy ledger` in a YYLO controller or `yylo-ledger` standalone. Inspect
+`COMMAND artifact --help`; if unavailable, do not create store files manually.
+A Ledger Artifact Record is durable evidence, not an npm/Python release artifact
+and not an implicit request to publish or deploy.
+
+## Classify before capture
+
+Choose the profile matching the evidence:
+
+- `stdout`: bounded process output;
+- `model-output`: an agent/model response;
+- `report`: a generated human- or machine-readable result;
+- `receipt`: evidence binding an operation and its inputs/outcome.
+
+Choose payload mode deliberately:
+
+- `inline`: small immutable bytes embedded in the Record;
+- `local`: immutable content-addressed bytes in Ledger storage;
+- `external`: immutable external bytes with URI, digest, and size;
+- `link`: URI reference without an immutable-byte guarantee.
+
+Prefer immutable evidence when later verification depends on exact bytes. A link
+must never be presented as content-addressed proof.
+
+## Create explicitly
+
+Use file/stdin transport and provide the media type:
+
+```bash
+yy ledger artifact create --title "Focused test report" --profile report \
+  --mode local --media-type application/json --file report.json
+```
+
+For external immutable content, provide the supported URI, SHA-256 digest, and
+size shown by installed help. Never embed URI credentials. Ledger rejects unsafe
+schemes, traversal, size/digest mismatches, oversized capture, and known secret
+patterns.
+
+Attach only supported, non-secret provenance such as actor, agent, model,
+session, run, invocation, task, or workflow identity. Task/workflow provenance
+uses immutable Record IDs. Select `temporary`, `standard`, or `permanent`
+retention deliberately; retention metadata does not itself authorize deletion.
+
+## Quick reference: find and verify
+
+```bash
+yy ledger artifact search --profile report --projection summary --limit 20 -f json
+yy ledger artifact get RECORD_ID -f json
+yy ledger artifact history RECORD_ID -f ndjson
+```
+
+Use bounded metadata/summary projections before requesting payload details.
+Verify profile, mode, media type, digest, size, provenance, retention, revision,
+and immutable ID before relying on evidence.
+
+Artifact payloads are immutable evidence. Represent replacement with explicit
+predecessor/successor relationships and the installed revision-safe update
+contract; do not overwrite bytes or edit content objects. Archive is a lifecycle
+transition, not deletion. Release, publication, external upload, retention
+execution, and production mutation always require separate authority.
+
+## Complete request
+
+$ARGUMENTS

--- a/openclaw-skills/ledger-tasks-yylo/LICENSE
+++ b/openclaw-skills/ledger-tasks-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openclaw-skills/ledger-tasks-yylo/SKILL.md
+++ b/openclaw-skills/ledger-tasks-yylo/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: ledger-tasks-yylo
+description: 'Comprehensive guide for YYLO Ledger task management: all commands (create, list, search, get, mark, update, archive, deps, ready, order, merge), dependency management, best practices, and workflow patterns.'
+zh_description: "YYLO Ledger 看板任务管理完整参考：创建、检索、状态流转、依赖与排序、冷归档与多目录合并，以及控制器路由与环境变量。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/ledger-tasks-yylo"
+license: MIT
+tags: '[yylo, kanban, task-management, dependencies, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 4
+complexity: intermediate
+---
+
+## YYLO Ledger CLI Reference
+
+Use `yy ledger` for all commands. YYLO 0.2.2 supports the exact `yylo-ledger 0.2.0` task CLI. `yy kanban` is a labelled compatibility alias for the same controller-routed task runtime.
+
+### Supported task contract
+
+- The public Ledger 0.2.0 surface is task-oriented: create, get, update, mark, archive, list/search, dependencies, ordering, history, doctor, compatibility, conversion, rollback, and cold archive operations.
+- Do not advertise `record`, `wiki`, `workflow`, or `artifact` namespaces unless the installed `yy ledger --help` explicitly provides them in a future supported release.
+- Read current task state before mutation, preserve mutation receipts where offered, and never bypass controller routing or lifecycle state with direct file edits.
+- Normal discovery is hot-only unless an explicit cold-archive command is used.
+
+### Opt-in cross-project routing
+
+Cross-project access is disabled by default. The source `.juno_task/config.json` must set `kanbanRegistry.enabled: true` and explicitly list `allowedProjects`; environment overrides are `YYLO_LEDGER_REGISTRY_ENABLED` and `YYLO_LEDGER_REGISTRY_ALLOWED_PROJECTS`. Register with `yy ledger project add ALIAS --path /absolute/project`, then route any command with `--project ALIAS`. The destination wrapper/runtime remains authoritative, and routing failures never fall back to the source board.
+
+### Legacy Task compatibility commands
+
+**CREATE** — Add a new task
+```bash
+yy ledger create "Task description here" --status backlog --tags feature,backend
+```
+Options: `--status` (backlog|todo|in_progress|done), `--tags` (comma/space-separated), `--blocked-by` (task IDs), `--related-tasks` (task IDs)
+
+**LIST** — Browse tasks with summary stats
+```bash
+yy ledger list --limit 5 --sort asc
+yy ledger list --status todo --sort asc
+yy ledger list --status todo,in_progress --limit 10
+```
+
+**SEARCH** — Find tasks by criteria
+```bash
+yy ledger search --status todo --tag backend --limit 10
+yy ledger search --body "OAuth" --open
+yy ledger search --commit abc123
+```
+Filters: `--status`, `--tag`, `--body`, `--response`, `--commit`, `--open` (no agent_response), `--recent`, `--exclude` (exclude tags)
+
+**GET** — Full task details (including dependency info and related task details)
+```bash
+yy ledger get TASK_ID
+```
+
+**MARK** — Update status with required response message
+```bash
+yy ledger mark in_progress --id TASK_ID --response "Starting work on this"
+yy ledger mark done --id TASK_ID --response "Completed: implemented X, tested Y" --commit abc123def
+yy ledger mark todo --id TASK_ID --response "Reopening: found regression"
+```
+Required: `--id` and `--response`. Optional: `--commit` (recommended for done).
+
+**UPDATE** — Modify task fields
+```bash
+yy ledger update TASK_ID --status todo --tags backend,urgent
+yy ledger update TASK_ID --commit abc123def
+yy ledger update TASK_ID --response "Additional context"
+```
+
+**ARCHIVE** — Soft delete (preserves data, sets status to archive)
+```bash
+yy ledger archive TASK_ID
+```
+
+### Immutable cold archive packs
+
+Normal `list`, `search`, `ready`, and `order` are deliberately hot-only. Exact `get TASK_ID` transparently resolves a hot task or a read-only archived task; use `history TASK_ID` explicitly for its ledger. Discover cold tasks only with bounded, projected `archive-search` output:
+
+```bash
+yy ledger archive-search --tag backend --before 2026-01-01 --limit 20 --projection metadata
+```
+
+Before archive maintenance, preflight the installed version/help and obtain explicit owner authorization. The repository and index must be clean, and reports must be durable new paths outside the repository:
+
+```bash
+yy ledger --version
+yy ledger archive-pack plan --status done,archive --older-than 90d --max-tasks 1000 --target-bytes 26214400 --hard-max-bytes 47185920 --report /external/receipts/archive-plan.json
+# Independently inspect selected IDs, revisions, source HEAD, policy, and plan hash.
+yy ledger archive-pack create --plan /external/receipts/archive-plan.json --report /external/receipts/archive-create.json
+yy ledger archive-pack doctor
+yy ledger doctor
+```
+
+A stale plan or selected-task/worktree conflict must fail closed: discard the plan, resolve the conflict, and plan again. Never automate archival, edit/append packs or manifests, restore/reopen an archived ID, use force/lossy controls, or enumerate archive files directly. Create follow-up work as a new hot task related to the archived ID. Production archival, push/deploy, and post-deploy E2E each require separate authorization; agents must not infer it from implementation approval.
+
+### Dependency Management
+
+**DEPS** — View, add, or remove task dependencies
+```bash
+# View dependency info (blockers, dependents, priority score)
+yy ledger deps TASK_ID
+
+# Add blockers (TASK_ID cannot start until BLOCKER1 and BLOCKER2 are done)
+yy ledger deps add --id TASK_ID --blocked-by BLOCKER1 BLOCKER2
+
+# Remove a blocker
+yy ledger deps remove --id TASK_ID --blocked-by BLOCKER1
+```
+Cycle detection prevents circular dependencies automatically.
+
+**READY** — Tasks with all blockers satisfied (safe to work on)
+```bash
+yy ledger ready
+yy ledger ready --tag backend --limit 5
+```
+Returns tasks where status is backlog/todo/in_progress AND all `blocked_by` tasks are done/archive.
+
+**ORDER** — Topological sort of open tasks respecting dependencies
+```bash
+yy ledger order
+yy ledger order --scores
+```
+Use for determining safe parallel execution order.
+
+### Body Markup for Inline Dependencies
+
+Declare dependencies and relations directly in task body text:
+
+```
+[blocked_by]TASK_ID[/blocked_by]          — This task is blocked by TASK_ID
+[blocked_by]ID1, ID2[/blocked_by]         — Blocked by multiple tasks
+[task_id]RELATED_ID[/task_id]             — Reference a related task
+[task_id]ID1 ID2[/task_id]                — Multiple related tasks
+```
+
+These are parsed automatically when the task is created/updated.
+
+### Merge (Multi-Directory Consolidation)
+
+When tasks get scattered across subdirectories:
+```bash
+# First produce and review a deterministic plan
+yy ledger merge ./sub1/.juno_task ./sub2/.juno_task --into ./.juno_task \
+  --dry-run --plan-file /external/ledger-merge-plan.json
+
+# Apply only that reviewed plan and retain its receipt
+yy ledger merge ./sub1/.juno_task ./sub2/.juno_task --into ./.juno_task \
+  --apply-plan /external/ledger-merge-plan.json \
+  --receipt-file /external/ledger-merge-receipt.json
+```
+
+### Output Formats
+
+All commands support: `-f json`, `-f ndjson` (default), `-f xml`, `-f table`
+Add `--raw` for compact output. Add `-p` for pretty print.
+
+## Best Practices
+
+1. **Task sizing**: Create tasks small enough to complete in one iteration without filling the context window
+2. **Status flow**: backlog → todo → in_progress → done (or archive for abandoned tasks)
+3. **Always include `--response`** when using `mark` — document what you did and how you tested it
+4. **Attach commits**: Use `--commit HASH` when marking done, then `update TASK_ID --commit HASH` to link the git history
+5. **Use `ready`** before starting work to find unblocked tasks
+6. **Use `order --scores`** to plan parallel execution pipelines
+7. **Use `[blocked_by]` markup** in task body when creating tasks that depend on others
+8. **Use `[task_id]` markup** in task body to cross-reference related tasks
+9. **Use `get TASK_ID`** to see full task details including resolved dependency and related task info
+10. **Concurrent features are supported** — start each selected task with `yy task start TASK_ID`; each gets a dedicated product worktree, while `yy merge` serializes only target updates
+
+### Canonical Controller Routing
+
+YYLO Ledger mutation resolves the controller in this order: explicit `JUNO_TASK_ROOT`, repository-local registration, then the current project root. Diagnose before orchestration with `.juno_task/scripts/controller_resolver.py --cwd "$PWD" --operation kanban`. The resolver may bootstrap or idempotently confirm a registration, but changing an existing controller requires `yy migrate registration plan` followed by a separately authorized apply. Explicit/registered path or branch errors fail closed—YYLO Ledger never switches Git branches or falls back silently.
+
+Run YYLO Ledger and workflows from the controller. A task checkout may implement/test but routes task/session writes to that controller. An integration-owner checkout stays clean and refuses Kanban/orchestration/session writes in strict mode; launch from the controller and pass the product checkout separately as `TASK_ROOT`.
+
+### Environment Variables
+
+- `JUNO_TASK_ROOT` — Explicit canonical controller/task-storage root (not the product `TASK_ROOT`)
+- `JUNO_CONTROLLER_BRANCH` — Expected controller branch for environment-based routing
+- `JUNO_WORKSPACE_ROLE` — `controller`, `task`, or `integration-owner`
+- `JUNO_WORKSPACE_ENFORCEMENT` — `off`, `warn`, or `strict`
+- `JUNO_DEBUG=true` — Show diagnostic messages
+- `JUNO_VERBOSE=true` — Show informational messages
+- `JUNO_KANBAN_LIST_BODY_TRUNCATE_CHARS=N` — Override list body truncation (default: 1200)
+
+$ARGUMENTS

--- a/openclaw-skills/wiki-yylo/LICENSE
+++ b/openclaw-skills/wiki-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openclaw-skills/wiki-yylo/SKILL.md
+++ b/openclaw-skills/wiki-yylo/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: wiki-yylo
+description: 'Use YYLO Ledger wiki Records as durable project knowledge. Search before creating, classify information correctly, and make revision-safe Markdown updates without editing Ledger storage directly.'
+zh_description: "把 YYLO Ledger wiki 记录当作持久项目知识：先检索后创建、按记录类型正确分类，并通过修订安全契约更新 Markdown。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/wiki-yylo"
+license: MIT
+tags: '[yylo, wiki, knowledge-management, markdown, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 3
+complexity: intermediate
+---
+
+# Use YYLO wiki Records
+
+Treat Ledger as the source of truth. Use `yy ledger` in a YYLO controller and
+`yylo-ledger` in a standalone Ledger project. Inspect `COMMAND wiki --help` before
+acting; if `wiki` is absent, the installed Ledger version does not expose native
+Record commands and must not be bypassed with direct file edits.
+
+## Choose the right record
+
+Before writing, decide where the information belongs:
+
+- **Wiki**: durable explanatory project or domain knowledge that future work must discover.
+- **Task**: scoped requested work, status, dependencies, acceptance criteria, and completion evidence.
+- **Workflow**: validated structured steps, not prose guidance.
+- **Artifact**: generated evidence, reports, receipts, logs, model output, or binary payloads.
+- **Source documentation**: documentation released and versioned with product code.
+
+Do not put secrets, caches, session transcripts, temporary status, bulky generated
+evidence, or owner-only operational receipts in a wiki.
+
+## Quick reference: discover before creating
+
+Use bounded summary searches first. Resolve records by immutable ID whenever one
+is known; slugs and aliases are discovery conveniences, not replacement identity.
+
+```bash
+yy ledger wiki search --text "deployment policy" --projection summary --limit 20 -f json
+yy ledger wiki get RECORD_ID -f json
+yy ledger wiki get RECORD_ID --raw
+```
+
+Use `--scope archive|all` only when the request requires cold records. Request
+`full` projection only when payload bytes are necessary.
+
+## Create durable Markdown
+
+Use a file or stdin for substantial or shell-sensitive content:
+
+```bash
+yy ledger wiki create --title "Service ownership" --file ownership.md
+yy ledger wiki create --title "Incident notes" --file - < incident-notes.md
+```
+
+Choose a stable title, namespace, slug, aliases, and relations deliberately. Keep
+one topic per Record and link related immutable Record IDs rather than duplicating
+truth.
+
+## Update safely
+
+1. Read the current Record and revision.
+2. Preserve its immutable ID and inspect history when intent is unclear.
+3. Follow `wiki update --help` for the installed compare-and-replace controls.
+4. Supply the expected revision and required preimage/digest evidence.
+5. Use file transport; do not rewrite Ledger files yourself.
+6. Read back the resulting revision and receipt.
+
+A revision or preimage mismatch means the source changed: reread and reconcile.
+Never force past concurrent edits. Archive is a lifecycle transition, not delete.
+
+Use `--front-matter` only for canonical front-matter interchange and `--rendered`
+for inert, HTML-escaped rendering. Use `history RECORD_ID` to understand revisions;
+do not infer history from the latest payload alone.
+
+## Project wiki boundary
+
+Portable controller guidance may live under the controller wiki, while project
+and domain pages retain project-owned paths. Package-managed and project-owned
+pages can coexist. Migration, runtime replacement, exceptional merge recovery,
+release, deployment, and cold-archive maintenance remain authoritative runbooks,
+not content to summarize into an everyday global skill.
+
+## Complete request
+
+$ARGUMENTS

--- a/openclaw-skills/workflow-yylo/LICENSE
+++ b/openclaw-skills/workflow-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openclaw-skills/workflow-yylo/SKILL.md
+++ b/openclaw-skills/workflow-yylo/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: workflow-yylo
+description: 'Create and maintain validated YYLO Ledger workflow Records while keeping storage, execution, and run evidence as separate explicit boundaries.'
+zh_description: "以 YYLO Ledger 工作流记录为中心：安全创建、校验与修订可执行工作流定义，并保持存储、执行与运行证据三类边界分离。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/workflow-yylo"
+license: MIT
+tags: '[yylo, workflow, validation, agent-automation, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 2
+complexity: intermediate
+---
+
+# Use YYLO workflow Records
+
+Treat Ledger as the source of truth for workflow identity, validated definition,
+and revision history. Use `yy ledger` in a YYLO controller or `yylo-ledger`
+standalone. Inspect `COMMAND workflow --help`; if the namespace is absent, do not
+invent it or edit Ledger storage directly.
+
+## Keep three boundaries distinct
+
+1. **Ledger stores and validates workflow data.** It does not execute workflows.
+2. **A separately selected YYLO runner executes reviewed workflow data.** Storage
+   does not grant execution, network, mutation, release, or deployment authority.
+3. **Artifact Records retain run evidence.** Do not overwrite the workflow
+   definition with stdout, logs, model output, reports, or receipts.
+
+The read-only Ledger host also has no workflow execution endpoint.
+
+## Discover and inspect
+
+```bash
+yy ledger workflow search --text "release verification" --projection summary --limit 20 -f json
+yy ledger workflow get RECORD_ID -f json
+yy ledger workflow get RECORD_ID --raw
+yy ledger workflow get RECORD_ID --validated
+```
+
+Prefer immutable IDs after discovery. Use bounded projections and explicit archive
+scope. `--validated` emits normalized YAML only after schema validation.
+
+## Author safe workflow data
+
+A workflow v1 document requires a mapping with `schema_version: v1`, a non-empty
+`workflow_id`, and a `steps` list whose step IDs are non-empty and unique.
+
+```yaml
+schema_version: v1
+workflow_id: focused-validation
+steps:
+  - id: test
+    command: ["npm", "test"]
+```
+
+Create through file/stdin transport:
+
+```bash
+yy ledger workflow create --title "Focused validation" --file workflow.yaml
+```
+
+Ledger rejects unsafe or non-portable YAML, including duplicate keys, aliases,
+anchors, explicit tags, recursive structures, non-string mapping keys, implicit
+date/time values, non-finite numbers, CRLF input, and unsupported values. Never
+weaken validation by storing executable shell as an unvalidated substitute.
+
+## Revise safely
+
+Read the current revision and history, then follow the installed
+`workflow update --help` compare-and-replace contract. Bind updates to the
+expected revision and preimage/digests, validate the result, and read it back.
+On drift, stop and reconcile instead of forcing. Archive is non-destructive.
+
+Before execution, freeze the exact workflow Record ID, revision, payload digest,
+runner identity, inputs, and granted authorities. After execution, store bounded
+outputs under `artifact-yylo` with workflow/run provenance. An execution request
+never implies merge, release, publication, deployment, or production authority.
+
+## Complete request
+
+$ARGUMENTS

--- a/skills/ai-workflow/README.md
+++ b/skills/ai-workflow/README.md
@@ -4,7 +4,7 @@
 
 聚焦 AI 编程 Agent 的规格、计划、实现、测试、审查、发布与持续同步工作流。
 
-当前分类共 **47** 个技能。
+当前分类共 **51** 个技能。
 
 ## 推荐先看
 
@@ -20,6 +20,7 @@
 | `agent-workflow-designer` | 设计多智能体协作流程、任务交接、状态管理和故障恢复。 | [目录](./agent-workflow-designer/) | [SKILL.md](./agent-workflow-designer/SKILL.md) |
 | `andrej-karpathy-skills` | 用于应用 Andrej Karpathy 风格的 AI 学习、构建和研究实践。 | [目录](./andrej-karpathy-skills/) | [SKILL.md](./andrej-karpathy-skills/SKILL.md) |
 | `api-and-interface-design` | 设计稳定的 API、模块接口和类型契约。 | [目录](./api-and-interface-design/) | [SKILL.md](./api-and-interface-design/SKILL.md) |
+| `artifact-yylo` | 捕获与检索 YYLO Ledger 工件记录：按用途选择档案与载荷模式，附加来源与保留策略，沉淀不可变、防泄密的运行证据。 | [目录](./artifact-yylo/) | [SKILL.md](./artifact-yylo/SKILL.md) |
 | `brainstorming` | 用于在实现前澄清创意型产品或工程需求，探索目标、约束、方案与取舍。 | [目录](./brainstorming/) | [SKILL.md](./brainstorming/SKILL.md) |
 | `browser-testing-with-devtools` | 用于通过浏览器 DevTools 测试、调试和验证前端行为。 | [目录](./browser-testing-with-devtools/) | [SKILL.md](./browser-testing-with-devtools/SKILL.md) |
 | `ci-cd-and-automation` | 建立和优化持续集成、质量检查与部署自动化。 | [目录](./ci-cd-and-automation/) | [SKILL.md](./ci-cd-and-automation/SKILL.md) |
@@ -40,6 +41,7 @@
 | `idea-refine` | 澄清初步想法，比较方案并检验关键假设。 | [目录](./idea-refine/) | [SKILL.md](./idea-refine/SKILL.md) |
 | `incremental-implementation` | 将功能拆成可验证的小步改动并逐步完成实现。 | [目录](./incremental-implementation/) | [SKILL.md](./incremental-implementation/SKILL.md) |
 | `interview-me` | 通过逐问访谈澄清真实需求、目标用户与成功标准，避免在含糊请求上过早实施。 | [目录](./interview-me/) | [SKILL.md](./interview-me/SKILL.md) |
+| `ledger-tasks-yylo` | YYLO Ledger 看板任务管理完整参考：创建、检索、状态流转、依赖与排序、冷归档与多目录合并，以及控制器路由与环境变量。 | [目录](./ledger-tasks-yylo/) | [SKILL.md](./ledger-tasks-yylo/SKILL.md) |
 | `nexus` | 多智能体任务分解、链路编排、执行协调和结果整合。 | [目录](./nexus/) | [SKILL.md](./nexus/SKILL.md) |
 | `nlpm-audit` | 审计 SKILL.md、AGENTS.md、CLAUDE.md、插件清单、hooks、commands 和提示词，检查安装一致性、质量评分、安全风险与版本漂移。 | [目录](./nlpm-audit/) | [SKILL.md](./nlpm-audit/SKILL.md) |
 | `observability-and-instrumentation` | 为生产代码设计日志、指标、追踪和告警，使行为可观测、问题可诊断。 | [目录](./observability-and-instrumentation/) | [SKILL.md](./observability-and-instrumentation/SKILL.md) |
@@ -62,6 +64,8 @@
 | `using-git-worktrees` | 用于使用 Git worktree 隔离并行开发和审查工作。 | [目录](./using-git-worktrees/) | [SKILL.md](./using-git-worktrees/SKILL.md) |
 | `using-superpowers` | 用于使用 Superpowers 工作流提升计划、执行和验证质量。 | [目录](./using-superpowers/) | [SKILL.md](./using-superpowers/SKILL.md) |
 | `verification-before-completion` | 在宣告完成前核对当前代码的验证证据与适用范围。 | [目录](./verification-before-completion/) | [SKILL.md](./verification-before-completion/SKILL.md) |
+| `wiki-yylo` | 把 YYLO Ledger wiki 记录当作持久项目知识：先检索后创建、按记录类型正确分类，并通过修订安全契约更新 Markdown。 | [目录](./wiki-yylo/) | [SKILL.md](./wiki-yylo/SKILL.md) |
+| `workflow-yylo` | 以 YYLO Ledger 工作流记录为中心：安全创建、校验与修订可执行工作流定义，并保持存储、执行与运行证据三类边界分离。 | [目录](./workflow-yylo/) | [SKILL.md](./workflow-yylo/SKILL.md) |
 | `writing-plans` | 编写包含任务依赖、修改范围和验收方法的实现计划。 | [目录](./writing-plans/) | [SKILL.md](./writing-plans/SKILL.md) |
 | `writing-skills` | 编写可复用的技能指导并验证实际触发和执行行为。 | [目录](./writing-skills/) | [SKILL.md](./writing-skills/SKILL.md) |
 

--- a/skills/ai-workflow/artifact-yylo/LICENSE
+++ b/skills/ai-workflow/artifact-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ai-workflow/artifact-yylo/SKILL.md
+++ b/skills/ai-workflow/artifact-yylo/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: artifact-yylo
+description: 'Capture and retrieve durable YYLO Ledger artifact Records with intentional profiles, payload modes, provenance, retention, and secret-safe immutable evidence.'
+zh_description: "捕获与检索 YYLO Ledger 工件记录：按用途选择档案与载荷模式，附加来源与保留策略，沉淀不可变、防泄密的运行证据。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/artifact-yylo"
+license: MIT
+tags: '[yylo, artifacts, evidence, provenance, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 2
+complexity: intermediate
+---
+
+# Use YYLO artifact Records
+
+Treat Ledger as the source of truth for artifact identity and metadata. Use
+`yy ledger` in a YYLO controller or `yylo-ledger` standalone. Inspect
+`COMMAND artifact --help`; if unavailable, do not create store files manually.
+A Ledger Artifact Record is durable evidence, not an npm/Python release artifact
+and not an implicit request to publish or deploy.
+
+## Classify before capture
+
+Choose the profile matching the evidence:
+
+- `stdout`: bounded process output;
+- `model-output`: an agent/model response;
+- `report`: a generated human- or machine-readable result;
+- `receipt`: evidence binding an operation and its inputs/outcome.
+
+Choose payload mode deliberately:
+
+- `inline`: small immutable bytes embedded in the Record;
+- `local`: immutable content-addressed bytes in Ledger storage;
+- `external`: immutable external bytes with URI, digest, and size;
+- `link`: URI reference without an immutable-byte guarantee.
+
+Prefer immutable evidence when later verification depends on exact bytes. A link
+must never be presented as content-addressed proof.
+
+## Create explicitly
+
+Use file/stdin transport and provide the media type:
+
+```bash
+yy ledger artifact create --title "Focused test report" --profile report \
+  --mode local --media-type application/json --file report.json
+```
+
+For external immutable content, provide the supported URI, SHA-256 digest, and
+size shown by installed help. Never embed URI credentials. Ledger rejects unsafe
+schemes, traversal, size/digest mismatches, oversized capture, and known secret
+patterns.
+
+Attach only supported, non-secret provenance such as actor, agent, model,
+session, run, invocation, task, or workflow identity. Task/workflow provenance
+uses immutable Record IDs. Select `temporary`, `standard`, or `permanent`
+retention deliberately; retention metadata does not itself authorize deletion.
+
+## Quick reference: find and verify
+
+```bash
+yy ledger artifact search --profile report --projection summary --limit 20 -f json
+yy ledger artifact get RECORD_ID -f json
+yy ledger artifact history RECORD_ID -f ndjson
+```
+
+Use bounded metadata/summary projections before requesting payload details.
+Verify profile, mode, media type, digest, size, provenance, retention, revision,
+and immutable ID before relying on evidence.
+
+Artifact payloads are immutable evidence. Represent replacement with explicit
+predecessor/successor relationships and the installed revision-safe update
+contract; do not overwrite bytes or edit content objects. Archive is a lifecycle
+transition, not deletion. Release, publication, external upload, retention
+execution, and production mutation always require separate authority.
+
+## Complete request
+
+$ARGUMENTS

--- a/skills/ai-workflow/ledger-tasks-yylo/LICENSE
+++ b/skills/ai-workflow/ledger-tasks-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ai-workflow/ledger-tasks-yylo/SKILL.md
+++ b/skills/ai-workflow/ledger-tasks-yylo/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: ledger-tasks-yylo
+description: 'Comprehensive guide for YYLO Ledger task management: all commands (create, list, search, get, mark, update, archive, deps, ready, order, merge), dependency management, best practices, and workflow patterns.'
+zh_description: "YYLO Ledger 看板任务管理完整参考：创建、检索、状态流转、依赖与排序、冷归档与多目录合并，以及控制器路由与环境变量。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/ledger-tasks-yylo"
+license: MIT
+tags: '[yylo, kanban, task-management, dependencies, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 4
+complexity: intermediate
+---
+
+## YYLO Ledger CLI Reference
+
+Use `yy ledger` for all commands. YYLO 0.2.2 supports the exact `yylo-ledger 0.2.0` task CLI. `yy kanban` is a labelled compatibility alias for the same controller-routed task runtime.
+
+### Supported task contract
+
+- The public Ledger 0.2.0 surface is task-oriented: create, get, update, mark, archive, list/search, dependencies, ordering, history, doctor, compatibility, conversion, rollback, and cold archive operations.
+- Do not advertise `record`, `wiki`, `workflow`, or `artifact` namespaces unless the installed `yy ledger --help` explicitly provides them in a future supported release.
+- Read current task state before mutation, preserve mutation receipts where offered, and never bypass controller routing or lifecycle state with direct file edits.
+- Normal discovery is hot-only unless an explicit cold-archive command is used.
+
+### Opt-in cross-project routing
+
+Cross-project access is disabled by default. The source `.juno_task/config.json` must set `kanbanRegistry.enabled: true` and explicitly list `allowedProjects`; environment overrides are `YYLO_LEDGER_REGISTRY_ENABLED` and `YYLO_LEDGER_REGISTRY_ALLOWED_PROJECTS`. Register with `yy ledger project add ALIAS --path /absolute/project`, then route any command with `--project ALIAS`. The destination wrapper/runtime remains authoritative, and routing failures never fall back to the source board.
+
+### Legacy Task compatibility commands
+
+**CREATE** — Add a new task
+```bash
+yy ledger create "Task description here" --status backlog --tags feature,backend
+```
+Options: `--status` (backlog|todo|in_progress|done), `--tags` (comma/space-separated), `--blocked-by` (task IDs), `--related-tasks` (task IDs)
+
+**LIST** — Browse tasks with summary stats
+```bash
+yy ledger list --limit 5 --sort asc
+yy ledger list --status todo --sort asc
+yy ledger list --status todo,in_progress --limit 10
+```
+
+**SEARCH** — Find tasks by criteria
+```bash
+yy ledger search --status todo --tag backend --limit 10
+yy ledger search --body "OAuth" --open
+yy ledger search --commit abc123
+```
+Filters: `--status`, `--tag`, `--body`, `--response`, `--commit`, `--open` (no agent_response), `--recent`, `--exclude` (exclude tags)
+
+**GET** — Full task details (including dependency info and related task details)
+```bash
+yy ledger get TASK_ID
+```
+
+**MARK** — Update status with required response message
+```bash
+yy ledger mark in_progress --id TASK_ID --response "Starting work on this"
+yy ledger mark done --id TASK_ID --response "Completed: implemented X, tested Y" --commit abc123def
+yy ledger mark todo --id TASK_ID --response "Reopening: found regression"
+```
+Required: `--id` and `--response`. Optional: `--commit` (recommended for done).
+
+**UPDATE** — Modify task fields
+```bash
+yy ledger update TASK_ID --status todo --tags backend,urgent
+yy ledger update TASK_ID --commit abc123def
+yy ledger update TASK_ID --response "Additional context"
+```
+
+**ARCHIVE** — Soft delete (preserves data, sets status to archive)
+```bash
+yy ledger archive TASK_ID
+```
+
+### Immutable cold archive packs
+
+Normal `list`, `search`, `ready`, and `order` are deliberately hot-only. Exact `get TASK_ID` transparently resolves a hot task or a read-only archived task; use `history TASK_ID` explicitly for its ledger. Discover cold tasks only with bounded, projected `archive-search` output:
+
+```bash
+yy ledger archive-search --tag backend --before 2026-01-01 --limit 20 --projection metadata
+```
+
+Before archive maintenance, preflight the installed version/help and obtain explicit owner authorization. The repository and index must be clean, and reports must be durable new paths outside the repository:
+
+```bash
+yy ledger --version
+yy ledger archive-pack plan --status done,archive --older-than 90d --max-tasks 1000 --target-bytes 26214400 --hard-max-bytes 47185920 --report /external/receipts/archive-plan.json
+# Independently inspect selected IDs, revisions, source HEAD, policy, and plan hash.
+yy ledger archive-pack create --plan /external/receipts/archive-plan.json --report /external/receipts/archive-create.json
+yy ledger archive-pack doctor
+yy ledger doctor
+```
+
+A stale plan or selected-task/worktree conflict must fail closed: discard the plan, resolve the conflict, and plan again. Never automate archival, edit/append packs or manifests, restore/reopen an archived ID, use force/lossy controls, or enumerate archive files directly. Create follow-up work as a new hot task related to the archived ID. Production archival, push/deploy, and post-deploy E2E each require separate authorization; agents must not infer it from implementation approval.
+
+### Dependency Management
+
+**DEPS** — View, add, or remove task dependencies
+```bash
+# View dependency info (blockers, dependents, priority score)
+yy ledger deps TASK_ID
+
+# Add blockers (TASK_ID cannot start until BLOCKER1 and BLOCKER2 are done)
+yy ledger deps add --id TASK_ID --blocked-by BLOCKER1 BLOCKER2
+
+# Remove a blocker
+yy ledger deps remove --id TASK_ID --blocked-by BLOCKER1
+```
+Cycle detection prevents circular dependencies automatically.
+
+**READY** — Tasks with all blockers satisfied (safe to work on)
+```bash
+yy ledger ready
+yy ledger ready --tag backend --limit 5
+```
+Returns tasks where status is backlog/todo/in_progress AND all `blocked_by` tasks are done/archive.
+
+**ORDER** — Topological sort of open tasks respecting dependencies
+```bash
+yy ledger order
+yy ledger order --scores
+```
+Use for determining safe parallel execution order.
+
+### Body Markup for Inline Dependencies
+
+Declare dependencies and relations directly in task body text:
+
+```
+[blocked_by]TASK_ID[/blocked_by]          — This task is blocked by TASK_ID
+[blocked_by]ID1, ID2[/blocked_by]         — Blocked by multiple tasks
+[task_id]RELATED_ID[/task_id]             — Reference a related task
+[task_id]ID1 ID2[/task_id]                — Multiple related tasks
+```
+
+These are parsed automatically when the task is created/updated.
+
+### Merge (Multi-Directory Consolidation)
+
+When tasks get scattered across subdirectories:
+```bash
+# First produce and review a deterministic plan
+yy ledger merge ./sub1/.juno_task ./sub2/.juno_task --into ./.juno_task \
+  --dry-run --plan-file /external/ledger-merge-plan.json
+
+# Apply only that reviewed plan and retain its receipt
+yy ledger merge ./sub1/.juno_task ./sub2/.juno_task --into ./.juno_task \
+  --apply-plan /external/ledger-merge-plan.json \
+  --receipt-file /external/ledger-merge-receipt.json
+```
+
+### Output Formats
+
+All commands support: `-f json`, `-f ndjson` (default), `-f xml`, `-f table`
+Add `--raw` for compact output. Add `-p` for pretty print.
+
+## Best Practices
+
+1. **Task sizing**: Create tasks small enough to complete in one iteration without filling the context window
+2. **Status flow**: backlog → todo → in_progress → done (or archive for abandoned tasks)
+3. **Always include `--response`** when using `mark` — document what you did and how you tested it
+4. **Attach commits**: Use `--commit HASH` when marking done, then `update TASK_ID --commit HASH` to link the git history
+5. **Use `ready`** before starting work to find unblocked tasks
+6. **Use `order --scores`** to plan parallel execution pipelines
+7. **Use `[blocked_by]` markup** in task body when creating tasks that depend on others
+8. **Use `[task_id]` markup** in task body to cross-reference related tasks
+9. **Use `get TASK_ID`** to see full task details including resolved dependency and related task info
+10. **Concurrent features are supported** — start each selected task with `yy task start TASK_ID`; each gets a dedicated product worktree, while `yy merge` serializes only target updates
+
+### Canonical Controller Routing
+
+YYLO Ledger mutation resolves the controller in this order: explicit `JUNO_TASK_ROOT`, repository-local registration, then the current project root. Diagnose before orchestration with `.juno_task/scripts/controller_resolver.py --cwd "$PWD" --operation kanban`. The resolver may bootstrap or idempotently confirm a registration, but changing an existing controller requires `yy migrate registration plan` followed by a separately authorized apply. Explicit/registered path or branch errors fail closed—YYLO Ledger never switches Git branches or falls back silently.
+
+Run YYLO Ledger and workflows from the controller. A task checkout may implement/test but routes task/session writes to that controller. An integration-owner checkout stays clean and refuses Kanban/orchestration/session writes in strict mode; launch from the controller and pass the product checkout separately as `TASK_ROOT`.
+
+### Environment Variables
+
+- `JUNO_TASK_ROOT` — Explicit canonical controller/task-storage root (not the product `TASK_ROOT`)
+- `JUNO_CONTROLLER_BRANCH` — Expected controller branch for environment-based routing
+- `JUNO_WORKSPACE_ROLE` — `controller`, `task`, or `integration-owner`
+- `JUNO_WORKSPACE_ENFORCEMENT` — `off`, `warn`, or `strict`
+- `JUNO_DEBUG=true` — Show diagnostic messages
+- `JUNO_VERBOSE=true` — Show informational messages
+- `JUNO_KANBAN_LIST_BODY_TRUNCATE_CHARS=N` — Override list body truncation (default: 1200)
+
+$ARGUMENTS

--- a/skills/ai-workflow/wiki-yylo/LICENSE
+++ b/skills/ai-workflow/wiki-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ai-workflow/wiki-yylo/SKILL.md
+++ b/skills/ai-workflow/wiki-yylo/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: wiki-yylo
+description: 'Use YYLO Ledger wiki Records as durable project knowledge. Search before creating, classify information correctly, and make revision-safe Markdown updates without editing Ledger storage directly.'
+zh_description: "把 YYLO Ledger wiki 记录当作持久项目知识：先检索后创建、按记录类型正确分类，并通过修订安全契约更新 Markdown。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/wiki-yylo"
+license: MIT
+tags: '[yylo, wiki, knowledge-management, markdown, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 3
+complexity: intermediate
+---
+
+# Use YYLO wiki Records
+
+Treat Ledger as the source of truth. Use `yy ledger` in a YYLO controller and
+`yylo-ledger` in a standalone Ledger project. Inspect `COMMAND wiki --help` before
+acting; if `wiki` is absent, the installed Ledger version does not expose native
+Record commands and must not be bypassed with direct file edits.
+
+## Choose the right record
+
+Before writing, decide where the information belongs:
+
+- **Wiki**: durable explanatory project or domain knowledge that future work must discover.
+- **Task**: scoped requested work, status, dependencies, acceptance criteria, and completion evidence.
+- **Workflow**: validated structured steps, not prose guidance.
+- **Artifact**: generated evidence, reports, receipts, logs, model output, or binary payloads.
+- **Source documentation**: documentation released and versioned with product code.
+
+Do not put secrets, caches, session transcripts, temporary status, bulky generated
+evidence, or owner-only operational receipts in a wiki.
+
+## Quick reference: discover before creating
+
+Use bounded summary searches first. Resolve records by immutable ID whenever one
+is known; slugs and aliases are discovery conveniences, not replacement identity.
+
+```bash
+yy ledger wiki search --text "deployment policy" --projection summary --limit 20 -f json
+yy ledger wiki get RECORD_ID -f json
+yy ledger wiki get RECORD_ID --raw
+```
+
+Use `--scope archive|all` only when the request requires cold records. Request
+`full` projection only when payload bytes are necessary.
+
+## Create durable Markdown
+
+Use a file or stdin for substantial or shell-sensitive content:
+
+```bash
+yy ledger wiki create --title "Service ownership" --file ownership.md
+yy ledger wiki create --title "Incident notes" --file - < incident-notes.md
+```
+
+Choose a stable title, namespace, slug, aliases, and relations deliberately. Keep
+one topic per Record and link related immutable Record IDs rather than duplicating
+truth.
+
+## Update safely
+
+1. Read the current Record and revision.
+2. Preserve its immutable ID and inspect history when intent is unclear.
+3. Follow `wiki update --help` for the installed compare-and-replace controls.
+4. Supply the expected revision and required preimage/digest evidence.
+5. Use file transport; do not rewrite Ledger files yourself.
+6. Read back the resulting revision and receipt.
+
+A revision or preimage mismatch means the source changed: reread and reconcile.
+Never force past concurrent edits. Archive is a lifecycle transition, not delete.
+
+Use `--front-matter` only for canonical front-matter interchange and `--rendered`
+for inert, HTML-escaped rendering. Use `history RECORD_ID` to understand revisions;
+do not infer history from the latest payload alone.
+
+## Project wiki boundary
+
+Portable controller guidance may live under the controller wiki, while project
+and domain pages retain project-owned paths. Package-managed and project-owned
+pages can coexist. Migration, runtime replacement, exceptional merge recovery,
+release, deployment, and cold-archive maintenance remain authoritative runbooks,
+not content to summarize into an everyday global skill.
+
+## Complete request
+
+$ARGUMENTS

--- a/skills/ai-workflow/workflow-yylo/LICENSE
+++ b/skills/ai-workflow/workflow-yylo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JUNO AI INC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ai-workflow/workflow-yylo/SKILL.md
+++ b/skills/ai-workflow/workflow-yylo/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: workflow-yylo
+description: 'Create and maintain validated YYLO Ledger workflow Records while keeping storage, execution, and run evidence as separate explicit boundaries.'
+zh_description: "以 YYLO Ledger 工作流记录为中心：安全创建、校验与修订可执行工作流定义，并保持存储、执行与运行证据三类边界分离。"
+version: "2.0.0"
+author: yylo-dev
+source: github:yylo-dev/yylo-skills
+source_url: "https://github.com/yylo-dev/yylo-skills/tree/506edfd8d3fab524df2fdbc0bc739af876c95aa1/skills/workflow-yylo"
+license: MIT
+tags: '[yylo, workflow, validation, agent-automation, cli]'
+created_at: "2026-09-11"
+updated_at: "2026-09-11"
+quality: 2
+complexity: intermediate
+---
+
+# Use YYLO workflow Records
+
+Treat Ledger as the source of truth for workflow identity, validated definition,
+and revision history. Use `yy ledger` in a YYLO controller or `yylo-ledger`
+standalone. Inspect `COMMAND workflow --help`; if the namespace is absent, do not
+invent it or edit Ledger storage directly.
+
+## Keep three boundaries distinct
+
+1. **Ledger stores and validates workflow data.** It does not execute workflows.
+2. **A separately selected YYLO runner executes reviewed workflow data.** Storage
+   does not grant execution, network, mutation, release, or deployment authority.
+3. **Artifact Records retain run evidence.** Do not overwrite the workflow
+   definition with stdout, logs, model output, reports, or receipts.
+
+The read-only Ledger host also has no workflow execution endpoint.
+
+## Discover and inspect
+
+```bash
+yy ledger workflow search --text "release verification" --projection summary --limit 20 -f json
+yy ledger workflow get RECORD_ID -f json
+yy ledger workflow get RECORD_ID --raw
+yy ledger workflow get RECORD_ID --validated
+```
+
+Prefer immutable IDs after discovery. Use bounded projections and explicit archive
+scope. `--validated` emits normalized YAML only after schema validation.
+
+## Author safe workflow data
+
+A workflow v1 document requires a mapping with `schema_version: v1`, a non-empty
+`workflow_id`, and a `steps` list whose step IDs are non-empty and unique.
+
+```yaml
+schema_version: v1
+workflow_id: focused-validation
+steps:
+  - id: test
+    command: ["npm", "test"]
+```
+
+Create through file/stdin transport:
+
+```bash
+yy ledger workflow create --title "Focused validation" --file workflow.yaml
+```
+
+Ledger rejects unsafe or non-portable YAML, including duplicate keys, aliases,
+anchors, explicit tags, recursive structures, non-string mapping keys, implicit
+date/time values, non-finite numbers, CRLF input, and unsupported values. Never
+weaken validation by storing executable shell as an unvalidated substitute.
+
+## Revise safely
+
+Read the current revision and history, then follow the installed
+`workflow update --help` compare-and-replace contract. Bind updates to the
+expected revision and preimage/digests, validate the result, and read it back.
+On drift, stop and reconcile instead of forcing. Archive is non-destructive.
+
+Before execution, freeze the exact workflow Record ID, revision, payload digest,
+runner identity, inputs, and granted authorities. After execution, store bounded
+outputs under `artifact-yylo` with workflow/run provenance. An execution request
+never implies merge, release, publication, deployment, or production authority.
+
+## Complete request
+
+$ARGUMENTS

--- a/tests/test_sync_upstream.py
+++ b/tests/test_sync_upstream.py
@@ -991,7 +991,7 @@ class SyncUpstreamTests(unittest.TestCase):
             skill for skill in loaded if skill.get("kind") == "snapshot"
         ]
 
-        self.assertEqual(149, len(loaded))
+        self.assertEqual(153, len(loaded))
         self.assertEqual(25, len(snapshots))
         self.assertTrue(
             all(skill.get("expected_skip_reason") for skill in snapshots)


### PR DESCRIPTION
## What changed

Adds four MIT-licensed agent-workflow skills from [yylo-dev/yylo-skills](https://github.com/yylo-dev/yylo-skills) (pinned at `506edfd8`) under `skills/ai-workflow/`:

- **`ledger-tasks-yylo`** — full `yy ledger` task-management reference: create/list/search/get/mark/update/archive, dependencies, `ready`/`order`, cold-archive packs, and multi-directory merge.
- **`workflow-yylo`** — validated workflow Records: safe authoring, schema validation, revision-safe updates, with storage / execution / run-evidence boundaries kept distinct.
- **`wiki-yylo`** — durable project knowledge as wiki Records: search-before-create, record-type classification, revision-safe Markdown updates.
- **`artifact-yylo`** — durable evidence as artifact Records: profiles, payload modes, provenance, retention, secret-safe immutable capture.

YYLO is an open-source (MIT) coding-agent orchestrator — these skills drive its `yy` CLI for Codex / Claude Code style agents, so they slot naturally beside `planning-and-task-breakdown`, `executing-plans`, and `subagent-driven-development`.

**Disclosure:** I'm a maintainer of the YYLO project submitting our own skills — happy to adjust placement, trim the set, or drop any entry.

## Provenance

- `docs/sources/yylo-dev-yylo-skills-2026-09.skills.json` — schema v2, `kind: overlay`, `sync_mode: monitor`: frontmatter adapted to the house schema (zh_description, tags, quality, description within the 240-char budget) and at most one heading normalized to the section contract; prose and code blocks are verbatim from the pinned upstream commit.
- Per-skill local `LICENSE` (MIT, © 2026 JUNO AI INC.) beside each `SKILL.md`.
- Honest quality tiers against the line floors: ledger-tasks **4** (191 lines), wiki **3** (90), workflow **2** (84), artifact **2** (83); all clear the hard 50-line floor. The remaining three yylo skills stay upstream — they are thin entries that would fall below the floor.

## Verification

Ran the full local pipeline exactly as CI does:

```
python scripts/validate_repository.py --refresh   # exit 0 — 288 skills, 603 tests passed
python scripts/provenance_pipeline.py --mode all --config docs/sources/provenance.config.json  # exit 0
git diff --exit-code                              # clean after re-run (generated views committed fresh)
```

- Regenerated views included: bilingual README counts (16 categories / **288** skills), category README, `docs/catalog.json`, `docs/TAGS-INDEX.md`, repo banner, OpenClaw exports, in-house timestamp refresh.
- `tests/test_sync_upstream.py`: mapping-count assertion bumped 149 → 153 (mechanical, same as recent maintenance PRs; snapshot count unchanged — these are overlays, not snapshots).

## Notes for review

- Upstream is actively maintained (daily pushes); `sync_mode: monitor` lets the weekly upstream check track it without auto-replacing.
- If you'd rather start with a smaller donation, `ledger-tasks-yylo` alone is the flagship — I can trim the PR to one skill on request.
